### PR TITLE
[New Rule] Attempt to Modify or Delete Okta Application Sign On Policy

### DIFF
--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -19,7 +19,7 @@ false_positives = [
 index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
-name = "Modification or Removal of an Okta Application Sign On Policy"
+name = "Modification or Removal of an Okta Application Sign-On Policy"
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -31,5 +31,5 @@ tags = ["Elastic", "Okta"]
 type = "query"
 
 query = '''
-event.module:okta and event.dataset:okta.system and event.action:(application.policy.sign_on.update or application.policy.sign_on.rule.delete)
+event.category:authentication and event.type:access and event.dataset:okta.system and event.action:(application.policy.sign_on.update or application.policy.sign_on.rule.delete)
 '''

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -31,5 +31,5 @@ tags = ["Elastic", "Okta"]
 type = "query"
 
 query = '''
-event.dataset:okta.system and event.action:(application.policy.sign_on.update or application.policy.sign_on.rule.delete)
+event.module:okta and event.dataset:okta.system and event.action:(application.policy.sign_on.update or application.policy.sign_on.rule.delete)
 '''

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -19,7 +19,7 @@ false_positives = [
 index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
-name = "Attempt to Modify or Delete Okta Application Sign On Policy"
+name = "Modification or Removal of an Okta Application Sign On Policy"
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -1,0 +1,35 @@
+[metadata]
+creation_date = "2020/07/01"
+ecs_version = ["1.5.0"]
+maturity = "production"
+updated_date = "2020/07/01"
+
+[rule]
+author = ["Elastic"]
+description = """
+An adversary may attempt to modify or delete the sign on policy for an Okta application in order to remove or weaken an
+organization's security controls.
+"""
+false_positives = [
+    """
+    Consider adding exceptions to this rule to filter false positives if sign on policies for Okta applications are
+    regularly modified or deleted in your organization.
+    """,
+]
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "Attempt to Modify or Delete Okta Application Sign On Policy"
+references = [
+    "https://developer.okta.com/docs/reference/api/system-log/",
+    "https://developer.okta.com/docs/reference/api/event-types/",
+]
+risk_score = 47
+rule_id = "cd16fb10-0261-46e8-9932-a0336278cdbe"
+severity = "medium"
+tags = ["Elastic", "Okta"]
+type = "query"
+
+query = '''
+event.dataset:okta.system and event.action:(application.policy.sign_on.update or application.policy.sign_on.rule.delete)
+'''

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -31,5 +31,5 @@ tags = ["Elastic", "Okta"]
 type = "query"
 
 query = '''
-event.category:authentication and event.type:access and event.dataset:okta.system and event.action:(application.policy.sign_on.update or application.policy.sign_on.rule.delete)
+event.module:okta and event.dataset:okta.system and event.action:(application.policy.sign_on.update or application.policy.sign_on.rule.delete)
 '''


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #8 

## Summary
An adversary may attempt to modify or delete the sign on policy for an Okta application in order to remove or weaken an organization's security controls. Please see #8 for further details and example events that will trigger this rule.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
