### PR TITLE
Add vscode dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # PyCharm
 /.idea/
 
+# VSCode
+/.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary

Add the vscode dir to gitignore to keep local git status clean.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? :+1:
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? :+1:
