### PR TITLE
Add list_id to exceptions_list and remove endgame:* from external alerts rule

### DIFF
--- a/rules/promotions/elastic_endpoint.toml
+++ b/rules/promotions/elastic_endpoint.toml
@@ -32,6 +32,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 [[rule.exceptions_list]]
 id = "endpoint_list"
+list_id = "endpoint_list"
 namespace_type = "agnostic"
 type = "endpoint"
 

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -7,10 +7,10 @@ updated_date = "2020/07/08"
 [rule]
 author = ["Elastic"]
 description = """
-Generates a detection alert for each external alert written to the configured indices. Enabling
-this rule allows you to immediately begin investigating external alerts in the app.
+Generates a detection alert for each external alert written to the configured indices. Enabling this rule allows you to
+immediately begin investigating external alerts in the app.
 """
-index = ["apm-*-transaction*", "auditbeat-*", "endgame-*", "filebeat-*", "logs-*", "packetbeat-*", "winlogbeat-*"]
+index = ["apm-*-transaction*", "auditbeat-*", "filebeat-*", "logs-*", "packetbeat-*", "winlogbeat-*"]
 language = "kuery"
 license = "Elastic License"
 max_signals = 10000
@@ -56,4 +56,5 @@ field = "event.severity"
 operator = "equals"
 value = "99"
 severity = "critical"
+
 


### PR DESCRIPTION
## Summary

This PR updates the `elastic_endpoint` rule to include the `list_id` for the global endpoint exceptions list as so:
```
 "exceptions_list": [
    {
      "id": "endpoint_list",
      "list_id": "endpoint_list",
      "namespace_type": "agnostic",
      "type": "endpoint"
    }
  ],
```
...and removes `endgame: *` from the `external_alerts` rule `index` field.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? ✅ 
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? ✅ 
