### PR TITLE
[New Rule] Multi-Factor Authentication Disabled for an Azure User

### DIFF
--- a/rules/azure/defense_evasion_mfa_disabled_for_azure_user.toml
+++ b/rules/azure/defense_evasion_mfa_disabled_for_azure_user.toml
@@ -1,0 +1,42 @@
+[metadata]
+creation_date = "2020/08/20"
+ecs_version = ["1.5.0"]
+maturity = "production"
+updated_date = "2020/08/20"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when multi-factor authentication (MFA) is disabled for an Azure user account. An adversary may disable MFA
+for a user account in order to weaken the authentication requirements for the account.
+"""
+from = "now-25m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "Multi-Factor Authentication Disabled for an Azure User"
+note = "The Azure Filebeat module must be enabled to use this rule."
+risk_score = 47
+rule_id = "dafa3235-76dc-40e2-9f71-1773b96d24cf"
+severity = "medium"
+tags = ["Elastic", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+type = "query"
+
+query = '''
+event.module:azure and event.dataset:azure.auditlogs and event.category:AuditLogs and azure.auditlogs.operation_name:"Disable Strong Authentication" and event.outcome: "Success"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/azure/defense_evasion_mfa_disabled_for_azure_user.toml
+++ b/rules/azure/defense_evasion_mfa_disabled_for_azure_user.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/08/20"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/20"
 
@@ -39,4 +39,3 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-

--- a/rules/azure/defense_evasion_mfa_disabled_for_azure_user.toml
+++ b/rules/azure/defense_evasion_mfa_disabled_for_azure_user.toml
@@ -23,7 +23,7 @@ tags = ["Elastic", "Azure", "Continuous Monitoring", "SecOps", "Identity and Acc
 type = "query"
 
 query = '''
-event.module:azure and event.dataset:azure.auditlogs and event.category:AuditLogs and azure.auditlogs.operation_name:"Disable Strong Authentication" and event.outcome: "Success"
+event.module:azure and event.dataset:azure.auditlogs and event.category:AuditLogs and azure.auditlogs.operation_name:"Disable Strong Authentication" and event.outcome:Success
 '''
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #116 

## Summary
Identifies when multi-factor authentication (MFA) is disabled for an Azure user account. An adversary may disable MFA for a user account in order to weaken the authentication requirements for the account.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
