### PR TITLE
Generate linted .ts in package

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -5,11 +5,11 @@ Copyright 2020 Elasticsearch B.V.
 This product bundles rules based on https://github.com/BlueTeamLabs/sentinel-attack
 which is available under a "MIT" license. The files based on this license are:
 
-- defense_evasion_via_filter_manager.toml
-- discovery_process_discovery_via_tasklist_command.toml
-- persistence_priv_escalation_via_accessibility_features.toml
-- persistence_via_application_shimming.toml
-- defense_evasion_execution_via_trusted_developer_utilities.toml
+- defense_evasion_via_filter_manager
+- discovery_process_discovery_via_tasklist_command
+- persistence_priv_escalation_via_accessibility_features
+- persistence_via_application_shimming
+- defense_evasion_execution_via_trusted_developer_utilities
 
 MIT License
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -131,7 +131,7 @@ class Package(object):
             notice_txt = f.read()
 
         with open(os.path.join(save_dir, 'notice.ts'), 'wt') as f:
-            commented_notice = [' * ' + line for line in notice_txt.splitlines()]
+            commented_notice = [(' * ' + line).rstrip() for line in notice_txt.splitlines()]
             lines = ['/* eslint-disable @kbn/eslint/require-license-header */', '', '/* @notice']
             lines = lines + commented_notice + [' */', '']
             f.write('\n'.join(lines))
@@ -150,7 +150,7 @@ class Package(object):
         const_exports = ['export const rawRules = [']
         const_exports.extend(f"  rule{i}," for i, _ in enumerate(sorted_rules, 1))
         const_exports.append("];")
-        const_exports.append(" ")
+        const_exports.append("")
 
         index_ts = [JS_LICENSE, ""]
         index_ts.extend(comments)
@@ -158,6 +158,7 @@ class Package(object):
         index_ts.extend(rule_imports)
         index_ts.append("")
         index_ts.extend(const_exports)
+
         with open(os.path.join(save_dir, 'index.ts'), 'wt') as f:
             f.write('\n'.join(index_ts))
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -131,7 +131,7 @@ class Package(object):
             notice_txt = f.read()
 
         with open(os.path.join(save_dir, 'notice.ts'), 'wt') as f:
-            commented_notice = [(' * ' + line).rstrip() for line in notice_txt.splitlines()]
+            commented_notice = [f' * {line}'.rstrip() for line in notice_txt.splitlines()]
             lines = ['/* eslint-disable @kbn/eslint/require-license-header */', '', '/* @notice']
             lines = lines + commented_notice + [' */', '']
             f.write('\n'.join(lines))


### PR DESCRIPTION
## Issues
None

## Summary
We failed lint tests for https://github.com/elastic/kibana/pull/71332. Now the generated `.ts` files should pass the lint unit tests.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
