### PR TITLE
[Rule Tuning] Update Cloud rules with note field

### DIFF
--- a/rules/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/aws/collection_cloudtrail_logging_created.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS CloudTrail Log Created"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_CreateTrail.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudtrail/create-trail.html",

--- a/rules/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/aws/credential_access_iam_user_addition_to_group.toml
@@ -21,6 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS IAM User Addition to Group"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = ["https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddUserToGroup.html"]
 risk_score = 21
 rule_id = "333de828-8190-4cf5-8d7c-7575846f6fe0"
@@ -45,6 +46,8 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
+++ b/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
@@ -22,6 +22,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS Access Secret in Secrets Manager"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html",
     "http://detectioninthe.cloud/credential_access/access_secret_in_secrets_manager/",

--- a/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS CloudTrail Log Deleted"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_DeleteTrail.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudtrail/delete-trail.html",

--- a/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -24,6 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS CloudTrail Log Suspended"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_StopLogging.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudtrail/stop-logging.html",

--- a/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS CloudWatch Alarm Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudwatch/delete-alarms.html",
     "https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DeleteAlarms.html",

--- a/rules/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/aws/defense_evasion_config_service_rule_deletion.toml
@@ -24,6 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS Config Service Tampering"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.aws.amazon.com/config/latest/developerguide/how-does-config-work.html",
     "https://docs.aws.amazon.com/config/latest/APIReference/API_Operations.html",

--- a/rules/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS Configuration Recorder Stopped"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/configservice/stop-configuration-recorder.html",
     "https://docs.aws.amazon.com/config/latest/APIReference/API_StopConfigurationRecorder.html",

--- a/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS EC2 Flow Log Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/delete-flow-logs.html",
     "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteFlowLogs.html",

--- a/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS EC2 Network Access Control List Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/delete-network-acl.html",
     "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteNetworkAcl.html",

--- a/rules/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS GuardDuty Detector Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/guardduty/delete-detector.html",
     "https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DeleteDetector.html",

--- a/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS S3 Bucket Configuration Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketPolicy.html",
     "https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html",

--- a/rules/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/aws/defense_evasion_waf_acl_deletion.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS WAF Access Control List Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/waf-regional/delete-web-acl.html",
     "https://docs.aws.amazon.com/waf/latest/APIReference/API_wafRegional_DeleteWebACL.html",

--- a/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS WAF Rule or Rule Group Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/waf/delete-rule-group.html",
     "https://docs.aws.amazon.com/waf/latest/APIReference/API_waf_DeleteRuleGroup.html",

--- a/rules/aws/execution_via_system_manager.toml
+++ b/rules/aws/execution_via_system_manager.toml
@@ -24,6 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS Execution via System Manager"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = ["https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-plugins.html"]
 risk_score = 21
 rule_id = "37b211e8-4e2f-440f-86d8-06cc8f158cfa"
@@ -48,6 +49,8 @@ reference = "https://attack.mitre.org/techniques/T1064/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS EC2 Snapshot Activity"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/modify-snapshot-attribute.html",
     "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html",

--- a/rules/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/aws/impact_cloudtrail_logging_updated.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS CloudTrail Log Updated"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_UpdateTrail.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudtrail/update-trail.html",
@@ -47,6 +48,8 @@ reference = "https://attack.mitre.org/techniques/T1492/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_group_deletion.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS CloudWatch Log Group Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/logs/delete-log-group.html",
     "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DeleteLogGroup.html",
@@ -50,6 +51,8 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS CloudWatch Log Stream Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/logs/delete-log-stream.html",
     "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DeleteLogStream.html",
@@ -50,6 +51,8 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/aws/impact_ec2_disable_ebs_encryption.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS EC2 Encryption Disabled"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/disable-ebs-encryption-by-default.html",

--- a/rules/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/aws/impact_iam_deactivate_mfa_device.toml
@@ -24,6 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS IAM Deactivation of MFA Device"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/deactivate-mfa-device.html",
     "https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeactivateMFADevice.html",

--- a/rules/aws/impact_iam_group_deletion.toml
+++ b/rules/aws/impact_iam_group_deletion.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS IAM Group Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/delete-group.html",
     "https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteGroup.html",

--- a/rules/aws/impact_rds_cluster_deletion.toml
+++ b/rules/aws/impact_rds_cluster_deletion.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS RDS Cluster Deletion"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/delete-db-cluster.html",
     "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBCluster.html",

--- a/rules/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/aws/impact_rds_instance_cluster_stoppage.toml
@@ -20,6 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS RDS Instance/Cluster Stoppage"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/stop-db-cluster.html",
     "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StopDBCluster.html",

--- a/rules/aws/initial_access_console_login_root.toml
+++ b/rules/aws/initial_access_console_login_root.toml
@@ -21,6 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS Management Console Root Login"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]
 risk_score = 73
 rule_id = "e2a67480-3b79-403d-96e3-fdd2992c50ef"
@@ -45,6 +46,8 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/initial_access_password_recovery.toml
+++ b/rules/aws/initial_access_password_recovery.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS IAM Password Recovery Requested"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = ["https://www.cadosecurity.com/2020/06/11/an-ongoing-aws-phishing-campaign/"]
 risk_score = 21
 rule_id = "69c420e8-6c9e-4d28-86c0-8a2be2d1e78c"

--- a/rules/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/aws/persistence_ec2_network_acl_creation.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS EC2 Network Access Control List Creation"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/create-network-acl.html",
     "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkAcl.html",

--- a/rules/aws/persistence_iam_group_creation.toml
+++ b/rules/aws/persistence_iam_group_creation.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS IAM Group Creation"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/create-group.html",
     "https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateGroup.html",

--- a/rules/aws/persistence_rds_cluster_creation.toml
+++ b/rules/aws/persistence_rds_cluster_creation.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS RDS Cluster Creation"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-cluster.html",
     "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html",
@@ -52,6 +53,8 @@ reference = "https://attack.mitre.org/techniques/T1108/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -22,6 +22,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS Root Login Without MFA"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]
 risk_score = 21
 rule_id = "bc0c6f0d-dab0-47a3-b135-0925f0a333bc"

--- a/rules/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -23,6 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License"
 name = "AWS IAM Assume Role Policy Update"
+note = "The AWS Filebeat module must be enabled to use this rule."
 references = ["https://labs.bishopfox.com/tech-blog/5-privesc-attack-vectors-in-aws"]
 risk_score = 21
 rule_id = "a60326d7-dca7-4fb7-93eb-1ca03a1febbd"

--- a/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -14,6 +14,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempted Bypass of Okta MFA"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -20,6 +20,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Revoke Okta API Token"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/okta/impact_possible_okta_dos_attack.toml
@@ -14,6 +14,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Possible Okta DoS Attack"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -15,6 +15,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Suspicious Activity Reported by Okta User"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",
@@ -42,6 +43,8 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -54,6 +57,8 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -66,6 +71,8 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/okta/okta_attempt_to_deactivate_okta_mfa_rule.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_mfa_rule.toml
@@ -20,6 +20,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Deactivate Okta MFA Rule"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_delete_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy.toml
@@ -21,6 +21,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Delete Okta Policy"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_modify_okta_mfa_rule.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_mfa_rule.toml
@@ -20,6 +20,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Modify Okta MFA Rule"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
@@ -21,6 +21,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Modify Okta Network Zone"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_modify_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy.toml
@@ -21,6 +21,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Modify Okta Policy"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -20,6 +20,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Modification or Removal of an Okta Application Sign-On Policy"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
+++ b/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
@@ -15,6 +15,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Threat Detected by Okta ThreatInsight"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -20,6 +20,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Administrator Privileges Assigned to Okta Group"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -21,6 +21,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Create Okta API Token"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -20,6 +20,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Deactivate MFA for Okta User Account"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/persistence_attempt_to_deactivate_okta_policy.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_okta_policy.toml
@@ -21,6 +21,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Deactivate Okta Policy"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -20,6 +20,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Reset MFA Factors for Okta User Account"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #78 

## Summary
The current cloud rules for Okta and AWS require a module to be enabled within Filebeat. This may not be abundantly clear to the user, so thanks to @peasead review on PR #67, it was determined the notes field would be a good spot to inform the user of this necessity in order for the cloud rules to trigger on events as intended. 

This PR adds a note field for each cloud rule.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? n/a
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? yes
