### PR TITLE
[Rule Tuning] Increase lookback for endpoint rules

### DIFF
--- a/rules/linux/credential_access_tcpdump_activity.toml
+++ b/rules/linux/credential_access_tcpdump_activity.toml
@@ -17,6 +17,7 @@ false_positives = [
     troubleshooting.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -10,6 +10,7 @@ description = """
 Adversaries may attempt to disable the iptables or firewall service in an attempt to affect how a host is allowed to
 receive or send network traffic.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"
@@ -43,3 +44,4 @@ reference = "https://attack.mitre.org/techniques/T1089/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
@@ -10,6 +10,7 @@ description = """
 Adversaries may attempt to disable the syslog service in an attempt to an attempt to disrupt event logging and evade
 detection by security controls.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
@@ -13,6 +13,7 @@ false_positives = [
     filtered by the process executable or username values.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
@@ -13,6 +13,7 @@ false_positives = [
     filtered by the process executable or username values.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
+++ b/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
@@ -10,6 +10,7 @@ description = """
 Adversaries may attempt to clear the bash command line history in an attempt to evade detection or forensic
 investigations.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "lucene"
 license = "Elastic License"

--- a/rules/linux/defense_evasion_disable_selinux_attempt.toml
+++ b/rules/linux/defense_evasion_disable_selinux_attempt.toml
@@ -11,6 +11,7 @@ Identifies potential attempts to disable Security-Enhanced Linux (SELinux), whic
 support access control policies. Adversaries may disable security tools to avoid possible detection of their tools and
 activities.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/defense_evasion_file_deletion_via_shred.toml
+++ b/rules/linux/defense_evasion_file_deletion_via_shred.toml
@@ -11,6 +11,7 @@ Malware or other files dropped or created on a system by an adversary may leave 
 a network and how. Adversaries may remove these files over the course of an intrusion to keep their footprint low or
 remove them at the end as part of the post-intrusion cleanup process.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/defense_evasion_file_mod_writable_dir.toml
+++ b/rules/linux/defense_evasion_file_mod_writable_dir.toml
@@ -16,6 +16,7 @@ false_positives = [
     by username.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
@@ -13,6 +13,7 @@ false_positives = [
     filtered by the process executable or username values.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"
@@ -52,3 +53,4 @@ reference = "https://attack.mitre.org/techniques/T1027/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -17,6 +17,7 @@ false_positives = [
     behavior. These events can be filtered by the process arguments, username, or process name values.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "lucene"
 license = "Elastic License"
@@ -60,3 +61,4 @@ reference = "https://attack.mitre.org/techniques/T1158/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/linux/defense_evasion_kernel_module_removal.toml
+++ b/rules/linux/defense_evasion_kernel_module_removal.toml
@@ -17,6 +17,7 @@ false_positives = [
     Note that some Linux distributions are not built to support the removal of modules at all.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"
@@ -58,3 +59,4 @@ reference = "https://attack.mitre.org/techniques/T1215/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/linux/discovery_kernel_module_enumeration.toml
+++ b/rules/linux/discovery_kernel_module_enumeration.toml
@@ -17,6 +17,7 @@ false_positives = [
     by ordinary users is uncommon. These can be exempted by process name or username.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/discovery_virtual_machine_fingerprinting.toml
+++ b/rules/linux/discovery_virtual_machine_fingerprinting.toml
@@ -17,6 +17,7 @@ false_positives = [
     process arguments to eliminate potential noise.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"
@@ -50,3 +51,4 @@ reference = "https://attack.mitre.org/techniques/T1082/"
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/linux/discovery_whoami_commmand.toml
+++ b/rules/linux/discovery_whoami_commmand.toml
@@ -16,6 +16,7 @@ false_positives = [
     automation tools and frameworks.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/execution_perl_tty_shell.toml
+++ b/rules/linux/execution_perl_tty_shell.toml
@@ -10,6 +10,7 @@ description = """
 Identifies when a terminal (tty) is spawned via Perl. Attackers may upgrade a simple reverse shell to a fully
 interactive tty after obtaining initial access to a host.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -10,6 +10,7 @@ description = """
 Identifies when a terminal (tty) is spawned via Python. Attackers may upgrade a simple reverse shell to a fully
 interactive tty after obtaining initial access to a host.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/lateral_movement_telnet_network_activity_external.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_external.toml
@@ -18,6 +18,7 @@ false_positives = [
     suspicious.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/lateral_movement_telnet_network_activity_internal.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_internal.toml
@@ -18,6 +18,7 @@ false_positives = [
     suspicious.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_hping_activity.toml
+++ b/rules/linux/linux_hping_activity.toml
@@ -16,6 +16,7 @@ false_positives = [
     uncommon.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_iodine_activity.toml
+++ b/rules/linux/linux_iodine_activity.toml
@@ -16,6 +16,7 @@ false_positives = [
     uncommon.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_mknod_activity.toml
+++ b/rules/linux/linux_mknod_activity.toml
@@ -16,6 +16,7 @@ false_positives = [
     scripts, automation tools, and frameworks. Usage by web servers is more likely to be suspicious.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_netcat_network_connection.toml
+++ b/rules/linux/linux_netcat_network_connection.toml
@@ -18,6 +18,7 @@ false_positives = [
     originate from scripts, automation tools, and frameworks.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_nmap_activity.toml
+++ b/rules/linux/linux_nmap_activity.toml
@@ -18,6 +18,7 @@ false_positives = [
     uncommon.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_nping_activity.toml
+++ b/rules/linux/linux_nping_activity.toml
@@ -16,6 +16,7 @@ false_positives = [
     is usually not routine or unannounced. Use of `Nping` by non-engineers or ordinary users is uncommon.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_process_started_in_temp_directory.toml
+++ b/rules/linux/linux_process_started_in_temp_directory.toml
@@ -13,6 +13,7 @@ false_positives = [
     username.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_socat_activity.toml
+++ b/rules/linux/linux_socat_activity.toml
@@ -17,6 +17,7 @@ false_positives = [
     more likely to be suspicious.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/linux_strace_activity.toml
+++ b/rules/linux/linux_strace_activity.toml
@@ -16,6 +16,7 @@ false_positives = [
     originate from developers or SREs engaged in debugging or system call tracing.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/persistence_kernel_module_activity.toml
+++ b/rules/linux/persistence_kernel_module_activity.toml
@@ -13,6 +13,7 @@ false_positives = [
     programs by ordinary users is uncommon.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/persistence_shell_activity_by_web_server.toml
+++ b/rules/linux/persistence_shell_activity_by_web_server.toml
@@ -13,6 +13,7 @@ false_positives = [
     behavior.
     """,
 ]
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
@@ -12,6 +12,7 @@ group. An adversary can take advantage of this to either do a shell escape or ex
 with the setgid bit to get code running in a different user’s context. Additionally, adversaries can use this mechanism
 on their own malware to make sure they're able to execute in elevated contexts in the future.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "lucene"
 license = "Elastic License"

--- a/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
@@ -12,6 +12,7 @@ user. An adversary can take advantage of this to either do a shell escape or exp
 with the setuid bit to get code running in a different user’s context. Additionally, adversaries can use this mechanism
 on their own malware to make sure they're able to execute in elevated contexts in the future.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "lucene"
 license = "Elastic License"

--- a/rules/linux/privilege_escalation_sudoers_file_mod.toml
+++ b/rules/linux/privilege_escalation_sudoers_file_mod.toml
@@ -10,6 +10,7 @@ description = """
 A sudoers file specifies the commands that users or groups can run and from which terminals. Adversaries can take
 advantage of these configurations to execute commands as other users or spawn processes with higher privileges.
 """
+from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -10,6 +10,7 @@ description = """
 Identifies certutil.exe making a network connection. Adversaries could abuse certutil.exe to download a certificate, or
 malware, from a remote URL.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/credential_access_credential_dumping_msbuild.toml
+++ b/rules/windows/credential_access_credential_dumping_msbuild.toml
@@ -11,6 +11,7 @@ An instance of MSBuild, the Microsoft Build Engine, loaded DLLs (dynamically lin
 credential management. This technique is sometimes used for credential dumping.
 """
 false_positives = ["The Build Engine is commonly used by Windows developers but use by non-engineers is unusual."]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -7,6 +7,7 @@ updated_date = "2020/08/03"
 [rule]
 author = ["Elastic"]
 description = "Adversaries can add the 'hidden' attribute to files to hide them from the user in an attempt to evade detection."
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -10,6 +10,7 @@ description = """
 Identifies attempts to clear Windows event log stores. This is often done by attackers in an attempt to evade detection
 or destroy forensic evidence on a system.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
+++ b/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
@@ -10,6 +10,7 @@ description = """
 Identifies use of the fsutil.exe to delete the volume USNJRNL. This technique is used by attackers to eliminate evidence
 of files created during post-exploitation activities.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
@@ -10,6 +10,7 @@ description = """
 Identifies use of the wbadmin.exe to delete the backup catalog. Ransomware and other malware may do this to prevent
 system recovery.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -10,6 +10,7 @@ description = """
 Identifies use of the netsh.exe to disable or weaken the local firewall. Attackers will use this command line tool to
 disable the firewall during troubleshooting or to enable network mobility.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
+++ b/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
@@ -11,6 +11,7 @@ Identifies the use of certutil.exe to encode or decode data. CertUtil is a nativ
 Certificate Services. CertUtil is often abused by attackers to encode or decode base64 data for stealthier command and
 control or exfiltration.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -16,6 +16,7 @@ false_positives = [
     this program to be started by an Office application like Word or Excel.
     """,
 ]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
@@ -11,6 +11,7 @@ An instance of MSBuild, the Microsoft Build Engine, was started by a script or t
 behavior is unusual and is sometimes used by malicious payloads.
 """
 false_positives = ["The Build Engine is commonly used by Windows developers but use by non-engineers is unusual."]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
@@ -11,6 +11,7 @@ An instance of MSBuild, the Microsoft Build Engine, was started by Explorer or t
 Instrumentation) subsystem. This behavior is unusual and is sometimes used by malicious payloads.
 """
 false_positives = ["The Build Engine is commonly used by Windows developers but use by non-engineers is unusual."]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
@@ -11,6 +11,7 @@ An instance of MSBuild, the Microsoft Build Engine, was started after being rena
 indicate an attempt to run unnoticed or undetected.
 """
 false_positives = ["The Build Engine is commonly used by Windows developers but use by non-engineers is unusual."]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
@@ -16,6 +16,7 @@ false_positives = [
     triggers this rule it can be exempted by process, user or host name.
     """,
 ]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"
@@ -45,3 +46,4 @@ reference = "https://attack.mitre.org/techniques/T1500/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -11,6 +11,7 @@ Binaries signed with trusted digital certificates can execute on Windows systems
 validation. Adversaries may use these binaries to 'live off the land' and execute malicious files that could bypass
 application allowlists and signature validation.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -10,6 +10,7 @@ description = """
 Identifies use of bcdedit.exe to delete boot configuration data. This tactic is sometimes used as by malware or an
 attacker as a destructive technique.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_vssadmin.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_vssadmin.toml
@@ -10,6 +10,7 @@ description = """
 Identifies use of vssadmin.exe for shadow copy deletion on endpoints. This commonly occurs in tandem with ransomware or
 other destructive attacks.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
@@ -10,6 +10,7 @@ description = """
 Identifies use of wmic.exe for shadow copy deletion on endpoints. This commonly occurs in tandem with ransomware or
 other destructive attacks.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -10,6 +10,7 @@ description = """
 Identifies the SYSTEM account using the Net utility. The Net utility is a component of the Windows operating system. It
 is used in command line operations for control of users, groups, services, and network connections.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
+++ b/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
@@ -16,6 +16,7 @@ false_positives = [
     environment for network connections being made from the command prompt to determine any abnormal use of this tool.
     """,
 ]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_command_shell_started_by_powershell.toml
+++ b/rules/windows/execution_command_shell_started_by_powershell.toml
@@ -7,6 +7,7 @@ updated_date = "2020/08/03"
 [rule]
 author = ["Elastic"]
 description = "Identifies a suspicious parent child process relationship with cmd.exe descending from PowerShell.exe."
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -7,6 +7,7 @@ updated_date = "2020/08/03"
 [rule]
 author = ["Elastic"]
 description = "Identifies a suspicious parent child process relationship with cmd.exe descending from svchost.exe"
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
@@ -11,6 +11,7 @@ Compiled HTML files (.chm) are commonly distributed as part of the Microsoft HTM
 malicious code in a CHM file and deliver it to a victim for execution. CHM content is loaded by the HTML Help executable
 program (hh.exe).
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_local_service_commands.toml
+++ b/rules/windows/execution_local_service_commands.toml
@@ -10,6 +10,7 @@ description = """
 Identifies use of sc.exe to create, modify, or start services on remote hosts. This could be indicative of adversary
 lateral movement but will be noisy if commonly done by admins.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_msbuild_making_network_connections.toml
+++ b/rules/windows/execution_msbuild_making_network_connections.toml
@@ -10,6 +10,7 @@ description = """
 Identifies MsBuild.exe making outbound network connections. This may indicate adversarial activity as MsBuild is often
 leveraged by adversaries to execute code and evade detection.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_mshta_making_network_connections.toml
+++ b/rules/windows/execution_mshta_making_network_connections.toml
@@ -10,6 +10,7 @@ description = """
 Identifies mshta.exe making a network connection. This may indicate adversarial activity as mshta.exe is often leveraged
 by adversaries to execute malicious scripts and evade detection.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -10,6 +10,7 @@ description = """
 Identifies msxsl.exe making a network connection. This may indicate adversarial activity as msxsl.exe is often leveraged
 by adversaries to execute malicious scripts and evade detection.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_psexec_lateral_movement_command.toml
+++ b/rules/windows/execution_psexec_lateral_movement_command.toml
@@ -16,6 +16,7 @@ false_positives = [
     environment to determine the amount of noise to expect from this tool.
     """,
 ]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -16,6 +16,7 @@ false_positives = [
     is unusual.
     """,
 ]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_script_executing_powershell.toml
+++ b/rules/windows/execution_script_executing_powershell.toml
@@ -10,6 +10,7 @@ description = """
 Identifies a PowerShell process launched by either cscript.exe or wscript.exe. Observing Windows scripting processes
 executing a PowerShell script, may be indicative of malicious activity.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_suspicious_ms_office_child_process.toml
+++ b/rules/windows/execution_suspicious_ms_office_child_process.toml
@@ -11,6 +11,7 @@ Identifies suspicious child processes of frequently targeted Microsoft Office ap
 These child processes are often launched during exploitation of Office applications or from documents with malicious
 macros.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/execution_suspicious_ms_outlook_child_process.toml
@@ -10,6 +10,7 @@ description = """
 Identifies suspicious child processes of Microsoft Outlook. These child processes are often associated with spear
 phishing activity.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -10,6 +10,7 @@ description = """
 Identifies suspicious child processes of PDF reader applications. These child processes are often launched via
 exploitation of PDF applications or social engineering.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/execution_unusual_network_connection_via_rundll32.toml
@@ -10,6 +10,7 @@ description = """
 Identifies unusual instances of rundll32.exe making outbound network connections. This may indicate adversarial activity
 and may identify malicious DLLs.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_unusual_process_network_connection.toml
+++ b/rules/windows/execution_unusual_process_network_connection.toml
@@ -10,6 +10,7 @@ description = """
 Identifies network activity from unexpected system applications. This may indicate adversarial activity as these
 applications are often leveraged by adversaries to execute code and evade detection.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/execution_via_net_com_assemblies.toml
+++ b/rules/windows/execution_via_net_com_assemblies.toml
@@ -11,6 +11,7 @@ RegSvcs.exe and RegAsm.exe are Windows command line utilities that are used to r
 (COM) assemblies. Adversaries can use RegSvcs.exe and RegAsm.exe to proxy execution of code through a trusted Windows
 utility.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -12,6 +12,7 @@ over Server Message Block (SMB), which communicates between hosts using port 445
 connections are established by the kernel. Processes making 445/tcp connections may be port scanners, exploits, or
 suspicious user-level processes moving laterally.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -7,6 +7,7 @@ updated_date = "2020/08/03"
 [rule]
 author = ["Elastic"]
 description = "Detects writing executable files that will be automatically launched by Adobe on launch."
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/persistence_local_scheduled_task_commands.toml
+++ b/rules/windows/persistence_local_scheduled_task_commands.toml
@@ -8,6 +8,7 @@ updated_date = "2020/08/03"
 author = ["Elastic"]
 description = "A scheduled task can be used by an adversary to establish persistence, move laterally, and/or escalate privileges."
 false_positives = ["Legitimate scheduled tasks may be created during installation of new software."]
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -10,6 +10,7 @@ description = """
 Windows services typically run as SYSTEM and can be used as a privilege escalation opportunity. Malware or penetration
 testers may run a shell as a service to gain SYSTEM permissions.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -10,6 +10,7 @@ description = """
 Identifies attempts to create new local users. This is sometimes done by attackers to increase access to a system or
 domain.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -10,6 +10,7 @@ description = """
 Identifies User Account Control (UAC) bypass via eventvwr.exe. Attackers bypass UAC to stealthily execute code with
 elevated permissions.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -10,6 +10,7 @@ description = """
 Identifies Windows programs run from unexpected parent processes. This could indicate masquerading or other strange
 activity on a system.
 """
+from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"


### PR DESCRIPTION
## Issues
resolves #199 

## Summary
Increases the lookback on all rules targeting the `logs.endpoint.events.*` index by 3 minutes each. All of these rules were using the defaults (not set locally, which infers defaults from API):
 - `interval = "5m"`
-  `from = "now-6m"`

This changes the rules to `from = "now-9m"`