### PR TITLE
Downgrade rule version before uploading to Kibana

### DIFF
--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -182,7 +182,7 @@ def parse_config():
     global _CONFIG
 
     if not _CONFIG:
-        config_file = os.path.join(ROOT_DIR, '.siem-rules-cfg.json')
+        config_file = os.path.join(ROOT_DIR, '.detection-rules-cfg.json')
 
         if os.path.exists(config_file):
             with open(config_file) as f:

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -197,7 +197,7 @@ def set_param_values(ctx, param, value):
     """Get value for defined key."""
     key = param.name
     config = parse_config()
-    env_key = 'DR_' + key
+    env_key = 'DR_' + key.upper()
     prompt = True if param.hide_input is not False else False
 
     if value:

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -26,9 +26,10 @@ all_schemas = [
 CurrentSchema = max(all_schemas, key=lambda cls: Version(cls.STACK_VERSION))
 
 
-def downgrade(api_contents, target_version):
+def downgrade(api_contents: dict, target_version: str):
     """Downgrade a rule to a target stack version."""
     # truncate to (major, minor)
+    target_version_str = target_version
     target_version = Version(target_version)[:2]
     versions = set(Version(schema_cls.STACK_VERSION) for schema_cls in all_schemas)
     role = api_contents.get("type")
@@ -36,7 +37,7 @@ def downgrade(api_contents, target_version):
     check_versioned = "version" in api_contents
 
     if target_version not in versions:
-        raise ValueError(f"Unable to downgrade from {CurrentSchema.STACK_VERSION} to {target_version}")
+        raise ValueError(f"Unable to downgrade from {CurrentSchema.STACK_VERSION} to {target_version_str}")
 
     current_schema = None
 

--- a/kibana/connector.py
+++ b/kibana/connector.py
@@ -29,6 +29,7 @@ class Kibana(object):
         self.cloud_id = cloud_id
         self.kibana_url = url
         self.elastic_url = None
+        self.status = None
 
         if self.cloud_id:
             self.cluster_name, cloud_info = self.cloud_id.split(":")
@@ -44,6 +45,12 @@ class Kibana(object):
         if not verify:
             from requests.packages.urllib3.exceptions import InsecureRequestWarning
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+    @property
+    def version(self):
+        """Get the semantic version."""
+        if self.status:
+            return self.status.get("version", {}).get("number")
 
     def url(self, uri):
         """Get the full URL given a URI."""
@@ -99,6 +106,7 @@ class Kibana(object):
 
         self.post(path, data=payload, error=True)
         self.authenticated = True
+        self.status = self.get("/api/status")
 
         # create ES and force authentication
         if self.elasticsearch is None and self.elastic_url is not None:


### PR DESCRIPTION
## Issues
Closes #96 

## Summary
Now that #84 is done, we can connect all the pieces together for `kibana-upload`.
Now, `kibana-upload` can work for 7.8 and 7.8 stacks. If we were to extend support further back, we just need to update schemas/v77.py accordingly.

There are still some other things to figure out for a bigger picture repository <--> Kibana workflow. But for now, this helps with the ad-hoc upload command.

## Stdout

On error message (hard coded 7.7)
```console
...
  File "/Users/rwolf/Development/detection-rules/detection_rules/eswrap.py", line 256, in kibana_upload
    payload = downgrade(payload, "7.7.0")
  File "/Users/rwolf/Development/detection-rules/detection_rules/schemas/__init__.py", line 40, in downgrade
    raise ValueError(f"Unable to downgrade from {CurrentSchema.STACK_VERSION} to {target_version_str}")
ValueError: Unable to downgrade from 7.9 to 7.7.0
```

On success
```console
$ python -m detection_rules kibana-upload rules/aws/impact_iam_group_deletion.toml

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Loading rules from detection-rules/rules
Loaded 1 rules
Successfully uploaded 1 rules
```
