### PR TITLE
Update MySQL port to 3306 not 3336

### DIFF
--- a/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
@@ -30,7 +30,7 @@ tags = ["Elastic", "Network"]
 type = "query"
 
 query = '''
-network.transport:tcp and destination.port:(1433 or 1521 or 3336 or 5432) and
+network.transport:tcp and destination.port:(1433 or 1521 or 3306 or 5432) and
   source.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16) and
   not destination.ip:(10.0.0.0/8 or 127.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16 or "::1")
 '''

--- a/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.4.0"]
 maturity = "production"
-updated_date = "2020/03/09"
+updated_date = "2020/07/01"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Closes #3

## Summary
I believe this is a typo. See default port for MySQL: https://dev.mysql.com/doc/mysql-port-reference/en/mysql-ports-reference-tables.html#:~:text=Port%203306%20is%20the%20default,such%20as%20mysqldump%20and%20mysqlpump.



## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
