### PR TITLE
Add KQL -> DSL conversion

### DIFF
--- a/kql/dsl.py
+++ b/kql/dsl.py
@@ -39,10 +39,8 @@ def boolean(**kwargs):
     elif boolean_type == "should":
         # can flatten `should` of `should`
         for child in children:
-            if list(child) == "bool":
-                for k, v in children["bool"].items():
-                    if k != "minimum_should_match":
-                        dsl[k].extend(v)
+            if list(child) == ["bool"] and set(child["bool"]).issubset({"should", "minimum_should_match"}):
+                dsl["should"].extend(child["bool"]["should"])
             else:
                 dsl[boolean_type].append(child)
 

--- a/kql/dsl.py
+++ b/kql/dsl.py
@@ -47,8 +47,9 @@ def boolean(**kwargs):
     elif boolean_type == "must_not" and len(children) == 1:
         # must_not: [{bool: {must: x}}] -> {must_not: x}
         child = children[0]
-        if list(child) == ["bool"] and list(child["bool"]) in (["filter", "must"]):
-            dsl = {"must_not": children[0]["must"]}
+        if list(child) == ["bool"] and list(child["bool"]) in (["filter"], ["must"]):
+            negated, = child["bool"].values()
+            dsl = {"must_not": negated}
         else:
             dsl = {"must_not": children}
 
@@ -102,8 +103,8 @@ class ToDsl(Walker):
         return lambda field: boolean(should=[child(field) for child in children])
 
     def _walk_not_value(self, tree):
-        child = self.walk(tree.expr)
-        return lambda field: boolean(must_not=[child])
+        child = self.walk(tree.value)
+        return lambda field: boolean(must_not=[child(field)])
 
     def _walk_field_comparison(self, tree):
         field = self.walk(tree.field)

--- a/kql/dsl.py
+++ b/kql/dsl.py
@@ -1,0 +1,118 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+from collections import defaultdict
+from eql import Walker
+from .errors import KqlCompileError
+
+
+def boolean(**kwargs):
+    """Wrap a query in a boolean term and optimize while building."""
+    assert len(kwargs) == 1
+    [(boolean_type, children)] = kwargs.items()
+
+    if not isinstance(children, list):
+        children = [children]
+
+    dsl = defaultdict(list)
+
+    if boolean_type in ("must", "filter"):
+        # safe to convert and(and(x), y) -> and(x, y)
+        for child in children:
+            if list(child) == ["bool"]:
+                for child_type, child_terms in child["bool"].items():
+                    if child_type in ("must", "filter"):
+                        dsl[child_type].extend(child_terms)
+                    elif child_type == "should":
+                        if "should" not in dsl:
+                            dsl[child_type].extend(child_terms)
+                        else:
+                            dsl[boolean_type].append(boolean(should=child_terms))
+                    elif child_type == "must_not":
+                        dsl[child_type].extend(child_terms)
+                    elif child_type != "minimum_should_match":
+                        raise ValueError("Unknown term {}: {}".format(child_type, child_terms))
+            else:
+                dsl[boolean_type].append(child)
+
+    elif boolean_type == "should":
+        # can flatten `should` of `should`
+        for child in children:
+            if list(child) == "bool":
+                for k, v in children["bool"].items():
+                    if k != "minimum_should_match":
+                        dsl[k].extend(v)
+            else:
+                dsl[boolean_type].append(child)
+
+    elif boolean_type == "must_not" and len(children) == 1:
+        # must_not: [{bool: {must: x}}] -> {must_not: x}
+        child = children[0]
+        if list(child) == ["bool"] and list(child["bool"]) in (["filter", "must"]):
+            dsl = {"must_not": children[0]["must"]}
+        else:
+            dsl = {"must_not": children}
+
+    else:
+        dsl = dict(kwargs)
+
+    if "should" in dsl:
+        dsl.update(minimum_should_match=1)
+
+    dsl = {"bool": dict(dsl)}
+    return dsl
+
+
+class ToDsl(Walker):
+
+    def _walk_default(self, node, *args, **kwargs):
+        raise KqlCompileError("Unable to convert {}".format(node))
+
+    def _walk_exists(self, _):
+        return lambda field: {"exists": {"field": field}}
+
+    def _walk_wildcard(self, tree):
+        return lambda field: {"query_string": {"fields": [field], "query": tree.value}}
+
+    def _walk_value(self, tree):
+        return lambda field: {"match": {field: tree.value}}
+
+    def _walk_field(self, field):
+        return field.name
+
+    def _walk_field_range(self, tree):
+        operator_map = {"<": "lt", "<=": "lte", ">=": "gte", ">": "gt"}
+        field = self.walk(tree.field)
+        return {"range": {field: {operator_map[tree.operator]: tree.value.value}}}
+
+    def _walk_not_expr(self, tree):
+        return boolean(must_not=[self.walk(tree.expr)])
+
+    def _walk_and_expr(self, tree):
+        return boolean(filter=[self.walk(node) for node in tree.items])
+
+    def _walk_or_expr(self, tree):
+        return boolean(should=[self.walk(node) for node in tree.items])
+
+    def _walk_and_values(self, tree):
+        children = [self.walk(node) for node in tree.items]
+        return lambda field: boolean(filter=[child(field) for child in children])
+
+    def _walk_or_values(self, tree):
+        children = [self.walk(node) for node in tree.items]
+        return lambda field: boolean(should=[child(field) for child in children])
+
+    def _walk_not_value(self, tree):
+        child = self.walk(tree.expr)
+        return lambda field: boolean(must_not=[child])
+
+    def _walk_field_comparison(self, tree):
+        field = self.walk(tree.field)
+        value_fn = self.walk(tree.value)
+
+        return value_fn(field)
+
+    @classmethod
+    def convert(cls, tree):
+        return boolean(filter=[cls().walk(tree)])

--- a/kql/evaluator.py
+++ b/kql/evaluator.py
@@ -32,16 +32,19 @@ class FilterGenerator(Walker):
     def get_terms(cls, document, path):
         if isinstance(document, (tuple, list)):
             for d in document:
-                yield from cls.get_terms(d, path)
+                for term in cls.get_terms(d, path):
+                    yield term
 
         elif isinstance(document, dict):
             document = document.get(path[0])
             path = path[1:]
 
             if len(path) > 0:
-                yield from cls.get_terms(document, path)
+                for term in cls.get_terms(document, path):
+                    yield term
             elif isinstance(document, (tuple, list)):
-                yield from iter(document)
+                for term in document:
+                    yield term
             elif document is not None:
                 yield document
 

--- a/kql/kql2eql.py
+++ b/kql/kql2eql.py
@@ -2,8 +2,6 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-#!/usr/bin/env python
-
 import eql
 
 from .parser import BaseKqlParser

--- a/tests/kuery/test_dsl.py
+++ b/tests/kuery/test_dsl.py
@@ -50,6 +50,10 @@ class TestKQLtoDSL(unittest.TestCase):
     def test_not_query(self):
         self.validate("not field:value", {"must_not": [{"match": {"field": "value"}}]})
         self.validate("field:(not value)", {"must_not": [{"match": {"field": "value"}}]})
+        self.validate("field:(a and not b)", {
+            "filter": [{"match": {"field": "a"}}],
+            "must_not": [{"match": {"field": "b"}}]
+        })
         self.validate(
             "not field:value and not field2:value2",
             {"must_not": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}]},
@@ -69,10 +73,13 @@ class TestKQLtoDSL(unittest.TestCase):
             optimize=False,
         )
 
-        self.validate(
-            "not (field:value and field2:value2)",
-            {"must_not": [{"bool": {"filter": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}]}}]},
-        )
+        self.validate("not (field:value and field2:value2)",
+                      {
+                          "must_not": [
+                              {"match": {"field": "value"}},
+                              {"match": {"field2": "value2"}}
+                          ]
+                      })
 
     def test_optimizations(self):
         self.validate(

--- a/tests/kuery/test_dsl.py
+++ b/tests/kuery/test_dsl.py
@@ -38,34 +38,20 @@ class TestKQLtoDSL(unittest.TestCase):
     def test_or_query(self):
         self.validate(
             "field:value or field2:value2",
-            {
-                "should": [
-                    {"match": {"field": "value"}},
-                    {"match": {"field2": "value2"}},
-                ],
-                "minimum_should_match": 1,
-            },
+            {"should": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}], "minimum_should_match": 1,},
         )
 
     def test_and_query(self):
         self.validate(
             "field:value and field2:value2",
-            {
-                "filter": [
-                    {"match": {"field": "value"}},
-                    {"match": {"field2": "value2"}},
-                ]
-            },
+            {"filter": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}]},
         )
 
     def test_optimizations(self):
         self.validate(
             "(field:value or field2:value2) and field3:value3",
             {
-                "should": [
-                    {"match": {"field": "value"}},
-                    {"match": {"field2": "value2"}},
-                ],
+                "should": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}],
                 "filter": [{"match": {"field3": "value3"}}],
                 "minimum_should_match": 1,
             },
@@ -75,14 +61,7 @@ class TestKQLtoDSL(unittest.TestCase):
             "(field:value and field2:value2) or field3:value3",
             {
                 "should": [
-                    {
-                        "bool": {
-                            "filter": [
-                                {"match": {"field": "value"}},
-                                {"match": {"field2": "value2"}},
-                            ]
-                        }
-                    },
+                    {"bool": {"filter": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}]}},
                     {"match": {"field3": "value3"}},
                 ],
                 "minimum_should_match": 1,
@@ -93,14 +72,7 @@ class TestKQLtoDSL(unittest.TestCase):
             "(field:value and field2:value2) or field3:value3",
             {
                 "should": [
-                    {
-                        "bool": {
-                            "filter": [
-                                {"match": {"field": "value"}},
-                                {"match": {"field2": "value2"}},
-                            ]
-                        }
-                    },
+                    {"bool": {"filter": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}]}},
                     {"match": {"field3": "value3"}},
                 ],
                 "minimum_should_match": 1,
@@ -109,17 +81,10 @@ class TestKQLtoDSL(unittest.TestCase):
 
     def test_not_query(self):
         self.validate("not field:value", {"must_not": [{"match": {"field": "value"}}]})
-        self.validate(
-            "field:(not value)", {"must_not": [{"match": {"field": "value"}}]}
-        )
+        self.validate("field:(not value)", {"must_not": [{"match": {"field": "value"}}]})
         self.validate(
             "not field:value and not field2:value2",
-            {
-                "must_not": [
-                    {"match": {"field": "value"}},
-                    {"match": {"field2": "value2"}},
-                ]
-            },
+            {"must_not": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}},]},
         )
         self.validate(
             "not (field:value or field2:value2)",
@@ -128,10 +93,7 @@ class TestKQLtoDSL(unittest.TestCase):
                     {
                         "bool": {
                             "minimum_should_match": 1,
-                            "should": [
-                                {"match": {"field": "value"}},
-                                {"match": {"field2": "value2"}},
-                            ],
+                            "should": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}],
                         }
                     }
                 ]
@@ -141,16 +103,5 @@ class TestKQLtoDSL(unittest.TestCase):
 
         self.validate(
             "not (field:value and field2:value2)",
-            {
-                "must_not": [
-                    {
-                        "bool": {
-                            "filter": [
-                                {"match": {"field": "value"}},
-                                {"match": {"field2": "value2"}},
-                            ]
-                        }
-                    }
-                ]
-            },
+            {"must_not": [{"bool": {"filter": [{"match": {"field": "value"}}, {"match": {"field2": "value2"}}]}}]},
         )

--- a/tests/kuery/test_dsl.py
+++ b/tests/kuery/test_dsl.py
@@ -1,0 +1,156 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+
+import unittest
+import kql
+
+
+class TestKQLtoDSL(unittest.TestCase):
+    def validate(self, kql_source, dsl, **kwargs):
+        actual_dsl = kql.to_dsl(kql_source, **kwargs)
+        self.assertListEqual(list(actual_dsl), ["bool"])
+        self.assertDictEqual(actual_dsl["bool"], dsl)
+
+    def test_field_match(self):
+        def match(**kv):
+            return {"filter": [{"match": kv}]}
+
+        self.validate("user:bob", match(user="bob"))
+        self.validate("number:-1", match(number=-1))
+        self.validate("number:1.1", match(number=1.1))
+        self.validate("boolean:true", match(boolean=True))
+        self.validate("boolean:false", match(boolean=False))
+
+    def test_field_exists(self):
+        self.validate("user:*", {"filter": [{"exists": {"field": "user"}}]})
+
+    def test_field_inequality(self):
+        def rng(op, val):
+            return {"filter": [{"range": {"field": {op: val}}}]}
+
+        self.validate("field < value", rng("lt", "value"))
+        self.validate("field > -1", rng("gt", -1))
+        self.validate("field <= 1.1", rng("lte", 1.1))
+        self.validate("field >= 0", rng("gte", 0))
+        self.validate("field >= abc", rng("gte", "abc"))
+
+    def test_or_query(self):
+        self.validate(
+            "field:value or field2:value2",
+            {
+                "should": [
+                    {"match": {"field": "value"}},
+                    {"match": {"field2": "value2"}},
+                ],
+                "minimum_should_match": 1,
+            },
+        )
+
+    def test_and_query(self):
+        self.validate(
+            "field:value and field2:value2",
+            {
+                "filter": [
+                    {"match": {"field": "value"}},
+                    {"match": {"field2": "value2"}},
+                ]
+            },
+        )
+
+    def test_optimizations(self):
+        self.validate(
+            "(field:value or field2:value2) and field3:value3",
+            {
+                "should": [
+                    {"match": {"field": "value"}},
+                    {"match": {"field2": "value2"}},
+                ],
+                "filter": [{"match": {"field3": "value3"}}],
+                "minimum_should_match": 1,
+            },
+        )
+
+        self.validate(
+            "(field:value and field2:value2) or field3:value3",
+            {
+                "should": [
+                    {
+                        "bool": {
+                            "filter": [
+                                {"match": {"field": "value"}},
+                                {"match": {"field2": "value2"}},
+                            ]
+                        }
+                    },
+                    {"match": {"field3": "value3"}},
+                ],
+                "minimum_should_match": 1,
+            },
+        )
+
+        self.validate(
+            "(field:value and field2:value2) or field3:value3",
+            {
+                "should": [
+                    {
+                        "bool": {
+                            "filter": [
+                                {"match": {"field": "value"}},
+                                {"match": {"field2": "value2"}},
+                            ]
+                        }
+                    },
+                    {"match": {"field3": "value3"}},
+                ],
+                "minimum_should_match": 1,
+            },
+        )
+
+    def test_not_query(self):
+        self.validate("not field:value", {"must_not": [{"match": {"field": "value"}}]})
+        self.validate(
+            "field:(not value)", {"must_not": [{"match": {"field": "value"}}]}
+        )
+        self.validate(
+            "not field:value and not field2:value2",
+            {
+                "must_not": [
+                    {"match": {"field": "value"}},
+                    {"match": {"field2": "value2"}},
+                ]
+            },
+        )
+        self.validate(
+            "not (field:value or field2:value2)",
+            {
+                "must_not": [
+                    {
+                        "bool": {
+                            "minimum_should_match": 1,
+                            "should": [
+                                {"match": {"field": "value"}},
+                                {"match": {"field2": "value2"}},
+                            ],
+                        }
+                    }
+                ]
+            },
+            optimize=False,
+        )
+
+        self.validate(
+            "not (field:value and field2:value2)",
+            {
+                "must_not": [
+                    {
+                        "bool": {
+                            "filter": [
+                                {"match": {"field": "value"}},
+                                {"match": {"field2": "value2"}},
+                            ]
+                        }
+                    }
+                ]
+            },
+        )


### PR DESCRIPTION
## Issues
Closes #80

## Summary
Added a KQL to query DSL converter. I added a few optimizations so that the query DSL is flattened and doesn't produce overly deep trees.

Nothing is hooked up to the existing APIs. To use it, you need to nest the output underneath a `query: {...}` when building a request. Or put it in a different context when doing aggregations, etc.