### PR TITLE
[New Rule] Attempts to Brute Force an Okta User Account

### DIFF
--- a/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
+++ b/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
@@ -1,0 +1,50 @@
+[metadata]
+creation_date = "2020/08/19"
+ecs_version = ["1.5.0"]
+maturity = "production"
+updated_date = "2020/08/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when an Okta user account is locked out 3 times within a 3 hour window. An adversary may attempt a brute
+force or password spraying attack to obtain unauthorized access to user accounts. The default Okta authentication policy
+ensures that a user account is locked out after 10 failed authentication attempts.
+"""
+from = "now-180m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "Attempts to Brute Force an Okta User Account"
+references = [
+    "https://developer.okta.com/docs/reference/api/system-log/",
+    "https://developer.okta.com/docs/reference/api/event-types/",
+]
+risk_score = 47
+rule_id = "e08ccd49-0380-4b2b-8d71-8000377d6e49"
+severity = "medium"
+tags = ["Elastic", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
+type = "threshold"
+
+query = '''
+event.module:okta and event.dataset:okta.system and event.action:user.account.lock
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.threshold]
+field = "okta.actor.id"
+value = 3
+

--- a/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
+++ b/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
@@ -16,6 +16,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempts to Brute Force an Okta User Account"
+note = "The Okta Filebeat module must be enabled to use this rule."
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",
@@ -47,4 +48,3 @@ reference = "https://attack.mitre.org/tactics/TA0006/"
 [rule.threshold]
 field = "okta.actor.id"
 value = 3
-

--- a/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
+++ b/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/08/19"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/19"
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #73 

## Summary
Identifies when an Okta user account is locked out 3 times within a 3 hour window. An adversary may attempt a brute force or password spraying attack to obtain unauthorized access to user accounts. The default Okta authentication policy ensures that a user account is locked out after 10 failed authentication attempts.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
