### PR TITLE
Package notice file with release

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -125,7 +125,7 @@ class Package(object):
 
     @staticmethod
     def _package_notice_file(save_dir):
-        """convert and save notice file with package."""
+        """Convert and save notice file with package."""
         with open(NOTICE_FILE, 'rt') as f:
             notice_txt = f.read()
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -126,7 +126,7 @@ class Package(object):
     @staticmethod
     def _package_notice_file(save_dir):
         """convert and save notice file with package."""
-        with open(NOTICE_FILE, 'r') as f:
+        with open(NOTICE_FILE, 'rt') as f:
             notice_txt = f.read()
 
         with open(os.path.join(save_dir, 'notice.ts'), 'w') as f:
@@ -164,9 +164,10 @@ class Package(object):
         for rule in self.rules:
             rule.save(new_path=os.path.join(rules_dir, os.path.basename(rule.path)))
 
+        self._package_notice_file(rules_dir)
+
         if self.release:
             self.save_release_files(extras_dir, self.changed_rules, self.new_rules)
-            self._package_notice_file(rules_dir)
 
             # zip all rules only and place in extras
             shutil.make_archive(os.path.join(extras_dir, self.name), 'zip', root_dir=os.path.dirname(rules_dir),

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -125,7 +125,7 @@ class Package(object):
 
     @staticmethod
     def _package_notice_file(save_dir):
-        """Verify notices.txt is properly populated and save with package."""
+        """convert and save notice file with package."""
         with open(NOTICE_FILE, 'r') as f:
             notice_txt = f.read()
 


### PR DESCRIPTION
## Issues
resolves #31 

## Summary
Converts the notice.txt file to the expected notice.ts format and stages with it rules when building a package with `build-release`

This is the currently generated file:
```js
/* eslint-disable @kbn/eslint/require-license-header */

/* @notice
 * Detection Rules
 * Copyright 2020 Elasticsearch B.V.
 * 
 * ---
 * This product bundles rules based on https://github.com/BlueTeamLabs/sentinel-attack
 * which is available under a "MIT" license. The files based on this license are:
 * 
 * - defense_evasion_via_filter_manager.toml
 * - discovery_process_discovery_via_tasklist_command.toml
 * - persistence_priv_escalation_via_accessibility_features.toml
 * - persistence_via_application_shimming.toml
 * - defense_evasion_execution_via_trusted_developer_utilities.toml
 * 
 * MIT License
 * 
 * Copyright (c) 2019 Edoardo Gerosa, Olaf Hartong
 * 
 * Permission is hereby granted, free of charge, to any person obtaining a copy of
 * this software and associated documentation files (the "Software"), to deal in
 * the Software without restriction, including without limitation the rights to
 * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 * of the Software, and to permit persons to whom the Software is furnished to do
 * so, subject to the following conditions:
 * 
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
 * 
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 */
```

Note added by @rw-access:
This will replace this file https://github.com/elastic/kibana/blob/1216b0f7cd2c0697393547432bee343ed33b96b5/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/notice.ts