### PR TITLE
Update External Alerts rule index to match default securitySolution:defaultIndex value

### DIFF
--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -7,7 +7,7 @@ updated_date = "2020/07/08"
 [rule]
 author = ["Elastic"]
 description = """
-Generates a detection alert for each external alert written to the configured securitySolution:defaultIndex. Enabling
+Generates a detection alert for each external alert written to the configured indices. Enabling
 this rule allows you to immediately begin investigating external alerts in the app.
 """
 index = ["apm-*-transaction*", "auditbeat-*", "endgame-*", "filebeat-*", "logs-*", "packetbeat-*", "winlogbeat-*"]
@@ -56,5 +56,4 @@ field = "event.severity"
 operator = "equals"
 value = "99"
 severity = "critical"
-
 

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -10,6 +10,7 @@ description = """
 Generates a detection alert for each external alert written to the configured securitySolution:defaultIndex. Enabling
 this rule allows you to immediately begin investigating external alerts in the app.
 """
+index = ["apm-*-transaction*", "auditbeat-*", "endgame-*", "filebeat-*", "logs-*", "packetbeat-*", "winlogbeat-*"]
 language = "kuery"
 license = "Elastic License"
 max_signals = 10000
@@ -55,3 +56,5 @@ field = "event.severity"
 operator = "equals"
 value = "99"
 severity = "critical"
+
+


### PR DESCRIPTION
## Summary
Updates the External Alerts rule index to match default securitySolution:defaultIndex value


``` toml
index = ["apm-*-transaction*", "auditbeat-*", "endgame-*", "filebeat-*", "logs-*", "packetbeat-*", "winlogbeat-*"]
```

Note: extra spaces are from running `toml-lint`

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes!
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? Yes!
