### PR TITLE
Add Global Endpoint Exception List to Elastic Endpoint rule

### DIFF
--- a/rules/promotions/elastic_endpoint.toml
+++ b/rules/promotions/elastic_endpoint.toml
@@ -11,6 +11,7 @@ Generates a detection alert each time an Elastic Endpoint alert is received. Ena
 immediately begin investigating your Elastic Endpoint alerts.
 """
 enabled = true
+exceptions_list = [{ id = 'endpoint_list', namespace_type = 'agnostic', type = 'endpoint' }]
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
 language = "kuery"

--- a/rules/promotions/elastic_endpoint.toml
+++ b/rules/promotions/elastic_endpoint.toml
@@ -11,7 +11,6 @@ Generates a detection alert each time an Elastic Endpoint alert is received. Ena
 immediately begin investigating your Elastic Endpoint alerts.
 """
 enabled = true
-exceptions_list = [{ id = 'endpoint_list', namespace_type = 'agnostic', type = 'endpoint' }]
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
 language = "kuery"
@@ -30,6 +29,11 @@ query = '''
 event.kind:alert and event.module:(endpoint and not endgame)
 '''
 
+
+[[rule.exceptions_list]]
+id = "endpoint_list"
+namespace_type = "agnostic"
+type = "endpoint"
 
 [[rule.risk_score_mapping]]
 field = "event.risk_score"
@@ -59,3 +63,5 @@ field = "event.severity"
 operator = "equals"
 value = "99"
 severity = "critical"
+
+


### PR DESCRIPTION
## Summary
This adds a static reference of the Global Endpoint Exception List to the `Elastic Endpoint` rule. This ensures that the `Elastic Endpoint` has the ability to edit/add endpoint exceptions.


Reference:

``` ts
  "exceptions_list": [
    {
      "id": "endpoint_list",
      "namespace_type": "agnostic",
      "type": "endpoint"
    }
  ],
```


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Y!
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? Y!
