### PR TITLE
[New Rule] Meow Attack Detected

### DIFF
--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -31,9 +31,7 @@ tags = ["Elastic", "Elasticsearch"]
 type = "query"
 
 query = '''
-event.category:database AND event.kind:event AND event.module:elasticsearch
-AND event.dataset:elasticsearch.server AND event.type:info AND
-elasticsearch.component:o.e.c.m.MetadataCreateIndexService AND elasticsearch.index.name:/.*meow.*/ AND log.file.path:"/var/log/elasticsearch/elasticsearch_server.json"
+event.category:database AND event.kind:event AND event.module:elasticsearch AND event.dataset:elasticsearch.server AND event.type:info AND elasticsearch.component:o.e.c.m.MetadataCreateIndexService AND elasticsearch.index.name:(/[a-zA-Z0-9]+-(meow)/ OR meow) AND _exists_:elasticsearch.node.id
 '''
 
 
@@ -49,4 +47,3 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -19,7 +19,7 @@ false_positives = [
 index = ["filebeat-*"]
 language = "lucene"
 license = "Elastic License"
-name = "Meow Database Attack Detected"
+name = "Potential Meow Database Attack"
 note = "This detection rule requires the Elasticsearch Filebeat module. This rule will not prevent the Meow attack, it will notify the IR team that an attack has taken place and speed the mean-time-to-detection (MTTD)."
 references = [
     "https://arstechnica.com/information-technology/2020/07/more-than-1000-databases-have-been-nuked-by-mystery-meow-attack",

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -19,7 +19,7 @@ index = ["filebeat-*"]
 language = "lucene"
 license = "Elastic License"
 name = "Potential Meow Database Attack"
-note = "This detection rule requires the Elasticsearch Filebeat module. This rule will not prevent the Meow attack, it will notify the IR team that an attack has taken place and speed the mean-time-to-detection (MTTD)."
+note = "This detection rule requires the Elasticsearch Filebeat module. This rule will not prevent the Meow attack, it will notify the security team that an attack has taken place and decrease mean-time-to-detection (MTTD)."
 references = [
     "https://arstechnica.com/information-technology/2020/07/more-than-1000-databases-have-been-nuked-by-mystery-meow-attack",
 ]

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*"]
 language = "lucene"
 license = "Elastic License"
 name = "Meow Database Attack Detected"
-note = "This detection rule requires the Elasticsearch Filebeat module. If your `elasticsearch_server.json` logs are not stored in the default location, you'll need to update the Elasticsearch Filebeat module configuration as well as `log.file.path` in the rule. This rule will not prevent the Meow attack, it will notify the IR team that an attack has taken place and speed the mean-time-to-detection (MTTD)."
+note = "This detection rule requires the Elasticsearch Filebeat module. This rule will not prevent the Meow attack, it will notify the IR team that an attack has taken place and speed the mean-time-to-detection (MTTD)."
 references = [
     "https://arstechnica.com/information-technology/2020/07/more-than-1000-databases-have-been-nuked-by-mystery-meow-attack",
 ]

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -1,0 +1,51 @@
+[metadata]
+creation_date = "2020/08/10"
+ecs_version = ["1.5.0"]
+maturity = "production"
+updated_date = "2020/08/10"
+
+[rule]
+author = ["Elastic"]
+description = """
+The Meow attack targets insecurely configured Elasticsearch, MongoDB, and Cassandra databases. The attack destroys the contents of
+the database and replaces (or appends) the word "meow" to the database name.
+"""
+false_positives = [
+    """
+    The word "meow" used in database names will trigger this detection rule. Incident Responders should validate
+    the database is expected and modify this rule as appropriate.
+    """,
+]
+index = ["filebeat-*"]
+language = "lucene"
+license = "Elastic License"
+name = "Meow Database Attack Detected"
+note = "This detection rule requires the Elasticsearch Filebeat module. This rule will not prevent the Meow attack, it will notify the IR team that an attack has taken place and speed the mean-time-to-detection (MTTD)."
+references = [
+    "https://arstechnica.com/information-technology/2020/07/more-than-1000-databases-have-been-nuked-by-mystery-meow-attack",
+]
+risk_score = 47
+rule_id = "985fc3ad-ce00-4227-945f-684ab76b0256"
+severity = "medium"
+tags = ["Elastic", "Elasticsearch"]
+type = "query"
+
+query = '''
+event.category:database AND event.kind:event AND event.module: elasticsearch
+AND event.dataset:elasticsearch.server AND event.type:info AND
+elasticsearch.component:o.e.c.m.MetadataCreateIndexService AND elasticsearch.index.name:/.*meow.*/
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1485"
+name = "Data Destruction"
+reference = "https://attack.mitre.org/techniques/T1485/"
+
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*"]
 language = "lucene"
 license = "Elastic License"
 name = "Meow Database Attack Detected"
-note = "This detection rule requires the Elasticsearch Filebeat module. This rule will not prevent the Meow attack, it will notify the IR team that an attack has taken place and speed the mean-time-to-detection (MTTD)."
+note = "This detection rule requires the Elasticsearch Filebeat module. If your `elasticsearch_server.json` logs are not stored in the default location, you'll need to update the Elasticsearch Filebeat module configuration as well as `log.file.path` in the rule. This rule will not prevent the Meow attack, it will notify the IR team that an attack has taken place and speed the mean-time-to-detection (MTTD)."
 references = [
     "https://arstechnica.com/information-technology/2020/07/more-than-1000-databases-have-been-nuked-by-mystery-meow-attack",
 ]
@@ -33,7 +33,7 @@ type = "query"
 query = '''
 event.category:database AND event.kind:event AND event.module:elasticsearch
 AND event.dataset:elasticsearch.server AND event.type:info AND
-elasticsearch.component:o.e.c.m.MetadataCreateIndexService AND elasticsearch.index.name:/.*meow.*/
+elasticsearch.component:o.e.c.m.MetadataCreateIndexService AND elasticsearch.index.name:/.*meow.*/ AND log.file.path:"/var/log/elasticsearch/elasticsearch_server.json"
 '''
 
 

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -12,7 +12,8 @@ contents of the database and replaces (or appends) the word "meow" to the databa
 """
 false_positives = [
     """
-    This rule will be triggered by the word, "meow" in a database name. Analysts should validate the database name is expected and add exceptions to the rule as needed.
+    This rule will be triggered by the word, "meow" in a database name. Analysts should validate the database name is
+    expected and add exceptions to the rule as needed.
     """,
 ]
 index = ["filebeat-*"]
@@ -46,3 +47,4 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -7,13 +7,13 @@ updated_date = "2020/08/10"
 [rule]
 author = ["Elastic"]
 description = """
-The Meow attack targets insecurely configured Elasticsearch, MongoDB, and Cassandra databases. The attack destroys the contents of
-the database and replaces (or appends) the word "meow" to the database name.
+The Meow attack targets insecurely configured Elasticsearch, MongoDB, and Cassandra databases. The attack destroys the
+contents of the database and replaces (or appends) the word "meow" to the database name.
 """
 false_positives = [
     """
-    The word "meow" used in database names will trigger this detection rule. Incident Responders should validate
-    the database is expected and modify this rule as appropriate.
+    The word "meow" used in database names will trigger this detection rule. Incident Responders should validate the
+    database is expected and modify this rule as appropriate.
     """,
 ]
 index = ["filebeat-*"]
@@ -31,7 +31,7 @@ tags = ["Elastic", "Elasticsearch"]
 type = "query"
 
 query = '''
-event.category:database AND event.kind:event AND event.module: elasticsearch
+event.category:database AND event.kind:event AND event.module:elasticsearch
 AND event.dataset:elasticsearch.server AND event.type:info AND
 elasticsearch.component:o.e.c.m.MetadataCreateIndexService AND elasticsearch.index.name:/.*meow.*/
 '''

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -49,3 +49,4 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+

--- a/rules/cross-platform/data_destruction_meow_attack_detected.toml
+++ b/rules/cross-platform/data_destruction_meow_attack_detected.toml
@@ -12,8 +12,7 @@ contents of the database and replaces (or appends) the word "meow" to the databa
 """
 false_positives = [
     """
-    The word "meow" used in database names will trigger this detection rule. Incident Responders should validate the
-    database is expected and modify this rule as appropriate.
+    This rule will be triggered by the word, "meow" in a database name. Analysts should validate the database name is expected and add exceptions to the rule as needed.
     """,
 ]
 index = ["filebeat-*"]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
Resolves #104 

## Summary
The Meow attack targets insecurely configured Elasticsearch, MongoDB, and Cassandra databases. The attack destroys the
contents of the database and replaces (or appends) the word "meow" to the database name.

This detection rule requires the Elasticsearch Filebeat module. This rule will not prevent the Meow attack, it will notify the IR team that an attack has taken place and speed the mean-time-to-detection (MTTD).

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? Yes
