### PR TITLE
Handle comparisons of rules across multiple schemas for kibana-diff command

### DIFF
--- a/detection_rules/semver.py
+++ b/detection_rules/semver.py
@@ -12,7 +12,7 @@ class Version(tuple):
         if not isinstance(version, (int, list, tuple)):
             version = tuple(int(a) if a.isdigit() else a for a in re.split(r'[.-]', version))
 
-        return tuple.__new__(cls, version)
+        return tuple.__new__(cls, (version,) if isinstance(version, int) else version)
 
     def bump(self):
         """Increment the version."""


### PR DESCRIPTION
## Issues
None

## Summary
A change in the way the GitHub API was returning paginated results was preventing all valid branches from returning, which was erroneously causing valid branches in Kibana to appear invalid (such as `master`).

Upon fixing this bug, validation errors were occurring due to the different schemas of the rules, since rule files are loaded and validated in the `Rule` object in order to do the comparisons (since Kibana stores the API json format). This is resolved by now storing incompatible rules (by failing schema validation) into their own bucket. This should be fine because `kibana-diff` should ideally be run against Kibana branches with comparable schemas.

A summary output was also added for overall stats.

### Detailed outputs

<details>
<summary>Expand to see detailed outputs</summary>
<br>

#### non-existent Kibana branch
```console
python -m detection_rules kibana-diff -b 7.5555

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Downloading rules from 7.5555 branch in kibana repo...
Kibana branch: 7.5555 does not exist
```

#### valid Kibana branch before rules existed
```console
python -m detection_rules kibana-diff -b 7.5   

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Downloading rules from 7.5 branch in kibana repo...
rules directory does not exist for branch: 7.5
```

#### various branches across Kibana with non-comparable branches since running from current branch
```console
python -m detection_rules kibana-diff -b 7.6   

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Downloading rules from 7.6 branch in kibana repo...
{
  "diff": [],
  "missing_from_kibana": [
    ... snipped ...
    "56557cde-d923-4b88-adee-c61b3f3b5dc3 - Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)"
  ],
  "missing_from_rules": [],
  "non_comparable_schemas": [
    ... snipped ...
    "ef862985-3f13-4262-a686-5f357bbb9bc2 - Whoami Process Activity"
  ],
  "stats": {
    "diff": 0,
    "missing_from_kibana": 117,
    "missing_from_rules": 0,
    "non_comparable_schemas": 89,
    "total_gh_prod_rules": 89,
    "total_repo_prod_rules": 206
  }
}
python -m detection_rules kibana-diff -b 7.7

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Downloading rules from 7.7 branch in kibana repo...
{
  "diff": [],
  "missing_from_kibana": [
    ... snipped ...
    "5b03c9fb-9945-4d2f-9568-fd690fee3fba - Virtual Machine Fingerprinting"
  ],
  "missing_from_rules": [],
  "non_comparable_schemas": [
    ... snipped ...
    "ef862985-3f13-4262-a686-5f357bbb9bc2 - Whoami Process Activity"
  ],
  "stats": {
    "diff": 0,
    "missing_from_kibana": 79,
    "missing_from_rules": 0,
    "non_comparable_schemas": 127,
    "total_gh_prod_rules": 127,
    "total_repo_prod_rules": 206
  }
}
python -m detection_rules kibana-diff -b 7.8

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Downloading rules from 7.8 branch in kibana repo...
{
  "diff": [],
  "missing_from_kibana": [
    ... snipped ...
    "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9 - Unusual File Modification by dns.exe"
  ],
  "missing_from_rules": [],
  "non_comparable_schemas": [
    ... snipped ...
    "ef862985-3f13-4262-a686-5f357bbb9bc2 - Whoami Process Activity"
  ],
  "stats": {
    "diff": 0,
    "missing_from_kibana": 61,
    "missing_from_rules": 0,
    "non_comparable_schemas": 145,
    "total_gh_prod_rules": 145,
    "total_repo_prod_rules": 206
  }
}
```

#### current branch
```console
python -m detection_rules kibana-diff -b 7.9

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Downloading rules from 7.9 branch in kibana repo...
{
  "diff": [],
  "missing_from_kibana": [
    "11013227-0301-4a8c-b150-4db924484475 - Abnormally Large DNS Response",
    "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45 - Unusual Child Process of dns.exe",
    "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9 - Unusual File Modification by dns.exe"
  ],
  "missing_from_rules": [],
  "non_comparable_schemas": [],
  "stats": {
    "diff": 0,
    "missing_from_kibana": 3,
    "missing_from_rules": 0,
    "non_comparable_schemas": 0,
    "total_gh_prod_rules": 203,
    "total_repo_prod_rules": 206
  }
}
```

</details>
