### PR TITLE
Add kibana-push command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,8 @@ release: deps
 	rm -rf dist
 	mkdir dist
 	cp -r releases/*/*.zip dist/
+
+.PHONY: kibana-commit
+kibana-commit: deps
+	@echo "PREP KIBANA-COMMIT: $(app_name)"
+	$(PYTHON) -m detection_rules kibana-commit

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -368,15 +368,16 @@ def kibana_push(ctx, local_repo, github_repo, ssh, kibana_directory, message):
     if not os.path.exists(release_dir):
         click.secho("Release directory doesn't exist.", fg="red", err=True)
         click.echo(f"Run {click.style('python -m detection_rules build-release', bold=True)} to populate", err=True)
-        return
+        ctx.exit(1)
 
     if not git_exe:
         click.secho("Unable to find git", err=True, fg="red")
-        return
+        ctx.exit(1)
+
     try:
         if not os.path.exists(local_repo):
             if not click.confirm(f"Kibana repository doesn't exist at {local_repo}. Clone?"):
-                return
+                ctx.exit(1)
 
             url = f"git@github.com:{github_repo}.git" if ssh else f"https://github.com/{github_repo}.git"
             subprocess.check_call([git_exe, "clone", url, local_repo, "--depth", 1])


### PR DESCRIPTION
## Issues
Closes #36
Depends on #37

## Summary
Wipes the directory in Kibana away and rebuilds with the latest version of the repository. Assumes you've already built the release, and will pull it from the filesystem. I think it's good to keep these decoupled, makes things one step easier. Exit codes should be enough if we want to automate multiple commands in a row.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
