### PR TITLE
Loosen yaml requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytoml
 toml==0.10.0
 requests==2.22.0
 Click==7.0
-PyYAML==5.1.2
+PyYAML~=5
 
 eql~=0.9
 elasticsearch~=7.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytoml
 toml==0.10.0
 requests==2.22.0
 Click==7.0
-PyYAML~=5
+PyYAML~=5.3
 
 eql~=0.9
 elasticsearch~=7.5.1


### PR DESCRIPTION
## Issues
Apparently builds are breaking. Not sure why it can't find pyyaml.

## Summary
Loosed the requirement in requirements.txt


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
