### PR TITLE
[Bug] Set threshold.field to empty string instead of null

### DIFF
--- a/detection_rules/schema.py
+++ b/detection_rules/schema.py
@@ -107,7 +107,7 @@ class SeverityMapping(jsl.Document):
 class ThresholdMapping(jsl.Document):
     """Threshold mapping."""
 
-    field = jsl.StringField(required=False)
+    field = jsl.StringField(required=True, default="")
     value = jsl.IntField(minimum=1, required=True)
 
 

--- a/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -48,4 +48,5 @@ name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
 
 [rule.threshold]
+field = ""
 value = 25


### PR DESCRIPTION
## Issues
Found that this failed on PR because the field is not accepted.
https://github.com/elastic/kibana/pull/72613

## Summary
Made `threshold.field` required and populate it with an empty string instead of having it missing. This is what the API seems to do from the front end as well if a field is not specified.