### PR TITLE
[New Rule] High Number of Okta User Password Reset or Unlock Attempts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.venv/*
 
 .DS_Store
 /.DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv/*
 
 .DS_Store
 /.DS_STORE

--- a/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -1,0 +1,75 @@
+[metadata]
+creation_date = "2020/08/19"
+ecs_version = ["1.5.0"]
+maturity = "production"
+updated_date = "2020/08/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies a high number of Okta user password reset or account unlock attempts. An adversary may attempt to obtain
+unauthorized access to an account Okta user account using these methods and attempt to blend in with normal activity in
+their target's environment and evade detection.
+"""
+from = "now-120m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "High Number of Okta User Password Reset or Unlock Attempts"
+note = "The Okta Filebeat module must be enabled to use this rule."
+references = [
+    "https://developer.okta.com/docs/reference/api/system-log/",
+    "https://developer.okta.com/docs/reference/api/event-types/",
+]
+risk_score = 47
+rule_id = "e90ee3af-45fc-432e-a850-4a58cf14a457"
+severity = "medium"
+tags = ["Elastic", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
+type = "threshold"
+
+query = '''
+event.module:okta and event.dataset:okta.system and event.action:(system.email.account_unlock.sent_message or system.email.password_reset.sent_message or system.sms.send_account_unlock_message or system.sms.send_password_reset_message or system.voice.send_account_unlock_call or system.voice.send_password_reset_call or user.account.unlock_token)
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+
+[rule.threshold]
+field = "okta.actor.id"
+value = 5
+

--- a/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -37,13 +37,10 @@ type = "threshold"
 query = '''
 event.module:okta and
   event.dataset:okta.system and
-  event.action:(system.email.account_unlock.sent_message or
-    system.email.password_reset.sent_message or
-    system.sms.send_account_unlock_message or
-    system.sms.send_password_reset_message or
-    system.voice.send_account_unlock_call or
-    system.voice.send_password_reset_call or
-    user.account.unlock_token)
+  event.action:(system.email.account_unlock.sent_message or system.email.password_reset.sent_message or
+                system.sms.send_account_unlock_message or system.sms.send_password_reset_message or
+                system.voice.send_account_unlock_call or system.voice.send_password_reset_call or
+                user.account.unlock_token)
 '''
 
 

--- a/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -14,7 +14,7 @@ their target's environment and evade detection.
 false_positives = [
     """
     The number of Okta user password reset or account unlock attempts will likely vary between organizations. To fit
-    this rule to their organizatioin, users can duplicate this rule and edit the schedule and threshold values in the
+    this rule to their organization, users can duplicate this rule and edit the schedule and threshold values in the
     new rule.
     """,
 ]
@@ -87,4 +87,3 @@ reference = "https://attack.mitre.org/tactics/TA0001/"
 [rule.threshold]
 field = "okta.actor.id"
 value = 5
-

--- a/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -8,7 +8,7 @@ updated_date = "2020/08/19"
 author = ["Elastic"]
 description = """
 Identifies a high number of Okta user password reset or account unlock attempts. An adversary may attempt to obtain
-unauthorized access to an account Okta user account using these methods and attempt to blend in with normal activity in
+unauthorized access to an Okta user account using these methods and attempt to blend in with normal activity in
 their target's environment and evade detection.
 """
 false_positives = [

--- a/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -11,6 +11,13 @@ Identifies a high number of Okta user password reset or account unlock attempts.
 unauthorized access to an account Okta user account using these methods and attempt to blend in with normal activity in
 their target's environment and evade detection.
 """
+false_positives = [
+    """
+    The number of Okta user password reset or account unlock attempts will likely vary between organizations. To fit
+    this rule to their organizatioin, users can duplicate this rule and edit the schedule and threshold values in the
+    new rule.
+    """,
+]
 from = "now-60m"
 index = ["filebeat-*"]
 language = "kuery"
@@ -28,7 +35,15 @@ tags = ["Elastic", "Okta", "Continuous Monitoring", "SecOps", "Identity and Acce
 type = "threshold"
 
 query = '''
-event.module:okta and event.dataset:okta.system and event.action:(system.email.account_unlock.sent_message or system.email.password_reset.sent_message or system.sms.send_account_unlock_message or system.sms.send_password_reset_message or system.voice.send_account_unlock_call or system.voice.send_password_reset_call or user.account.unlock_token)
+event.module:okta and
+  event.dataset:okta.system and
+  event.action:(system.email.account_unlock.sent_message or
+    system.email.password_reset.sent_message or
+    system.sms.send_account_unlock_message or
+    system.sms.send_password_reset_message or
+    system.voice.send_account_unlock_call or
+    system.voice.send_password_reset_call or
+    user.account.unlock_token)
 '''
 
 
@@ -72,3 +87,4 @@ reference = "https://attack.mitre.org/tactics/TA0001/"
 [rule.threshold]
 field = "okta.actor.id"
 value = 5
+

--- a/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/08/19"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/19"
 
@@ -72,4 +72,3 @@ reference = "https://attack.mitre.org/tactics/TA0001/"
 [rule.threshold]
 field = "okta.actor.id"
 value = 5
-

--- a/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -11,7 +11,7 @@ Identifies a high number of Okta user password reset or account unlock attempts.
 unauthorized access to an account Okta user account using these methods and attempt to blend in with normal activity in
 their target's environment and evade detection.
 """
-from = "now-120m"
+from = "now-60m"
 index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #74 

## Summary
Identifies a high number of Okta user password reset or account unlock attempts. An adversary may attempt to obtain unauthorized access to an account Okta user account using these methods and attempt to blend in with normal activity in their target's environment and evade detection.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
