### PR TITLE
[Rule Tuning] Fix logic bug in rule, Attempt to Disable IPTables or Firewall

### DIFF
--- a/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -21,7 +21,11 @@ tags = ["Elastic", "Linux"]
 type = "query"
 
 query = '''
-event.action:(executed or process_started) and (process.name:service and process.args:stop or process.name:chkconfig and process.args:off) and process.args:(ip6tables or iptables or firewalld) or process.name:systemctl and process.args:((firewalld or iptables or ip6tables) and (disable or stop or kill))
+event.action:(executed or process_started) and (
+  (process.name:service and process.args:stop) or
+  (process.name:chkconfig and process.args:off) or
+  (process.name:systemctl and process.args:(disable or stop or kill))
+) and process.args:(ip6tables or iptables or firewalld)
 '''
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves https://github.com/elastic/detection-rules/issues/7

## Summary
Update this rule to ensure the correct order of precedence for conditions in the query. See https://github.com/elastic/detection-rules/issues/7 for further details and screenshot of query matching intended events.

https://github.com/elastic/detection-rules/blob/46a400857026c1077eefe7120195a983c7b96136/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml#L24

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
