### PR TITLE
Fix kibana-upload and remove cumbersome dataclasses

### DIFF
--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -260,7 +260,6 @@ def kibana_upload(toml_files, kibana_url, cloud_id, user, password):
             payload = downgrade(payload, kibana.version)
             rule = RuleResource(payload)
             api_payloads.append(rule)
-            print(api_payloads)
 
         rules = RuleResource.bulk_create(api_payloads)
         click.echo(f"Successfully uploaded {len(rules)} rules")

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -258,8 +258,9 @@ def kibana_upload(toml_files, kibana_url, cloud_id, user, password):
             meta["original"] = dict(id=rule.id, **rule.metadata)
             payload["rule_id"] = str(uuid4())
             payload = downgrade(payload, kibana.version)
-            rule = RuleResource.from_dict(payload)
+            rule = RuleResource(payload)
             api_payloads.append(rule)
+            print(api_payloads)
 
         rules = RuleResource.bulk_create(api_payloads)
         click.echo(f"Successfully uploaded {len(rules)} rules")

--- a/kibana/resources.py
+++ b/kibana/resources.py
@@ -2,12 +2,10 @@
 # or more contributor license agreements. Licensed under the Elastic License;
 # you may not use this file except in compliance with the Elastic License.
 
-from .connector import Kibana
-import abc
 import datetime
-from dataclasses import dataclass, field, fields
-from dataclasses_json import dataclass_json, config, DataClassJsonMixin
-from typing import List, Optional, Type, TypeVar
+from typing import List, Type
+
+from .connector import Kibana
 
 DEFAULT_PAGE_SIZE = 10
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ toml==0.10.0
 requests==2.22.0
 Click==7.0
 PyYAML~=5.3
-dataclasses-json~=0.4.2
 eql~=0.9
 elasticsearch~=7.5.1
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -18,6 +18,7 @@ class TestSchemas(unittest.TestCase):
         cls.compatible_rule = Rule("test.toml", {
             "author": ["Elastic"],
             "description": "test description",
+            "index": ["filebeat-*"],
             "language": "kuery",
             "license": "Elastic License",
             "name": "test rule",
@@ -55,6 +56,7 @@ class TestSchemas(unittest.TestCase):
         self.assertDictEqual(downgrade(api_contents, "7.8"), {
             # "author": ["Elastic"],
             "description": "test description",
+            "index": ["filebeat-*"],
             "language": "kuery",
             # "license": "Elastic License",
             "name": "test rule",
@@ -77,6 +79,7 @@ class TestSchemas(unittest.TestCase):
         self.assertDictEqual(downgrade(api_contents, "7.8"), {
             # "author": ["Elastic"],
             "description": "test description",
+            "index": ["filebeat-*"],
             "language": "kuery",
             # "license": "Elastic License",
             "name": "test rule",


### PR DESCRIPTION
## Issues
Closes #121

## Summary
dataclasses-json was silently dropping fields, and drifted from the JSON schemas. `index` wasn't included in the RuleResource class definition, the field was silently dropped. I removed the dataclasses-json approach, and just made RuleResource a subclass of dict instead. There is no validation in the schema, and I think that it's okay to make the client validate, since all of that code is there.

Here's the payload after the changes
```python
[{'author': ['Rule export'], 'description': 'The contents of crontab have been modified by a non-root user.', 'tags': ['prod'], 'index': ['filebeat-*'], 'language': 'kuery', 'license': 'Elastic License', 'name': 'Cron - Crontab entry changed', 'risk_score': 15, 'rule_id': '7230e517-3f0f-4652-8c47-c2edd9b25d19', 'severity': 'low', 'type': 'query', 'query': 'event.module: cron and event.action: changed and not user.name: root', 'threat': [{'framework': 'MITRE ATT&CK', 'technique': [{'id': 'T1053', 'name': 'Scheduled Task', 'reference': 'https://attack.mitre.org/techniques/T1053/'}], 'tactic': {'id': 'TA0002', 'name': 'Execution', 'reference': 'https://attack.mitre.org/tactics/TA0002/'}}, {'framework': 'MITRE ATT&CK', 'technique': [{'id': 'T1053', 'name': 'Scheduled Task', 'reference': 'https://attack.mitre.org/techniques/T1053/'}], 'tactic': {'id': 'TA0003', 'name': 'Persistence', 'reference': 'https://attack.mitre.org/tactics/TA0003/'}}], 'version': 1, 'meta': {'original': {'id': '9bad9907-1969-4a70-bfbd-367f0dcc0203', 'creation_date': '2020/08/11', 'ecs_version': ['1.5.0'], 'maturity': 'development', 'updated_date': '2020/08/11'}}}]
```