### PR TITLE
[New Rule] User Added as Owner for Azure Service Principal

### DIFF
--- a/rules/azure/defense_evasion_user_added_as_owner_for_azure_application.toml
+++ b/rules/azure/defense_evasion_user_added_as_owner_for_azure_application.toml
@@ -29,6 +29,5 @@ tags = ["Elastic", "Azure", "Continuous Monitoring", "SecOps", "Configuration Au
 type = "query"
 
 query = '''
-event.module:azure and event.dataset:azure.auditlogs and event.category:AuditLogs and azure.auditlogs.operation_name:("Add owner to service principal") and event.outcome:Success
+event.module:azure and event.dataset:azure.auditlogs and event.category:AuditLogs and azure.auditlogs.operation_name:"Add owner to service principal" and event.outcome:Success
 '''
-

--- a/rules/azure/defense_evasion_user_added_as_owner_for_azure_application.toml
+++ b/rules/azure/defense_evasion_user_added_as_owner_for_azure_application.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/08/20"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/20"
 

--- a/rules/azure/defense_evasion_user_added_as_owner_for_azure_application.toml
+++ b/rules/azure/defense_evasion_user_added_as_owner_for_azure_application.toml
@@ -1,0 +1,34 @@
+[metadata]
+creation_date = "2020/08/20"
+ecs_version = ["1.5.0"]
+maturity = "production"
+updated_date = "2020/08/20"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when a user is added as an owner for an Azure service principal. The service principal object defines what
+the application can do in the specific tenant, who can access the application, and what resources the app can access. A
+service principal object is created when an application is given permission to access resources in a tenant. An
+adversary may add a user account as an owner for a service principal and use that account in order to define what an
+application can do in the Azure AD tenant.
+"""
+from = "now-25m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "User Added as Owner for Service Principal"
+note = "The Azure Filebeat module must be enabled to use this rule."
+references = [
+    "https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals",
+]
+risk_score = 21
+rule_id = "38e5acdd-5f20-4d99-8fe4-f0a1a592077f"
+severity = "low"
+tags = ["Elastic", "Azure", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.module:azure and event.dataset:azure.auditlogs and event.category:AuditLogs and azure.auditlogs.operation_name:("Add owner to service principal") and event.outcome:Success
+'''
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #113 

## Summary
Identifies when a user is added as an owner for an Azure service principal. The service principal object defines what the application can do in the specific tenant, who can access the application, and what resources the app can access.

A service principal object is created when an application is given permission to access resources in a tenant. An adversary may add a user account as an owner for a service principal and use that account in order to define what an application can do in the Azure AD tenant.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
