### PR TITLE
Add test for duplicate file names

### DIFF
--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import unittest
+from collections import defaultdict
 
 import jsonschema
 import kql
@@ -111,3 +112,14 @@ class TestValidRules(unittest.TestCase):
                 rta_name, ext = os.path.splitext(matching_rta)
                 if rta_name not in ttp_names:
                     self.fail("{} ({}) references unknown RTA: {}".format(rule.name, rule.id, rta_name))
+
+    def test_duplicate_file_names(self):
+        """Test that no file names are duplicated."""
+        name_map = defaultdict(list)
+        for file_path in rule_loader.load_rule_files():
+            base_name = os.path.basename(file_path)
+            name_map[base_name].append(file_path)
+
+        duplicates = {name: paths for name, paths in name_map.items() if len(paths) > 1}
+        if duplicates:
+            self.fail(f"Found duplicated file names {duplicates}")


### PR DESCRIPTION
## Issues
None

## Summary
Added a unit test to make sure we don't have duplicate file names. Otherwise, we would have collisions when we flatten the directories and build a package before sending to Kibana.


```
FAILED tests/test_all_rules.py::TestValidRules::test_duplicate_file_names - AssertionError: Found duplicated file names {'credential_access_tcpdump_activity.toml': ['rules/aws/credential_access_tcpdump_activity.toml', 'rules/linux/credential_access_tcpdump_activity.toml']}
```