### PR TITLE
[New Rule] Azure Event Hub Authorization Rule Created or Updated

### DIFF
--- a/rules/azure/collection_update_event_hub_auth_rule.toml
+++ b/rules/azure/collection_update_event_hub_auth_rule.toml
@@ -24,7 +24,7 @@ from = "now-25m"
 index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
-name = "Azure Create or Update Event Hub Authorization Rule"
+name = "Azure Event Hub Authorization Rule Created or Updated"
 note = "The Azure Filebeat module must be enabled to use this rule."
 references = ["https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-shared-access-signature"]
 risk_score = 47
@@ -64,4 +64,3 @@ reference = "https://attack.mitre.org/techniques/T1537/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0010/"
-

--- a/rules/azure/collection_update_event_hub_auth_rule.toml
+++ b/rules/azure/collection_update_event_hub_auth_rule.toml
@@ -1,0 +1,67 @@
+[metadata]
+creation_date = "2020/08/18"
+ecs_version = ["1.5.0"]
+maturity = "production"
+updated_date = "2020/08/18"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when an Event Hub Authorization Rule is created or updated in Azure. An authorization rule is associated with
+specific rights, and carries a pair of cryptographic keys. When you create an Event Hubs namespace, a policy rule named
+RootManageSharedAccessKey is created for the namespace. This has manage permissions for the entire namespace and it's
+recommended that you treat this rule like an administrative root account and don't use it in your application.
+"""
+false_positives = [
+    """
+    Authorization rule additions or modifications may be done by a system or network administrator. Verify whether the
+    username, hostname, and/or resource name should be making changes in your environment. Authorization rule additions
+    or modifications from unfamiliar users or hosts should be investigated. If known behavior is causing false
+    positives, it can be exempted from the rule.
+    """,
+]
+from = "now-25m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "Azure Create or Update Event Hub Authorization Rule"
+note = "The Azure Filebeat module must be enabled to use this rule."
+references = ["https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-shared-access-signature"]
+risk_score = 47
+rule_id = "b6dce542-2b75-4ffb-b7d6-38787298ba9d"
+severity = "medium"
+tags = ["Azure", "Elastic", "SecOps", "Continuous Monitoring", "Logging"]
+type = "query"
+
+query = '''
+event.module:azure and event.dataset:azure.activitylogs and event.category:Administrative and azure.activitylogs.operation_name:MICROSOFT.EVENTHUB/NAMESPACES/AUTHORIZATIONRULES/WRITE and event.outcome:Success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1530"
+name = "Data from Cloud Storage Object"
+reference = "https://attack.mitre.org/techniques/T1530/"
+
+
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1537"
+name = "Transfer Data to Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1537/"
+
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"
+

--- a/rules/azure/collection_update_event_hub_auth_rule.toml
+++ b/rules/azure/collection_update_event_hub_auth_rule.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/08/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/18"
 


### PR DESCRIPTION
## Issue(s)
resolves #140 

## Description

Identifies when an Event Hub Authorization Rule is created or updated in Azure. An authorization rule is associated with specific rights, and carries a pair of cryptographic keys. When you create an Event Hubs namespace, a policy rule named RootManageSharedAccessKey is created for the namespace. This has manage permissions for the entire namespace and it's recommended that you treat this rule like an administrative root account and don't use it in your application.

## Checklists
Use ~~strikethroughs~~ to remove items which are not applicable to this issue.

### For submitter
- [x] Verify all query fields co-exist in a single event source (*beats) or annotated otherwise
  -- Query field process.name.text doesn't currently exist in endgame-* eventing data, but does exist for winlogbeats, and is case insensitive.
- [x] Verify all query fields co-exist within a single ECS version and annotated the minimum version
  -- 1.4.0
- [ ] Verified the query detects the intended event(s)
  - detonate
  - search in _discover_
  - trigger as a custom signal
- [x] Create rule using `create-rule`
- [x] Verify and convert to standard linting (`toml-lint -f <rule-file>`)
- [x] Run tests using `pytest -x -v unit_tests` or `make test`
- [ ] Internal search to determine noise and FP


### For reviewers
- [ ] Verify existing rule for activity doesn't exist as a siem or endpoint rule (unless intentionally specified in issue)
- [ ] Verify all query fields co-exist in a single event source (*beats) or annotated otherwise
- [ ] Verify all query fields co-exist within a single ECS version and annotated the minimum version
- [ ] Internal search to determine noise and FP
- [ ] Verify metadata accuracy and spelling
