### PR TITLE
Add ECS 1.6.0 schema for validation testing

### DIFF
--- a/detection_rules/ecs.py
+++ b/detection_rules/ecs.py
@@ -209,7 +209,7 @@ def download_schemas(refresh_master=True, refresh_all=False, verbose=True):
                 # load as yaml, save as json
                 contents = yaml.safe_load(archive.read(member))
                 out_file = file_name.replace(".yml", ".json")
-                save_etc_dump(contents, "schemas", out_file)
+                save_etc_dump(contents, "ecs_schemas", str(version), out_file)
                 saved.append(out_file)
 
             if verbose:

--- a/etc/ecs_schemas/1.6.0/ecs_flat.json
+++ b/etc/ecs_schemas/1.6.0/ecs_flat.json
@@ -3458,18 +3458,6 @@
     "short": "HTTP request method.",
     "type": "keyword"
   },
-  "http.request.mime_type": {
-    "dashed_name": "http-request-mime-type",
-    "description": "Mime type of the body of the request.\nThis value must only be populated based on the content of the request body, not on the `Content-Type` header. Comparing the mime type of a request with the request's Content-Type header can be helpful in detecting threats or misconfigured clients.",
-    "example": "image/gif",
-    "flat_name": "http.request.mime_type",
-    "ignore_above": 1024,
-    "level": "extended",
-    "name": "request.mime_type",
-    "normalize": [],
-    "short": "Mime type of the body of the request.",
-    "type": "keyword"
-  },
   "http.request.referrer": {
     "dashed_name": "http-request-referrer",
     "description": "Referrer for this HTTP request.",
@@ -3525,18 +3513,6 @@
     "normalize": [],
     "short": "Total size in bytes of the response (body and headers).",
     "type": "long"
-  },
-  "http.response.mime_type": {
-    "dashed_name": "http-response-mime-type",
-    "description": "Mime type of the body of the response.\nThis value must only be populated based on the content of the response body, not on the `Content-Type` header. Comparing the mime type of a response with the response's Content-Type header can be helpful in detecting misconfigured servers.",
-    "example": "image/gif",
-    "flat_name": "http.response.mime_type",
-    "ignore_above": 1024,
-    "level": "extended",
-    "name": "response.mime_type",
-    "normalize": [],
-    "short": "Mime type of the body of the response.",
-    "type": "keyword"
   },
   "http.response.status_code": {
     "dashed_name": "http-response-status-code",

--- a/etc/ecs_schemas/1.6.0/ecs_nested.json
+++ b/etc/ecs_schemas/1.6.0/ecs_nested.json
@@ -1,0 +1,10168 @@
+{
+  "agent": {
+    "description": "The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.\nExamples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.",
+    "fields": {
+      "agent.build.original": {
+        "dashed_name": "agent-build-original",
+        "description": "Extended build information for the agent.\nThis field is intended to contain any build information that a data source may provide, no specific formatting is required.",
+        "example": "metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",
+        "flat_name": "agent.build.original",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "build.original",
+        "normalize": [],
+        "short": "Extended build information for the agent.",
+        "type": "keyword"
+      },
+      "agent.ephemeral_id": {
+        "dashed_name": "agent-ephemeral-id",
+        "description": "Ephemeral identifier of this agent (if one exists).\nThis id normally changes across restarts, but `agent.id` does not.",
+        "example": "8a4f500f",
+        "flat_name": "agent.ephemeral_id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "ephemeral_id",
+        "normalize": [],
+        "short": "Ephemeral identifier of this agent.",
+        "type": "keyword"
+      },
+      "agent.id": {
+        "dashed_name": "agent-id",
+        "description": "Unique identifier of this agent (if one exists).\nExample: For Beats this would be beat.id.",
+        "example": "8a4f500d",
+        "flat_name": "agent.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique identifier of this agent.",
+        "type": "keyword"
+      },
+      "agent.name": {
+        "dashed_name": "agent-name",
+        "description": "Custom name of the agent.\nThis is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from.\nIf no name is given, the name is often left empty.",
+        "example": "foo",
+        "flat_name": "agent.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "name",
+        "normalize": [],
+        "short": "Custom name of the agent.",
+        "type": "keyword"
+      },
+      "agent.type": {
+        "dashed_name": "agent-type",
+        "description": "Type of the agent.\nThe agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine.",
+        "example": "filebeat",
+        "flat_name": "agent.type",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "type",
+        "normalize": [],
+        "short": "Type of the agent.",
+        "type": "keyword"
+      },
+      "agent.version": {
+        "dashed_name": "agent-version",
+        "description": "Version of the agent.",
+        "example": "6.0.0-rc2",
+        "flat_name": "agent.version",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "version",
+        "normalize": [],
+        "short": "Version of the agent.",
+        "type": "keyword"
+      }
+    },
+    "footnote": "Examples: In the case of Beats for logs, the agent.name is filebeat. For APM, it is the agent running in the app/service. The agent information does not change if data is sent through queuing systems like Kafka, Redis, or processing systems such as Logstash or APM Server.",
+    "group": 2,
+    "name": "agent",
+    "prefix": "agent.",
+    "short": "Fields about the monitoring agent.",
+    "title": "Agent",
+    "type": "group"
+  },
+  "as": {
+    "description": "An autonomous system (AS) is a collection of connected Internet Protocol (IP) routing prefixes under the control of one or more network operators on behalf of a single administrative entity or domain that presents a common, clearly defined routing policy to the internet.",
+    "fields": {
+      "as.number": {
+        "dashed_name": "as-number",
+        "description": "Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+        "example": 15169,
+        "flat_name": "as.number",
+        "level": "extended",
+        "name": "number",
+        "normalize": [],
+        "short": "Unique number allocated to the autonomous system.",
+        "type": "long"
+      },
+      "as.organization.name": {
+        "dashed_name": "as-organization-name",
+        "description": "Organization name.",
+        "example": "Google LLC",
+        "flat_name": "as.organization.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "as.organization.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "organization.name",
+        "normalize": [],
+        "short": "Organization name.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "as",
+    "prefix": "as.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "as",
+          "at": "client",
+          "full": "client.as"
+        },
+        {
+          "as": "as",
+          "at": "destination",
+          "full": "destination.as"
+        },
+        {
+          "as": "as",
+          "at": "server",
+          "full": "server.as"
+        },
+        {
+          "as": "as",
+          "at": "source",
+          "full": "source.as"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "Fields describing an Autonomous System (Internet routing prefix).",
+    "title": "Autonomous System",
+    "type": "group"
+  },
+  "base": {
+    "description": "The `base` field set contains all fields which are at the root of the events. These fields are common across all types of events.",
+    "fields": {
+      "@timestamp": {
+        "dashed_name": "-timestamp",
+        "description": "Date/time when the event originated.\nThis is the date/time extracted from the event, typically representing when the event was generated by the source.\nIf the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline.\nRequired field for all events.",
+        "example": "2016-05-23T08:05:34.853Z",
+        "flat_name": "@timestamp",
+        "level": "core",
+        "name": "@timestamp",
+        "normalize": [],
+        "required": true,
+        "short": "Date/time when the event originated.",
+        "type": "date"
+      },
+      "labels": {
+        "dashed_name": "labels",
+        "description": "Custom key/value pairs.\nCan be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.\nExample: `docker` and `k8s` labels.",
+        "example": "{\"application\": \"foo-bar\", \"env\": \"production\"}",
+        "flat_name": "labels",
+        "level": "core",
+        "name": "labels",
+        "normalize": [],
+        "object_type": "keyword",
+        "short": "Custom key/value pairs.",
+        "type": "object"
+      },
+      "message": {
+        "dashed_name": "message",
+        "description": "For log events the message field contains the log message, optimized for viewing in a log viewer.\nFor structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.\nIf multiple messages exist, they can be combined into one message.",
+        "example": "Hello World",
+        "flat_name": "message",
+        "level": "core",
+        "name": "message",
+        "normalize": [],
+        "norms": false,
+        "short": "Log message optimized for viewing in a log viewer.",
+        "type": "text"
+      },
+      "tags": {
+        "dashed_name": "tags",
+        "description": "List of keywords used to tag each event.",
+        "example": "[\"production\", \"env2\"]",
+        "flat_name": "tags",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "tags",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of keywords used to tag each event.",
+        "type": "keyword"
+      }
+    },
+    "group": 1,
+    "name": "base",
+    "prefix": "",
+    "root": true,
+    "short": "All fields defined directly at the root of the events.",
+    "title": "Base",
+    "type": "group"
+  },
+  "client": {
+    "description": "A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records.\nFor TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term \"originator\" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields. Client fields are generally not populated for packet-level events.\nClient / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.",
+    "fields": {
+      "client.address": {
+        "dashed_name": "client-address",
+        "description": "Some event client addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.",
+        "flat_name": "client.address",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "address",
+        "normalize": [],
+        "short": "Client network address.",
+        "type": "keyword"
+      },
+      "client.as.number": {
+        "dashed_name": "client-as-number",
+        "description": "Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+        "example": 15169,
+        "flat_name": "client.as.number",
+        "level": "extended",
+        "name": "number",
+        "normalize": [],
+        "original_fieldset": "as",
+        "short": "Unique number allocated to the autonomous system.",
+        "type": "long"
+      },
+      "client.as.organization.name": {
+        "dashed_name": "client-as-organization-name",
+        "description": "Organization name.",
+        "example": "Google LLC",
+        "flat_name": "client.as.organization.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "client.as.organization.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "organization.name",
+        "normalize": [],
+        "original_fieldset": "as",
+        "short": "Organization name.",
+        "type": "keyword"
+      },
+      "client.bytes": {
+        "dashed_name": "client-bytes",
+        "description": "Bytes sent from the client to the server.",
+        "example": 184,
+        "flat_name": "client.bytes",
+        "format": "bytes",
+        "level": "core",
+        "name": "bytes",
+        "normalize": [],
+        "short": "Bytes sent from the client to the server.",
+        "type": "long"
+      },
+      "client.domain": {
+        "dashed_name": "client-domain",
+        "description": "Client domain.",
+        "flat_name": "client.domain",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "domain",
+        "normalize": [],
+        "short": "Client domain.",
+        "type": "keyword"
+      },
+      "client.geo.city_name": {
+        "dashed_name": "client-geo-city-name",
+        "description": "City name.",
+        "example": "Montreal",
+        "flat_name": "client.geo.city_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "city_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "City name.",
+        "type": "keyword"
+      },
+      "client.geo.continent_name": {
+        "dashed_name": "client-geo-continent-name",
+        "description": "Name of the continent.",
+        "example": "North America",
+        "flat_name": "client.geo.continent_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "continent_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Name of the continent.",
+        "type": "keyword"
+      },
+      "client.geo.country_iso_code": {
+        "dashed_name": "client-geo-country-iso-code",
+        "description": "Country ISO code.",
+        "example": "CA",
+        "flat_name": "client.geo.country_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country ISO code.",
+        "type": "keyword"
+      },
+      "client.geo.country_name": {
+        "dashed_name": "client-geo-country-name",
+        "description": "Country name.",
+        "example": "Canada",
+        "flat_name": "client.geo.country_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country name.",
+        "type": "keyword"
+      },
+      "client.geo.location": {
+        "dashed_name": "client-geo-location",
+        "description": "Longitude and latitude.",
+        "example": "{ \"lon\": -73.614830, \"lat\": 45.505918 }",
+        "flat_name": "client.geo.location",
+        "level": "core",
+        "name": "location",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Longitude and latitude.",
+        "type": "geo_point"
+      },
+      "client.geo.name": {
+        "dashed_name": "client-geo-name",
+        "description": "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation.",
+        "example": "boston-dc",
+        "flat_name": "client.geo.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "User-defined description of a location.",
+        "type": "keyword"
+      },
+      "client.geo.region_iso_code": {
+        "dashed_name": "client-geo-region-iso-code",
+        "description": "Region ISO code.",
+        "example": "CA-QC",
+        "flat_name": "client.geo.region_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region ISO code.",
+        "type": "keyword"
+      },
+      "client.geo.region_name": {
+        "dashed_name": "client-geo-region-name",
+        "description": "Region name.",
+        "example": "Quebec",
+        "flat_name": "client.geo.region_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region name.",
+        "type": "keyword"
+      },
+      "client.ip": {
+        "dashed_name": "client-ip",
+        "description": "IP address of the client (IPv4 or IPv6).",
+        "flat_name": "client.ip",
+        "level": "core",
+        "name": "ip",
+        "normalize": [],
+        "short": "IP address of the client.",
+        "type": "ip"
+      },
+      "client.mac": {
+        "dashed_name": "client-mac",
+        "description": "MAC address of the client.",
+        "flat_name": "client.mac",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "mac",
+        "normalize": [],
+        "short": "MAC address of the client.",
+        "type": "keyword"
+      },
+      "client.nat.ip": {
+        "dashed_name": "client-nat-ip",
+        "description": "Translated IP of source based NAT sessions (e.g. internal client to internet).\nTypically connections traversing load balancers, firewalls, or routers.",
+        "flat_name": "client.nat.ip",
+        "level": "extended",
+        "name": "nat.ip",
+        "normalize": [],
+        "short": "Client NAT ip address",
+        "type": "ip"
+      },
+      "client.nat.port": {
+        "dashed_name": "client-nat-port",
+        "description": "Translated port of source based NAT sessions (e.g. internal client to internet).\nTypically connections traversing load balancers, firewalls, or routers.",
+        "flat_name": "client.nat.port",
+        "format": "string",
+        "level": "extended",
+        "name": "nat.port",
+        "normalize": [],
+        "short": "Client NAT port",
+        "type": "long"
+      },
+      "client.packets": {
+        "dashed_name": "client-packets",
+        "description": "Packets sent from the client to the server.",
+        "example": 12,
+        "flat_name": "client.packets",
+        "level": "core",
+        "name": "packets",
+        "normalize": [],
+        "short": "Packets sent from the client to the server.",
+        "type": "long"
+      },
+      "client.port": {
+        "dashed_name": "client-port",
+        "description": "Port of the client.",
+        "flat_name": "client.port",
+        "format": "string",
+        "level": "core",
+        "name": "port",
+        "normalize": [],
+        "short": "Port of the client.",
+        "type": "long"
+      },
+      "client.registered_domain": {
+        "dashed_name": "client-registered-domain",
+        "description": "The highest registered client domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
+        "example": "example.com",
+        "flat_name": "client.registered_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "registered_domain",
+        "normalize": [],
+        "short": "The highest registered client domain, stripped of the subdomain.",
+        "type": "keyword"
+      },
+      "client.top_level_domain": {
+        "dashed_name": "client-top-level-domain",
+        "description": "The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is \"com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as \"co.uk\".",
+        "example": "co.uk",
+        "flat_name": "client.top_level_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "top_level_domain",
+        "normalize": [],
+        "short": "The effective top level domain (com, org, net, co.uk).",
+        "type": "keyword"
+      },
+      "client.user.domain": {
+        "dashed_name": "client-user-domain",
+        "description": "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "client.user.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Name of the directory the user is a member of.",
+        "type": "keyword"
+      },
+      "client.user.email": {
+        "dashed_name": "client-user-email",
+        "description": "User email address.",
+        "flat_name": "client.user.email",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "email",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User email address.",
+        "type": "keyword"
+      },
+      "client.user.full_name": {
+        "dashed_name": "client-user-full-name",
+        "description": "User's full name, if available.",
+        "example": "Albert Einstein",
+        "flat_name": "client.user.full_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "client.user.full_name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full_name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User's full name, if available.",
+        "type": "keyword"
+      },
+      "client.user.group.domain": {
+        "dashed_name": "client-user-group-domain",
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "client.user.group.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the directory the group is a member of.",
+        "type": "keyword"
+      },
+      "client.user.group.id": {
+        "dashed_name": "client-user-group-id",
+        "description": "Unique identifier for the group on the system/platform.",
+        "flat_name": "client.user.group.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Unique identifier for the group on the system/platform.",
+        "type": "keyword"
+      },
+      "client.user.group.name": {
+        "dashed_name": "client-user-group-name",
+        "description": "Name of the group.",
+        "flat_name": "client.user.group.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the group.",
+        "type": "keyword"
+      },
+      "client.user.hash": {
+        "dashed_name": "client-user-hash",
+        "description": "Unique user hash to correlate information for a user in anonymized form.\nUseful if `user.id` or `user.name` contain confidential information and cannot be used.",
+        "flat_name": "client.user.hash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hash",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique user hash to correlate information for a user in anonymized form.",
+        "type": "keyword"
+      },
+      "client.user.id": {
+        "dashed_name": "client-user-id",
+        "description": "Unique identifier of the user.",
+        "flat_name": "client.user.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique identifier of the user.",
+        "type": "keyword"
+      },
+      "client.user.name": {
+        "dashed_name": "client-user-name",
+        "description": "Short name or login of the user.",
+        "example": "albert",
+        "flat_name": "client.user.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "multi_fields": [
+          {
+            "flat_name": "client.user.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Short name or login of the user.",
+        "type": "keyword"
+      },
+      "client.user.roles": {
+        "dashed_name": "client-user-roles",
+        "description": "Array of user roles at the time of the event.",
+        "example": "[\"kibana_admin\", \"reporting_user\"]",
+        "flat_name": "client.user.roles",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "roles",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "user",
+        "short": "Array of user roles at the time of the event.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "client",
+    "nestings": [
+      "client.as",
+      "client.geo",
+      "client.user"
+    ],
+    "prefix": "client.",
+    "reused_here": [
+      {
+        "full": "client.as",
+        "schema_name": "as",
+        "short": "Fields describing an Autonomous System (Internet routing prefix)."
+      },
+      {
+        "full": "client.geo",
+        "schema_name": "geo",
+        "short": "Fields describing a location."
+      },
+      {
+        "full": "client.user",
+        "schema_name": "user",
+        "short": "Fields to describe the user relevant to the event."
+      }
+    ],
+    "short": "Fields about the client side of a network connection, used with server.",
+    "title": "Client",
+    "type": "group"
+  },
+  "cloud": {
+    "description": "Fields related to the cloud or infrastructure the events are coming from.",
+    "fields": {
+      "cloud.account.id": {
+        "dashed_name": "cloud-account-id",
+        "description": "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier.",
+        "example": 666777888999,
+        "flat_name": "cloud.account.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "account.id",
+        "normalize": [],
+        "short": "The cloud account or organization id.",
+        "type": "keyword"
+      },
+      "cloud.account.name": {
+        "dashed_name": "cloud-account-name",
+        "description": "The cloud account name or alias used to identify different entities in a multi-tenant environment.\nExamples: AWS account name, Google Cloud ORG display name.",
+        "example": "elastic-dev",
+        "flat_name": "cloud.account.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "account.name",
+        "normalize": [],
+        "short": "The cloud account name.",
+        "type": "keyword"
+      },
+      "cloud.availability_zone": {
+        "dashed_name": "cloud-availability-zone",
+        "description": "Availability zone in which this host is running.",
+        "example": "us-east-1c",
+        "flat_name": "cloud.availability_zone",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "availability_zone",
+        "normalize": [],
+        "short": "Availability zone in which this host is running.",
+        "type": "keyword"
+      },
+      "cloud.instance.id": {
+        "dashed_name": "cloud-instance-id",
+        "description": "Instance ID of the host machine.",
+        "example": "i-1234567890abcdef0",
+        "flat_name": "cloud.instance.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "instance.id",
+        "normalize": [],
+        "short": "Instance ID of the host machine.",
+        "type": "keyword"
+      },
+      "cloud.instance.name": {
+        "dashed_name": "cloud-instance-name",
+        "description": "Instance name of the host machine.",
+        "flat_name": "cloud.instance.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "instance.name",
+        "normalize": [],
+        "short": "Instance name of the host machine.",
+        "type": "keyword"
+      },
+      "cloud.machine.type": {
+        "dashed_name": "cloud-machine-type",
+        "description": "Machine type of the host machine.",
+        "example": "t2.medium",
+        "flat_name": "cloud.machine.type",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "machine.type",
+        "normalize": [],
+        "short": "Machine type of the host machine.",
+        "type": "keyword"
+      },
+      "cloud.project.id": {
+        "dashed_name": "cloud-project-id",
+        "description": "The cloud project identifier.\nExamples: Google Cloud Project id, Azure Project id.",
+        "example": "my-project",
+        "flat_name": "cloud.project.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "project.id",
+        "normalize": [],
+        "short": "The cloud project id.",
+        "type": "keyword"
+      },
+      "cloud.project.name": {
+        "dashed_name": "cloud-project-name",
+        "description": "The cloud project name.\nExamples: Google Cloud Project name, Azure Project name.",
+        "example": "my project",
+        "flat_name": "cloud.project.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "project.name",
+        "normalize": [],
+        "short": "The cloud project name.",
+        "type": "keyword"
+      },
+      "cloud.provider": {
+        "dashed_name": "cloud-provider",
+        "description": "Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.",
+        "example": "aws",
+        "flat_name": "cloud.provider",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "provider",
+        "normalize": [],
+        "short": "Name of the cloud provider.",
+        "type": "keyword"
+      },
+      "cloud.region": {
+        "dashed_name": "cloud-region",
+        "description": "Region in which this host is running.",
+        "example": "us-east-1",
+        "flat_name": "cloud.region",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "region",
+        "normalize": [],
+        "short": "Region in which this host is running.",
+        "type": "keyword"
+      }
+    },
+    "footnote": "Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.",
+    "group": 2,
+    "name": "cloud",
+    "prefix": "cloud.",
+    "short": "Fields about the cloud resource.",
+    "title": "Cloud",
+    "type": "group"
+  },
+  "code_signature": {
+    "description": "These fields contain information about binary code signatures.",
+    "fields": {
+      "code_signature.exists": {
+        "dashed_name": "code-signature-exists",
+        "description": "Boolean to capture if a signature is present.",
+        "example": "true",
+        "flat_name": "code_signature.exists",
+        "level": "core",
+        "name": "exists",
+        "normalize": [],
+        "short": "Boolean to capture if a signature is present.",
+        "type": "boolean"
+      },
+      "code_signature.status": {
+        "dashed_name": "code-signature-status",
+        "description": "Additional information about the certificate status.\nThis is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.",
+        "example": "ERROR_UNTRUSTED_ROOT",
+        "flat_name": "code_signature.status",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "status",
+        "normalize": [],
+        "short": "Additional information about the certificate status.",
+        "type": "keyword"
+      },
+      "code_signature.subject_name": {
+        "dashed_name": "code-signature-subject-name",
+        "description": "Subject name of the code signer",
+        "example": "Microsoft Corporation",
+        "flat_name": "code_signature.subject_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "subject_name",
+        "normalize": [],
+        "short": "Subject name of the code signer",
+        "type": "keyword"
+      },
+      "code_signature.trusted": {
+        "dashed_name": "code-signature-trusted",
+        "description": "Stores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+        "example": "true",
+        "flat_name": "code_signature.trusted",
+        "level": "extended",
+        "name": "trusted",
+        "normalize": [],
+        "short": "Stores the trust status of the certificate chain.",
+        "type": "boolean"
+      },
+      "code_signature.valid": {
+        "dashed_name": "code-signature-valid",
+        "description": "Boolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+        "example": "true",
+        "flat_name": "code_signature.valid",
+        "level": "extended",
+        "name": "valid",
+        "normalize": [],
+        "short": "Boolean to capture if the digital signature is verified against the binary content.",
+        "type": "boolean"
+      }
+    },
+    "group": 2,
+    "name": "code_signature",
+    "prefix": "code_signature.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "code_signature",
+          "at": "file",
+          "full": "file.code_signature"
+        },
+        {
+          "as": "code_signature",
+          "at": "process",
+          "full": "process.code_signature"
+        },
+        {
+          "as": "code_signature",
+          "at": "dll",
+          "full": "dll.code_signature"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "These fields contain information about binary code signatures.",
+    "title": "Code Signature",
+    "type": "group"
+  },
+  "container": {
+    "description": "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime.",
+    "fields": {
+      "container.id": {
+        "dashed_name": "container-id",
+        "description": "Unique container id.",
+        "flat_name": "container.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique container id.",
+        "type": "keyword"
+      },
+      "container.image.name": {
+        "dashed_name": "container-image-name",
+        "description": "Name of the image the container was built on.",
+        "flat_name": "container.image.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "image.name",
+        "normalize": [],
+        "short": "Name of the image the container was built on.",
+        "type": "keyword"
+      },
+      "container.image.tag": {
+        "dashed_name": "container-image-tag",
+        "description": "Container image tags.",
+        "flat_name": "container.image.tag",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "image.tag",
+        "normalize": [
+          "array"
+        ],
+        "short": "Container image tags.",
+        "type": "keyword"
+      },
+      "container.labels": {
+        "dashed_name": "container-labels",
+        "description": "Image labels.",
+        "flat_name": "container.labels",
+        "level": "extended",
+        "name": "labels",
+        "normalize": [],
+        "object_type": "keyword",
+        "short": "Image labels.",
+        "type": "object"
+      },
+      "container.name": {
+        "dashed_name": "container-name",
+        "description": "Container name.",
+        "flat_name": "container.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Container name.",
+        "type": "keyword"
+      },
+      "container.runtime": {
+        "dashed_name": "container-runtime",
+        "description": "Runtime managing this container.",
+        "example": "docker",
+        "flat_name": "container.runtime",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "runtime",
+        "normalize": [],
+        "short": "Runtime managing this container.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "container",
+    "prefix": "container.",
+    "short": "Fields describing the container that generated this event.",
+    "title": "Container",
+    "type": "group"
+  },
+  "destination": {
+    "description": "Destination fields describe details about the destination of a packet/event.\nDestination fields are usually populated in conjunction with source fields.",
+    "fields": {
+      "destination.address": {
+        "dashed_name": "destination-address",
+        "description": "Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.",
+        "flat_name": "destination.address",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "address",
+        "normalize": [],
+        "short": "Destination network address.",
+        "type": "keyword"
+      },
+      "destination.as.number": {
+        "dashed_name": "destination-as-number",
+        "description": "Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+        "example": 15169,
+        "flat_name": "destination.as.number",
+        "level": "extended",
+        "name": "number",
+        "normalize": [],
+        "original_fieldset": "as",
+        "short": "Unique number allocated to the autonomous system.",
+        "type": "long"
+      },
+      "destination.as.organization.name": {
+        "dashed_name": "destination-as-organization-name",
+        "description": "Organization name.",
+        "example": "Google LLC",
+        "flat_name": "destination.as.organization.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "destination.as.organization.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "organization.name",
+        "normalize": [],
+        "original_fieldset": "as",
+        "short": "Organization name.",
+        "type": "keyword"
+      },
+      "destination.bytes": {
+        "dashed_name": "destination-bytes",
+        "description": "Bytes sent from the destination to the source.",
+        "example": 184,
+        "flat_name": "destination.bytes",
+        "format": "bytes",
+        "level": "core",
+        "name": "bytes",
+        "normalize": [],
+        "short": "Bytes sent from the destination to the source.",
+        "type": "long"
+      },
+      "destination.domain": {
+        "dashed_name": "destination-domain",
+        "description": "Destination domain.",
+        "flat_name": "destination.domain",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "domain",
+        "normalize": [],
+        "short": "Destination domain.",
+        "type": "keyword"
+      },
+      "destination.geo.city_name": {
+        "dashed_name": "destination-geo-city-name",
+        "description": "City name.",
+        "example": "Montreal",
+        "flat_name": "destination.geo.city_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "city_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "City name.",
+        "type": "keyword"
+      },
+      "destination.geo.continent_name": {
+        "dashed_name": "destination-geo-continent-name",
+        "description": "Name of the continent.",
+        "example": "North America",
+        "flat_name": "destination.geo.continent_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "continent_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Name of the continent.",
+        "type": "keyword"
+      },
+      "destination.geo.country_iso_code": {
+        "dashed_name": "destination-geo-country-iso-code",
+        "description": "Country ISO code.",
+        "example": "CA",
+        "flat_name": "destination.geo.country_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country ISO code.",
+        "type": "keyword"
+      },
+      "destination.geo.country_name": {
+        "dashed_name": "destination-geo-country-name",
+        "description": "Country name.",
+        "example": "Canada",
+        "flat_name": "destination.geo.country_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country name.",
+        "type": "keyword"
+      },
+      "destination.geo.location": {
+        "dashed_name": "destination-geo-location",
+        "description": "Longitude and latitude.",
+        "example": "{ \"lon\": -73.614830, \"lat\": 45.505918 }",
+        "flat_name": "destination.geo.location",
+        "level": "core",
+        "name": "location",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Longitude and latitude.",
+        "type": "geo_point"
+      },
+      "destination.geo.name": {
+        "dashed_name": "destination-geo-name",
+        "description": "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation.",
+        "example": "boston-dc",
+        "flat_name": "destination.geo.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "User-defined description of a location.",
+        "type": "keyword"
+      },
+      "destination.geo.region_iso_code": {
+        "dashed_name": "destination-geo-region-iso-code",
+        "description": "Region ISO code.",
+        "example": "CA-QC",
+        "flat_name": "destination.geo.region_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region ISO code.",
+        "type": "keyword"
+      },
+      "destination.geo.region_name": {
+        "dashed_name": "destination-geo-region-name",
+        "description": "Region name.",
+        "example": "Quebec",
+        "flat_name": "destination.geo.region_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region name.",
+        "type": "keyword"
+      },
+      "destination.ip": {
+        "dashed_name": "destination-ip",
+        "description": "IP address of the destination (IPv4 or IPv6).",
+        "flat_name": "destination.ip",
+        "level": "core",
+        "name": "ip",
+        "normalize": [],
+        "short": "IP address of the destination.",
+        "type": "ip"
+      },
+      "destination.mac": {
+        "dashed_name": "destination-mac",
+        "description": "MAC address of the destination.",
+        "flat_name": "destination.mac",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "mac",
+        "normalize": [],
+        "short": "MAC address of the destination.",
+        "type": "keyword"
+      },
+      "destination.nat.ip": {
+        "dashed_name": "destination-nat-ip",
+        "description": "Translated ip of destination based NAT sessions (e.g. internet to private DMZ)\nTypically used with load balancers, firewalls, or routers.",
+        "flat_name": "destination.nat.ip",
+        "level": "extended",
+        "name": "nat.ip",
+        "normalize": [],
+        "short": "Destination NAT ip",
+        "type": "ip"
+      },
+      "destination.nat.port": {
+        "dashed_name": "destination-nat-port",
+        "description": "Port the source session is translated to by NAT Device.\nTypically used with load balancers, firewalls, or routers.",
+        "flat_name": "destination.nat.port",
+        "format": "string",
+        "level": "extended",
+        "name": "nat.port",
+        "normalize": [],
+        "short": "Destination NAT Port",
+        "type": "long"
+      },
+      "destination.packets": {
+        "dashed_name": "destination-packets",
+        "description": "Packets sent from the destination to the source.",
+        "example": 12,
+        "flat_name": "destination.packets",
+        "level": "core",
+        "name": "packets",
+        "normalize": [],
+        "short": "Packets sent from the destination to the source.",
+        "type": "long"
+      },
+      "destination.port": {
+        "dashed_name": "destination-port",
+        "description": "Port of the destination.",
+        "flat_name": "destination.port",
+        "format": "string",
+        "level": "core",
+        "name": "port",
+        "normalize": [],
+        "short": "Port of the destination.",
+        "type": "long"
+      },
+      "destination.registered_domain": {
+        "dashed_name": "destination-registered-domain",
+        "description": "The highest registered destination domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
+        "example": "example.com",
+        "flat_name": "destination.registered_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "registered_domain",
+        "normalize": [],
+        "short": "The highest registered destination domain, stripped of the subdomain.",
+        "type": "keyword"
+      },
+      "destination.top_level_domain": {
+        "dashed_name": "destination-top-level-domain",
+        "description": "The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is \"com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as \"co.uk\".",
+        "example": "co.uk",
+        "flat_name": "destination.top_level_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "top_level_domain",
+        "normalize": [],
+        "short": "The effective top level domain (com, org, net, co.uk).",
+        "type": "keyword"
+      },
+      "destination.user.domain": {
+        "dashed_name": "destination-user-domain",
+        "description": "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "destination.user.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Name of the directory the user is a member of.",
+        "type": "keyword"
+      },
+      "destination.user.email": {
+        "dashed_name": "destination-user-email",
+        "description": "User email address.",
+        "flat_name": "destination.user.email",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "email",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User email address.",
+        "type": "keyword"
+      },
+      "destination.user.full_name": {
+        "dashed_name": "destination-user-full-name",
+        "description": "User's full name, if available.",
+        "example": "Albert Einstein",
+        "flat_name": "destination.user.full_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "destination.user.full_name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full_name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User's full name, if available.",
+        "type": "keyword"
+      },
+      "destination.user.group.domain": {
+        "dashed_name": "destination-user-group-domain",
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "destination.user.group.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the directory the group is a member of.",
+        "type": "keyword"
+      },
+      "destination.user.group.id": {
+        "dashed_name": "destination-user-group-id",
+        "description": "Unique identifier for the group on the system/platform.",
+        "flat_name": "destination.user.group.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Unique identifier for the group on the system/platform.",
+        "type": "keyword"
+      },
+      "destination.user.group.name": {
+        "dashed_name": "destination-user-group-name",
+        "description": "Name of the group.",
+        "flat_name": "destination.user.group.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the group.",
+        "type": "keyword"
+      },
+      "destination.user.hash": {
+        "dashed_name": "destination-user-hash",
+        "description": "Unique user hash to correlate information for a user in anonymized form.\nUseful if `user.id` or `user.name` contain confidential information and cannot be used.",
+        "flat_name": "destination.user.hash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hash",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique user hash to correlate information for a user in anonymized form.",
+        "type": "keyword"
+      },
+      "destination.user.id": {
+        "dashed_name": "destination-user-id",
+        "description": "Unique identifier of the user.",
+        "flat_name": "destination.user.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique identifier of the user.",
+        "type": "keyword"
+      },
+      "destination.user.name": {
+        "dashed_name": "destination-user-name",
+        "description": "Short name or login of the user.",
+        "example": "albert",
+        "flat_name": "destination.user.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "multi_fields": [
+          {
+            "flat_name": "destination.user.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Short name or login of the user.",
+        "type": "keyword"
+      },
+      "destination.user.roles": {
+        "dashed_name": "destination-user-roles",
+        "description": "Array of user roles at the time of the event.",
+        "example": "[\"kibana_admin\", \"reporting_user\"]",
+        "flat_name": "destination.user.roles",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "roles",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "user",
+        "short": "Array of user roles at the time of the event.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "destination",
+    "nestings": [
+      "destination.as",
+      "destination.geo",
+      "destination.user"
+    ],
+    "prefix": "destination.",
+    "reused_here": [
+      {
+        "full": "destination.as",
+        "schema_name": "as",
+        "short": "Fields describing an Autonomous System (Internet routing prefix)."
+      },
+      {
+        "full": "destination.geo",
+        "schema_name": "geo",
+        "short": "Fields describing a location."
+      },
+      {
+        "full": "destination.user",
+        "schema_name": "user",
+        "short": "Fields to describe the user relevant to the event."
+      }
+    ],
+    "short": "Fields about the destination side of a network connection, used with source.",
+    "title": "Destination",
+    "type": "group"
+  },
+  "dll": {
+    "description": "These fields contain information about code libraries dynamically loaded into processes.\n\nMany operating systems refer to \"shared code libraries\" with different names, but this field set refers to all of the following:\n* Dynamic-link library (`.dll`) commonly used on Windows\n* Shared Object (`.so`) commonly used on Unix-like operating systems\n* Dynamic library (`.dylib`) commonly used on macOS",
+    "fields": {
+      "dll.code_signature.exists": {
+        "dashed_name": "dll-code-signature-exists",
+        "description": "Boolean to capture if a signature is present.",
+        "example": "true",
+        "flat_name": "dll.code_signature.exists",
+        "level": "core",
+        "name": "exists",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Boolean to capture if a signature is present.",
+        "type": "boolean"
+      },
+      "dll.code_signature.status": {
+        "dashed_name": "dll-code-signature-status",
+        "description": "Additional information about the certificate status.\nThis is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.",
+        "example": "ERROR_UNTRUSTED_ROOT",
+        "flat_name": "dll.code_signature.status",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "status",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Additional information about the certificate status.",
+        "type": "keyword"
+      },
+      "dll.code_signature.subject_name": {
+        "dashed_name": "dll-code-signature-subject-name",
+        "description": "Subject name of the code signer",
+        "example": "Microsoft Corporation",
+        "flat_name": "dll.code_signature.subject_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "subject_name",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Subject name of the code signer",
+        "type": "keyword"
+      },
+      "dll.code_signature.trusted": {
+        "dashed_name": "dll-code-signature-trusted",
+        "description": "Stores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+        "example": "true",
+        "flat_name": "dll.code_signature.trusted",
+        "level": "extended",
+        "name": "trusted",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Stores the trust status of the certificate chain.",
+        "type": "boolean"
+      },
+      "dll.code_signature.valid": {
+        "dashed_name": "dll-code-signature-valid",
+        "description": "Boolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+        "example": "true",
+        "flat_name": "dll.code_signature.valid",
+        "level": "extended",
+        "name": "valid",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Boolean to capture if the digital signature is verified against the binary content.",
+        "type": "boolean"
+      },
+      "dll.hash.md5": {
+        "dashed_name": "dll-hash-md5",
+        "description": "MD5 hash.",
+        "flat_name": "dll.hash.md5",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "md5",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "MD5 hash.",
+        "type": "keyword"
+      },
+      "dll.hash.sha1": {
+        "dashed_name": "dll-hash-sha1",
+        "description": "SHA1 hash.",
+        "flat_name": "dll.hash.sha1",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha1",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA1 hash.",
+        "type": "keyword"
+      },
+      "dll.hash.sha256": {
+        "dashed_name": "dll-hash-sha256",
+        "description": "SHA256 hash.",
+        "flat_name": "dll.hash.sha256",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha256",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA256 hash.",
+        "type": "keyword"
+      },
+      "dll.hash.sha512": {
+        "dashed_name": "dll-hash-sha512",
+        "description": "SHA512 hash.",
+        "flat_name": "dll.hash.sha512",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha512",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA512 hash.",
+        "type": "keyword"
+      },
+      "dll.name": {
+        "dashed_name": "dll-name",
+        "description": "Name of the library.\nThis generally maps to the name of the file on disk.",
+        "example": "kernel32.dll",
+        "flat_name": "dll.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "name",
+        "normalize": [],
+        "short": "Name of the library.",
+        "type": "keyword"
+      },
+      "dll.path": {
+        "dashed_name": "dll-path",
+        "description": "Full file path of the library.",
+        "example": "C:\\Windows\\System32\\kernel32.dll",
+        "flat_name": "dll.path",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "path",
+        "normalize": [],
+        "short": "Full file path of the library.",
+        "type": "keyword"
+      },
+      "dll.pe.architecture": {
+        "dashed_name": "dll-pe-architecture",
+        "description": "CPU architecture target for the file.",
+        "example": "x64",
+        "flat_name": "dll.pe.architecture",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "architecture",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "CPU architecture target for the file.",
+        "type": "keyword"
+      },
+      "dll.pe.company": {
+        "dashed_name": "dll-pe-company",
+        "description": "Internal company name of the file, provided at compile-time.",
+        "example": "Microsoft Corporation",
+        "flat_name": "dll.pe.company",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "company",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal company name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "dll.pe.description": {
+        "dashed_name": "dll-pe-description",
+        "description": "Internal description of the file, provided at compile-time.",
+        "example": "Paint",
+        "flat_name": "dll.pe.description",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "description",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal description of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "dll.pe.file_version": {
+        "dashed_name": "dll-pe-file-version",
+        "description": "Internal version of the file, provided at compile-time.",
+        "example": "6.3.9600.17415",
+        "flat_name": "dll.pe.file_version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "file_version",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Process name.",
+        "type": "keyword"
+      },
+      "dll.pe.imphash": {
+        "dashed_name": "dll-pe-imphash",
+        "description": "A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
+        "example": "0c6803c4e922103c4dca5963aad36ddf",
+        "flat_name": "dll.pe.imphash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "imphash",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "A hash of the imports in a PE file.",
+        "type": "keyword"
+      },
+      "dll.pe.original_file_name": {
+        "dashed_name": "dll-pe-original-file-name",
+        "description": "Internal name of the file, provided at compile-time.",
+        "example": "MSPAINT.EXE",
+        "flat_name": "dll.pe.original_file_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "original_file_name",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "dll.pe.product": {
+        "dashed_name": "dll-pe-product",
+        "description": "Internal product name of the file, provided at compile-time.",
+        "example": "Microsoft\u00ae Windows\u00ae Operating System",
+        "flat_name": "dll.pe.product",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "product",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal product name of the file, provided at compile-time.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "dll",
+    "nestings": [
+      "dll.code_signature",
+      "dll.hash",
+      "dll.pe"
+    ],
+    "prefix": "dll.",
+    "reused_here": [
+      {
+        "full": "dll.code_signature",
+        "schema_name": "code_signature",
+        "short": "These fields contain information about binary code signatures."
+      },
+      {
+        "full": "dll.hash",
+        "schema_name": "hash",
+        "short": "Hashes, usually file hashes."
+      },
+      {
+        "full": "dll.pe",
+        "schema_name": "pe",
+        "short": "These fields contain Windows Portable Executable (PE) metadata."
+      }
+    ],
+    "short": "These fields contain information about code libraries dynamically loaded into processes.",
+    "title": "DLL",
+    "type": "group"
+  },
+  "dns": {
+    "description": "Fields describing DNS queries and answers.\nDNS events should either represent a single DNS query prior to getting answers (`dns.type:query`) or they should represent a full exchange and contain the query details as well as all of the answers that were provided for this query (`dns.type:answer`).",
+    "fields": {
+      "dns.answers": {
+        "dashed_name": "dns-answers",
+        "description": "An array containing an object for each answer section returned by the server.\nThe main keys that should be present in these objects are defined by ECS. Records that have more information may contain more keys than what ECS defines.\nNot all DNS data sources give all details about DNS answers. At minimum, answer objects must contain the `data` key. If more information is available, map as much of it to ECS as possible, and add any additional fields to the answer objects as custom fields.",
+        "flat_name": "dns.answers",
+        "level": "extended",
+        "name": "answers",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array of DNS answers.",
+        "type": "object"
+      },
+      "dns.answers.class": {
+        "dashed_name": "dns-answers-class",
+        "description": "The class of DNS data contained in this resource record.",
+        "example": "IN",
+        "flat_name": "dns.answers.class",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "answers.class",
+        "normalize": [],
+        "short": "The class of DNS data contained in this resource record.",
+        "type": "keyword"
+      },
+      "dns.answers.data": {
+        "dashed_name": "dns-answers-data",
+        "description": "The data describing the resource.\nThe meaning of this data depends on the type and class of the resource record.",
+        "example": "10.10.10.10",
+        "flat_name": "dns.answers.data",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "answers.data",
+        "normalize": [],
+        "short": "The data describing the resource.",
+        "type": "keyword"
+      },
+      "dns.answers.name": {
+        "dashed_name": "dns-answers-name",
+        "description": "The domain name to which this resource record pertains.\nIf a chain of CNAME is being resolved, each answer's `name` should be the one that corresponds with the answer's `data`. It should not simply be the original `question.name` repeated.",
+        "example": "www.example.com",
+        "flat_name": "dns.answers.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "answers.name",
+        "normalize": [],
+        "short": "The domain name to which this resource record pertains.",
+        "type": "keyword"
+      },
+      "dns.answers.ttl": {
+        "dashed_name": "dns-answers-ttl",
+        "description": "The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached.",
+        "example": 180,
+        "flat_name": "dns.answers.ttl",
+        "level": "extended",
+        "name": "answers.ttl",
+        "normalize": [],
+        "short": "The time interval in seconds that this resource record may be cached before it should be discarded.",
+        "type": "long"
+      },
+      "dns.answers.type": {
+        "dashed_name": "dns-answers-type",
+        "description": "The type of data contained in this resource record.",
+        "example": "CNAME",
+        "flat_name": "dns.answers.type",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "answers.type",
+        "normalize": [],
+        "short": "The type of data contained in this resource record.",
+        "type": "keyword"
+      },
+      "dns.header_flags": {
+        "dashed_name": "dns-header-flags",
+        "description": "Array of 2 letter DNS header flags.\nExpected values are: AA, TC, RD, RA, AD, CD, DO.",
+        "example": [
+          "RD",
+          "RA"
+        ],
+        "flat_name": "dns.header_flags",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "header_flags",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array of DNS header flags.",
+        "type": "keyword"
+      },
+      "dns.id": {
+        "dashed_name": "dns-id",
+        "description": "The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.",
+        "example": 62111,
+        "flat_name": "dns.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "short": "The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.",
+        "type": "keyword"
+      },
+      "dns.op_code": {
+        "dashed_name": "dns-op-code",
+        "description": "The DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response.",
+        "example": "QUERY",
+        "flat_name": "dns.op_code",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "op_code",
+        "normalize": [],
+        "short": "The DNS operation code that specifies the kind of query in the message.",
+        "type": "keyword"
+      },
+      "dns.question.class": {
+        "dashed_name": "dns-question-class",
+        "description": "The class of records being queried.",
+        "example": "IN",
+        "flat_name": "dns.question.class",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "question.class",
+        "normalize": [],
+        "short": "The class of records being queried.",
+        "type": "keyword"
+      },
+      "dns.question.name": {
+        "dashed_name": "dns-question-name",
+        "description": "The name being queried.\nIf the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \\t, \\r, and \\n respectively.",
+        "example": "www.example.com",
+        "flat_name": "dns.question.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "question.name",
+        "normalize": [],
+        "short": "The name being queried.",
+        "type": "keyword"
+      },
+      "dns.question.registered_domain": {
+        "dashed_name": "dns-question-registered-domain",
+        "description": "The highest registered domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
+        "example": "example.com",
+        "flat_name": "dns.question.registered_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "question.registered_domain",
+        "normalize": [],
+        "short": "The highest registered domain, stripped of the subdomain.",
+        "type": "keyword"
+      },
+      "dns.question.subdomain": {
+        "dashed_name": "dns-question-subdomain",
+        "description": "The subdomain is all of the labels under the registered_domain.\nIf the domain has multiple levels of subdomain, such as \"sub2.sub1.example.com\", the subdomain field should contain \"sub2.sub1\", with no trailing period.",
+        "example": "www",
+        "flat_name": "dns.question.subdomain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "question.subdomain",
+        "normalize": [],
+        "short": "The subdomain of the domain.",
+        "type": "keyword"
+      },
+      "dns.question.top_level_domain": {
+        "dashed_name": "dns-question-top-level-domain",
+        "description": "The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is \"com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as \"co.uk\".",
+        "example": "co.uk",
+        "flat_name": "dns.question.top_level_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "question.top_level_domain",
+        "normalize": [],
+        "short": "The effective top level domain (com, org, net, co.uk).",
+        "type": "keyword"
+      },
+      "dns.question.type": {
+        "dashed_name": "dns-question-type",
+        "description": "The type of record being queried.",
+        "example": "AAAA",
+        "flat_name": "dns.question.type",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "question.type",
+        "normalize": [],
+        "short": "The type of record being queried.",
+        "type": "keyword"
+      },
+      "dns.resolved_ip": {
+        "dashed_name": "dns-resolved-ip",
+        "description": "Array containing all IPs seen in `answers.data`.\nThe `answers` array can be difficult to use, because of the variety of data formats it can contain. Extracting all IP addresses seen in there to `dns.resolved_ip` makes it possible to index them as IP addresses, and makes them easier to visualize and query for.",
+        "example": [
+          "10.10.10.10",
+          "10.10.10.11"
+        ],
+        "flat_name": "dns.resolved_ip",
+        "level": "extended",
+        "name": "resolved_ip",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array containing all IPs seen in answers.data",
+        "type": "ip"
+      },
+      "dns.response_code": {
+        "dashed_name": "dns-response-code",
+        "description": "The DNS response code.",
+        "example": "NOERROR",
+        "flat_name": "dns.response_code",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "response_code",
+        "normalize": [],
+        "short": "The DNS response code.",
+        "type": "keyword"
+      },
+      "dns.type": {
+        "dashed_name": "dns-type",
+        "description": "The type of DNS event captured, query or answer.\nIf your source of DNS events only gives you DNS queries, you should only create dns events of type `dns.type:query`.\nIf your source of DNS events gives you answers as well, you should create one event per query (optionally as soon as the query is seen). And a second event containing all query details as well as an array of answers.",
+        "example": "answer",
+        "flat_name": "dns.type",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "type",
+        "normalize": [],
+        "short": "The type of DNS event captured, query or answer.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "dns",
+    "prefix": "dns.",
+    "short": "Fields describing DNS queries and answers.",
+    "title": "DNS",
+    "type": "group"
+  },
+  "ecs": {
+    "description": "Meta-information specific to ECS.",
+    "fields": {
+      "ecs.version": {
+        "dashed_name": "ecs-version",
+        "description": "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events.",
+        "example": "1.0.0",
+        "flat_name": "ecs.version",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "version",
+        "normalize": [],
+        "required": true,
+        "short": "ECS version this event conforms to.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "ecs",
+    "prefix": "ecs.",
+    "short": "Meta-information specific to ECS.",
+    "title": "ECS",
+    "type": "group"
+  },
+  "error": {
+    "description": "These fields can represent errors of any kind.\nUse them for errors that happen while fetching events or in cases where the event itself contains an error.",
+    "fields": {
+      "error.code": {
+        "dashed_name": "error-code",
+        "description": "Error code describing the error.",
+        "flat_name": "error.code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "code",
+        "normalize": [],
+        "short": "Error code describing the error.",
+        "type": "keyword"
+      },
+      "error.id": {
+        "dashed_name": "error-id",
+        "description": "Unique identifier for the error.",
+        "flat_name": "error.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique identifier for the error.",
+        "type": "keyword"
+      },
+      "error.message": {
+        "dashed_name": "error-message",
+        "description": "Error message.",
+        "flat_name": "error.message",
+        "level": "core",
+        "name": "message",
+        "normalize": [],
+        "norms": false,
+        "short": "Error message.",
+        "type": "text"
+      },
+      "error.stack_trace": {
+        "dashed_name": "error-stack-trace",
+        "description": "The stack trace of this error in plain text.",
+        "doc_values": false,
+        "flat_name": "error.stack_trace",
+        "ignore_above": 1024,
+        "index": false,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "error.stack_trace.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "stack_trace",
+        "normalize": [],
+        "short": "The stack trace of this error in plain text.",
+        "type": "keyword"
+      },
+      "error.type": {
+        "dashed_name": "error-type",
+        "description": "The type of the error, for example the class name of the exception.",
+        "example": "java.lang.NullPointerException",
+        "flat_name": "error.type",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "type",
+        "normalize": [],
+        "short": "The type of the error, for example the class name of the exception.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "error",
+    "prefix": "error.",
+    "short": "Fields about errors of any kind.",
+    "title": "Error",
+    "type": "group"
+  },
+  "event": {
+    "description": "The event fields are used for context information about the log or metric event itself.\nA log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host and device temperature. See the `event.kind` definition in this section for additional details about metric and state events.",
+    "fields": {
+      "event.action": {
+        "dashed_name": "event-action",
+        "description": "The action captured by the event.\nThis describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer.",
+        "example": "user-password-change",
+        "flat_name": "event.action",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "action",
+        "normalize": [],
+        "short": "The action captured by the event.",
+        "type": "keyword"
+      },
+      "event.category": {
+        "allowed_values": [
+          {
+            "description": "Events in this category are related to the challenge and response process in which credentials are supplied and verified to allow the creation of a session. Common sources for these logs are Windows event logs and ssh logs. Visualize and analyze events in this category to look for failed logins, and other authentication-related activity.",
+            "expected_event_types": [
+              "start",
+              "end",
+              "info"
+            ],
+            "name": "authentication"
+          },
+          {
+            "description": "The database category denotes events and metrics relating to a data storage and retrieval system. Note that use of this category is not limited to relational database systems. Examples include event logs from MS SQL, MySQL, Elasticsearch, MongoDB, etc. Use this category to visualize and analyze database activity such as accesses and changes.",
+            "expected_event_types": [
+              "access",
+              "change",
+              "info",
+              "error"
+            ],
+            "name": "database"
+          },
+          {
+            "description": "Events in the driver category have to do with operating system device drivers and similar software entities such as Windows drivers, kernel extensions, kernel modules, etc.\nUse events and metrics in this category to visualize and analyze driver-related activity and status on hosts.",
+            "expected_event_types": [
+              "change",
+              "end",
+              "info",
+              "start"
+            ],
+            "name": "driver"
+          },
+          {
+            "description": "Relating to a set of information that has been created on, or has existed on a filesystem. Use this category of events to visualize and analyze the creation, access, and deletions of files. Events in this category can come from both host-based and network-based sources. An example source of a network-based detection of a file transfer would be the Zeek file.log.",
+            "expected_event_types": [
+              "change",
+              "creation",
+              "deletion",
+              "info"
+            ],
+            "name": "file"
+          },
+          {
+            "description": "Use this category to visualize and analyze information such as host inventory or host lifecycle events.\nMost of the events in this category can usually be observed from the outside, such as from a hypervisor or a control plane's point of view. Some can also be seen from within, such as \"start\" or \"end\".\nNote that this category is for information about hosts themselves; it is not meant to capture activity \"happening on a host\".",
+            "expected_event_types": [
+              "access",
+              "change",
+              "end",
+              "info",
+              "start"
+            ],
+            "name": "host"
+          },
+          {
+            "description": "Identity and access management (IAM) events relating to users, groups, and administration. Use this category to visualize and analyze IAM-related logs and data from active directory, LDAP, Okta, Duo, and other IAM systems.",
+            "expected_event_types": [
+              "admin",
+              "change",
+              "creation",
+              "deletion",
+              "group",
+              "info",
+              "user"
+            ],
+            "name": "iam"
+          },
+          {
+            "description": "Relating to intrusion detections from IDS/IPS systems and functions, both network and host-based. Use this category to visualize and analyze intrusion detection alerts from systems such as Snort, Suricata, and Palo Alto threat detections.",
+            "expected_event_types": [
+              "allowed",
+              "denied",
+              "info"
+            ],
+            "name": "intrusion_detection"
+          },
+          {
+            "description": "Malware detection events and alerts. Use this category to visualize and analyze malware detections from EDR/EPP systems such as Elastic Endpoint Security, Symantec Endpoint Protection, Crowdstrike, and network IDS/IPS systems such as Suricata, or other sources of malware-related events such as Palo Alto Networks threat logs and Wildfire logs.",
+            "expected_event_types": [
+              "info"
+            ],
+            "name": "malware"
+          },
+          {
+            "description": "Relating to all network activity, including network connection lifecycle, network traffic, and essentially any event that includes an IP address. Many events containing decoded network protocol transactions fit into this category. Use events in this category to visualize or analyze counts of network ports, protocols, addresses, geolocation information, etc.",
+            "expected_event_types": [
+              "access",
+              "allowed",
+              "connection",
+              "denied",
+              "end",
+              "info",
+              "protocol",
+              "start"
+            ],
+            "name": "network"
+          },
+          {
+            "description": "Relating to software packages installed on hosts. Use this category to visualize and analyze inventory of software installed on various hosts, or to determine host vulnerability in the absence of vulnerability scan data.",
+            "expected_event_types": [
+              "access",
+              "change",
+              "deletion",
+              "info",
+              "installation",
+              "start"
+            ],
+            "name": "package"
+          },
+          {
+            "description": "Use this category of events to visualize and analyze process-specific information such as lifecycle events or process ancestry.",
+            "expected_event_types": [
+              "access",
+              "change",
+              "end",
+              "info",
+              "start"
+            ],
+            "name": "process"
+          },
+          {
+            "description": "Relating to web server access. Use this category to create a dashboard of web server/proxy activity from apache, IIS, nginx web servers, etc. Note: events from network observers such as Zeek http log may also be included in this category.",
+            "expected_event_types": [
+              "access",
+              "error",
+              "info"
+            ],
+            "name": "web"
+          }
+        ],
+        "dashed_name": "event-category",
+        "description": "This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy.\n`event.category` represents the \"big buckets\" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory.\nThis field is an array. This will allow proper categorization of some events that fall in multiple categories.",
+        "example": "authentication",
+        "flat_name": "event.category",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "category",
+        "normalize": [
+          "array"
+        ],
+        "short": "Event category. The second categorization field in the hierarchy.",
+        "type": "keyword"
+      },
+      "event.code": {
+        "dashed_name": "event-code",
+        "description": "Identification code for this event, if one exists.\nSome event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.",
+        "example": 4648,
+        "flat_name": "event.code",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "code",
+        "normalize": [],
+        "short": "Identification code for this event.",
+        "type": "keyword"
+      },
+      "event.created": {
+        "dashed_name": "event-created",
+        "description": "event.created contains the date/time when the event was first read by an agent, or by your pipeline.\nThis field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event.\nIn most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source.\nIn case the two timestamps are identical, @timestamp should be used.",
+        "example": "2016-05-23T08:05:34.857Z",
+        "flat_name": "event.created",
+        "level": "core",
+        "name": "created",
+        "normalize": [],
+        "short": "Time when the event was first read by an agent or by your pipeline.",
+        "type": "date"
+      },
+      "event.dataset": {
+        "dashed_name": "event-dataset",
+        "description": "Name of the dataset.\nIf an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from.\nIt's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.",
+        "example": "apache.access",
+        "flat_name": "event.dataset",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "dataset",
+        "normalize": [],
+        "short": "Name of the dataset.",
+        "type": "keyword"
+      },
+      "event.duration": {
+        "dashed_name": "event-duration",
+        "description": "Duration of the event in nanoseconds.\nIf event.start and event.end are known this value should be the difference between the end and start time.",
+        "flat_name": "event.duration",
+        "format": "duration",
+        "input_format": "nanoseconds",
+        "level": "core",
+        "name": "duration",
+        "normalize": [],
+        "output_format": "asMilliseconds",
+        "output_precision": 1,
+        "short": "Duration of the event in nanoseconds.",
+        "type": "long"
+      },
+      "event.end": {
+        "dashed_name": "event-end",
+        "description": "event.end contains the date when the event ended or when the activity was last observed.",
+        "flat_name": "event.end",
+        "level": "extended",
+        "name": "end",
+        "normalize": [],
+        "short": "event.end contains the date when the event ended or when the activity was last observed.",
+        "type": "date"
+      },
+      "event.hash": {
+        "dashed_name": "event-hash",
+        "description": "Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.",
+        "example": "123456789012345678901234567890ABCD",
+        "flat_name": "event.hash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hash",
+        "normalize": [],
+        "short": "Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.",
+        "type": "keyword"
+      },
+      "event.id": {
+        "dashed_name": "event-id",
+        "description": "Unique ID to describe the event.",
+        "example": "8a4f500d",
+        "flat_name": "event.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique ID to describe the event.",
+        "type": "keyword"
+      },
+      "event.ingested": {
+        "dashed_name": "event-ingested",
+        "description": "Timestamp when an event arrived in the central data store.\nThis is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event.\nIn normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`.",
+        "example": "2016-05-23T08:05:35.101Z",
+        "flat_name": "event.ingested",
+        "level": "core",
+        "name": "ingested",
+        "normalize": [],
+        "short": "Timestamp when an event arrived in the central data store.",
+        "type": "date"
+      },
+      "event.kind": {
+        "allowed_values": [
+          {
+            "description": "This value indicates an event that describes an alert or notable event, triggered by a detection rule.\n`event.kind:alert` is often populated for events coming from firewalls, intrusion detection systems, endpoint detection and response systems, and so on.",
+            "name": "alert"
+          },
+          {
+            "description": "This value is the most general and most common value for this field. It is used to represent events that indicate that something happened.",
+            "name": "event"
+          },
+          {
+            "description": "This value is used to indicate that this event describes a numeric measurement taken at given point in time.\nExamples include CPU utilization, memory usage, or device temperature.\nMetric events are often collected on a predictable frequency, such as once every few seconds, or once a minute, but can also be used to describe ad-hoc numeric metric queries.",
+            "name": "metric"
+          },
+          {
+            "description": "The state value is similar to metric, indicating that this event describes a measurement taken at given point in time, except that the measurement does not result in a numeric value, but rather one of a fixed set of categorical values that represent conditions or states.\nExamples include periodic events reporting Elasticsearch cluster state (green/yellow/red), the state of a TCP connection (open, closed, fin_wait, etc.), the state of a host with respect to a software vulnerability (vulnerable, not vulnerable), and the state of a system regarding compliance with a regulatory standard (compliant, not compliant).\nNote that an event that describes a change of state would not use `event.kind:state`, but instead would use 'event.kind:event' since a state change fits the more general event definition of something that happened.\nState events are often collected on a predictable frequency, such as once every few seconds, once a minute, once an hour, or once a day, but can also be used to describe ad-hoc state queries.",
+            "name": "state"
+          },
+          {
+            "description": "This value indicates that an error occurred during the ingestion of this event, and that event data may be missing, inconsistent, or incorrect. `event.kind:pipeline_error` is often associated with parsing errors.",
+            "name": "pipeline_error"
+          },
+          {
+            "description": "This value is used by the Elastic SIEM app to denote an Elasticsearch document that was created by a SIEM detection engine rule.\nA signal will typically trigger a notification that something meaningful happened and should be investigated.\nUsage of this value is reserved, and pipelines should not populate `event.kind` with the value \"signal\".",
+            "name": "signal"
+          }
+        ],
+        "dashed_name": "event-kind",
+        "description": "This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy.\n`event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events.\nThe value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not.",
+        "example": "alert",
+        "flat_name": "event.kind",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "kind",
+        "normalize": [],
+        "short": "The kind of the event. The highest categorization field in the hierarchy.",
+        "type": "keyword"
+      },
+      "event.module": {
+        "dashed_name": "event-module",
+        "description": "Name of the module this data is coming from.\nIf your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.",
+        "example": "apache",
+        "flat_name": "event.module",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "module",
+        "normalize": [],
+        "short": "Name of the module this data is coming from.",
+        "type": "keyword"
+      },
+      "event.original": {
+        "dashed_name": "event-original",
+        "description": "Raw text message of entire event. Used to demonstrate log integrity.\nThis field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`.",
+        "doc_values": false,
+        "example": "Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232",
+        "flat_name": "event.original",
+        "ignore_above": 1024,
+        "index": false,
+        "level": "core",
+        "name": "original",
+        "normalize": [],
+        "short": "Raw text message of entire event.",
+        "type": "keyword"
+      },
+      "event.outcome": {
+        "allowed_values": [
+          {
+            "description": "Indicates that this event describes a failed result. A common example is `event.category:file AND event.type:access AND event.outcome:failure` to indicate that a file access was attempted, but was not successful.",
+            "name": "failure"
+          },
+          {
+            "description": "Indicates that this event describes a successful result. A common example is `event.category:file AND event.type:create AND event.outcome:success` to indicate that a file was successfully created.",
+            "name": "success"
+          },
+          {
+            "description": "Indicates that this event describes only an attempt for which the result is unknown from the perspective of the event producer. For example, if the event contains information only about the request side of a transaction that results in a response, populating `event.outcome:unknown` in the request event is appropriate. The unknown value should not be used when an outcome doesn't make logical sense for the event. In such cases `event.outcome` should not be populated.",
+            "name": "unknown"
+          }
+        ],
+        "dashed_name": "event-outcome",
+        "description": "This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.\n`event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.\nNote that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.\nAlso note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.\nFurther note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.",
+        "example": "success",
+        "flat_name": "event.outcome",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "outcome",
+        "normalize": [],
+        "short": "The outcome of the event. The lowest level categorization field in the hierarchy.",
+        "type": "keyword"
+      },
+      "event.provider": {
+        "dashed_name": "event-provider",
+        "description": "Source of the event.\nEvent transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).",
+        "example": "kernel",
+        "flat_name": "event.provider",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "provider",
+        "normalize": [],
+        "short": "Source of the event.",
+        "type": "keyword"
+      },
+      "event.reason": {
+        "dashed_name": "event-reason",
+        "description": "Reason why this event happened, according to the source.\nThis describes the why of a particular action or outcome captured in the event. Where `event.action` captures the action from the event, `event.reason` describes why that action was taken. For example, a web proxy with an `event.action` which denied the request may also populate `event.reason` with the reason why (e.g. `blocked site`).",
+        "example": "Terminated an unexpected process",
+        "flat_name": "event.reason",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "reason",
+        "normalize": [],
+        "short": "Reason why this event happened, according to the source",
+        "type": "keyword"
+      },
+      "event.reference": {
+        "dashed_name": "event-reference",
+        "description": "Reference URL linking to additional information about this event.\nThis URL links to a static definition of the this event. Alert events, indicated by `event.kind:alert`, are a common use case for this field.",
+        "example": "https://system.example.com/event/#0001234",
+        "flat_name": "event.reference",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "reference",
+        "normalize": [],
+        "short": "Event reference URL",
+        "type": "keyword"
+      },
+      "event.risk_score": {
+        "dashed_name": "event-risk-score",
+        "description": "Risk score or priority of the event (e.g. security solutions). Use your system's original value here.",
+        "flat_name": "event.risk_score",
+        "level": "core",
+        "name": "risk_score",
+        "normalize": [],
+        "short": "Risk score or priority of the event (e.g. security solutions). Use your system's original value here.",
+        "type": "float"
+      },
+      "event.risk_score_norm": {
+        "dashed_name": "event-risk-score-norm",
+        "description": "Normalized risk score or priority of the event, on a scale of 0 to 100.\nThis is mainly useful if you use more than one system that assigns risk scores, and you want to see a normalized value across all systems.",
+        "flat_name": "event.risk_score_norm",
+        "level": "extended",
+        "name": "risk_score_norm",
+        "normalize": [],
+        "short": "Normalized risk score or priority of the event (0-100).",
+        "type": "float"
+      },
+      "event.sequence": {
+        "dashed_name": "event-sequence",
+        "description": "Sequence number of the event.\nThe sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.",
+        "flat_name": "event.sequence",
+        "format": "string",
+        "level": "extended",
+        "name": "sequence",
+        "normalize": [],
+        "short": "Sequence number of the event.",
+        "type": "long"
+      },
+      "event.severity": {
+        "dashed_name": "event-severity",
+        "description": "The numeric severity of the event according to your event source.\nWhat the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.\nThe Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.",
+        "example": 7,
+        "flat_name": "event.severity",
+        "format": "string",
+        "level": "core",
+        "name": "severity",
+        "normalize": [],
+        "short": "Numeric severity of the event.",
+        "type": "long"
+      },
+      "event.start": {
+        "dashed_name": "event-start",
+        "description": "event.start contains the date when the event started or when the activity was first observed.",
+        "flat_name": "event.start",
+        "level": "extended",
+        "name": "start",
+        "normalize": [],
+        "short": "event.start contains the date when the event started or when the activity was first observed.",
+        "type": "date"
+      },
+      "event.timezone": {
+        "dashed_name": "event-timezone",
+        "description": "This field should be populated when the event's timestamp does not include timezone information already (e.g. default Syslog timestamps). It's optional otherwise.\nAcceptable timezone formats are: a canonical ID (e.g. \"Europe/Amsterdam\"), abbreviated (e.g. \"EST\") or an HH:mm differential (e.g. \"-05:00\").",
+        "flat_name": "event.timezone",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "timezone",
+        "normalize": [],
+        "short": "Event time zone.",
+        "type": "keyword"
+      },
+      "event.type": {
+        "allowed_values": [
+          {
+            "description": "The access event type is used for the subset of events within a category that indicate that something was accessed. Common examples include `event.category:database AND event.type:access`, or `event.category:file AND event.type:access`. Note for file access, both directory listings and file opens should be included in this subcategory. You can further distinguish access operations using the ECS `event.action` field.",
+            "name": "access"
+          },
+          {
+            "description": "The admin event type is used for the subset of events within a category that are related to admin objects. For example, administrative changes within an IAM framework that do not specifically affect a user or group (e.g., adding new applications to a federation solution or connecting discrete forests in Active Directory) would fall into this subcategory. Common example: `event.category:iam AND event.type:change AND event.type:admin`. You can further distinguish admin operations using the ECS `event.action` field.",
+            "name": "admin"
+          },
+          {
+            "description": "The allowed event type is used for the subset of events within a category that indicate that something was allowed. Common examples include `event.category:network AND event.type:connection AND event.type:allowed` (to indicate a network firewall event for which the firewall disposition was to allow the connection to complete) and `event.category:intrusion_detection AND event.type:allowed` (to indicate a network intrusion prevention system event for which the IPS disposition was to allow the connection to complete). You can further distinguish allowed operations using the ECS `event.action` field, populating with values of your choosing, such as \"allow\", \"detect\", or \"pass\".",
+            "name": "allowed"
+          },
+          {
+            "description": "The change event type is used for the subset of events within a category that indicate that something has changed. If semantics best describe an event as modified, then include them in this subcategory. Common examples include `event.category:process AND event.type:change`, and `event.category:file AND event.type:change`. You can further distinguish change operations using the ECS `event.action` field.",
+            "name": "change"
+          },
+          {
+            "description": "Used primarily with `event.category:network` this value is used for the subset of network traffic that includes sufficient information for the event to be included in flow or connection analysis. Events in this subcategory will contain at least source and destination IP addresses, source and destination TCP/UDP ports, and will usually contain counts of bytes and/or packets transferred. Events in this subcategory may contain unidirectional or bidirectional information, including summary information. Use this subcategory to visualize and analyze network connections. Flow analysis, including Netflow, IPFIX, and other flow-related events fit in this subcategory. Note that firewall events from many Next-Generation Firewall (NGFW) devices will also fit into this subcategory.  A common filter for flow/connection information would be `event.category:network AND event.type:connection AND event.type:end` (to view or analyze all completed network connections, ignoring mid-flow reports). You can further distinguish connection events using the ECS `event.action` field, populating with values of your choosing, such as \"timeout\", or \"reset\".",
+            "name": "connection"
+          },
+          {
+            "description": "The \"creation\" event type is used for the subset of events within a category that indicate that something was created. A common example is `event.category:file AND event.type:creation`.",
+            "name": "creation"
+          },
+          {
+            "description": "The deletion event type is used for the subset of events within a category that indicate that something was deleted. A common example is `event.category:file AND event.type:deletion` to indicate that a file has been deleted.",
+            "name": "deletion"
+          },
+          {
+            "description": "The denied event type is used for the subset of events within a category that indicate that something was denied. Common examples include `event.category:network AND event.type:denied` (to indicate a network firewall event for which the firewall disposition was to deny the connection) and `event.category:intrusion_detection AND event.type:denied` (to indicate a network intrusion prevention system event for which the IPS disposition was to deny the connection to complete). You can further distinguish denied operations using the ECS `event.action` field, populating with values of your choosing, such as \"blocked\", \"dropped\", or \"quarantined\".",
+            "name": "denied"
+          },
+          {
+            "description": "The end event type is used for the subset of events within a category that indicate something has ended. A common example is `event.category:process AND event.type:end`.",
+            "name": "end"
+          },
+          {
+            "description": "The error event type is used for the subset of events within a category that indicate or describe an error. A common example is `event.category:database AND event.type:error`. Note that pipeline errors that occur during the event ingestion process should not use this `event.type` value. Instead, they should use `event.kind:pipeline_error`.",
+            "name": "error"
+          },
+          {
+            "description": "The group event type is used for the subset of events within a category that are related to group objects. Common example: `event.category:iam AND event.type:creation AND event.type:group`. You can further distinguish group operations using the ECS `event.action` field.",
+            "name": "group"
+          },
+          {
+            "description": "The info event type is used for the subset of events within a category that indicate that they are purely informational, and don't report a state change, or any type of action. For example, an initial run of a file integrity monitoring system (FIM), where an agent reports all files under management, would fall into the \"info\" subcategory. Similarly, an event containing a dump of all currently running processes (as opposed to reporting that a process started/ended) would fall into the \"info\" subcategory. An additional common examples is `event.category:intrusion_detection AND event.type:info`.",
+            "name": "info"
+          },
+          {
+            "description": "The installation event type is used for the subset of events within a category that indicate that something was installed. A common example is `event.category:package` AND `event.type:installation`.",
+            "name": "installation"
+          },
+          {
+            "description": "The protocol event type is used for the subset of events within a category that indicate that they contain protocol details or analysis, beyond simply identifying the protocol. Generally, network events that contain specific protocol details will fall into this subcategory. A common example is `event.category:network AND event.type:protocol AND event.type:connection AND event.type:end` (to indicate that the event is a network connection event sent at the end of a connection that also includes a protocol detail breakdown). Note that events that only indicate the name or id of the protocol should not use the protocol value. Further note that when the protocol subcategory is used, the identified protocol is populated in the ECS `network.protocol` field.",
+            "expected_event_types": [
+              "access",
+              "change",
+              "end",
+              "info",
+              "start"
+            ],
+            "name": "protocol"
+          },
+          {
+            "description": "The start event type is used for the subset of events within a category that indicate something has started. A common example is `event.category:process AND event.type:start`.",
+            "name": "start"
+          },
+          {
+            "description": "The user event type is used for the subset of events within a category that are related to user objects. Common example: `event.category:iam AND event.type:deletion AND event.type:user`. You can further distinguish user operations using the ECS `event.action` field.",
+            "name": "user"
+          }
+        ],
+        "dashed_name": "event-type",
+        "description": "This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy.\n`event.type` represents a categorization \"sub-bucket\" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization.\nThis field is an array. This will allow proper categorization of some events that fall in multiple event types.",
+        "flat_name": "event.type",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "type",
+        "normalize": [
+          "array"
+        ],
+        "short": "Event type. The third categorization field in the hierarchy.",
+        "type": "keyword"
+      },
+      "event.url": {
+        "dashed_name": "event-url",
+        "description": "URL linking to an external system to continue investigation of this event.\nThis URL links to another system where in-depth investigation of the specific occurrence of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.",
+        "example": "https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe",
+        "flat_name": "event.url",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "url",
+        "normalize": [],
+        "short": "Event investigation URL",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "event",
+    "prefix": "event.",
+    "short": "Fields breaking down the event details.",
+    "title": "Event",
+    "type": "group"
+  },
+  "file": {
+    "description": "A file is defined as a set of information that has been created on, or has existed on a filesystem.\nFile objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.",
+    "fields": {
+      "file.accessed": {
+        "dashed_name": "file-accessed",
+        "description": "Last time the file was accessed.\nNote that not all filesystems keep track of access time.",
+        "flat_name": "file.accessed",
+        "level": "extended",
+        "name": "accessed",
+        "normalize": [],
+        "short": "Last time the file was accessed.",
+        "type": "date"
+      },
+      "file.attributes": {
+        "dashed_name": "file-attributes",
+        "description": "Array of file attributes.\nAttributes names will vary by platform. Here's a non-exhaustive list of values that are expected in this field: archive, compressed, directory, encrypted, execute, hidden, read, readonly, system, write.",
+        "example": "[\"readonly\", \"system\"]",
+        "flat_name": "file.attributes",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "attributes",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array of file attributes.",
+        "type": "keyword"
+      },
+      "file.code_signature.exists": {
+        "dashed_name": "file-code-signature-exists",
+        "description": "Boolean to capture if a signature is present.",
+        "example": "true",
+        "flat_name": "file.code_signature.exists",
+        "level": "core",
+        "name": "exists",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Boolean to capture if a signature is present.",
+        "type": "boolean"
+      },
+      "file.code_signature.status": {
+        "dashed_name": "file-code-signature-status",
+        "description": "Additional information about the certificate status.\nThis is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.",
+        "example": "ERROR_UNTRUSTED_ROOT",
+        "flat_name": "file.code_signature.status",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "status",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Additional information about the certificate status.",
+        "type": "keyword"
+      },
+      "file.code_signature.subject_name": {
+        "dashed_name": "file-code-signature-subject-name",
+        "description": "Subject name of the code signer",
+        "example": "Microsoft Corporation",
+        "flat_name": "file.code_signature.subject_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "subject_name",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Subject name of the code signer",
+        "type": "keyword"
+      },
+      "file.code_signature.trusted": {
+        "dashed_name": "file-code-signature-trusted",
+        "description": "Stores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+        "example": "true",
+        "flat_name": "file.code_signature.trusted",
+        "level": "extended",
+        "name": "trusted",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Stores the trust status of the certificate chain.",
+        "type": "boolean"
+      },
+      "file.code_signature.valid": {
+        "dashed_name": "file-code-signature-valid",
+        "description": "Boolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+        "example": "true",
+        "flat_name": "file.code_signature.valid",
+        "level": "extended",
+        "name": "valid",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Boolean to capture if the digital signature is verified against the binary content.",
+        "type": "boolean"
+      },
+      "file.created": {
+        "dashed_name": "file-created",
+        "description": "File creation time.\nNote that not all filesystems store the creation time.",
+        "flat_name": "file.created",
+        "level": "extended",
+        "name": "created",
+        "normalize": [],
+        "short": "File creation time.",
+        "type": "date"
+      },
+      "file.ctime": {
+        "dashed_name": "file-ctime",
+        "description": "Last time the file attributes or metadata changed.\nNote that changes to the file content will update `mtime`. This implies `ctime` will be adjusted at the same time, since `mtime` is an attribute of the file.",
+        "flat_name": "file.ctime",
+        "level": "extended",
+        "name": "ctime",
+        "normalize": [],
+        "short": "Last time the file attributes or metadata changed.",
+        "type": "date"
+      },
+      "file.device": {
+        "dashed_name": "file-device",
+        "description": "Device that is the source of the file.",
+        "example": "sda",
+        "flat_name": "file.device",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "device",
+        "normalize": [],
+        "short": "Device that is the source of the file.",
+        "type": "keyword"
+      },
+      "file.directory": {
+        "dashed_name": "file-directory",
+        "description": "Directory where the file is located. It should include the drive letter, when appropriate.",
+        "example": "/home/alice",
+        "flat_name": "file.directory",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "directory",
+        "normalize": [],
+        "short": "Directory where the file is located.",
+        "type": "keyword"
+      },
+      "file.drive_letter": {
+        "dashed_name": "file-drive-letter",
+        "description": "Drive letter where the file is located. This field is only relevant on Windows.\nThe value should be uppercase, and not include the colon.",
+        "example": "C",
+        "flat_name": "file.drive_letter",
+        "ignore_above": 1,
+        "level": "extended",
+        "name": "drive_letter",
+        "normalize": [],
+        "short": "Drive letter where the file is located.",
+        "type": "keyword"
+      },
+      "file.extension": {
+        "dashed_name": "file-extension",
+        "description": "File extension.",
+        "example": "png",
+        "flat_name": "file.extension",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "extension",
+        "normalize": [],
+        "short": "File extension.",
+        "type": "keyword"
+      },
+      "file.gid": {
+        "dashed_name": "file-gid",
+        "description": "Primary group ID (GID) of the file.",
+        "example": "1001",
+        "flat_name": "file.gid",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "gid",
+        "normalize": [],
+        "short": "Primary group ID (GID) of the file.",
+        "type": "keyword"
+      },
+      "file.group": {
+        "dashed_name": "file-group",
+        "description": "Primary group name of the file.",
+        "example": "alice",
+        "flat_name": "file.group",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "group",
+        "normalize": [],
+        "short": "Primary group name of the file.",
+        "type": "keyword"
+      },
+      "file.hash.md5": {
+        "dashed_name": "file-hash-md5",
+        "description": "MD5 hash.",
+        "flat_name": "file.hash.md5",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "md5",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "MD5 hash.",
+        "type": "keyword"
+      },
+      "file.hash.sha1": {
+        "dashed_name": "file-hash-sha1",
+        "description": "SHA1 hash.",
+        "flat_name": "file.hash.sha1",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha1",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA1 hash.",
+        "type": "keyword"
+      },
+      "file.hash.sha256": {
+        "dashed_name": "file-hash-sha256",
+        "description": "SHA256 hash.",
+        "flat_name": "file.hash.sha256",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha256",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA256 hash.",
+        "type": "keyword"
+      },
+      "file.hash.sha512": {
+        "dashed_name": "file-hash-sha512",
+        "description": "SHA512 hash.",
+        "flat_name": "file.hash.sha512",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha512",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA512 hash.",
+        "type": "keyword"
+      },
+      "file.inode": {
+        "dashed_name": "file-inode",
+        "description": "Inode representing the file in the filesystem.",
+        "example": "256383",
+        "flat_name": "file.inode",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "inode",
+        "normalize": [],
+        "short": "Inode representing the file in the filesystem.",
+        "type": "keyword"
+      },
+      "file.mime_type": {
+        "dashed_name": "file-mime-type",
+        "description": "MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used.",
+        "flat_name": "file.mime_type",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "mime_type",
+        "normalize": [],
+        "short": "Media type of file, document, or arrangement of bytes.",
+        "type": "keyword"
+      },
+      "file.mode": {
+        "dashed_name": "file-mode",
+        "description": "Mode of the file in octal representation.",
+        "example": "0640",
+        "flat_name": "file.mode",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "mode",
+        "normalize": [],
+        "short": "Mode of the file in octal representation.",
+        "type": "keyword"
+      },
+      "file.mtime": {
+        "dashed_name": "file-mtime",
+        "description": "Last time the file content was modified.",
+        "flat_name": "file.mtime",
+        "level": "extended",
+        "name": "mtime",
+        "normalize": [],
+        "short": "Last time the file content was modified.",
+        "type": "date"
+      },
+      "file.name": {
+        "dashed_name": "file-name",
+        "description": "Name of the file including the extension, without the directory.",
+        "example": "example.png",
+        "flat_name": "file.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Name of the file including the extension, without the directory.",
+        "type": "keyword"
+      },
+      "file.owner": {
+        "dashed_name": "file-owner",
+        "description": "File owner's username.",
+        "example": "alice",
+        "flat_name": "file.owner",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "owner",
+        "normalize": [],
+        "short": "File owner's username.",
+        "type": "keyword"
+      },
+      "file.path": {
+        "dashed_name": "file-path",
+        "description": "Full path to the file, including the file name. It should include the drive letter, when appropriate.",
+        "example": "/home/alice/example.png",
+        "flat_name": "file.path",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "file.path.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "path",
+        "normalize": [],
+        "short": "Full path to the file, including the file name.",
+        "type": "keyword"
+      },
+      "file.pe.architecture": {
+        "dashed_name": "file-pe-architecture",
+        "description": "CPU architecture target for the file.",
+        "example": "x64",
+        "flat_name": "file.pe.architecture",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "architecture",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "CPU architecture target for the file.",
+        "type": "keyword"
+      },
+      "file.pe.company": {
+        "dashed_name": "file-pe-company",
+        "description": "Internal company name of the file, provided at compile-time.",
+        "example": "Microsoft Corporation",
+        "flat_name": "file.pe.company",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "company",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal company name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "file.pe.description": {
+        "dashed_name": "file-pe-description",
+        "description": "Internal description of the file, provided at compile-time.",
+        "example": "Paint",
+        "flat_name": "file.pe.description",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "description",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal description of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "file.pe.file_version": {
+        "dashed_name": "file-pe-file-version",
+        "description": "Internal version of the file, provided at compile-time.",
+        "example": "6.3.9600.17415",
+        "flat_name": "file.pe.file_version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "file_version",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Process name.",
+        "type": "keyword"
+      },
+      "file.pe.imphash": {
+        "dashed_name": "file-pe-imphash",
+        "description": "A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
+        "example": "0c6803c4e922103c4dca5963aad36ddf",
+        "flat_name": "file.pe.imphash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "imphash",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "A hash of the imports in a PE file.",
+        "type": "keyword"
+      },
+      "file.pe.original_file_name": {
+        "dashed_name": "file-pe-original-file-name",
+        "description": "Internal name of the file, provided at compile-time.",
+        "example": "MSPAINT.EXE",
+        "flat_name": "file.pe.original_file_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "original_file_name",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "file.pe.product": {
+        "dashed_name": "file-pe-product",
+        "description": "Internal product name of the file, provided at compile-time.",
+        "example": "Microsoft\u00ae Windows\u00ae Operating System",
+        "flat_name": "file.pe.product",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "product",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal product name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "file.size": {
+        "dashed_name": "file-size",
+        "description": "File size in bytes.\nOnly relevant when `file.type` is \"file\".",
+        "example": 16384,
+        "flat_name": "file.size",
+        "level": "extended",
+        "name": "size",
+        "normalize": [],
+        "short": "File size in bytes.",
+        "type": "long"
+      },
+      "file.target_path": {
+        "dashed_name": "file-target-path",
+        "description": "Target path for symlinks.",
+        "flat_name": "file.target_path",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "file.target_path.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "target_path",
+        "normalize": [],
+        "short": "Target path for symlinks.",
+        "type": "keyword"
+      },
+      "file.type": {
+        "dashed_name": "file-type",
+        "description": "File type (file, dir, or symlink).",
+        "example": "file",
+        "flat_name": "file.type",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "type",
+        "normalize": [],
+        "short": "File type (file, dir, or symlink).",
+        "type": "keyword"
+      },
+      "file.uid": {
+        "dashed_name": "file-uid",
+        "description": "The user ID (UID) or security identifier (SID) of the file owner.",
+        "example": "1001",
+        "flat_name": "file.uid",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "uid",
+        "normalize": [],
+        "short": "The user ID (UID) or security identifier (SID) of the file owner.",
+        "type": "keyword"
+      },
+      "file.x509.alternative_names": {
+        "dashed_name": "file-x509-alternative-names",
+        "description": "List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
+        "example": "*.elastic.co",
+        "flat_name": "file.x509.alternative_names",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "alternative_names",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of subject alternative names (SAN).",
+        "type": "keyword"
+      },
+      "file.x509.issuer.common_name": {
+        "dashed_name": "file-x509-issuer-common-name",
+        "description": "List of common name (CN) of issuing certificate authority.",
+        "example": "Example SHA2 High Assurance Server CA",
+        "flat_name": "file.x509.issuer.common_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.common_name",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of common name (CN) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "file.x509.issuer.country": {
+        "dashed_name": "file-x509-issuer-country",
+        "description": "List of country (C) codes",
+        "example": "US",
+        "flat_name": "file.x509.issuer.country",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.country",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of country (C) codes",
+        "type": "keyword"
+      },
+      "file.x509.issuer.distinguished_name": {
+        "dashed_name": "file-x509-issuer-distinguished-name",
+        "description": "Distinguished name (DN) of issuing certificate authority.",
+        "example": "C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",
+        "flat_name": "file.x509.issuer.distinguished_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.distinguished_name",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Distinguished name (DN) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "file.x509.issuer.locality": {
+        "dashed_name": "file-x509-issuer-locality",
+        "description": "List of locality names (L)",
+        "example": "Mountain View",
+        "flat_name": "file.x509.issuer.locality",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.locality",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of locality names (L)",
+        "type": "keyword"
+      },
+      "file.x509.issuer.organization": {
+        "dashed_name": "file-x509-issuer-organization",
+        "description": "List of organizations (O) of issuing certificate authority.",
+        "example": "Example Inc",
+        "flat_name": "file.x509.issuer.organization",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.organization",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizations (O) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "file.x509.issuer.organizational_unit": {
+        "dashed_name": "file-x509-issuer-organizational-unit",
+        "description": "List of organizational units (OU) of issuing certificate authority.",
+        "example": "www.example.com",
+        "flat_name": "file.x509.issuer.organizational_unit",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.organizational_unit",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizational units (OU) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "file.x509.issuer.state_or_province": {
+        "dashed_name": "file-x509-issuer-state-or-province",
+        "description": "List of state or province names (ST, S, or P)",
+        "example": "California",
+        "flat_name": "file.x509.issuer.state_or_province",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.state_or_province",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of state or province names (ST, S, or P)",
+        "type": "keyword"
+      },
+      "file.x509.not_after": {
+        "dashed_name": "file-x509-not-after",
+        "description": "Time at which the certificate is no longer considered valid.",
+        "example": "2020-07-16T03:15:39+00:00",
+        "flat_name": "file.x509.not_after",
+        "level": "extended",
+        "name": "not_after",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Time at which the certificate is no longer considered valid.",
+        "type": "date"
+      },
+      "file.x509.not_before": {
+        "dashed_name": "file-x509-not-before",
+        "description": "Time at which the certificate is first considered valid.",
+        "example": "2019-08-16T01:40:25+00:00",
+        "flat_name": "file.x509.not_before",
+        "level": "extended",
+        "name": "not_before",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Time at which the certificate is first considered valid.",
+        "type": "date"
+      },
+      "file.x509.public_key_algorithm": {
+        "dashed_name": "file-x509-public-key-algorithm",
+        "description": "Algorithm used to generate the public key.",
+        "example": "RSA",
+        "flat_name": "file.x509.public_key_algorithm",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "public_key_algorithm",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Algorithm used to generate the public key.",
+        "type": "keyword"
+      },
+      "file.x509.public_key_curve": {
+        "dashed_name": "file-x509-public-key-curve",
+        "description": "The curve used by the elliptic curve public key algorithm. This is algorithm specific.",
+        "example": "nistp521",
+        "flat_name": "file.x509.public_key_curve",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "public_key_curve",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "The curve used by the elliptic curve public key algorithm. This is algorithm specific.",
+        "type": "keyword"
+      },
+      "file.x509.public_key_exponent": {
+        "dashed_name": "file-x509-public-key-exponent",
+        "description": "Exponent used to derive the public key. This is algorithm specific.",
+        "doc_values": false,
+        "example": 65537,
+        "flat_name": "file.x509.public_key_exponent",
+        "index": false,
+        "level": "extended",
+        "name": "public_key_exponent",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Exponent used to derive the public key. This is algorithm specific.",
+        "type": "long"
+      },
+      "file.x509.public_key_size": {
+        "dashed_name": "file-x509-public-key-size",
+        "description": "The size of the public key space in bits.",
+        "example": 2048,
+        "flat_name": "file.x509.public_key_size",
+        "level": "extended",
+        "name": "public_key_size",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "The size of the public key space in bits.",
+        "type": "long"
+      },
+      "file.x509.serial_number": {
+        "dashed_name": "file-x509-serial-number",
+        "description": "Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters.",
+        "example": "55FBB9C7DEBF09809D12CCAA",
+        "flat_name": "file.x509.serial_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "serial_number",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Unique serial number issued by the certificate authority.",
+        "type": "keyword"
+      },
+      "file.x509.signature_algorithm": {
+        "dashed_name": "file-x509-signature-algorithm",
+        "description": "Identifier for certificate signature algorithm. We recommend using names found in Go Lang Crypto library. See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353.",
+        "example": "SHA256-RSA",
+        "flat_name": "file.x509.signature_algorithm",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "signature_algorithm",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Identifier for certificate signature algorithm.",
+        "type": "keyword"
+      },
+      "file.x509.subject.common_name": {
+        "dashed_name": "file-x509-subject-common-name",
+        "description": "List of common names (CN) of subject.",
+        "example": "shared.global.example.net",
+        "flat_name": "file.x509.subject.common_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.common_name",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of common names (CN) of subject.",
+        "type": "keyword"
+      },
+      "file.x509.subject.country": {
+        "dashed_name": "file-x509-subject-country",
+        "description": "List of country (C) code",
+        "example": "US",
+        "flat_name": "file.x509.subject.country",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.country",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of country (C) code",
+        "type": "keyword"
+      },
+      "file.x509.subject.distinguished_name": {
+        "dashed_name": "file-x509-subject-distinguished-name",
+        "description": "Distinguished name (DN) of the certificate subject entity.",
+        "example": "C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",
+        "flat_name": "file.x509.subject.distinguished_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.distinguished_name",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Distinguished name (DN) of the certificate subject entity.",
+        "type": "keyword"
+      },
+      "file.x509.subject.locality": {
+        "dashed_name": "file-x509-subject-locality",
+        "description": "List of locality names (L)",
+        "example": "San Francisco",
+        "flat_name": "file.x509.subject.locality",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.locality",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of locality names (L)",
+        "type": "keyword"
+      },
+      "file.x509.subject.organization": {
+        "dashed_name": "file-x509-subject-organization",
+        "description": "List of organizations (O) of subject.",
+        "example": "Example, Inc.",
+        "flat_name": "file.x509.subject.organization",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.organization",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizations (O) of subject.",
+        "type": "keyword"
+      },
+      "file.x509.subject.organizational_unit": {
+        "dashed_name": "file-x509-subject-organizational-unit",
+        "description": "List of organizational units (OU) of subject.",
+        "flat_name": "file.x509.subject.organizational_unit",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.organizational_unit",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizational units (OU) of subject.",
+        "type": "keyword"
+      },
+      "file.x509.subject.state_or_province": {
+        "dashed_name": "file-x509-subject-state-or-province",
+        "description": "List of state or province names (ST, S, or P)",
+        "example": "California",
+        "flat_name": "file.x509.subject.state_or_province",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.state_or_province",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of state or province names (ST, S, or P)",
+        "type": "keyword"
+      },
+      "file.x509.version_number": {
+        "dashed_name": "file-x509-version-number",
+        "description": "Version of x509 format.",
+        "example": 3,
+        "flat_name": "file.x509.version_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version_number",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Version of x509 format.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "file",
+    "nestings": [
+      "file.code_signature",
+      "file.hash",
+      "file.pe",
+      "file.x509"
+    ],
+    "prefix": "file.",
+    "reused_here": [
+      {
+        "full": "file.code_signature",
+        "schema_name": "code_signature",
+        "short": "These fields contain information about binary code signatures."
+      },
+      {
+        "full": "file.hash",
+        "schema_name": "hash",
+        "short": "Hashes, usually file hashes."
+      },
+      {
+        "full": "file.pe",
+        "schema_name": "pe",
+        "short": "These fields contain Windows Portable Executable (PE) metadata."
+      },
+      {
+        "full": "file.x509",
+        "schema_name": "x509",
+        "short": "These fields contain x509 certificate metadata."
+      }
+    ],
+    "short": "Fields describing files.",
+    "title": "File",
+    "type": "group"
+  },
+  "geo": {
+    "description": "Geo fields can carry data about a specific location related to an event.\nThis geolocation information can be derived from techniques such as Geo IP, or be user-supplied.",
+    "fields": {
+      "geo.city_name": {
+        "dashed_name": "geo-city-name",
+        "description": "City name.",
+        "example": "Montreal",
+        "flat_name": "geo.city_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "city_name",
+        "normalize": [],
+        "short": "City name.",
+        "type": "keyword"
+      },
+      "geo.continent_name": {
+        "dashed_name": "geo-continent-name",
+        "description": "Name of the continent.",
+        "example": "North America",
+        "flat_name": "geo.continent_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "continent_name",
+        "normalize": [],
+        "short": "Name of the continent.",
+        "type": "keyword"
+      },
+      "geo.country_iso_code": {
+        "dashed_name": "geo-country-iso-code",
+        "description": "Country ISO code.",
+        "example": "CA",
+        "flat_name": "geo.country_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_iso_code",
+        "normalize": [],
+        "short": "Country ISO code.",
+        "type": "keyword"
+      },
+      "geo.country_name": {
+        "dashed_name": "geo-country-name",
+        "description": "Country name.",
+        "example": "Canada",
+        "flat_name": "geo.country_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_name",
+        "normalize": [],
+        "short": "Country name.",
+        "type": "keyword"
+      },
+      "geo.location": {
+        "dashed_name": "geo-location",
+        "description": "Longitude and latitude.",
+        "example": "{ \"lon\": -73.614830, \"lat\": 45.505918 }",
+        "flat_name": "geo.location",
+        "level": "core",
+        "name": "location",
+        "normalize": [],
+        "short": "Longitude and latitude.",
+        "type": "geo_point"
+      },
+      "geo.name": {
+        "dashed_name": "geo-name",
+        "description": "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation.",
+        "example": "boston-dc",
+        "flat_name": "geo.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "User-defined description of a location.",
+        "type": "keyword"
+      },
+      "geo.region_iso_code": {
+        "dashed_name": "geo-region-iso-code",
+        "description": "Region ISO code.",
+        "example": "CA-QC",
+        "flat_name": "geo.region_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_iso_code",
+        "normalize": [],
+        "short": "Region ISO code.",
+        "type": "keyword"
+      },
+      "geo.region_name": {
+        "dashed_name": "geo-region-name",
+        "description": "Region name.",
+        "example": "Quebec",
+        "flat_name": "geo.region_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_name",
+        "normalize": [],
+        "short": "Region name.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "geo",
+    "prefix": "geo.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "geo",
+          "at": "client",
+          "full": "client.geo"
+        },
+        {
+          "as": "geo",
+          "at": "destination",
+          "full": "destination.geo"
+        },
+        {
+          "as": "geo",
+          "at": "observer",
+          "full": "observer.geo"
+        },
+        {
+          "as": "geo",
+          "at": "host",
+          "full": "host.geo"
+        },
+        {
+          "as": "geo",
+          "at": "server",
+          "full": "server.geo"
+        },
+        {
+          "as": "geo",
+          "at": "source",
+          "full": "source.geo"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "Fields describing a location.",
+    "title": "Geo",
+    "type": "group"
+  },
+  "group": {
+    "description": "The group fields are meant to represent groups that are relevant to the event.",
+    "fields": {
+      "group.domain": {
+        "dashed_name": "group-domain",
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "group.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "short": "Name of the directory the group is a member of.",
+        "type": "keyword"
+      },
+      "group.id": {
+        "dashed_name": "group-id",
+        "description": "Unique identifier for the group on the system/platform.",
+        "flat_name": "group.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique identifier for the group on the system/platform.",
+        "type": "keyword"
+      },
+      "group.name": {
+        "dashed_name": "group-name",
+        "description": "Name of the group.",
+        "flat_name": "group.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Name of the group.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "group",
+    "prefix": "group.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "group",
+          "at": "user",
+          "full": "user.group"
+        }
+      ],
+      "top_level": true
+    },
+    "short": "User's group relevant to the event.",
+    "title": "Group",
+    "type": "group"
+  },
+  "hash": {
+    "description": "The hash fields represent different hash algorithms and their values.\nField names for common hashes (e.g. MD5, SHA1) are predefined. Add fields for other hashes by lowercasing the hash algorithm name and using underscore separators as appropriate (snake case, e.g. sha3_512).",
+    "fields": {
+      "hash.md5": {
+        "dashed_name": "hash-md5",
+        "description": "MD5 hash.",
+        "flat_name": "hash.md5",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "md5",
+        "normalize": [],
+        "short": "MD5 hash.",
+        "type": "keyword"
+      },
+      "hash.sha1": {
+        "dashed_name": "hash-sha1",
+        "description": "SHA1 hash.",
+        "flat_name": "hash.sha1",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha1",
+        "normalize": [],
+        "short": "SHA1 hash.",
+        "type": "keyword"
+      },
+      "hash.sha256": {
+        "dashed_name": "hash-sha256",
+        "description": "SHA256 hash.",
+        "flat_name": "hash.sha256",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha256",
+        "normalize": [],
+        "short": "SHA256 hash.",
+        "type": "keyword"
+      },
+      "hash.sha512": {
+        "dashed_name": "hash-sha512",
+        "description": "SHA512 hash.",
+        "flat_name": "hash.sha512",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha512",
+        "normalize": [],
+        "short": "SHA512 hash.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "hash",
+    "prefix": "hash.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "hash",
+          "at": "file",
+          "full": "file.hash"
+        },
+        {
+          "as": "hash",
+          "at": "process",
+          "full": "process.hash"
+        },
+        {
+          "as": "hash",
+          "at": "dll",
+          "full": "dll.hash"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "Hashes, usually file hashes.",
+    "title": "Hash",
+    "type": "group"
+  },
+  "host": {
+    "description": "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.",
+    "fields": {
+      "host.architecture": {
+        "dashed_name": "host-architecture",
+        "description": "Operating system architecture.",
+        "example": "x86_64",
+        "flat_name": "host.architecture",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "architecture",
+        "normalize": [],
+        "short": "Operating system architecture.",
+        "type": "keyword"
+      },
+      "host.domain": {
+        "dashed_name": "host-domain",
+        "description": "Name of the domain of which the host is a member.\nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider.",
+        "example": "CONTOSO",
+        "flat_name": "host.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "short": "Name of the directory the group is a member of.",
+        "type": "keyword"
+      },
+      "host.geo.city_name": {
+        "dashed_name": "host-geo-city-name",
+        "description": "City name.",
+        "example": "Montreal",
+        "flat_name": "host.geo.city_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "city_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "City name.",
+        "type": "keyword"
+      },
+      "host.geo.continent_name": {
+        "dashed_name": "host-geo-continent-name",
+        "description": "Name of the continent.",
+        "example": "North America",
+        "flat_name": "host.geo.continent_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "continent_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Name of the continent.",
+        "type": "keyword"
+      },
+      "host.geo.country_iso_code": {
+        "dashed_name": "host-geo-country-iso-code",
+        "description": "Country ISO code.",
+        "example": "CA",
+        "flat_name": "host.geo.country_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country ISO code.",
+        "type": "keyword"
+      },
+      "host.geo.country_name": {
+        "dashed_name": "host-geo-country-name",
+        "description": "Country name.",
+        "example": "Canada",
+        "flat_name": "host.geo.country_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country name.",
+        "type": "keyword"
+      },
+      "host.geo.location": {
+        "dashed_name": "host-geo-location",
+        "description": "Longitude and latitude.",
+        "example": "{ \"lon\": -73.614830, \"lat\": 45.505918 }",
+        "flat_name": "host.geo.location",
+        "level": "core",
+        "name": "location",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Longitude and latitude.",
+        "type": "geo_point"
+      },
+      "host.geo.name": {
+        "dashed_name": "host-geo-name",
+        "description": "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation.",
+        "example": "boston-dc",
+        "flat_name": "host.geo.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "User-defined description of a location.",
+        "type": "keyword"
+      },
+      "host.geo.region_iso_code": {
+        "dashed_name": "host-geo-region-iso-code",
+        "description": "Region ISO code.",
+        "example": "CA-QC",
+        "flat_name": "host.geo.region_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region ISO code.",
+        "type": "keyword"
+      },
+      "host.geo.region_name": {
+        "dashed_name": "host-geo-region-name",
+        "description": "Region name.",
+        "example": "Quebec",
+        "flat_name": "host.geo.region_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region name.",
+        "type": "keyword"
+      },
+      "host.hostname": {
+        "dashed_name": "host-hostname",
+        "description": "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine.",
+        "flat_name": "host.hostname",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "hostname",
+        "normalize": [],
+        "short": "Hostname of the host.",
+        "type": "keyword"
+      },
+      "host.id": {
+        "dashed_name": "host-id",
+        "description": "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`.",
+        "flat_name": "host.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique host id.",
+        "type": "keyword"
+      },
+      "host.ip": {
+        "dashed_name": "host-ip",
+        "description": "Host ip addresses.",
+        "flat_name": "host.ip",
+        "level": "core",
+        "name": "ip",
+        "normalize": [
+          "array"
+        ],
+        "short": "Host ip addresses.",
+        "type": "ip"
+      },
+      "host.mac": {
+        "dashed_name": "host-mac",
+        "description": "Host mac addresses.",
+        "flat_name": "host.mac",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "mac",
+        "normalize": [
+          "array"
+        ],
+        "short": "Host mac addresses.",
+        "type": "keyword"
+      },
+      "host.name": {
+        "dashed_name": "host-name",
+        "description": "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.",
+        "flat_name": "host.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "name",
+        "normalize": [],
+        "short": "Name of the host.",
+        "type": "keyword"
+      },
+      "host.os.family": {
+        "dashed_name": "host-os-family",
+        "description": "OS family (such as redhat, debian, freebsd, windows).",
+        "example": "debian",
+        "flat_name": "host.os.family",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "family",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "OS family (such as redhat, debian, freebsd, windows).",
+        "type": "keyword"
+      },
+      "host.os.full": {
+        "dashed_name": "host-os-full",
+        "description": "Operating system name, including the version or code name.",
+        "example": "Mac OS Mojave",
+        "flat_name": "host.os.full",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "host.os.full.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system name, including the version or code name.",
+        "type": "keyword"
+      },
+      "host.os.kernel": {
+        "dashed_name": "host-os-kernel",
+        "description": "Operating system kernel version as a raw string.",
+        "example": "4.4.0-112-generic",
+        "flat_name": "host.os.kernel",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "kernel",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system kernel version as a raw string.",
+        "type": "keyword"
+      },
+      "host.os.name": {
+        "dashed_name": "host-os-name",
+        "description": "Operating system name, without the version.",
+        "example": "Mac OS X",
+        "flat_name": "host.os.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "host.os.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system name, without the version.",
+        "type": "keyword"
+      },
+      "host.os.platform": {
+        "dashed_name": "host-os-platform",
+        "description": "Operating system platform (such centos, ubuntu, windows).",
+        "example": "darwin",
+        "flat_name": "host.os.platform",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "platform",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system platform (such centos, ubuntu, windows).",
+        "type": "keyword"
+      },
+      "host.os.version": {
+        "dashed_name": "host-os-version",
+        "description": "Operating system version as a raw string.",
+        "example": "10.14.1",
+        "flat_name": "host.os.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system version as a raw string.",
+        "type": "keyword"
+      },
+      "host.type": {
+        "dashed_name": "host-type",
+        "description": "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.",
+        "flat_name": "host.type",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "type",
+        "normalize": [],
+        "short": "Type of host.",
+        "type": "keyword"
+      },
+      "host.uptime": {
+        "dashed_name": "host-uptime",
+        "description": "Seconds the host has been up.",
+        "example": 1325,
+        "flat_name": "host.uptime",
+        "level": "extended",
+        "name": "uptime",
+        "normalize": [],
+        "short": "Seconds the host has been up.",
+        "type": "long"
+      },
+      "host.user.domain": {
+        "dashed_name": "host-user-domain",
+        "description": "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "host.user.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Name of the directory the user is a member of.",
+        "type": "keyword"
+      },
+      "host.user.email": {
+        "dashed_name": "host-user-email",
+        "description": "User email address.",
+        "flat_name": "host.user.email",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "email",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User email address.",
+        "type": "keyword"
+      },
+      "host.user.full_name": {
+        "dashed_name": "host-user-full-name",
+        "description": "User's full name, if available.",
+        "example": "Albert Einstein",
+        "flat_name": "host.user.full_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "host.user.full_name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full_name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User's full name, if available.",
+        "type": "keyword"
+      },
+      "host.user.group.domain": {
+        "dashed_name": "host-user-group-domain",
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "host.user.group.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the directory the group is a member of.",
+        "type": "keyword"
+      },
+      "host.user.group.id": {
+        "dashed_name": "host-user-group-id",
+        "description": "Unique identifier for the group on the system/platform.",
+        "flat_name": "host.user.group.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Unique identifier for the group on the system/platform.",
+        "type": "keyword"
+      },
+      "host.user.group.name": {
+        "dashed_name": "host-user-group-name",
+        "description": "Name of the group.",
+        "flat_name": "host.user.group.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the group.",
+        "type": "keyword"
+      },
+      "host.user.hash": {
+        "dashed_name": "host-user-hash",
+        "description": "Unique user hash to correlate information for a user in anonymized form.\nUseful if `user.id` or `user.name` contain confidential information and cannot be used.",
+        "flat_name": "host.user.hash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hash",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique user hash to correlate information for a user in anonymized form.",
+        "type": "keyword"
+      },
+      "host.user.id": {
+        "dashed_name": "host-user-id",
+        "description": "Unique identifier of the user.",
+        "flat_name": "host.user.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique identifier of the user.",
+        "type": "keyword"
+      },
+      "host.user.name": {
+        "dashed_name": "host-user-name",
+        "description": "Short name or login of the user.",
+        "example": "albert",
+        "flat_name": "host.user.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "multi_fields": [
+          {
+            "flat_name": "host.user.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Short name or login of the user.",
+        "type": "keyword"
+      },
+      "host.user.roles": {
+        "dashed_name": "host-user-roles",
+        "description": "Array of user roles at the time of the event.",
+        "example": "[\"kibana_admin\", \"reporting_user\"]",
+        "flat_name": "host.user.roles",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "roles",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "user",
+        "short": "Array of user roles at the time of the event.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "host",
+    "nestings": [
+      "host.geo",
+      "host.os",
+      "host.user"
+    ],
+    "prefix": "host.",
+    "reused_here": [
+      {
+        "full": "host.geo",
+        "schema_name": "geo",
+        "short": "Fields describing a location."
+      },
+      {
+        "full": "host.os",
+        "schema_name": "os",
+        "short": "OS fields contain information about the operating system."
+      },
+      {
+        "full": "host.user",
+        "schema_name": "user",
+        "short": "Fields to describe the user relevant to the event."
+      }
+    ],
+    "short": "Fields describing the relevant computing instance.",
+    "title": "Host",
+    "type": "group"
+  },
+  "http": {
+    "description": "Fields related to HTTP activity. Use the `url` field set to store the url of the request.",
+    "fields": {
+      "http.request.body.bytes": {
+        "dashed_name": "http-request-body-bytes",
+        "description": "Size in bytes of the request body.",
+        "example": 887,
+        "flat_name": "http.request.body.bytes",
+        "format": "bytes",
+        "level": "extended",
+        "name": "request.body.bytes",
+        "normalize": [],
+        "short": "Size in bytes of the request body.",
+        "type": "long"
+      },
+      "http.request.body.content": {
+        "dashed_name": "http-request-body-content",
+        "description": "The full HTTP request body.",
+        "example": "Hello world",
+        "flat_name": "http.request.body.content",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "http.request.body.content.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "request.body.content",
+        "normalize": [],
+        "short": "The full HTTP request body.",
+        "type": "keyword"
+      },
+      "http.request.bytes": {
+        "dashed_name": "http-request-bytes",
+        "description": "Total size in bytes of the request (body and headers).",
+        "example": 1437,
+        "flat_name": "http.request.bytes",
+        "format": "bytes",
+        "level": "extended",
+        "name": "request.bytes",
+        "normalize": [],
+        "short": "Total size in bytes of the request (body and headers).",
+        "type": "long"
+      },
+      "http.request.method": {
+        "dashed_name": "http-request-method",
+        "description": "HTTP request method.\nPrior to ECS 1.6.0 the following guidance was provided:\n\"The field value must be normalized to lowercase for querying.\"\nAs of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0",
+        "example": "GET, POST, PUT, PoST",
+        "flat_name": "http.request.method",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "request.method",
+        "normalize": [],
+        "short": "HTTP request method.",
+        "type": "keyword"
+      },
+      "http.request.referrer": {
+        "dashed_name": "http-request-referrer",
+        "description": "Referrer for this HTTP request.",
+        "example": "https://blog.example.com/",
+        "flat_name": "http.request.referrer",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "request.referrer",
+        "normalize": [],
+        "short": "Referrer for this HTTP request.",
+        "type": "keyword"
+      },
+      "http.response.body.bytes": {
+        "dashed_name": "http-response-body-bytes",
+        "description": "Size in bytes of the response body.",
+        "example": 887,
+        "flat_name": "http.response.body.bytes",
+        "format": "bytes",
+        "level": "extended",
+        "name": "response.body.bytes",
+        "normalize": [],
+        "short": "Size in bytes of the response body.",
+        "type": "long"
+      },
+      "http.response.body.content": {
+        "dashed_name": "http-response-body-content",
+        "description": "The full HTTP response body.",
+        "example": "Hello world",
+        "flat_name": "http.response.body.content",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "http.response.body.content.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "response.body.content",
+        "normalize": [],
+        "short": "The full HTTP response body.",
+        "type": "keyword"
+      },
+      "http.response.bytes": {
+        "dashed_name": "http-response-bytes",
+        "description": "Total size in bytes of the response (body and headers).",
+        "example": 1437,
+        "flat_name": "http.response.bytes",
+        "format": "bytes",
+        "level": "extended",
+        "name": "response.bytes",
+        "normalize": [],
+        "short": "Total size in bytes of the response (body and headers).",
+        "type": "long"
+      },
+      "http.response.status_code": {
+        "dashed_name": "http-response-status-code",
+        "description": "HTTP response status code.",
+        "example": 404,
+        "flat_name": "http.response.status_code",
+        "format": "string",
+        "level": "extended",
+        "name": "response.status_code",
+        "normalize": [],
+        "short": "HTTP response status code.",
+        "type": "long"
+      },
+      "http.version": {
+        "dashed_name": "http-version",
+        "description": "HTTP version.",
+        "example": 1.1,
+        "flat_name": "http.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "short": "HTTP version.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "http",
+    "prefix": "http.",
+    "short": "Fields describing an HTTP request.",
+    "title": "HTTP",
+    "type": "group"
+  },
+  "interface": {
+    "description": "The interface fields are used to record ingress and egress interface information when reported by an observer (e.g. firewall, router, load balancer) in the context of the observer handling a network connection.  In the case of a single observer interface (e.g. network sensor on a span port) only the observer.ingress information should be populated.",
+    "fields": {
+      "interface.alias": {
+        "dashed_name": "interface-alias",
+        "description": "Interface alias as reported by the system, typically used in firewall implementations for e.g. inside, outside, or dmz logical interface naming.",
+        "example": "outside",
+        "flat_name": "interface.alias",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "alias",
+        "normalize": [],
+        "short": "Interface alias",
+        "type": "keyword"
+      },
+      "interface.id": {
+        "dashed_name": "interface-id",
+        "description": "Interface ID as reported by an observer (typically SNMP interface ID).",
+        "example": 10,
+        "flat_name": "interface.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "short": "Interface ID",
+        "type": "keyword"
+      },
+      "interface.name": {
+        "dashed_name": "interface-name",
+        "description": "Interface name as reported by the system.",
+        "example": "eth0",
+        "flat_name": "interface.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Interface name",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "interface",
+    "prefix": "interface.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "interface",
+          "at": "observer.ingress",
+          "full": "observer.ingress.interface"
+        },
+        {
+          "as": "interface",
+          "at": "observer.egress",
+          "full": "observer.egress.interface"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "Fields to describe observer interface information.",
+    "title": "Interface",
+    "type": "group"
+  },
+  "log": {
+    "description": "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields.",
+    "fields": {
+      "log.file.path": {
+        "dashed_name": "log-file-path",
+        "description": "Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate.\nIf the event wasn't read from a log file, do not populate this field.",
+        "example": "/var/log/fun-times.log",
+        "flat_name": "log.file.path",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "file.path",
+        "normalize": [],
+        "short": "Full path to the log file this event came from.",
+        "type": "keyword"
+      },
+      "log.level": {
+        "dashed_name": "log-level",
+        "description": "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`.",
+        "example": "error",
+        "flat_name": "log.level",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "level",
+        "normalize": [],
+        "short": "Log level of the log event.",
+        "type": "keyword"
+      },
+      "log.logger": {
+        "dashed_name": "log-logger",
+        "description": "The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name.",
+        "example": "org.elasticsearch.bootstrap.Bootstrap",
+        "flat_name": "log.logger",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "logger",
+        "normalize": [],
+        "short": "Name of the logger.",
+        "type": "keyword"
+      },
+      "log.origin.file.line": {
+        "dashed_name": "log-origin-file-line",
+        "description": "The line number of the file containing the source code which originated the log event.",
+        "example": 42,
+        "flat_name": "log.origin.file.line",
+        "level": "extended",
+        "name": "origin.file.line",
+        "normalize": [],
+        "short": "The line number of the file which originated the log event.",
+        "type": "integer"
+      },
+      "log.origin.file.name": {
+        "dashed_name": "log-origin-file-name",
+        "description": "The name of the file containing the source code which originated the log event.\nNote that this field is not meant to capture the log file. The correct field to capture the log file is `log.file.path`.",
+        "example": "Bootstrap.java",
+        "flat_name": "log.origin.file.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "origin.file.name",
+        "normalize": [],
+        "short": "The code file which originated the log event.",
+        "type": "keyword"
+      },
+      "log.origin.function": {
+        "dashed_name": "log-origin-function",
+        "description": "The name of the function or method which originated the log event.",
+        "example": "init",
+        "flat_name": "log.origin.function",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "origin.function",
+        "normalize": [],
+        "short": "The function which originated the log event.",
+        "type": "keyword"
+      },
+      "log.original": {
+        "dashed_name": "log-original",
+        "description": "This is the original log message and contains the full log message before splitting it up in multiple parts.\nIn contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.\nThis field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.",
+        "doc_values": false,
+        "example": "Sep 19 08:26:10 localhost My log",
+        "flat_name": "log.original",
+        "ignore_above": 1024,
+        "index": false,
+        "level": "core",
+        "name": "original",
+        "normalize": [],
+        "short": "Original log message with light interpretation only (encoding, newlines).",
+        "type": "keyword"
+      },
+      "log.syslog": {
+        "dashed_name": "log-syslog",
+        "description": "The Syslog metadata of the event, if the event was transmitted via Syslog. Please see RFCs 5424 or 3164.",
+        "flat_name": "log.syslog",
+        "level": "extended",
+        "name": "syslog",
+        "normalize": [],
+        "short": "Syslog metadata",
+        "type": "object"
+      },
+      "log.syslog.facility.code": {
+        "dashed_name": "log-syslog-facility-code",
+        "description": "The Syslog numeric facility of the log event, if available.\nAccording to RFCs 5424 and 3164, this value should be an integer between 0 and 23.",
+        "example": 23,
+        "flat_name": "log.syslog.facility.code",
+        "format": "string",
+        "level": "extended",
+        "name": "syslog.facility.code",
+        "normalize": [],
+        "short": "Syslog numeric facility of the event.",
+        "type": "long"
+      },
+      "log.syslog.facility.name": {
+        "dashed_name": "log-syslog-facility-name",
+        "description": "The Syslog text-based facility of the log event, if available.",
+        "example": "local7",
+        "flat_name": "log.syslog.facility.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "syslog.facility.name",
+        "normalize": [],
+        "short": "Syslog text-based facility of the event.",
+        "type": "keyword"
+      },
+      "log.syslog.priority": {
+        "dashed_name": "log-syslog-priority",
+        "description": "Syslog numeric priority of the event, if available.\nAccording to RFCs 5424 and 3164, the priority is 8 * facility + severity. This number is therefore expected to contain a value between 0 and 191.",
+        "example": 135,
+        "flat_name": "log.syslog.priority",
+        "format": "string",
+        "level": "extended",
+        "name": "syslog.priority",
+        "normalize": [],
+        "short": "Syslog priority of the event.",
+        "type": "long"
+      },
+      "log.syslog.severity.code": {
+        "dashed_name": "log-syslog-severity-code",
+        "description": "The Syslog numeric severity of the log event, if available.\nIf the event source publishing via Syslog provides a different numeric severity value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `event.severity`.",
+        "example": 3,
+        "flat_name": "log.syslog.severity.code",
+        "level": "extended",
+        "name": "syslog.severity.code",
+        "normalize": [],
+        "short": "Syslog numeric severity of the event.",
+        "type": "long"
+      },
+      "log.syslog.severity.name": {
+        "dashed_name": "log-syslog-severity-name",
+        "description": "The Syslog numeric severity of the log event, if available.\nIf the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), your source's text severity should go to `log.level`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `log.level`.",
+        "example": "Error",
+        "flat_name": "log.syslog.severity.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "syslog.severity.name",
+        "normalize": [],
+        "short": "Syslog text-based severity of the event.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "log",
+    "prefix": "log.",
+    "short": "Details about the event's logging mechanism.",
+    "title": "Log",
+    "type": "group"
+  },
+  "network": {
+    "description": "The network is defined as the communication path over which a host or network event happens.\nThe network.* fields should be populated with details about the network activity associated with an event.",
+    "fields": {
+      "network.application": {
+        "dashed_name": "network-application",
+        "description": "A name given to an application level protocol. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format.\nThe field value must be normalized to lowercase for querying. See the documentation section \"Implementing ECS\".",
+        "example": "aim",
+        "flat_name": "network.application",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "application",
+        "normalize": [],
+        "short": "Application level protocol name.",
+        "type": "keyword"
+      },
+      "network.bytes": {
+        "dashed_name": "network-bytes",
+        "description": "Total bytes transferred in both directions.\nIf `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum.",
+        "example": 368,
+        "flat_name": "network.bytes",
+        "format": "bytes",
+        "level": "core",
+        "name": "bytes",
+        "normalize": [],
+        "short": "Total bytes transferred in both directions.",
+        "type": "long"
+      },
+      "network.community_id": {
+        "dashed_name": "network-community-id",
+        "description": "A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows.\nLearn more at https://github.com/corelight/community-id-spec.",
+        "example": "1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=",
+        "flat_name": "network.community_id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "community_id",
+        "normalize": [],
+        "short": "A hash of source and destination IPs and ports.",
+        "type": "keyword"
+      },
+      "network.direction": {
+        "dashed_name": "network-direction",
+        "description": "Direction of the network traffic.\nRecommended values are:\n  * inbound\n  * outbound\n  * internal\n  * external\n  * unknown\n\nWhen mapping events from a host-based monitoring context, populate this field from the host's point of view.\nWhen mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter.",
+        "example": "inbound",
+        "flat_name": "network.direction",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "direction",
+        "normalize": [],
+        "short": "Direction of the network traffic.",
+        "type": "keyword"
+      },
+      "network.forwarded_ip": {
+        "dashed_name": "network-forwarded-ip",
+        "description": "Host IP address when the source IP address is the proxy.",
+        "example": "192.1.1.2",
+        "flat_name": "network.forwarded_ip",
+        "level": "core",
+        "name": "forwarded_ip",
+        "normalize": [],
+        "short": "Host IP address when the source IP address is the proxy.",
+        "type": "ip"
+      },
+      "network.iana_number": {
+        "dashed_name": "network-iana-number",
+        "description": "IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which use the IANA Protocol Number.",
+        "example": 6,
+        "flat_name": "network.iana_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "iana_number",
+        "normalize": [],
+        "short": "IANA Protocol Number.",
+        "type": "keyword"
+      },
+      "network.inner": {
+        "dashed_name": "network-inner",
+        "description": "Network.inner fields are added in addition to network.vlan fields to describe  the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include  vlan.id and vlan.name. Inner vlan fields are typically used when sending traffic with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.)",
+        "flat_name": "network.inner",
+        "level": "extended",
+        "name": "inner",
+        "normalize": [],
+        "short": "Inner VLAN tag information",
+        "type": "object"
+      },
+      "network.inner.vlan.id": {
+        "dashed_name": "network-inner-vlan-id",
+        "description": "VLAN ID as reported by the observer.",
+        "example": 10,
+        "flat_name": "network.inner.vlan.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "vlan",
+        "short": "VLAN ID as reported by the observer.",
+        "type": "keyword"
+      },
+      "network.inner.vlan.name": {
+        "dashed_name": "network-inner-vlan-name",
+        "description": "Optional VLAN name as reported by the observer.",
+        "example": "outside",
+        "flat_name": "network.inner.vlan.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "vlan",
+        "short": "Optional VLAN name as reported by the observer.",
+        "type": "keyword"
+      },
+      "network.name": {
+        "dashed_name": "network-name",
+        "description": "Name given by operators to sections of their network.",
+        "example": "Guest Wifi",
+        "flat_name": "network.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Name given by operators to sections of their network.",
+        "type": "keyword"
+      },
+      "network.packets": {
+        "dashed_name": "network-packets",
+        "description": "Total packets transferred in both directions.\nIf `source.packets` and `destination.packets` are known, `network.packets` is their sum.",
+        "example": 24,
+        "flat_name": "network.packets",
+        "level": "core",
+        "name": "packets",
+        "normalize": [],
+        "short": "Total packets transferred in both directions.",
+        "type": "long"
+      },
+      "network.protocol": {
+        "dashed_name": "network-protocol",
+        "description": "L7 Network protocol name. ex. http, lumberjack, transport protocol.\nThe field value must be normalized to lowercase for querying. See the documentation section \"Implementing ECS\".",
+        "example": "http",
+        "flat_name": "network.protocol",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "protocol",
+        "normalize": [],
+        "short": "L7 Network protocol name.",
+        "type": "keyword"
+      },
+      "network.transport": {
+        "dashed_name": "network-transport",
+        "description": "Same as network.iana_number, but instead using the Keyword name of the transport layer (udp, tcp, ipv6-icmp, etc.)\nThe field value must be normalized to lowercase for querying. See the documentation section \"Implementing ECS\".",
+        "example": "tcp",
+        "flat_name": "network.transport",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "transport",
+        "normalize": [],
+        "short": "Protocol Name corresponding to the field `iana_number`.",
+        "type": "keyword"
+      },
+      "network.type": {
+        "dashed_name": "network-type",
+        "description": "In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc\nThe field value must be normalized to lowercase for querying. See the documentation section \"Implementing ECS\".",
+        "example": "ipv4",
+        "flat_name": "network.type",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "type",
+        "normalize": [],
+        "short": "In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc",
+        "type": "keyword"
+      },
+      "network.vlan.id": {
+        "dashed_name": "network-vlan-id",
+        "description": "VLAN ID as reported by the observer.",
+        "example": 10,
+        "flat_name": "network.vlan.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "vlan",
+        "short": "VLAN ID as reported by the observer.",
+        "type": "keyword"
+      },
+      "network.vlan.name": {
+        "dashed_name": "network-vlan-name",
+        "description": "Optional VLAN name as reported by the observer.",
+        "example": "outside",
+        "flat_name": "network.vlan.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "vlan",
+        "short": "Optional VLAN name as reported by the observer.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "network",
+    "nestings": [
+      "network.inner.vlan",
+      "network.vlan"
+    ],
+    "prefix": "network.",
+    "reused_here": [
+      {
+        "full": "network.vlan",
+        "schema_name": "vlan",
+        "short": "Fields to describe observed VLAN information."
+      },
+      {
+        "full": "network.inner.vlan",
+        "schema_name": "vlan",
+        "short": "Fields to describe observed VLAN information."
+      }
+    ],
+    "short": "Fields describing the communication path over which the event happened.",
+    "title": "Network",
+    "type": "group"
+  },
+  "observer": {
+    "description": "An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.\nThis could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, web proxies, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.",
+    "fields": {
+      "observer.egress": {
+        "dashed_name": "observer-egress",
+        "description": "Observer.egress holds information like interface number and name, vlan, and zone information to  classify egress traffic.  Single armed monitoring such as a network sensor on a span port should  only use observer.ingress to categorize traffic.",
+        "flat_name": "observer.egress",
+        "level": "extended",
+        "name": "egress",
+        "normalize": [],
+        "short": "Object field for egress information",
+        "type": "object"
+      },
+      "observer.egress.interface.alias": {
+        "dashed_name": "observer-egress-interface-alias",
+        "description": "Interface alias as reported by the system, typically used in firewall implementations for e.g. inside, outside, or dmz logical interface naming.",
+        "example": "outside",
+        "flat_name": "observer.egress.interface.alias",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "alias",
+        "normalize": [],
+        "original_fieldset": "interface",
+        "short": "Interface alias",
+        "type": "keyword"
+      },
+      "observer.egress.interface.id": {
+        "dashed_name": "observer-egress-interface-id",
+        "description": "Interface ID as reported by an observer (typically SNMP interface ID).",
+        "example": 10,
+        "flat_name": "observer.egress.interface.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "interface",
+        "short": "Interface ID",
+        "type": "keyword"
+      },
+      "observer.egress.interface.name": {
+        "dashed_name": "observer-egress-interface-name",
+        "description": "Interface name as reported by the system.",
+        "example": "eth0",
+        "flat_name": "observer.egress.interface.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "interface",
+        "short": "Interface name",
+        "type": "keyword"
+      },
+      "observer.egress.vlan.id": {
+        "dashed_name": "observer-egress-vlan-id",
+        "description": "VLAN ID as reported by the observer.",
+        "example": 10,
+        "flat_name": "observer.egress.vlan.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "vlan",
+        "short": "VLAN ID as reported by the observer.",
+        "type": "keyword"
+      },
+      "observer.egress.vlan.name": {
+        "dashed_name": "observer-egress-vlan-name",
+        "description": "Optional VLAN name as reported by the observer.",
+        "example": "outside",
+        "flat_name": "observer.egress.vlan.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "vlan",
+        "short": "Optional VLAN name as reported by the observer.",
+        "type": "keyword"
+      },
+      "observer.egress.zone": {
+        "dashed_name": "observer-egress-zone",
+        "description": "Network zone of outbound traffic as reported by the observer to categorize the destination area of egress  traffic, e.g. Internal, External, DMZ, HR, Legal, etc.",
+        "example": "Public_Internet",
+        "flat_name": "observer.egress.zone",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "egress.zone",
+        "normalize": [],
+        "short": "Observer Egress zone",
+        "type": "keyword"
+      },
+      "observer.geo.city_name": {
+        "dashed_name": "observer-geo-city-name",
+        "description": "City name.",
+        "example": "Montreal",
+        "flat_name": "observer.geo.city_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "city_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "City name.",
+        "type": "keyword"
+      },
+      "observer.geo.continent_name": {
+        "dashed_name": "observer-geo-continent-name",
+        "description": "Name of the continent.",
+        "example": "North America",
+        "flat_name": "observer.geo.continent_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "continent_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Name of the continent.",
+        "type": "keyword"
+      },
+      "observer.geo.country_iso_code": {
+        "dashed_name": "observer-geo-country-iso-code",
+        "description": "Country ISO code.",
+        "example": "CA",
+        "flat_name": "observer.geo.country_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country ISO code.",
+        "type": "keyword"
+      },
+      "observer.geo.country_name": {
+        "dashed_name": "observer-geo-country-name",
+        "description": "Country name.",
+        "example": "Canada",
+        "flat_name": "observer.geo.country_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country name.",
+        "type": "keyword"
+      },
+      "observer.geo.location": {
+        "dashed_name": "observer-geo-location",
+        "description": "Longitude and latitude.",
+        "example": "{ \"lon\": -73.614830, \"lat\": 45.505918 }",
+        "flat_name": "observer.geo.location",
+        "level": "core",
+        "name": "location",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Longitude and latitude.",
+        "type": "geo_point"
+      },
+      "observer.geo.name": {
+        "dashed_name": "observer-geo-name",
+        "description": "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation.",
+        "example": "boston-dc",
+        "flat_name": "observer.geo.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "User-defined description of a location.",
+        "type": "keyword"
+      },
+      "observer.geo.region_iso_code": {
+        "dashed_name": "observer-geo-region-iso-code",
+        "description": "Region ISO code.",
+        "example": "CA-QC",
+        "flat_name": "observer.geo.region_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region ISO code.",
+        "type": "keyword"
+      },
+      "observer.geo.region_name": {
+        "dashed_name": "observer-geo-region-name",
+        "description": "Region name.",
+        "example": "Quebec",
+        "flat_name": "observer.geo.region_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region name.",
+        "type": "keyword"
+      },
+      "observer.hostname": {
+        "dashed_name": "observer-hostname",
+        "description": "Hostname of the observer.",
+        "flat_name": "observer.hostname",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "hostname",
+        "normalize": [],
+        "short": "Hostname of the observer.",
+        "type": "keyword"
+      },
+      "observer.ingress": {
+        "dashed_name": "observer-ingress",
+        "description": "Observer.ingress holds information like interface number and name, vlan, and zone information to  classify ingress traffic.  Single armed monitoring such as a network sensor on a span port should  only use observer.ingress to categorize traffic.",
+        "flat_name": "observer.ingress",
+        "level": "extended",
+        "name": "ingress",
+        "normalize": [],
+        "short": "Object field for ingress information",
+        "type": "object"
+      },
+      "observer.ingress.interface.alias": {
+        "dashed_name": "observer-ingress-interface-alias",
+        "description": "Interface alias as reported by the system, typically used in firewall implementations for e.g. inside, outside, or dmz logical interface naming.",
+        "example": "outside",
+        "flat_name": "observer.ingress.interface.alias",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "alias",
+        "normalize": [],
+        "original_fieldset": "interface",
+        "short": "Interface alias",
+        "type": "keyword"
+      },
+      "observer.ingress.interface.id": {
+        "dashed_name": "observer-ingress-interface-id",
+        "description": "Interface ID as reported by an observer (typically SNMP interface ID).",
+        "example": 10,
+        "flat_name": "observer.ingress.interface.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "interface",
+        "short": "Interface ID",
+        "type": "keyword"
+      },
+      "observer.ingress.interface.name": {
+        "dashed_name": "observer-ingress-interface-name",
+        "description": "Interface name as reported by the system.",
+        "example": "eth0",
+        "flat_name": "observer.ingress.interface.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "interface",
+        "short": "Interface name",
+        "type": "keyword"
+      },
+      "observer.ingress.vlan.id": {
+        "dashed_name": "observer-ingress-vlan-id",
+        "description": "VLAN ID as reported by the observer.",
+        "example": 10,
+        "flat_name": "observer.ingress.vlan.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "vlan",
+        "short": "VLAN ID as reported by the observer.",
+        "type": "keyword"
+      },
+      "observer.ingress.vlan.name": {
+        "dashed_name": "observer-ingress-vlan-name",
+        "description": "Optional VLAN name as reported by the observer.",
+        "example": "outside",
+        "flat_name": "observer.ingress.vlan.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "vlan",
+        "short": "Optional VLAN name as reported by the observer.",
+        "type": "keyword"
+      },
+      "observer.ingress.zone": {
+        "dashed_name": "observer-ingress-zone",
+        "description": "Network zone of incoming traffic as reported by the observer to categorize the source area of ingress  traffic. e.g. internal, External, DMZ, HR, Legal, etc.",
+        "example": "DMZ",
+        "flat_name": "observer.ingress.zone",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "ingress.zone",
+        "normalize": [],
+        "short": "Observer ingress zone",
+        "type": "keyword"
+      },
+      "observer.ip": {
+        "dashed_name": "observer-ip",
+        "description": "IP addresses of the observer.",
+        "flat_name": "observer.ip",
+        "level": "core",
+        "name": "ip",
+        "normalize": [
+          "array"
+        ],
+        "short": "IP addresses of the observer.",
+        "type": "ip"
+      },
+      "observer.mac": {
+        "dashed_name": "observer-mac",
+        "description": "MAC addresses of the observer",
+        "flat_name": "observer.mac",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "mac",
+        "normalize": [
+          "array"
+        ],
+        "short": "MAC addresses of the observer",
+        "type": "keyword"
+      },
+      "observer.name": {
+        "dashed_name": "observer-name",
+        "description": "Custom name of the observer.\nThis is a name that can be given to an observer. This can be helpful for example if multiple firewalls of the same model are used in an organization.\nIf no custom name is needed, the field can be left empty.",
+        "example": "1_proxySG",
+        "flat_name": "observer.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Custom name of the observer.",
+        "type": "keyword"
+      },
+      "observer.os.family": {
+        "dashed_name": "observer-os-family",
+        "description": "OS family (such as redhat, debian, freebsd, windows).",
+        "example": "debian",
+        "flat_name": "observer.os.family",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "family",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "OS family (such as redhat, debian, freebsd, windows).",
+        "type": "keyword"
+      },
+      "observer.os.full": {
+        "dashed_name": "observer-os-full",
+        "description": "Operating system name, including the version or code name.",
+        "example": "Mac OS Mojave",
+        "flat_name": "observer.os.full",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "observer.os.full.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system name, including the version or code name.",
+        "type": "keyword"
+      },
+      "observer.os.kernel": {
+        "dashed_name": "observer-os-kernel",
+        "description": "Operating system kernel version as a raw string.",
+        "example": "4.4.0-112-generic",
+        "flat_name": "observer.os.kernel",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "kernel",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system kernel version as a raw string.",
+        "type": "keyword"
+      },
+      "observer.os.name": {
+        "dashed_name": "observer-os-name",
+        "description": "Operating system name, without the version.",
+        "example": "Mac OS X",
+        "flat_name": "observer.os.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "observer.os.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system name, without the version.",
+        "type": "keyword"
+      },
+      "observer.os.platform": {
+        "dashed_name": "observer-os-platform",
+        "description": "Operating system platform (such centos, ubuntu, windows).",
+        "example": "darwin",
+        "flat_name": "observer.os.platform",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "platform",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system platform (such centos, ubuntu, windows).",
+        "type": "keyword"
+      },
+      "observer.os.version": {
+        "dashed_name": "observer-os-version",
+        "description": "Operating system version as a raw string.",
+        "example": "10.14.1",
+        "flat_name": "observer.os.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system version as a raw string.",
+        "type": "keyword"
+      },
+      "observer.product": {
+        "dashed_name": "observer-product",
+        "description": "The product name of the observer.",
+        "example": "s200",
+        "flat_name": "observer.product",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "product",
+        "normalize": [],
+        "short": "The product name of the observer.",
+        "type": "keyword"
+      },
+      "observer.serial_number": {
+        "dashed_name": "observer-serial-number",
+        "description": "Observer serial number.",
+        "flat_name": "observer.serial_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "serial_number",
+        "normalize": [],
+        "short": "Observer serial number.",
+        "type": "keyword"
+      },
+      "observer.type": {
+        "dashed_name": "observer-type",
+        "description": "The type of the observer the data is coming from.\nThere is no predefined list of observer types. Some examples are `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM server`.",
+        "example": "firewall",
+        "flat_name": "observer.type",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "type",
+        "normalize": [],
+        "short": "The type of the observer the data is coming from.",
+        "type": "keyword"
+      },
+      "observer.vendor": {
+        "dashed_name": "observer-vendor",
+        "description": "Vendor name of the observer.",
+        "example": "Symantec",
+        "flat_name": "observer.vendor",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "vendor",
+        "normalize": [],
+        "short": "Vendor name of the observer.",
+        "type": "keyword"
+      },
+      "observer.version": {
+        "dashed_name": "observer-version",
+        "description": "Observer version.",
+        "flat_name": "observer.version",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "version",
+        "normalize": [],
+        "short": "Observer version.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "observer",
+    "nestings": [
+      "observer.egress.interface",
+      "observer.egress.vlan",
+      "observer.geo",
+      "observer.ingress.interface",
+      "observer.ingress.vlan",
+      "observer.os"
+    ],
+    "prefix": "observer.",
+    "reused_here": [
+      {
+        "full": "observer.geo",
+        "schema_name": "geo",
+        "short": "Fields describing a location."
+      },
+      {
+        "full": "observer.ingress.interface",
+        "schema_name": "interface",
+        "short": "Fields to describe observer interface information."
+      },
+      {
+        "full": "observer.egress.interface",
+        "schema_name": "interface",
+        "short": "Fields to describe observer interface information."
+      },
+      {
+        "full": "observer.os",
+        "schema_name": "os",
+        "short": "OS fields contain information about the operating system."
+      },
+      {
+        "full": "observer.ingress.vlan",
+        "schema_name": "vlan",
+        "short": "Fields to describe observed VLAN information."
+      },
+      {
+        "full": "observer.egress.vlan",
+        "schema_name": "vlan",
+        "short": "Fields to describe observed VLAN information."
+      }
+    ],
+    "short": "Fields describing an entity observing the event from outside the host.",
+    "title": "Observer",
+    "type": "group"
+  },
+  "organization": {
+    "description": "The organization fields enrich data with information about the company or entity the data is associated with.\nThese fields help you arrange or filter data stored in an index by one or multiple organizations.",
+    "fields": {
+      "organization.id": {
+        "dashed_name": "organization-id",
+        "description": "Unique identifier for the organization.",
+        "flat_name": "organization.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique identifier for the organization.",
+        "type": "keyword"
+      },
+      "organization.name": {
+        "dashed_name": "organization-name",
+        "description": "Organization name.",
+        "flat_name": "organization.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "organization.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "short": "Organization name.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "organization",
+    "prefix": "organization.",
+    "short": "Fields describing the organization or company the event is associated with.",
+    "title": "Organization",
+    "type": "group"
+  },
+  "os": {
+    "description": "The OS fields contain information about the operating system.",
+    "fields": {
+      "os.family": {
+        "dashed_name": "os-family",
+        "description": "OS family (such as redhat, debian, freebsd, windows).",
+        "example": "debian",
+        "flat_name": "os.family",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "family",
+        "normalize": [],
+        "short": "OS family (such as redhat, debian, freebsd, windows).",
+        "type": "keyword"
+      },
+      "os.full": {
+        "dashed_name": "os-full",
+        "description": "Operating system name, including the version or code name.",
+        "example": "Mac OS Mojave",
+        "flat_name": "os.full",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "os.full.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full",
+        "normalize": [],
+        "short": "Operating system name, including the version or code name.",
+        "type": "keyword"
+      },
+      "os.kernel": {
+        "dashed_name": "os-kernel",
+        "description": "Operating system kernel version as a raw string.",
+        "example": "4.4.0-112-generic",
+        "flat_name": "os.kernel",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "kernel",
+        "normalize": [],
+        "short": "Operating system kernel version as a raw string.",
+        "type": "keyword"
+      },
+      "os.name": {
+        "dashed_name": "os-name",
+        "description": "Operating system name, without the version.",
+        "example": "Mac OS X",
+        "flat_name": "os.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "os.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "short": "Operating system name, without the version.",
+        "type": "keyword"
+      },
+      "os.platform": {
+        "dashed_name": "os-platform",
+        "description": "Operating system platform (such centos, ubuntu, windows).",
+        "example": "darwin",
+        "flat_name": "os.platform",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "platform",
+        "normalize": [],
+        "short": "Operating system platform (such centos, ubuntu, windows).",
+        "type": "keyword"
+      },
+      "os.version": {
+        "dashed_name": "os-version",
+        "description": "Operating system version as a raw string.",
+        "example": "10.14.1",
+        "flat_name": "os.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "short": "Operating system version as a raw string.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "os",
+    "prefix": "os.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "os",
+          "at": "observer",
+          "full": "observer.os"
+        },
+        {
+          "as": "os",
+          "at": "host",
+          "full": "host.os"
+        },
+        {
+          "as": "os",
+          "at": "user_agent",
+          "full": "user_agent.os"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "OS fields contain information about the operating system.",
+    "title": "Operating System",
+    "type": "group"
+  },
+  "package": {
+    "description": "These fields contain information about an installed software package. It contains general information about a package, such as name, version or size. It also contains installation details, such as time or location.",
+    "fields": {
+      "package.architecture": {
+        "dashed_name": "package-architecture",
+        "description": "Package architecture.",
+        "example": "x86_64",
+        "flat_name": "package.architecture",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "architecture",
+        "normalize": [],
+        "short": "Package architecture.",
+        "type": "keyword"
+      },
+      "package.build_version": {
+        "dashed_name": "package-build-version",
+        "description": "Additional information about the build version of the installed package.\nFor example use the commit SHA of a non-released package.",
+        "example": "36f4f7e89dd61b0988b12ee000b98966867710cd",
+        "flat_name": "package.build_version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "build_version",
+        "normalize": [],
+        "short": "Build version information",
+        "type": "keyword"
+      },
+      "package.checksum": {
+        "dashed_name": "package-checksum",
+        "description": "Checksum of the installed package for verification.",
+        "example": "68b329da9893e34099c7d8ad5cb9c940",
+        "flat_name": "package.checksum",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "checksum",
+        "normalize": [],
+        "short": "Checksum of the installed package for verification.",
+        "type": "keyword"
+      },
+      "package.description": {
+        "dashed_name": "package-description",
+        "description": "Description of the package.",
+        "example": "Open source programming language to build simple/reliable/efficient software.",
+        "flat_name": "package.description",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "description",
+        "normalize": [],
+        "short": "Description of the package.",
+        "type": "keyword"
+      },
+      "package.install_scope": {
+        "dashed_name": "package-install-scope",
+        "description": "Indicating how the package was installed, e.g. user-local, global.",
+        "example": "global",
+        "flat_name": "package.install_scope",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "install_scope",
+        "normalize": [],
+        "short": "Indicating how the package was installed, e.g. user-local, global.",
+        "type": "keyword"
+      },
+      "package.installed": {
+        "dashed_name": "package-installed",
+        "description": "Time when package was installed.",
+        "flat_name": "package.installed",
+        "level": "extended",
+        "name": "installed",
+        "normalize": [],
+        "short": "Time when package was installed.",
+        "type": "date"
+      },
+      "package.license": {
+        "dashed_name": "package-license",
+        "description": "License under which the package was released.\nUse a short name, e.g. the license identifier from SPDX License List where possible (https://spdx.org/licenses/).",
+        "example": "Apache License 2.0",
+        "flat_name": "package.license",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "license",
+        "normalize": [],
+        "short": "Package license",
+        "type": "keyword"
+      },
+      "package.name": {
+        "dashed_name": "package-name",
+        "description": "Package name",
+        "example": "go",
+        "flat_name": "package.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Package name",
+        "type": "keyword"
+      },
+      "package.path": {
+        "dashed_name": "package-path",
+        "description": "Path where the package is installed.",
+        "example": "/usr/local/Cellar/go/1.12.9/",
+        "flat_name": "package.path",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "path",
+        "normalize": [],
+        "short": "Path where the package is installed.",
+        "type": "keyword"
+      },
+      "package.reference": {
+        "dashed_name": "package-reference",
+        "description": "Home page or reference URL of the software in this package, if available.",
+        "example": "https://golang.org",
+        "flat_name": "package.reference",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "reference",
+        "normalize": [],
+        "short": "Package home page or reference URL",
+        "type": "keyword"
+      },
+      "package.size": {
+        "dashed_name": "package-size",
+        "description": "Package size in bytes.",
+        "example": 62231,
+        "flat_name": "package.size",
+        "format": "string",
+        "level": "extended",
+        "name": "size",
+        "normalize": [],
+        "short": "Package size in bytes.",
+        "type": "long"
+      },
+      "package.type": {
+        "dashed_name": "package-type",
+        "description": "Type of package.\nThis should contain the package file type, rather than the package manager name. Examples: rpm, dpkg, brew, npm, gem, nupkg, jar.",
+        "example": "rpm",
+        "flat_name": "package.type",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "type",
+        "normalize": [],
+        "short": "Package type",
+        "type": "keyword"
+      },
+      "package.version": {
+        "dashed_name": "package-version",
+        "description": "Package version",
+        "example": "1.12.9",
+        "flat_name": "package.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "short": "Package version",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "package",
+    "prefix": "package.",
+    "short": "These fields contain information about an installed software package.",
+    "title": "Package",
+    "type": "group"
+  },
+  "pe": {
+    "description": "These fields contain Windows Portable Executable (PE) metadata.",
+    "fields": {
+      "pe.architecture": {
+        "dashed_name": "pe-architecture",
+        "description": "CPU architecture target for the file.",
+        "example": "x64",
+        "flat_name": "pe.architecture",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "architecture",
+        "normalize": [],
+        "short": "CPU architecture target for the file.",
+        "type": "keyword"
+      },
+      "pe.company": {
+        "dashed_name": "pe-company",
+        "description": "Internal company name of the file, provided at compile-time.",
+        "example": "Microsoft Corporation",
+        "flat_name": "pe.company",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "company",
+        "normalize": [],
+        "short": "Internal company name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "pe.description": {
+        "dashed_name": "pe-description",
+        "description": "Internal description of the file, provided at compile-time.",
+        "example": "Paint",
+        "flat_name": "pe.description",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "description",
+        "normalize": [],
+        "short": "Internal description of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "pe.file_version": {
+        "dashed_name": "pe-file-version",
+        "description": "Internal version of the file, provided at compile-time.",
+        "example": "6.3.9600.17415",
+        "flat_name": "pe.file_version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "file_version",
+        "normalize": [],
+        "short": "Process name.",
+        "type": "keyword"
+      },
+      "pe.imphash": {
+        "dashed_name": "pe-imphash",
+        "description": "A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
+        "example": "0c6803c4e922103c4dca5963aad36ddf",
+        "flat_name": "pe.imphash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "imphash",
+        "normalize": [],
+        "short": "A hash of the imports in a PE file.",
+        "type": "keyword"
+      },
+      "pe.original_file_name": {
+        "dashed_name": "pe-original-file-name",
+        "description": "Internal name of the file, provided at compile-time.",
+        "example": "MSPAINT.EXE",
+        "flat_name": "pe.original_file_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "original_file_name",
+        "normalize": [],
+        "short": "Internal name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "pe.product": {
+        "dashed_name": "pe-product",
+        "description": "Internal product name of the file, provided at compile-time.",
+        "example": "Microsoft\u00ae Windows\u00ae Operating System",
+        "flat_name": "pe.product",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "product",
+        "normalize": [],
+        "short": "Internal product name of the file, provided at compile-time.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "pe",
+    "prefix": "pe.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "pe",
+          "at": "file",
+          "full": "file.pe"
+        },
+        {
+          "as": "pe",
+          "at": "dll",
+          "full": "dll.pe"
+        },
+        {
+          "as": "pe",
+          "at": "process",
+          "full": "process.pe"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "These fields contain Windows Portable Executable (PE) metadata.",
+    "title": "PE Header",
+    "type": "group"
+  },
+  "process": {
+    "description": "These fields contain information about a process.\nThese fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation.",
+    "fields": {
+      "process.args": {
+        "dashed_name": "process-args",
+        "description": "Array of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
+        "example": [
+          "/usr/bin/ssh",
+          "-l",
+          "user",
+          "10.0.0.16"
+        ],
+        "flat_name": "process.args",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "args",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array of process arguments.",
+        "type": "keyword"
+      },
+      "process.args_count": {
+        "dashed_name": "process-args-count",
+        "description": "Length of the process.args array.\nThis field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.",
+        "example": 4,
+        "flat_name": "process.args_count",
+        "level": "extended",
+        "name": "args_count",
+        "normalize": [],
+        "short": "Length of the process.args array.",
+        "type": "long"
+      },
+      "process.code_signature.exists": {
+        "dashed_name": "process-code-signature-exists",
+        "description": "Boolean to capture if a signature is present.",
+        "example": "true",
+        "flat_name": "process.code_signature.exists",
+        "level": "core",
+        "name": "exists",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Boolean to capture if a signature is present.",
+        "type": "boolean"
+      },
+      "process.code_signature.status": {
+        "dashed_name": "process-code-signature-status",
+        "description": "Additional information about the certificate status.\nThis is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.",
+        "example": "ERROR_UNTRUSTED_ROOT",
+        "flat_name": "process.code_signature.status",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "status",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Additional information about the certificate status.",
+        "type": "keyword"
+      },
+      "process.code_signature.subject_name": {
+        "dashed_name": "process-code-signature-subject-name",
+        "description": "Subject name of the code signer",
+        "example": "Microsoft Corporation",
+        "flat_name": "process.code_signature.subject_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "subject_name",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Subject name of the code signer",
+        "type": "keyword"
+      },
+      "process.code_signature.trusted": {
+        "dashed_name": "process-code-signature-trusted",
+        "description": "Stores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+        "example": "true",
+        "flat_name": "process.code_signature.trusted",
+        "level": "extended",
+        "name": "trusted",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Stores the trust status of the certificate chain.",
+        "type": "boolean"
+      },
+      "process.code_signature.valid": {
+        "dashed_name": "process-code-signature-valid",
+        "description": "Boolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+        "example": "true",
+        "flat_name": "process.code_signature.valid",
+        "level": "extended",
+        "name": "valid",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Boolean to capture if the digital signature is verified against the binary content.",
+        "type": "boolean"
+      },
+      "process.command_line": {
+        "dashed_name": "process-command-line",
+        "description": "Full command line that started the process, including the absolute path to the executable, and all arguments.\nSome arguments may be filtered to protect sensitive information.",
+        "example": "/usr/bin/ssh -l user 10.0.0.16",
+        "flat_name": "process.command_line",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.command_line.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "command_line",
+        "normalize": [],
+        "short": "Full command line that started the process.",
+        "type": "keyword"
+      },
+      "process.entity_id": {
+        "dashed_name": "process-entity-id",
+        "description": "Unique identifier for the process.\nThe implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.\nConstructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.",
+        "example": "c2c455d9f99375d",
+        "flat_name": "process.entity_id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "entity_id",
+        "normalize": [],
+        "short": "Unique identifier for the process.",
+        "type": "keyword"
+      },
+      "process.executable": {
+        "dashed_name": "process-executable",
+        "description": "Absolute path to the process executable.",
+        "example": "/usr/bin/ssh",
+        "flat_name": "process.executable",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.executable.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "executable",
+        "normalize": [],
+        "short": "Absolute path to the process executable.",
+        "type": "keyword"
+      },
+      "process.exit_code": {
+        "dashed_name": "process-exit-code",
+        "description": "The exit code of the process, if this is a termination event.\nThe field should be absent if there is no exit code for the event (e.g. process start).",
+        "example": 137,
+        "flat_name": "process.exit_code",
+        "level": "extended",
+        "name": "exit_code",
+        "normalize": [],
+        "short": "The exit code of the process.",
+        "type": "long"
+      },
+      "process.hash.md5": {
+        "dashed_name": "process-hash-md5",
+        "description": "MD5 hash.",
+        "flat_name": "process.hash.md5",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "md5",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "MD5 hash.",
+        "type": "keyword"
+      },
+      "process.hash.sha1": {
+        "dashed_name": "process-hash-sha1",
+        "description": "SHA1 hash.",
+        "flat_name": "process.hash.sha1",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha1",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA1 hash.",
+        "type": "keyword"
+      },
+      "process.hash.sha256": {
+        "dashed_name": "process-hash-sha256",
+        "description": "SHA256 hash.",
+        "flat_name": "process.hash.sha256",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha256",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA256 hash.",
+        "type": "keyword"
+      },
+      "process.hash.sha512": {
+        "dashed_name": "process-hash-sha512",
+        "description": "SHA512 hash.",
+        "flat_name": "process.hash.sha512",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha512",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA512 hash.",
+        "type": "keyword"
+      },
+      "process.name": {
+        "dashed_name": "process-name",
+        "description": "Process name.\nSometimes called program name or similar.",
+        "example": "ssh",
+        "flat_name": "process.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "short": "Process name.",
+        "type": "keyword"
+      },
+      "process.parent.args": {
+        "dashed_name": "process-parent-args",
+        "description": "Array of process arguments, starting with the absolute path to the executable.\nMay be filtered to protect sensitive information.",
+        "example": [
+          "/usr/bin/ssh",
+          "-l",
+          "user",
+          "10.0.0.16"
+        ],
+        "flat_name": "process.parent.args",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "args",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "process",
+        "short": "Array of process arguments.",
+        "type": "keyword"
+      },
+      "process.parent.args_count": {
+        "dashed_name": "process-parent-args-count",
+        "description": "Length of the process.args array.\nThis field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.",
+        "example": 4,
+        "flat_name": "process.parent.args_count",
+        "level": "extended",
+        "name": "args_count",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Length of the process.args array.",
+        "type": "long"
+      },
+      "process.parent.code_signature.exists": {
+        "dashed_name": "process-parent-code-signature-exists",
+        "description": "Boolean to capture if a signature is present.",
+        "example": "true",
+        "flat_name": "process.parent.code_signature.exists",
+        "level": "core",
+        "name": "exists",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Boolean to capture if a signature is present.",
+        "type": "boolean"
+      },
+      "process.parent.code_signature.status": {
+        "dashed_name": "process-parent-code-signature-status",
+        "description": "Additional information about the certificate status.\nThis is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.",
+        "example": "ERROR_UNTRUSTED_ROOT",
+        "flat_name": "process.parent.code_signature.status",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "status",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Additional information about the certificate status.",
+        "type": "keyword"
+      },
+      "process.parent.code_signature.subject_name": {
+        "dashed_name": "process-parent-code-signature-subject-name",
+        "description": "Subject name of the code signer",
+        "example": "Microsoft Corporation",
+        "flat_name": "process.parent.code_signature.subject_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "subject_name",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Subject name of the code signer",
+        "type": "keyword"
+      },
+      "process.parent.code_signature.trusted": {
+        "dashed_name": "process-parent-code-signature-trusted",
+        "description": "Stores the trust status of the certificate chain.\nValidating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.",
+        "example": "true",
+        "flat_name": "process.parent.code_signature.trusted",
+        "level": "extended",
+        "name": "trusted",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Stores the trust status of the certificate chain.",
+        "type": "boolean"
+      },
+      "process.parent.code_signature.valid": {
+        "dashed_name": "process-parent-code-signature-valid",
+        "description": "Boolean to capture if the digital signature is verified against the binary content.\nLeave unpopulated if a certificate was unchecked.",
+        "example": "true",
+        "flat_name": "process.parent.code_signature.valid",
+        "level": "extended",
+        "name": "valid",
+        "normalize": [],
+        "original_fieldset": "code_signature",
+        "short": "Boolean to capture if the digital signature is verified against the binary content.",
+        "type": "boolean"
+      },
+      "process.parent.command_line": {
+        "dashed_name": "process-parent-command-line",
+        "description": "Full command line that started the process, including the absolute path to the executable, and all arguments.\nSome arguments may be filtered to protect sensitive information.",
+        "example": "/usr/bin/ssh -l user 10.0.0.16",
+        "flat_name": "process.parent.command_line",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.parent.command_line.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "command_line",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Full command line that started the process.",
+        "type": "keyword"
+      },
+      "process.parent.entity_id": {
+        "dashed_name": "process-parent-entity-id",
+        "description": "Unique identifier for the process.\nThe implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.\nConstructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.",
+        "example": "c2c455d9f99375d",
+        "flat_name": "process.parent.entity_id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "entity_id",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Unique identifier for the process.",
+        "type": "keyword"
+      },
+      "process.parent.executable": {
+        "dashed_name": "process-parent-executable",
+        "description": "Absolute path to the process executable.",
+        "example": "/usr/bin/ssh",
+        "flat_name": "process.parent.executable",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.parent.executable.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "executable",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Absolute path to the process executable.",
+        "type": "keyword"
+      },
+      "process.parent.exit_code": {
+        "dashed_name": "process-parent-exit-code",
+        "description": "The exit code of the process, if this is a termination event.\nThe field should be absent if there is no exit code for the event (e.g. process start).",
+        "example": 137,
+        "flat_name": "process.parent.exit_code",
+        "level": "extended",
+        "name": "exit_code",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "The exit code of the process.",
+        "type": "long"
+      },
+      "process.parent.hash.md5": {
+        "dashed_name": "process-parent-hash-md5",
+        "description": "MD5 hash.",
+        "flat_name": "process.parent.hash.md5",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "md5",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "MD5 hash.",
+        "type": "keyword"
+      },
+      "process.parent.hash.sha1": {
+        "dashed_name": "process-parent-hash-sha1",
+        "description": "SHA1 hash.",
+        "flat_name": "process.parent.hash.sha1",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha1",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA1 hash.",
+        "type": "keyword"
+      },
+      "process.parent.hash.sha256": {
+        "dashed_name": "process-parent-hash-sha256",
+        "description": "SHA256 hash.",
+        "flat_name": "process.parent.hash.sha256",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha256",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA256 hash.",
+        "type": "keyword"
+      },
+      "process.parent.hash.sha512": {
+        "dashed_name": "process-parent-hash-sha512",
+        "description": "SHA512 hash.",
+        "flat_name": "process.parent.hash.sha512",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "sha512",
+        "normalize": [],
+        "original_fieldset": "hash",
+        "short": "SHA512 hash.",
+        "type": "keyword"
+      },
+      "process.parent.name": {
+        "dashed_name": "process-parent-name",
+        "description": "Process name.\nSometimes called program name or similar.",
+        "example": "ssh",
+        "flat_name": "process.parent.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.parent.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Process name.",
+        "type": "keyword"
+      },
+      "process.parent.pe.architecture": {
+        "dashed_name": "process-parent-pe-architecture",
+        "description": "CPU architecture target for the file.",
+        "example": "x64",
+        "flat_name": "process.parent.pe.architecture",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "architecture",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "CPU architecture target for the file.",
+        "type": "keyword"
+      },
+      "process.parent.pe.company": {
+        "dashed_name": "process-parent-pe-company",
+        "description": "Internal company name of the file, provided at compile-time.",
+        "example": "Microsoft Corporation",
+        "flat_name": "process.parent.pe.company",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "company",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal company name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "process.parent.pe.description": {
+        "dashed_name": "process-parent-pe-description",
+        "description": "Internal description of the file, provided at compile-time.",
+        "example": "Paint",
+        "flat_name": "process.parent.pe.description",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "description",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal description of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "process.parent.pe.file_version": {
+        "dashed_name": "process-parent-pe-file-version",
+        "description": "Internal version of the file, provided at compile-time.",
+        "example": "6.3.9600.17415",
+        "flat_name": "process.parent.pe.file_version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "file_version",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Process name.",
+        "type": "keyword"
+      },
+      "process.parent.pe.imphash": {
+        "dashed_name": "process-parent-pe-imphash",
+        "description": "A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
+        "example": "0c6803c4e922103c4dca5963aad36ddf",
+        "flat_name": "process.parent.pe.imphash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "imphash",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "A hash of the imports in a PE file.",
+        "type": "keyword"
+      },
+      "process.parent.pe.original_file_name": {
+        "dashed_name": "process-parent-pe-original-file-name",
+        "description": "Internal name of the file, provided at compile-time.",
+        "example": "MSPAINT.EXE",
+        "flat_name": "process.parent.pe.original_file_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "original_file_name",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "process.parent.pe.product": {
+        "dashed_name": "process-parent-pe-product",
+        "description": "Internal product name of the file, provided at compile-time.",
+        "example": "Microsoft\u00ae Windows\u00ae Operating System",
+        "flat_name": "process.parent.pe.product",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "product",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal product name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "process.parent.pgid": {
+        "dashed_name": "process-parent-pgid",
+        "description": "Identifier of the group of processes the process belongs to.",
+        "flat_name": "process.parent.pgid",
+        "format": "string",
+        "level": "extended",
+        "name": "pgid",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Identifier of the group of processes the process belongs to.",
+        "type": "long"
+      },
+      "process.parent.pid": {
+        "dashed_name": "process-parent-pid",
+        "description": "Process id.",
+        "example": 4242,
+        "flat_name": "process.parent.pid",
+        "format": "string",
+        "level": "core",
+        "name": "pid",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Process id.",
+        "type": "long"
+      },
+      "process.parent.ppid": {
+        "dashed_name": "process-parent-ppid",
+        "description": "Parent process' pid.",
+        "example": 4241,
+        "flat_name": "process.parent.ppid",
+        "format": "string",
+        "level": "extended",
+        "name": "ppid",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Parent process' pid.",
+        "type": "long"
+      },
+      "process.parent.start": {
+        "dashed_name": "process-parent-start",
+        "description": "The time the process started.",
+        "example": "2016-05-23T08:05:34.853Z",
+        "flat_name": "process.parent.start",
+        "level": "extended",
+        "name": "start",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "The time the process started.",
+        "type": "date"
+      },
+      "process.parent.thread.id": {
+        "dashed_name": "process-parent-thread-id",
+        "description": "Thread ID.",
+        "example": 4242,
+        "flat_name": "process.parent.thread.id",
+        "format": "string",
+        "level": "extended",
+        "name": "thread.id",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Thread ID.",
+        "type": "long"
+      },
+      "process.parent.thread.name": {
+        "dashed_name": "process-parent-thread-name",
+        "description": "Thread name.",
+        "example": "thread-0",
+        "flat_name": "process.parent.thread.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "thread.name",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Thread name.",
+        "type": "keyword"
+      },
+      "process.parent.title": {
+        "dashed_name": "process-parent-title",
+        "description": "Process title.\nThe proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.",
+        "flat_name": "process.parent.title",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.parent.title.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "title",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Process title.",
+        "type": "keyword"
+      },
+      "process.parent.uptime": {
+        "dashed_name": "process-parent-uptime",
+        "description": "Seconds the process has been up.",
+        "example": 1325,
+        "flat_name": "process.parent.uptime",
+        "level": "extended",
+        "name": "uptime",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "Seconds the process has been up.",
+        "type": "long"
+      },
+      "process.parent.working_directory": {
+        "dashed_name": "process-parent-working-directory",
+        "description": "The working directory of the process.",
+        "example": "/home/alice",
+        "flat_name": "process.parent.working_directory",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.parent.working_directory.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "working_directory",
+        "normalize": [],
+        "original_fieldset": "process",
+        "short": "The working directory of the process.",
+        "type": "keyword"
+      },
+      "process.pe.architecture": {
+        "dashed_name": "process-pe-architecture",
+        "description": "CPU architecture target for the file.",
+        "example": "x64",
+        "flat_name": "process.pe.architecture",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "architecture",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "CPU architecture target for the file.",
+        "type": "keyword"
+      },
+      "process.pe.company": {
+        "dashed_name": "process-pe-company",
+        "description": "Internal company name of the file, provided at compile-time.",
+        "example": "Microsoft Corporation",
+        "flat_name": "process.pe.company",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "company",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal company name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "process.pe.description": {
+        "dashed_name": "process-pe-description",
+        "description": "Internal description of the file, provided at compile-time.",
+        "example": "Paint",
+        "flat_name": "process.pe.description",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "description",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal description of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "process.pe.file_version": {
+        "dashed_name": "process-pe-file-version",
+        "description": "Internal version of the file, provided at compile-time.",
+        "example": "6.3.9600.17415",
+        "flat_name": "process.pe.file_version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "file_version",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Process name.",
+        "type": "keyword"
+      },
+      "process.pe.imphash": {
+        "dashed_name": "process-pe-imphash",
+        "description": "A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.\nLearn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.",
+        "example": "0c6803c4e922103c4dca5963aad36ddf",
+        "flat_name": "process.pe.imphash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "imphash",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "A hash of the imports in a PE file.",
+        "type": "keyword"
+      },
+      "process.pe.original_file_name": {
+        "dashed_name": "process-pe-original-file-name",
+        "description": "Internal name of the file, provided at compile-time.",
+        "example": "MSPAINT.EXE",
+        "flat_name": "process.pe.original_file_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "original_file_name",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "process.pe.product": {
+        "dashed_name": "process-pe-product",
+        "description": "Internal product name of the file, provided at compile-time.",
+        "example": "Microsoft\u00ae Windows\u00ae Operating System",
+        "flat_name": "process.pe.product",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "product",
+        "normalize": [],
+        "original_fieldset": "pe",
+        "short": "Internal product name of the file, provided at compile-time.",
+        "type": "keyword"
+      },
+      "process.pgid": {
+        "dashed_name": "process-pgid",
+        "description": "Identifier of the group of processes the process belongs to.",
+        "flat_name": "process.pgid",
+        "format": "string",
+        "level": "extended",
+        "name": "pgid",
+        "normalize": [],
+        "short": "Identifier of the group of processes the process belongs to.",
+        "type": "long"
+      },
+      "process.pid": {
+        "dashed_name": "process-pid",
+        "description": "Process id.",
+        "example": 4242,
+        "flat_name": "process.pid",
+        "format": "string",
+        "level": "core",
+        "name": "pid",
+        "normalize": [],
+        "short": "Process id.",
+        "type": "long"
+      },
+      "process.ppid": {
+        "dashed_name": "process-ppid",
+        "description": "Parent process' pid.",
+        "example": 4241,
+        "flat_name": "process.ppid",
+        "format": "string",
+        "level": "extended",
+        "name": "ppid",
+        "normalize": [],
+        "short": "Parent process' pid.",
+        "type": "long"
+      },
+      "process.start": {
+        "dashed_name": "process-start",
+        "description": "The time the process started.",
+        "example": "2016-05-23T08:05:34.853Z",
+        "flat_name": "process.start",
+        "level": "extended",
+        "name": "start",
+        "normalize": [],
+        "short": "The time the process started.",
+        "type": "date"
+      },
+      "process.thread.id": {
+        "dashed_name": "process-thread-id",
+        "description": "Thread ID.",
+        "example": 4242,
+        "flat_name": "process.thread.id",
+        "format": "string",
+        "level": "extended",
+        "name": "thread.id",
+        "normalize": [],
+        "short": "Thread ID.",
+        "type": "long"
+      },
+      "process.thread.name": {
+        "dashed_name": "process-thread-name",
+        "description": "Thread name.",
+        "example": "thread-0",
+        "flat_name": "process.thread.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "thread.name",
+        "normalize": [],
+        "short": "Thread name.",
+        "type": "keyword"
+      },
+      "process.title": {
+        "dashed_name": "process-title",
+        "description": "Process title.\nThe proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.",
+        "flat_name": "process.title",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.title.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "title",
+        "normalize": [],
+        "short": "Process title.",
+        "type": "keyword"
+      },
+      "process.uptime": {
+        "dashed_name": "process-uptime",
+        "description": "Seconds the process has been up.",
+        "example": 1325,
+        "flat_name": "process.uptime",
+        "level": "extended",
+        "name": "uptime",
+        "normalize": [],
+        "short": "Seconds the process has been up.",
+        "type": "long"
+      },
+      "process.working_directory": {
+        "dashed_name": "process-working-directory",
+        "description": "The working directory of the process.",
+        "example": "/home/alice",
+        "flat_name": "process.working_directory",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "process.working_directory.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "working_directory",
+        "normalize": [],
+        "short": "The working directory of the process.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "process",
+    "nestings": [
+      "process.code_signature",
+      "process.hash",
+      "process.parent",
+      "process.pe"
+    ],
+    "prefix": "process.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "parent",
+          "at": "process",
+          "full": "process.parent"
+        }
+      ],
+      "top_level": true
+    },
+    "reused_here": [
+      {
+        "full": "process.code_signature",
+        "schema_name": "code_signature",
+        "short": "These fields contain information about binary code signatures."
+      },
+      {
+        "full": "process.hash",
+        "schema_name": "hash",
+        "short": "Hashes, usually file hashes."
+      },
+      {
+        "full": "process.pe",
+        "schema_name": "pe",
+        "short": "These fields contain Windows Portable Executable (PE) metadata."
+      },
+      {
+        "full": "process.parent",
+        "schema_name": "process",
+        "short": "These fields contain information about a process."
+      }
+    ],
+    "short": "These fields contain information about a process.",
+    "title": "Process",
+    "type": "group"
+  },
+  "registry": {
+    "description": "Fields related to Windows Registry operations.",
+    "fields": {
+      "registry.data.bytes": {
+        "dashed_name": "registry-data-bytes",
+        "description": "Original bytes written with base64 encoding.\nFor Windows registry operations, such as SetValueEx and RegQueryValueEx, this corresponds to the data pointed by `lp_data`. This is optional but provides better recoverability and should be populated for REG_BINARY encoded values.",
+        "example": "ZQBuAC0AVQBTAAAAZQBuAAAAAAA=",
+        "flat_name": "registry.data.bytes",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "data.bytes",
+        "normalize": [],
+        "short": "Original bytes written with base64 encoding.",
+        "type": "keyword"
+      },
+      "registry.data.strings": {
+        "dashed_name": "registry-data-strings",
+        "description": "Content when writing string types.\nPopulated as an array when writing string data to the registry. For single string registry types (REG_SZ, REG_EXPAND_SZ), this should be an array with one string. For sequences of string with REG_MULTI_SZ, this array will be variable length. For numeric data, such as REG_DWORD and REG_QWORD, this should be populated with the decimal representation (e.g `\"1\"`).",
+        "example": "[\"C:\\rta\\red_ttp\\bin\\myapp.exe\"]",
+        "flat_name": "registry.data.strings",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "data.strings",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of strings representing what was written to the registry.",
+        "type": "keyword"
+      },
+      "registry.data.type": {
+        "dashed_name": "registry-data-type",
+        "description": "Standard registry type for encoding contents",
+        "example": "REG_SZ",
+        "flat_name": "registry.data.type",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "data.type",
+        "normalize": [],
+        "short": "Standard registry type for encoding contents",
+        "type": "keyword"
+      },
+      "registry.hive": {
+        "dashed_name": "registry-hive",
+        "description": "Abbreviated name for the hive.",
+        "example": "HKLM",
+        "flat_name": "registry.hive",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "hive",
+        "normalize": [],
+        "short": "Abbreviated name for the hive.",
+        "type": "keyword"
+      },
+      "registry.key": {
+        "dashed_name": "registry-key",
+        "description": "Hive-relative path of keys.",
+        "example": "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\winword.exe",
+        "flat_name": "registry.key",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "key",
+        "normalize": [],
+        "short": "Hive-relative path of keys.",
+        "type": "keyword"
+      },
+      "registry.path": {
+        "dashed_name": "registry-path",
+        "description": "Full path, including hive, key and value",
+        "example": "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\winword.exe\\Debugger",
+        "flat_name": "registry.path",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "path",
+        "normalize": [],
+        "short": "Full path, including hive, key and value",
+        "type": "keyword"
+      },
+      "registry.value": {
+        "dashed_name": "registry-value",
+        "description": "Name of the value written.",
+        "example": "Debugger",
+        "flat_name": "registry.value",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "value",
+        "normalize": [],
+        "short": "Name of the value written.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "registry",
+    "prefix": "registry.",
+    "short": "Fields related to Windows Registry operations.",
+    "title": "Registry",
+    "type": "group"
+  },
+  "related": {
+    "description": "This field set is meant to facilitate pivoting around a piece of data.\nSome pieces of information can be seen in many places in an ECS event. To facilitate searching for them, store an array of all seen values to their corresponding field in `related.`.\nA concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:192.0.2.15`.",
+    "fields": {
+      "related.hash": {
+        "dashed_name": "related-hash",
+        "description": "All the hashes seen on your event. Populating this field, then using it to search for hashes can help in situations where you're unsure what the hash algorithm is (and therefore which key name to search).",
+        "flat_name": "related.hash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hash",
+        "normalize": [
+          "array"
+        ],
+        "short": "All the hashes seen on your event.",
+        "type": "keyword"
+      },
+      "related.hosts": {
+        "dashed_name": "related-hosts",
+        "description": "All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases.",
+        "flat_name": "related.hosts",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hosts",
+        "normalize": [
+          "array"
+        ],
+        "short": "All the host identifiers seen on your event.",
+        "type": "keyword"
+      },
+      "related.ip": {
+        "dashed_name": "related-ip",
+        "description": "All of the IPs seen on your event.",
+        "flat_name": "related.ip",
+        "level": "extended",
+        "name": "ip",
+        "normalize": [
+          "array"
+        ],
+        "short": "All of the IPs seen on your event.",
+        "type": "ip"
+      },
+      "related.user": {
+        "dashed_name": "related-user",
+        "description": "All the user names seen on your event.",
+        "flat_name": "related.user",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "user",
+        "normalize": [
+          "array"
+        ],
+        "short": "All the user names seen on your event.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "related",
+    "prefix": "related.",
+    "short": "Fields meant to facilitate pivoting around a piece of data.",
+    "title": "Related",
+    "type": "group"
+  },
+  "rule": {
+    "description": "Rule fields are used to capture the specifics of any observer or agent rules that generate alerts or other notable events.\nExamples of data sources that would populate the rule fields include: network admission control platforms, network or host IDS/IPS, network firewalls, web application firewalls, url filters, endpoint detection and response (EDR) systems, etc.",
+    "fields": {
+      "rule.author": {
+        "dashed_name": "rule-author",
+        "description": "Name, organization, or pseudonym of the author or authors who created the rule used to generate this event.",
+        "example": [
+          "Star-Lord"
+        ],
+        "flat_name": "rule.author",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "author",
+        "normalize": [
+          "array"
+        ],
+        "short": "Rule author",
+        "type": "keyword"
+      },
+      "rule.category": {
+        "dashed_name": "rule-category",
+        "description": "A categorization value keyword used by the entity using the rule for detection of this event.",
+        "example": "Attempted Information Leak",
+        "flat_name": "rule.category",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "category",
+        "normalize": [],
+        "short": "Rule category",
+        "type": "keyword"
+      },
+      "rule.description": {
+        "dashed_name": "rule-description",
+        "description": "The description of the rule generating the event.",
+        "example": "Block requests to public DNS over HTTPS / TLS protocols",
+        "flat_name": "rule.description",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "description",
+        "normalize": [],
+        "short": "Rule description",
+        "type": "keyword"
+      },
+      "rule.id": {
+        "dashed_name": "rule-id",
+        "description": "A rule ID that is unique within the scope of an agent, observer, or other entity using the rule for detection of this event.",
+        "example": 101,
+        "flat_name": "rule.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "short": "Rule ID",
+        "type": "keyword"
+      },
+      "rule.license": {
+        "dashed_name": "rule-license",
+        "description": "Name of the license under which the rule used to generate this event is made available.",
+        "example": "Apache 2.0",
+        "flat_name": "rule.license",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "license",
+        "normalize": [],
+        "short": "Rule license",
+        "type": "keyword"
+      },
+      "rule.name": {
+        "dashed_name": "rule-name",
+        "description": "The name of the rule or signature generating the event.",
+        "example": "BLOCK_DNS_over_TLS",
+        "flat_name": "rule.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Rule name",
+        "type": "keyword"
+      },
+      "rule.reference": {
+        "dashed_name": "rule-reference",
+        "description": "Reference URL to additional information about the rule used to generate this event.\nThe URL can point to the vendor's documentation about the rule. If that's not available, it can also be a link to a more general page describing this type of alert.",
+        "example": "https://en.wikipedia.org/wiki/DNS_over_TLS",
+        "flat_name": "rule.reference",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "reference",
+        "normalize": [],
+        "short": "Rule reference URL",
+        "type": "keyword"
+      },
+      "rule.ruleset": {
+        "dashed_name": "rule-ruleset",
+        "description": "Name of the ruleset, policy, group, or parent category in which the rule used to generate this event is a member.",
+        "example": "Standard_Protocol_Filters",
+        "flat_name": "rule.ruleset",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "ruleset",
+        "normalize": [],
+        "short": "Rule ruleset",
+        "type": "keyword"
+      },
+      "rule.uuid": {
+        "dashed_name": "rule-uuid",
+        "description": "A rule ID that is unique within the scope of a set or group of agents, observers, or other entities using the rule for detection of this event.",
+        "example": 1100110011,
+        "flat_name": "rule.uuid",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "uuid",
+        "normalize": [],
+        "short": "Rule UUID",
+        "type": "keyword"
+      },
+      "rule.version": {
+        "dashed_name": "rule-version",
+        "description": "The version / revision of the rule being used for analysis.",
+        "example": 1.1,
+        "flat_name": "rule.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "short": "Rule version",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "rule",
+    "prefix": "rule.",
+    "short": "Fields to capture details about rules used to generate alerts or other notable events.",
+    "title": "Rule",
+    "type": "group"
+  },
+  "server": {
+    "description": "A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records.\nFor TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term \"responder\" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.\nClient / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.",
+    "fields": {
+      "server.address": {
+        "dashed_name": "server-address",
+        "description": "Some event server addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.",
+        "flat_name": "server.address",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "address",
+        "normalize": [],
+        "short": "Server network address.",
+        "type": "keyword"
+      },
+      "server.as.number": {
+        "dashed_name": "server-as-number",
+        "description": "Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+        "example": 15169,
+        "flat_name": "server.as.number",
+        "level": "extended",
+        "name": "number",
+        "normalize": [],
+        "original_fieldset": "as",
+        "short": "Unique number allocated to the autonomous system.",
+        "type": "long"
+      },
+      "server.as.organization.name": {
+        "dashed_name": "server-as-organization-name",
+        "description": "Organization name.",
+        "example": "Google LLC",
+        "flat_name": "server.as.organization.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "server.as.organization.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "organization.name",
+        "normalize": [],
+        "original_fieldset": "as",
+        "short": "Organization name.",
+        "type": "keyword"
+      },
+      "server.bytes": {
+        "dashed_name": "server-bytes",
+        "description": "Bytes sent from the server to the client.",
+        "example": 184,
+        "flat_name": "server.bytes",
+        "format": "bytes",
+        "level": "core",
+        "name": "bytes",
+        "normalize": [],
+        "short": "Bytes sent from the server to the client.",
+        "type": "long"
+      },
+      "server.domain": {
+        "dashed_name": "server-domain",
+        "description": "Server domain.",
+        "flat_name": "server.domain",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "domain",
+        "normalize": [],
+        "short": "Server domain.",
+        "type": "keyword"
+      },
+      "server.geo.city_name": {
+        "dashed_name": "server-geo-city-name",
+        "description": "City name.",
+        "example": "Montreal",
+        "flat_name": "server.geo.city_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "city_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "City name.",
+        "type": "keyword"
+      },
+      "server.geo.continent_name": {
+        "dashed_name": "server-geo-continent-name",
+        "description": "Name of the continent.",
+        "example": "North America",
+        "flat_name": "server.geo.continent_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "continent_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Name of the continent.",
+        "type": "keyword"
+      },
+      "server.geo.country_iso_code": {
+        "dashed_name": "server-geo-country-iso-code",
+        "description": "Country ISO code.",
+        "example": "CA",
+        "flat_name": "server.geo.country_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country ISO code.",
+        "type": "keyword"
+      },
+      "server.geo.country_name": {
+        "dashed_name": "server-geo-country-name",
+        "description": "Country name.",
+        "example": "Canada",
+        "flat_name": "server.geo.country_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country name.",
+        "type": "keyword"
+      },
+      "server.geo.location": {
+        "dashed_name": "server-geo-location",
+        "description": "Longitude and latitude.",
+        "example": "{ \"lon\": -73.614830, \"lat\": 45.505918 }",
+        "flat_name": "server.geo.location",
+        "level": "core",
+        "name": "location",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Longitude and latitude.",
+        "type": "geo_point"
+      },
+      "server.geo.name": {
+        "dashed_name": "server-geo-name",
+        "description": "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation.",
+        "example": "boston-dc",
+        "flat_name": "server.geo.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "User-defined description of a location.",
+        "type": "keyword"
+      },
+      "server.geo.region_iso_code": {
+        "dashed_name": "server-geo-region-iso-code",
+        "description": "Region ISO code.",
+        "example": "CA-QC",
+        "flat_name": "server.geo.region_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region ISO code.",
+        "type": "keyword"
+      },
+      "server.geo.region_name": {
+        "dashed_name": "server-geo-region-name",
+        "description": "Region name.",
+        "example": "Quebec",
+        "flat_name": "server.geo.region_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region name.",
+        "type": "keyword"
+      },
+      "server.ip": {
+        "dashed_name": "server-ip",
+        "description": "IP address of the server (IPv4 or IPv6).",
+        "flat_name": "server.ip",
+        "level": "core",
+        "name": "ip",
+        "normalize": [],
+        "short": "IP address of the server.",
+        "type": "ip"
+      },
+      "server.mac": {
+        "dashed_name": "server-mac",
+        "description": "MAC address of the server.",
+        "flat_name": "server.mac",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "mac",
+        "normalize": [],
+        "short": "MAC address of the server.",
+        "type": "keyword"
+      },
+      "server.nat.ip": {
+        "dashed_name": "server-nat-ip",
+        "description": "Translated ip of destination based NAT sessions (e.g. internet to private DMZ)\nTypically used with load balancers, firewalls, or routers.",
+        "flat_name": "server.nat.ip",
+        "level": "extended",
+        "name": "nat.ip",
+        "normalize": [],
+        "short": "Server NAT ip",
+        "type": "ip"
+      },
+      "server.nat.port": {
+        "dashed_name": "server-nat-port",
+        "description": "Translated port of destination based NAT sessions (e.g. internet to private DMZ)\nTypically used with load balancers, firewalls, or routers.",
+        "flat_name": "server.nat.port",
+        "format": "string",
+        "level": "extended",
+        "name": "nat.port",
+        "normalize": [],
+        "short": "Server NAT port",
+        "type": "long"
+      },
+      "server.packets": {
+        "dashed_name": "server-packets",
+        "description": "Packets sent from the server to the client.",
+        "example": 12,
+        "flat_name": "server.packets",
+        "level": "core",
+        "name": "packets",
+        "normalize": [],
+        "short": "Packets sent from the server to the client.",
+        "type": "long"
+      },
+      "server.port": {
+        "dashed_name": "server-port",
+        "description": "Port of the server.",
+        "flat_name": "server.port",
+        "format": "string",
+        "level": "core",
+        "name": "port",
+        "normalize": [],
+        "short": "Port of the server.",
+        "type": "long"
+      },
+      "server.registered_domain": {
+        "dashed_name": "server-registered-domain",
+        "description": "The highest registered server domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
+        "example": "example.com",
+        "flat_name": "server.registered_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "registered_domain",
+        "normalize": [],
+        "short": "The highest registered server domain, stripped of the subdomain.",
+        "type": "keyword"
+      },
+      "server.top_level_domain": {
+        "dashed_name": "server-top-level-domain",
+        "description": "The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is \"com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as \"co.uk\".",
+        "example": "co.uk",
+        "flat_name": "server.top_level_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "top_level_domain",
+        "normalize": [],
+        "short": "The effective top level domain (com, org, net, co.uk).",
+        "type": "keyword"
+      },
+      "server.user.domain": {
+        "dashed_name": "server-user-domain",
+        "description": "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "server.user.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Name of the directory the user is a member of.",
+        "type": "keyword"
+      },
+      "server.user.email": {
+        "dashed_name": "server-user-email",
+        "description": "User email address.",
+        "flat_name": "server.user.email",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "email",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User email address.",
+        "type": "keyword"
+      },
+      "server.user.full_name": {
+        "dashed_name": "server-user-full-name",
+        "description": "User's full name, if available.",
+        "example": "Albert Einstein",
+        "flat_name": "server.user.full_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "server.user.full_name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full_name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User's full name, if available.",
+        "type": "keyword"
+      },
+      "server.user.group.domain": {
+        "dashed_name": "server-user-group-domain",
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "server.user.group.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the directory the group is a member of.",
+        "type": "keyword"
+      },
+      "server.user.group.id": {
+        "dashed_name": "server-user-group-id",
+        "description": "Unique identifier for the group on the system/platform.",
+        "flat_name": "server.user.group.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Unique identifier for the group on the system/platform.",
+        "type": "keyword"
+      },
+      "server.user.group.name": {
+        "dashed_name": "server-user-group-name",
+        "description": "Name of the group.",
+        "flat_name": "server.user.group.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the group.",
+        "type": "keyword"
+      },
+      "server.user.hash": {
+        "dashed_name": "server-user-hash",
+        "description": "Unique user hash to correlate information for a user in anonymized form.\nUseful if `user.id` or `user.name` contain confidential information and cannot be used.",
+        "flat_name": "server.user.hash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hash",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique user hash to correlate information for a user in anonymized form.",
+        "type": "keyword"
+      },
+      "server.user.id": {
+        "dashed_name": "server-user-id",
+        "description": "Unique identifier of the user.",
+        "flat_name": "server.user.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique identifier of the user.",
+        "type": "keyword"
+      },
+      "server.user.name": {
+        "dashed_name": "server-user-name",
+        "description": "Short name or login of the user.",
+        "example": "albert",
+        "flat_name": "server.user.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "multi_fields": [
+          {
+            "flat_name": "server.user.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Short name or login of the user.",
+        "type": "keyword"
+      },
+      "server.user.roles": {
+        "dashed_name": "server-user-roles",
+        "description": "Array of user roles at the time of the event.",
+        "example": "[\"kibana_admin\", \"reporting_user\"]",
+        "flat_name": "server.user.roles",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "roles",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "user",
+        "short": "Array of user roles at the time of the event.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "server",
+    "nestings": [
+      "server.as",
+      "server.geo",
+      "server.user"
+    ],
+    "prefix": "server.",
+    "reused_here": [
+      {
+        "full": "server.as",
+        "schema_name": "as",
+        "short": "Fields describing an Autonomous System (Internet routing prefix)."
+      },
+      {
+        "full": "server.geo",
+        "schema_name": "geo",
+        "short": "Fields describing a location."
+      },
+      {
+        "full": "server.user",
+        "schema_name": "user",
+        "short": "Fields to describe the user relevant to the event."
+      }
+    ],
+    "short": "Fields about the server side of a network connection, used with client.",
+    "title": "Server",
+    "type": "group"
+  },
+  "service": {
+    "description": "The service fields describe the service for or from which the data was collected.\nThese fields help you find and correlate logs for a specific service and version.",
+    "fields": {
+      "service.ephemeral_id": {
+        "dashed_name": "service-ephemeral-id",
+        "description": "Ephemeral identifier of this service (if one exists).\nThis id normally changes across restarts, but `service.id` does not.",
+        "example": "8a4f500f",
+        "flat_name": "service.ephemeral_id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "ephemeral_id",
+        "normalize": [],
+        "short": "Ephemeral identifier of this service.",
+        "type": "keyword"
+      },
+      "service.id": {
+        "dashed_name": "service-id",
+        "description": "Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes.\nThis id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event.\nNote that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead.",
+        "example": "d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6",
+        "flat_name": "service.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique identifier of the running service.",
+        "type": "keyword"
+      },
+      "service.name": {
+        "dashed_name": "service-name",
+        "description": "Name of the service data is collected from.\nThe name of the service is normally user given. This allows for distributed services that run on multiple hosts to correlate the related instances based on the name.\nIn the case of Elasticsearch the `service.name` could contain the cluster name. For Beats the `service.name` is by default a copy of the `service.type` field if no name is specified.",
+        "example": "elasticsearch-metrics",
+        "flat_name": "service.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "name",
+        "normalize": [],
+        "short": "Name of the service.",
+        "type": "keyword"
+      },
+      "service.node.name": {
+        "dashed_name": "service-node-name",
+        "description": "Name of a service node.\nThis allows for two nodes of the same service running on the same host to be differentiated. Therefore, `service.node.name` should typically be unique across nodes of a given service.\nIn the case of Elasticsearch, the `service.node.name` could contain the unique node name within the Elasticsearch cluster. In cases where the service doesn't have the concept of a node name, the host name or container name can be used to distinguish running instances that make up this service. If those do not provide uniqueness (e.g. multiple instances of the service running on the same host) - the node name can be manually set.",
+        "example": "instance-0000000016",
+        "flat_name": "service.node.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "node.name",
+        "normalize": [],
+        "short": "Name of the service node.",
+        "type": "keyword"
+      },
+      "service.state": {
+        "dashed_name": "service-state",
+        "description": "Current state of the service.",
+        "flat_name": "service.state",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "state",
+        "normalize": [],
+        "short": "Current state of the service.",
+        "type": "keyword"
+      },
+      "service.type": {
+        "dashed_name": "service-type",
+        "description": "The type of the service data is collected from.\nThe type can be used to group and correlate logs and metrics from one service type.\nExample: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`.",
+        "example": "elasticsearch",
+        "flat_name": "service.type",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "type",
+        "normalize": [],
+        "short": "The type of the service.",
+        "type": "keyword"
+      },
+      "service.version": {
+        "dashed_name": "service-version",
+        "description": "Version of the service the data was collected from.\nThis allows to look at a data set only for a specific version of a service.",
+        "example": "3.2.4",
+        "flat_name": "service.version",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "version",
+        "normalize": [],
+        "short": "Version of the service.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "service",
+    "prefix": "service.",
+    "short": "Fields describing the service for or from which the data was collected.",
+    "title": "Service",
+    "type": "group"
+  },
+  "source": {
+    "description": "Source fields describe details about the source of a packet/event.\nSource fields are usually populated in conjunction with destination fields.",
+    "fields": {
+      "source.address": {
+        "dashed_name": "source-address",
+        "description": "Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.",
+        "flat_name": "source.address",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "address",
+        "normalize": [],
+        "short": "Source network address.",
+        "type": "keyword"
+      },
+      "source.as.number": {
+        "dashed_name": "source-as-number",
+        "description": "Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.",
+        "example": 15169,
+        "flat_name": "source.as.number",
+        "level": "extended",
+        "name": "number",
+        "normalize": [],
+        "original_fieldset": "as",
+        "short": "Unique number allocated to the autonomous system.",
+        "type": "long"
+      },
+      "source.as.organization.name": {
+        "dashed_name": "source-as-organization-name",
+        "description": "Organization name.",
+        "example": "Google LLC",
+        "flat_name": "source.as.organization.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "source.as.organization.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "organization.name",
+        "normalize": [],
+        "original_fieldset": "as",
+        "short": "Organization name.",
+        "type": "keyword"
+      },
+      "source.bytes": {
+        "dashed_name": "source-bytes",
+        "description": "Bytes sent from the source to the destination.",
+        "example": 184,
+        "flat_name": "source.bytes",
+        "format": "bytes",
+        "level": "core",
+        "name": "bytes",
+        "normalize": [],
+        "short": "Bytes sent from the source to the destination.",
+        "type": "long"
+      },
+      "source.domain": {
+        "dashed_name": "source-domain",
+        "description": "Source domain.",
+        "flat_name": "source.domain",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "domain",
+        "normalize": [],
+        "short": "Source domain.",
+        "type": "keyword"
+      },
+      "source.geo.city_name": {
+        "dashed_name": "source-geo-city-name",
+        "description": "City name.",
+        "example": "Montreal",
+        "flat_name": "source.geo.city_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "city_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "City name.",
+        "type": "keyword"
+      },
+      "source.geo.continent_name": {
+        "dashed_name": "source-geo-continent-name",
+        "description": "Name of the continent.",
+        "example": "North America",
+        "flat_name": "source.geo.continent_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "continent_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Name of the continent.",
+        "type": "keyword"
+      },
+      "source.geo.country_iso_code": {
+        "dashed_name": "source-geo-country-iso-code",
+        "description": "Country ISO code.",
+        "example": "CA",
+        "flat_name": "source.geo.country_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country ISO code.",
+        "type": "keyword"
+      },
+      "source.geo.country_name": {
+        "dashed_name": "source-geo-country-name",
+        "description": "Country name.",
+        "example": "Canada",
+        "flat_name": "source.geo.country_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "country_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Country name.",
+        "type": "keyword"
+      },
+      "source.geo.location": {
+        "dashed_name": "source-geo-location",
+        "description": "Longitude and latitude.",
+        "example": "{ \"lon\": -73.614830, \"lat\": 45.505918 }",
+        "flat_name": "source.geo.location",
+        "level": "core",
+        "name": "location",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Longitude and latitude.",
+        "type": "geo_point"
+      },
+      "source.geo.name": {
+        "dashed_name": "source-geo-name",
+        "description": "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation.",
+        "example": "boston-dc",
+        "flat_name": "source.geo.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "User-defined description of a location.",
+        "type": "keyword"
+      },
+      "source.geo.region_iso_code": {
+        "dashed_name": "source-geo-region-iso-code",
+        "description": "Region ISO code.",
+        "example": "CA-QC",
+        "flat_name": "source.geo.region_iso_code",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_iso_code",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region ISO code.",
+        "type": "keyword"
+      },
+      "source.geo.region_name": {
+        "dashed_name": "source-geo-region-name",
+        "description": "Region name.",
+        "example": "Quebec",
+        "flat_name": "source.geo.region_name",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "region_name",
+        "normalize": [],
+        "original_fieldset": "geo",
+        "short": "Region name.",
+        "type": "keyword"
+      },
+      "source.ip": {
+        "dashed_name": "source-ip",
+        "description": "IP address of the source (IPv4 or IPv6).",
+        "flat_name": "source.ip",
+        "level": "core",
+        "name": "ip",
+        "normalize": [],
+        "short": "IP address of the source.",
+        "type": "ip"
+      },
+      "source.mac": {
+        "dashed_name": "source-mac",
+        "description": "MAC address of the source.",
+        "flat_name": "source.mac",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "mac",
+        "normalize": [],
+        "short": "MAC address of the source.",
+        "type": "keyword"
+      },
+      "source.nat.ip": {
+        "dashed_name": "source-nat-ip",
+        "description": "Translated ip of source based NAT sessions (e.g. internal client to internet)\nTypically connections traversing load balancers, firewalls, or routers.",
+        "flat_name": "source.nat.ip",
+        "level": "extended",
+        "name": "nat.ip",
+        "normalize": [],
+        "short": "Source NAT ip",
+        "type": "ip"
+      },
+      "source.nat.port": {
+        "dashed_name": "source-nat-port",
+        "description": "Translated port of source based NAT sessions. (e.g. internal client to internet)\nTypically used with load balancers, firewalls, or routers.",
+        "flat_name": "source.nat.port",
+        "format": "string",
+        "level": "extended",
+        "name": "nat.port",
+        "normalize": [],
+        "short": "Source NAT port",
+        "type": "long"
+      },
+      "source.packets": {
+        "dashed_name": "source-packets",
+        "description": "Packets sent from the source to the destination.",
+        "example": 12,
+        "flat_name": "source.packets",
+        "level": "core",
+        "name": "packets",
+        "normalize": [],
+        "short": "Packets sent from the source to the destination.",
+        "type": "long"
+      },
+      "source.port": {
+        "dashed_name": "source-port",
+        "description": "Port of the source.",
+        "flat_name": "source.port",
+        "format": "string",
+        "level": "core",
+        "name": "port",
+        "normalize": [],
+        "short": "Port of the source.",
+        "type": "long"
+      },
+      "source.registered_domain": {
+        "dashed_name": "source-registered-domain",
+        "description": "The highest registered source domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
+        "example": "example.com",
+        "flat_name": "source.registered_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "registered_domain",
+        "normalize": [],
+        "short": "The highest registered source domain, stripped of the subdomain.",
+        "type": "keyword"
+      },
+      "source.top_level_domain": {
+        "dashed_name": "source-top-level-domain",
+        "description": "The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is \"com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as \"co.uk\".",
+        "example": "co.uk",
+        "flat_name": "source.top_level_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "top_level_domain",
+        "normalize": [],
+        "short": "The effective top level domain (com, org, net, co.uk).",
+        "type": "keyword"
+      },
+      "source.user.domain": {
+        "dashed_name": "source-user-domain",
+        "description": "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "source.user.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Name of the directory the user is a member of.",
+        "type": "keyword"
+      },
+      "source.user.email": {
+        "dashed_name": "source-user-email",
+        "description": "User email address.",
+        "flat_name": "source.user.email",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "email",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User email address.",
+        "type": "keyword"
+      },
+      "source.user.full_name": {
+        "dashed_name": "source-user-full-name",
+        "description": "User's full name, if available.",
+        "example": "Albert Einstein",
+        "flat_name": "source.user.full_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "source.user.full_name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full_name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "User's full name, if available.",
+        "type": "keyword"
+      },
+      "source.user.group.domain": {
+        "dashed_name": "source-user-group-domain",
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "source.user.group.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the directory the group is a member of.",
+        "type": "keyword"
+      },
+      "source.user.group.id": {
+        "dashed_name": "source-user-group-id",
+        "description": "Unique identifier for the group on the system/platform.",
+        "flat_name": "source.user.group.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Unique identifier for the group on the system/platform.",
+        "type": "keyword"
+      },
+      "source.user.group.name": {
+        "dashed_name": "source-user-group-name",
+        "description": "Name of the group.",
+        "flat_name": "source.user.group.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the group.",
+        "type": "keyword"
+      },
+      "source.user.hash": {
+        "dashed_name": "source-user-hash",
+        "description": "Unique user hash to correlate information for a user in anonymized form.\nUseful if `user.id` or `user.name` contain confidential information and cannot be used.",
+        "flat_name": "source.user.hash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hash",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique user hash to correlate information for a user in anonymized form.",
+        "type": "keyword"
+      },
+      "source.user.id": {
+        "dashed_name": "source-user-id",
+        "description": "Unique identifier of the user.",
+        "flat_name": "source.user.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Unique identifier of the user.",
+        "type": "keyword"
+      },
+      "source.user.name": {
+        "dashed_name": "source-user-name",
+        "description": "Short name or login of the user.",
+        "example": "albert",
+        "flat_name": "source.user.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "multi_fields": [
+          {
+            "flat_name": "source.user.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "user",
+        "short": "Short name or login of the user.",
+        "type": "keyword"
+      },
+      "source.user.roles": {
+        "dashed_name": "source-user-roles",
+        "description": "Array of user roles at the time of the event.",
+        "example": "[\"kibana_admin\", \"reporting_user\"]",
+        "flat_name": "source.user.roles",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "roles",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "user",
+        "short": "Array of user roles at the time of the event.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "source",
+    "nestings": [
+      "source.as",
+      "source.geo",
+      "source.user"
+    ],
+    "prefix": "source.",
+    "reused_here": [
+      {
+        "full": "source.as",
+        "schema_name": "as",
+        "short": "Fields describing an Autonomous System (Internet routing prefix)."
+      },
+      {
+        "full": "source.geo",
+        "schema_name": "geo",
+        "short": "Fields describing a location."
+      },
+      {
+        "full": "source.user",
+        "schema_name": "user",
+        "short": "Fields to describe the user relevant to the event."
+      }
+    ],
+    "short": "Fields about the source side of a network connection, used with destination.",
+    "title": "Source",
+    "type": "group"
+  },
+  "threat": {
+    "description": "Fields to classify events and alerts according to a threat taxonomy such as the MITRE ATT&CK\u00ae framework.\nThese fields are for users to classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are meant to capture the high level category of the threat (e.g. \"impact\"). The threat.technique.* fields are meant to capture which kind of approach is used by this detected threat, to accomplish the goal (e.g. \"endpoint denial of service\").",
+    "fields": {
+      "threat.framework": {
+        "dashed_name": "threat-framework",
+        "description": "Name of the threat framework used to further categorize and classify the tactic and technique of the reported threat. Framework classification can be provided by detecting systems, evaluated at ingest time, or retrospectively tagged to events.",
+        "example": "MITRE ATT&CK",
+        "flat_name": "threat.framework",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "framework",
+        "normalize": [],
+        "short": "Threat classification framework.",
+        "type": "keyword"
+      },
+      "threat.tactic.id": {
+        "dashed_name": "threat-tactic-id",
+        "description": "The id of tactic used by this threat. You can use a MITRE ATT&CK\u00ae tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )",
+        "example": "TA0040",
+        "flat_name": "threat.tactic.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "tactic.id",
+        "normalize": [
+          "array"
+        ],
+        "short": "Threat tactic id.",
+        "type": "keyword"
+      },
+      "threat.tactic.name": {
+        "dashed_name": "threat-tactic-name",
+        "description": "Name of the type of tactic used by this threat. You can use a MITRE ATT&CK\u00ae tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)",
+        "example": "impact",
+        "flat_name": "threat.tactic.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "tactic.name",
+        "normalize": [
+          "array"
+        ],
+        "short": "Threat tactic.",
+        "type": "keyword"
+      },
+      "threat.tactic.reference": {
+        "dashed_name": "threat-tactic-reference",
+        "description": "The reference url of tactic used by this threat. You can use a MITRE ATT&CK\u00ae tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )",
+        "example": "https://attack.mitre.org/tactics/TA0040/",
+        "flat_name": "threat.tactic.reference",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "tactic.reference",
+        "normalize": [
+          "array"
+        ],
+        "short": "Threat tactic URL reference.",
+        "type": "keyword"
+      },
+      "threat.technique.id": {
+        "dashed_name": "threat-technique-id",
+        "description": "The id of technique used by this threat. You can use a MITRE ATT&CK\u00ae technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)",
+        "example": "T1499",
+        "flat_name": "threat.technique.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "technique.id",
+        "normalize": [
+          "array"
+        ],
+        "short": "Threat technique id.",
+        "type": "keyword"
+      },
+      "threat.technique.name": {
+        "dashed_name": "threat-technique-name",
+        "description": "The name of technique used by this threat. You can use a MITRE ATT&CK\u00ae technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)",
+        "example": "Endpoint Denial of Service",
+        "flat_name": "threat.technique.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "threat.technique.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "technique.name",
+        "normalize": [
+          "array"
+        ],
+        "short": "Threat technique name.",
+        "type": "keyword"
+      },
+      "threat.technique.reference": {
+        "dashed_name": "threat-technique-reference",
+        "description": "The reference url of technique used by this threat. You can use a MITRE ATT&CK\u00ae technique, for example. (ex. https://attack.mitre.org/techniques/T1499/ )",
+        "example": "https://attack.mitre.org/techniques/T1499/",
+        "flat_name": "threat.technique.reference",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "technique.reference",
+        "normalize": [
+          "array"
+        ],
+        "short": "Threat technique URL reference.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "threat",
+    "prefix": "threat.",
+    "short": "Fields to classify events and alerts according to a threat taxonomy.",
+    "title": "Threat",
+    "type": "group"
+  },
+  "tls": {
+    "description": "Fields related to a TLS connection. These fields focus on the TLS protocol itself and intentionally avoids in-depth analysis of the related x.509 certificate files.",
+    "fields": {
+      "tls.cipher": {
+        "dashed_name": "tls-cipher",
+        "description": "String indicating the cipher used during the current connection.",
+        "example": "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+        "flat_name": "tls.cipher",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "cipher",
+        "normalize": [],
+        "short": "String indicating the cipher used during the current connection.",
+        "type": "keyword"
+      },
+      "tls.client.certificate": {
+        "dashed_name": "tls-client-certificate",
+        "description": "PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.",
+        "example": "MII...",
+        "flat_name": "tls.client.certificate",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.certificate",
+        "normalize": [],
+        "short": "PEM-encoded stand-alone certificate offered by the client.",
+        "type": "keyword"
+      },
+      "tls.client.certificate_chain": {
+        "dashed_name": "tls-client-certificate-chain",
+        "description": "Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.",
+        "example": [
+          "MII...",
+          "MII..."
+        ],
+        "flat_name": "tls.client.certificate_chain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.certificate_chain",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array of PEM-encoded certificates that make up the certificate chain offered by the client.",
+        "type": "keyword"
+      },
+      "tls.client.hash.md5": {
+        "dashed_name": "tls-client-hash-md5",
+        "description": "Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.",
+        "example": "0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC",
+        "flat_name": "tls.client.hash.md5",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.hash.md5",
+        "normalize": [],
+        "short": "Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client.",
+        "type": "keyword"
+      },
+      "tls.client.hash.sha1": {
+        "dashed_name": "tls-client-hash-sha1",
+        "description": "Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.",
+        "example": "9E393D93138888D288266C2D915214D1D1CCEB2A",
+        "flat_name": "tls.client.hash.sha1",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.hash.sha1",
+        "normalize": [],
+        "short": "Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client.",
+        "type": "keyword"
+      },
+      "tls.client.hash.sha256": {
+        "dashed_name": "tls-client-hash-sha256",
+        "description": "Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash.",
+        "example": "0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0",
+        "flat_name": "tls.client.hash.sha256",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.hash.sha256",
+        "normalize": [],
+        "short": "Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client.",
+        "type": "keyword"
+      },
+      "tls.client.issuer": {
+        "dashed_name": "tls-client-issuer",
+        "description": "Distinguished name of subject of the issuer of the x.509 certificate presented by the client.",
+        "example": "CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",
+        "flat_name": "tls.client.issuer",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.issuer",
+        "normalize": [],
+        "short": "Distinguished name of subject of the issuer of the x.509 certificate presented by the client.",
+        "type": "keyword"
+      },
+      "tls.client.ja3": {
+        "dashed_name": "tls-client-ja3",
+        "description": "A hash that identifies clients based on how they perform an SSL/TLS handshake.",
+        "example": "d4e5b18d6b55c71272893221c96ba240",
+        "flat_name": "tls.client.ja3",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.ja3",
+        "normalize": [],
+        "short": "A hash that identifies clients based on how they perform an SSL/TLS handshake.",
+        "type": "keyword"
+      },
+      "tls.client.not_after": {
+        "dashed_name": "tls-client-not-after",
+        "description": "Date/Time indicating when client certificate is no longer considered valid.",
+        "example": "2021-01-01T00:00:00.000Z",
+        "flat_name": "tls.client.not_after",
+        "level": "extended",
+        "name": "client.not_after",
+        "normalize": [],
+        "short": "Date/Time indicating when client certificate is no longer considered valid.",
+        "type": "date"
+      },
+      "tls.client.not_before": {
+        "dashed_name": "tls-client-not-before",
+        "description": "Date/Time indicating when client certificate is first considered valid.",
+        "example": "1970-01-01T00:00:00.000Z",
+        "flat_name": "tls.client.not_before",
+        "level": "extended",
+        "name": "client.not_before",
+        "normalize": [],
+        "short": "Date/Time indicating when client certificate is first considered valid.",
+        "type": "date"
+      },
+      "tls.client.server_name": {
+        "dashed_name": "tls-client-server-name",
+        "description": "Also called an SNI, this tells the server which hostname to which the client is attempting to connect to. When this value is available, it should get copied to `destination.domain`.",
+        "example": "www.elastic.co",
+        "flat_name": "tls.client.server_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.server_name",
+        "normalize": [],
+        "short": "Hostname the client is trying to connect to. Also called the SNI.",
+        "type": "keyword"
+      },
+      "tls.client.subject": {
+        "dashed_name": "tls-client-subject",
+        "description": "Distinguished name of subject of the x.509 certificate presented by the client.",
+        "example": "CN=myclient, OU=Documentation Team, DC=example, DC=com",
+        "flat_name": "tls.client.subject",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.subject",
+        "normalize": [],
+        "short": "Distinguished name of subject of the x.509 certificate presented by the client.",
+        "type": "keyword"
+      },
+      "tls.client.supported_ciphers": {
+        "dashed_name": "tls-client-supported-ciphers",
+        "description": "Array of ciphers offered by the client during the client hello.",
+        "example": [
+          "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+          "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+          "..."
+        ],
+        "flat_name": "tls.client.supported_ciphers",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "client.supported_ciphers",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array of ciphers offered by the client during the client hello.",
+        "type": "keyword"
+      },
+      "tls.client.x509.alternative_names": {
+        "dashed_name": "tls-client-x509-alternative-names",
+        "description": "List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
+        "example": "*.elastic.co",
+        "flat_name": "tls.client.x509.alternative_names",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "alternative_names",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of subject alternative names (SAN).",
+        "type": "keyword"
+      },
+      "tls.client.x509.issuer.common_name": {
+        "dashed_name": "tls-client-x509-issuer-common-name",
+        "description": "List of common name (CN) of issuing certificate authority.",
+        "example": "Example SHA2 High Assurance Server CA",
+        "flat_name": "tls.client.x509.issuer.common_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.common_name",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of common name (CN) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "tls.client.x509.issuer.country": {
+        "dashed_name": "tls-client-x509-issuer-country",
+        "description": "List of country (C) codes",
+        "example": "US",
+        "flat_name": "tls.client.x509.issuer.country",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.country",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of country (C) codes",
+        "type": "keyword"
+      },
+      "tls.client.x509.issuer.distinguished_name": {
+        "dashed_name": "tls-client-x509-issuer-distinguished-name",
+        "description": "Distinguished name (DN) of issuing certificate authority.",
+        "example": "C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",
+        "flat_name": "tls.client.x509.issuer.distinguished_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.distinguished_name",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Distinguished name (DN) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "tls.client.x509.issuer.locality": {
+        "dashed_name": "tls-client-x509-issuer-locality",
+        "description": "List of locality names (L)",
+        "example": "Mountain View",
+        "flat_name": "tls.client.x509.issuer.locality",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.locality",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of locality names (L)",
+        "type": "keyword"
+      },
+      "tls.client.x509.issuer.organization": {
+        "dashed_name": "tls-client-x509-issuer-organization",
+        "description": "List of organizations (O) of issuing certificate authority.",
+        "example": "Example Inc",
+        "flat_name": "tls.client.x509.issuer.organization",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.organization",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizations (O) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "tls.client.x509.issuer.organizational_unit": {
+        "dashed_name": "tls-client-x509-issuer-organizational-unit",
+        "description": "List of organizational units (OU) of issuing certificate authority.",
+        "example": "www.example.com",
+        "flat_name": "tls.client.x509.issuer.organizational_unit",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.organizational_unit",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizational units (OU) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "tls.client.x509.issuer.state_or_province": {
+        "dashed_name": "tls-client-x509-issuer-state-or-province",
+        "description": "List of state or province names (ST, S, or P)",
+        "example": "California",
+        "flat_name": "tls.client.x509.issuer.state_or_province",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.state_or_province",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of state or province names (ST, S, or P)",
+        "type": "keyword"
+      },
+      "tls.client.x509.not_after": {
+        "dashed_name": "tls-client-x509-not-after",
+        "description": "Time at which the certificate is no longer considered valid.",
+        "example": "2020-07-16T03:15:39+00:00",
+        "flat_name": "tls.client.x509.not_after",
+        "level": "extended",
+        "name": "not_after",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Time at which the certificate is no longer considered valid.",
+        "type": "date"
+      },
+      "tls.client.x509.not_before": {
+        "dashed_name": "tls-client-x509-not-before",
+        "description": "Time at which the certificate is first considered valid.",
+        "example": "2019-08-16T01:40:25+00:00",
+        "flat_name": "tls.client.x509.not_before",
+        "level": "extended",
+        "name": "not_before",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Time at which the certificate is first considered valid.",
+        "type": "date"
+      },
+      "tls.client.x509.public_key_algorithm": {
+        "dashed_name": "tls-client-x509-public-key-algorithm",
+        "description": "Algorithm used to generate the public key.",
+        "example": "RSA",
+        "flat_name": "tls.client.x509.public_key_algorithm",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "public_key_algorithm",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Algorithm used to generate the public key.",
+        "type": "keyword"
+      },
+      "tls.client.x509.public_key_curve": {
+        "dashed_name": "tls-client-x509-public-key-curve",
+        "description": "The curve used by the elliptic curve public key algorithm. This is algorithm specific.",
+        "example": "nistp521",
+        "flat_name": "tls.client.x509.public_key_curve",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "public_key_curve",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "The curve used by the elliptic curve public key algorithm. This is algorithm specific.",
+        "type": "keyword"
+      },
+      "tls.client.x509.public_key_exponent": {
+        "dashed_name": "tls-client-x509-public-key-exponent",
+        "description": "Exponent used to derive the public key. This is algorithm specific.",
+        "doc_values": false,
+        "example": 65537,
+        "flat_name": "tls.client.x509.public_key_exponent",
+        "index": false,
+        "level": "extended",
+        "name": "public_key_exponent",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Exponent used to derive the public key. This is algorithm specific.",
+        "type": "long"
+      },
+      "tls.client.x509.public_key_size": {
+        "dashed_name": "tls-client-x509-public-key-size",
+        "description": "The size of the public key space in bits.",
+        "example": 2048,
+        "flat_name": "tls.client.x509.public_key_size",
+        "level": "extended",
+        "name": "public_key_size",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "The size of the public key space in bits.",
+        "type": "long"
+      },
+      "tls.client.x509.serial_number": {
+        "dashed_name": "tls-client-x509-serial-number",
+        "description": "Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters.",
+        "example": "55FBB9C7DEBF09809D12CCAA",
+        "flat_name": "tls.client.x509.serial_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "serial_number",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Unique serial number issued by the certificate authority.",
+        "type": "keyword"
+      },
+      "tls.client.x509.signature_algorithm": {
+        "dashed_name": "tls-client-x509-signature-algorithm",
+        "description": "Identifier for certificate signature algorithm. We recommend using names found in Go Lang Crypto library. See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353.",
+        "example": "SHA256-RSA",
+        "flat_name": "tls.client.x509.signature_algorithm",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "signature_algorithm",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Identifier for certificate signature algorithm.",
+        "type": "keyword"
+      },
+      "tls.client.x509.subject.common_name": {
+        "dashed_name": "tls-client-x509-subject-common-name",
+        "description": "List of common names (CN) of subject.",
+        "example": "shared.global.example.net",
+        "flat_name": "tls.client.x509.subject.common_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.common_name",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of common names (CN) of subject.",
+        "type": "keyword"
+      },
+      "tls.client.x509.subject.country": {
+        "dashed_name": "tls-client-x509-subject-country",
+        "description": "List of country (C) code",
+        "example": "US",
+        "flat_name": "tls.client.x509.subject.country",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.country",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of country (C) code",
+        "type": "keyword"
+      },
+      "tls.client.x509.subject.distinguished_name": {
+        "dashed_name": "tls-client-x509-subject-distinguished-name",
+        "description": "Distinguished name (DN) of the certificate subject entity.",
+        "example": "C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",
+        "flat_name": "tls.client.x509.subject.distinguished_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.distinguished_name",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Distinguished name (DN) of the certificate subject entity.",
+        "type": "keyword"
+      },
+      "tls.client.x509.subject.locality": {
+        "dashed_name": "tls-client-x509-subject-locality",
+        "description": "List of locality names (L)",
+        "example": "San Francisco",
+        "flat_name": "tls.client.x509.subject.locality",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.locality",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of locality names (L)",
+        "type": "keyword"
+      },
+      "tls.client.x509.subject.organization": {
+        "dashed_name": "tls-client-x509-subject-organization",
+        "description": "List of organizations (O) of subject.",
+        "example": "Example, Inc.",
+        "flat_name": "tls.client.x509.subject.organization",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.organization",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizations (O) of subject.",
+        "type": "keyword"
+      },
+      "tls.client.x509.subject.organizational_unit": {
+        "dashed_name": "tls-client-x509-subject-organizational-unit",
+        "description": "List of organizational units (OU) of subject.",
+        "flat_name": "tls.client.x509.subject.organizational_unit",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.organizational_unit",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizational units (OU) of subject.",
+        "type": "keyword"
+      },
+      "tls.client.x509.subject.state_or_province": {
+        "dashed_name": "tls-client-x509-subject-state-or-province",
+        "description": "List of state or province names (ST, S, or P)",
+        "example": "California",
+        "flat_name": "tls.client.x509.subject.state_or_province",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.state_or_province",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of state or province names (ST, S, or P)",
+        "type": "keyword"
+      },
+      "tls.client.x509.version_number": {
+        "dashed_name": "tls-client-x509-version-number",
+        "description": "Version of x509 format.",
+        "example": 3,
+        "flat_name": "tls.client.x509.version_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version_number",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Version of x509 format.",
+        "type": "keyword"
+      },
+      "tls.curve": {
+        "dashed_name": "tls-curve",
+        "description": "String indicating the curve used for the given cipher, when applicable.",
+        "example": "secp256r1",
+        "flat_name": "tls.curve",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "curve",
+        "normalize": [],
+        "short": "String indicating the curve used for the given cipher, when applicable.",
+        "type": "keyword"
+      },
+      "tls.established": {
+        "dashed_name": "tls-established",
+        "description": "Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.",
+        "flat_name": "tls.established",
+        "level": "extended",
+        "name": "established",
+        "normalize": [],
+        "short": "Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.",
+        "type": "boolean"
+      },
+      "tls.next_protocol": {
+        "dashed_name": "tls-next-protocol",
+        "description": "String indicating the protocol being tunneled. Per the values in the IANA registry (https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids), this string should be lower case.",
+        "example": "http/1.1",
+        "flat_name": "tls.next_protocol",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "next_protocol",
+        "normalize": [],
+        "short": "String indicating the protocol being tunneled.",
+        "type": "keyword"
+      },
+      "tls.resumed": {
+        "dashed_name": "tls-resumed",
+        "description": "Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.",
+        "flat_name": "tls.resumed",
+        "level": "extended",
+        "name": "resumed",
+        "normalize": [],
+        "short": "Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.",
+        "type": "boolean"
+      },
+      "tls.server.certificate": {
+        "dashed_name": "tls-server-certificate",
+        "description": "PEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of `server.certificate_chain` since this value also exists in that list.",
+        "example": "MII...",
+        "flat_name": "tls.server.certificate",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "server.certificate",
+        "normalize": [],
+        "short": "PEM-encoded stand-alone certificate offered by the server.",
+        "type": "keyword"
+      },
+      "tls.server.certificate_chain": {
+        "dashed_name": "tls-server-certificate-chain",
+        "description": "Array of PEM-encoded certificates that make up the certificate chain offered by the server. This is usually mutually-exclusive of `server.certificate` since that value should be the first certificate in the chain.",
+        "example": [
+          "MII...",
+          "MII..."
+        ],
+        "flat_name": "tls.server.certificate_chain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "server.certificate_chain",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array of PEM-encoded certificates that make up the certificate chain offered by the server.",
+        "type": "keyword"
+      },
+      "tls.server.hash.md5": {
+        "dashed_name": "tls-server-hash-md5",
+        "description": "Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.",
+        "example": "0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC",
+        "flat_name": "tls.server.hash.md5",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "server.hash.md5",
+        "normalize": [],
+        "short": "Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server.",
+        "type": "keyword"
+      },
+      "tls.server.hash.sha1": {
+        "dashed_name": "tls-server-hash-sha1",
+        "description": "Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.",
+        "example": "9E393D93138888D288266C2D915214D1D1CCEB2A",
+        "flat_name": "tls.server.hash.sha1",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "server.hash.sha1",
+        "normalize": [],
+        "short": "Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server.",
+        "type": "keyword"
+      },
+      "tls.server.hash.sha256": {
+        "dashed_name": "tls-server-hash-sha256",
+        "description": "Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash.",
+        "example": "0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0",
+        "flat_name": "tls.server.hash.sha256",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "server.hash.sha256",
+        "normalize": [],
+        "short": "Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server.",
+        "type": "keyword"
+      },
+      "tls.server.issuer": {
+        "dashed_name": "tls-server-issuer",
+        "description": "Subject of the issuer of the x.509 certificate presented by the server.",
+        "example": "CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",
+        "flat_name": "tls.server.issuer",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "server.issuer",
+        "normalize": [],
+        "short": "Subject of the issuer of the x.509 certificate presented by the server.",
+        "type": "keyword"
+      },
+      "tls.server.ja3s": {
+        "dashed_name": "tls-server-ja3s",
+        "description": "A hash that identifies servers based on how they perform an SSL/TLS handshake.",
+        "example": "394441ab65754e2207b1e1b457b3641d",
+        "flat_name": "tls.server.ja3s",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "server.ja3s",
+        "normalize": [],
+        "short": "A hash that identifies servers based on how they perform an SSL/TLS handshake.",
+        "type": "keyword"
+      },
+      "tls.server.not_after": {
+        "dashed_name": "tls-server-not-after",
+        "description": "Timestamp indicating when server certificate is no longer considered valid.",
+        "example": "2021-01-01T00:00:00.000Z",
+        "flat_name": "tls.server.not_after",
+        "level": "extended",
+        "name": "server.not_after",
+        "normalize": [],
+        "short": "Timestamp indicating when server certificate is no longer considered valid.",
+        "type": "date"
+      },
+      "tls.server.not_before": {
+        "dashed_name": "tls-server-not-before",
+        "description": "Timestamp indicating when server certificate is first considered valid.",
+        "example": "1970-01-01T00:00:00.000Z",
+        "flat_name": "tls.server.not_before",
+        "level": "extended",
+        "name": "server.not_before",
+        "normalize": [],
+        "short": "Timestamp indicating when server certificate is first considered valid.",
+        "type": "date"
+      },
+      "tls.server.subject": {
+        "dashed_name": "tls-server-subject",
+        "description": "Subject of the x.509 certificate presented by the server.",
+        "example": "CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com",
+        "flat_name": "tls.server.subject",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "server.subject",
+        "normalize": [],
+        "short": "Subject of the x.509 certificate presented by the server.",
+        "type": "keyword"
+      },
+      "tls.server.x509.alternative_names": {
+        "dashed_name": "tls-server-x509-alternative-names",
+        "description": "List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
+        "example": "*.elastic.co",
+        "flat_name": "tls.server.x509.alternative_names",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "alternative_names",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of subject alternative names (SAN).",
+        "type": "keyword"
+      },
+      "tls.server.x509.issuer.common_name": {
+        "dashed_name": "tls-server-x509-issuer-common-name",
+        "description": "List of common name (CN) of issuing certificate authority.",
+        "example": "Example SHA2 High Assurance Server CA",
+        "flat_name": "tls.server.x509.issuer.common_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.common_name",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of common name (CN) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "tls.server.x509.issuer.country": {
+        "dashed_name": "tls-server-x509-issuer-country",
+        "description": "List of country (C) codes",
+        "example": "US",
+        "flat_name": "tls.server.x509.issuer.country",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.country",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of country (C) codes",
+        "type": "keyword"
+      },
+      "tls.server.x509.issuer.distinguished_name": {
+        "dashed_name": "tls-server-x509-issuer-distinguished-name",
+        "description": "Distinguished name (DN) of issuing certificate authority.",
+        "example": "C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",
+        "flat_name": "tls.server.x509.issuer.distinguished_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.distinguished_name",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Distinguished name (DN) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "tls.server.x509.issuer.locality": {
+        "dashed_name": "tls-server-x509-issuer-locality",
+        "description": "List of locality names (L)",
+        "example": "Mountain View",
+        "flat_name": "tls.server.x509.issuer.locality",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.locality",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of locality names (L)",
+        "type": "keyword"
+      },
+      "tls.server.x509.issuer.organization": {
+        "dashed_name": "tls-server-x509-issuer-organization",
+        "description": "List of organizations (O) of issuing certificate authority.",
+        "example": "Example Inc",
+        "flat_name": "tls.server.x509.issuer.organization",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.organization",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizations (O) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "tls.server.x509.issuer.organizational_unit": {
+        "dashed_name": "tls-server-x509-issuer-organizational-unit",
+        "description": "List of organizational units (OU) of issuing certificate authority.",
+        "example": "www.example.com",
+        "flat_name": "tls.server.x509.issuer.organizational_unit",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.organizational_unit",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizational units (OU) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "tls.server.x509.issuer.state_or_province": {
+        "dashed_name": "tls-server-x509-issuer-state-or-province",
+        "description": "List of state or province names (ST, S, or P)",
+        "example": "California",
+        "flat_name": "tls.server.x509.issuer.state_or_province",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.state_or_province",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of state or province names (ST, S, or P)",
+        "type": "keyword"
+      },
+      "tls.server.x509.not_after": {
+        "dashed_name": "tls-server-x509-not-after",
+        "description": "Time at which the certificate is no longer considered valid.",
+        "example": "2020-07-16T03:15:39+00:00",
+        "flat_name": "tls.server.x509.not_after",
+        "level": "extended",
+        "name": "not_after",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Time at which the certificate is no longer considered valid.",
+        "type": "date"
+      },
+      "tls.server.x509.not_before": {
+        "dashed_name": "tls-server-x509-not-before",
+        "description": "Time at which the certificate is first considered valid.",
+        "example": "2019-08-16T01:40:25+00:00",
+        "flat_name": "tls.server.x509.not_before",
+        "level": "extended",
+        "name": "not_before",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Time at which the certificate is first considered valid.",
+        "type": "date"
+      },
+      "tls.server.x509.public_key_algorithm": {
+        "dashed_name": "tls-server-x509-public-key-algorithm",
+        "description": "Algorithm used to generate the public key.",
+        "example": "RSA",
+        "flat_name": "tls.server.x509.public_key_algorithm",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "public_key_algorithm",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Algorithm used to generate the public key.",
+        "type": "keyword"
+      },
+      "tls.server.x509.public_key_curve": {
+        "dashed_name": "tls-server-x509-public-key-curve",
+        "description": "The curve used by the elliptic curve public key algorithm. This is algorithm specific.",
+        "example": "nistp521",
+        "flat_name": "tls.server.x509.public_key_curve",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "public_key_curve",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "The curve used by the elliptic curve public key algorithm. This is algorithm specific.",
+        "type": "keyword"
+      },
+      "tls.server.x509.public_key_exponent": {
+        "dashed_name": "tls-server-x509-public-key-exponent",
+        "description": "Exponent used to derive the public key. This is algorithm specific.",
+        "doc_values": false,
+        "example": 65537,
+        "flat_name": "tls.server.x509.public_key_exponent",
+        "index": false,
+        "level": "extended",
+        "name": "public_key_exponent",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Exponent used to derive the public key. This is algorithm specific.",
+        "type": "long"
+      },
+      "tls.server.x509.public_key_size": {
+        "dashed_name": "tls-server-x509-public-key-size",
+        "description": "The size of the public key space in bits.",
+        "example": 2048,
+        "flat_name": "tls.server.x509.public_key_size",
+        "level": "extended",
+        "name": "public_key_size",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "The size of the public key space in bits.",
+        "type": "long"
+      },
+      "tls.server.x509.serial_number": {
+        "dashed_name": "tls-server-x509-serial-number",
+        "description": "Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters.",
+        "example": "55FBB9C7DEBF09809D12CCAA",
+        "flat_name": "tls.server.x509.serial_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "serial_number",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Unique serial number issued by the certificate authority.",
+        "type": "keyword"
+      },
+      "tls.server.x509.signature_algorithm": {
+        "dashed_name": "tls-server-x509-signature-algorithm",
+        "description": "Identifier for certificate signature algorithm. We recommend using names found in Go Lang Crypto library. See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353.",
+        "example": "SHA256-RSA",
+        "flat_name": "tls.server.x509.signature_algorithm",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "signature_algorithm",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Identifier for certificate signature algorithm.",
+        "type": "keyword"
+      },
+      "tls.server.x509.subject.common_name": {
+        "dashed_name": "tls-server-x509-subject-common-name",
+        "description": "List of common names (CN) of subject.",
+        "example": "shared.global.example.net",
+        "flat_name": "tls.server.x509.subject.common_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.common_name",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of common names (CN) of subject.",
+        "type": "keyword"
+      },
+      "tls.server.x509.subject.country": {
+        "dashed_name": "tls-server-x509-subject-country",
+        "description": "List of country (C) code",
+        "example": "US",
+        "flat_name": "tls.server.x509.subject.country",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.country",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of country (C) code",
+        "type": "keyword"
+      },
+      "tls.server.x509.subject.distinguished_name": {
+        "dashed_name": "tls-server-x509-subject-distinguished-name",
+        "description": "Distinguished name (DN) of the certificate subject entity.",
+        "example": "C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",
+        "flat_name": "tls.server.x509.subject.distinguished_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.distinguished_name",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Distinguished name (DN) of the certificate subject entity.",
+        "type": "keyword"
+      },
+      "tls.server.x509.subject.locality": {
+        "dashed_name": "tls-server-x509-subject-locality",
+        "description": "List of locality names (L)",
+        "example": "San Francisco",
+        "flat_name": "tls.server.x509.subject.locality",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.locality",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of locality names (L)",
+        "type": "keyword"
+      },
+      "tls.server.x509.subject.organization": {
+        "dashed_name": "tls-server-x509-subject-organization",
+        "description": "List of organizations (O) of subject.",
+        "example": "Example, Inc.",
+        "flat_name": "tls.server.x509.subject.organization",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.organization",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizations (O) of subject.",
+        "type": "keyword"
+      },
+      "tls.server.x509.subject.organizational_unit": {
+        "dashed_name": "tls-server-x509-subject-organizational-unit",
+        "description": "List of organizational units (OU) of subject.",
+        "flat_name": "tls.server.x509.subject.organizational_unit",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.organizational_unit",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of organizational units (OU) of subject.",
+        "type": "keyword"
+      },
+      "tls.server.x509.subject.state_or_province": {
+        "dashed_name": "tls-server-x509-subject-state-or-province",
+        "description": "List of state or province names (ST, S, or P)",
+        "example": "California",
+        "flat_name": "tls.server.x509.subject.state_or_province",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.state_or_province",
+        "normalize": [
+          "array"
+        ],
+        "original_fieldset": "x509",
+        "short": "List of state or province names (ST, S, or P)",
+        "type": "keyword"
+      },
+      "tls.server.x509.version_number": {
+        "dashed_name": "tls-server-x509-version-number",
+        "description": "Version of x509 format.",
+        "example": 3,
+        "flat_name": "tls.server.x509.version_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version_number",
+        "normalize": [],
+        "original_fieldset": "x509",
+        "short": "Version of x509 format.",
+        "type": "keyword"
+      },
+      "tls.version": {
+        "dashed_name": "tls-version",
+        "description": "Numeric part of the version parsed from the original string.",
+        "example": "1.2",
+        "flat_name": "tls.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "short": "Numeric part of the version parsed from the original string.",
+        "type": "keyword"
+      },
+      "tls.version_protocol": {
+        "dashed_name": "tls-version-protocol",
+        "description": "Normalized lowercase protocol name parsed from original string.",
+        "example": "tls",
+        "flat_name": "tls.version_protocol",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version_protocol",
+        "normalize": [],
+        "short": "Normalized lowercase protocol name parsed from original string.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "tls",
+    "nestings": [
+      "tls.client.x509",
+      "tls.server.x509"
+    ],
+    "prefix": "tls.",
+    "reused_here": [
+      {
+        "full": "tls.client.x509",
+        "schema_name": "x509",
+        "short": "These fields contain x509 certificate metadata."
+      },
+      {
+        "full": "tls.server.x509",
+        "schema_name": "x509",
+        "short": "These fields contain x509 certificate metadata."
+      }
+    ],
+    "short": "Fields describing a TLS connection.",
+    "title": "TLS",
+    "type": "group"
+  },
+  "tracing": {
+    "description": "Distributed tracing makes it possible to analyze performance throughout a microservice architecture all in one view. This is accomplished by tracing all of the requests - from the initial web request in the front-end service - to queries made through multiple back-end services.",
+    "fields": {
+      "span.id": {
+        "dashed_name": "span-id",
+        "description": "Unique identifier of the span within the scope of its trace.\nA span represents an operation within a transaction, such as a request to another service, or a database query.",
+        "example": "3ff9a8981b7ccd5a",
+        "flat_name": "span.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "span.id",
+        "normalize": [],
+        "short": "Unique identifier of the span within the scope of its trace.",
+        "type": "keyword"
+      },
+      "trace.id": {
+        "dashed_name": "trace-id",
+        "description": "Unique identifier of the trace.\nA trace groups multiple events like transactions that belong together. For example, a user request handled by multiple inter-connected services.",
+        "example": "4bf92f3577b34da6a3ce929d0e0e4736",
+        "flat_name": "trace.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "trace.id",
+        "normalize": [],
+        "short": "Unique identifier of the trace.",
+        "type": "keyword"
+      },
+      "transaction.id": {
+        "dashed_name": "transaction-id",
+        "description": "Unique identifier of the transaction within the scope of its trace.\nA transaction is the highest level of work measured within a service, such as a request to a server.",
+        "example": "00f067aa0ba902b7",
+        "flat_name": "transaction.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "transaction.id",
+        "normalize": [],
+        "short": "Unique identifier of the transaction within the scope of its trace.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "tracing",
+    "prefix": "",
+    "root": true,
+    "short": "Fields related to distributed tracing.",
+    "title": "Tracing",
+    "type": "group"
+  },
+  "url": {
+    "description": "URL fields provide support for complete or partial URLs, and supports the breaking down into scheme, domain, path, and so on.",
+    "fields": {
+      "url.domain": {
+        "dashed_name": "url-domain",
+        "description": "Domain of the url, such as \"www.elastic.co\".\nIn some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field.",
+        "example": "www.elastic.co",
+        "flat_name": "url.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "short": "Domain of the url.",
+        "type": "keyword"
+      },
+      "url.extension": {
+        "dashed_name": "url-extension",
+        "description": "The field contains the file extension from the original request url.\nThe file extension is only set if it exists, as not every url has a file extension.\nThe leading period must not be included. For example, the value must be \"png\", not \".png\".",
+        "example": "png",
+        "flat_name": "url.extension",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "extension",
+        "normalize": [],
+        "short": "File extension from the original request url.",
+        "type": "keyword"
+      },
+      "url.fragment": {
+        "dashed_name": "url-fragment",
+        "description": "Portion of the url after the `#`, such as \"top\".\nThe `#` is not part of the fragment.",
+        "flat_name": "url.fragment",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "fragment",
+        "normalize": [],
+        "short": "Portion of the url after the `#`.",
+        "type": "keyword"
+      },
+      "url.full": {
+        "dashed_name": "url-full",
+        "description": "If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.",
+        "example": "https://www.elastic.co:443/search?q=elasticsearch#top",
+        "flat_name": "url.full",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "url.full.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full",
+        "normalize": [],
+        "short": "Full unparsed URL.",
+        "type": "keyword"
+      },
+      "url.original": {
+        "dashed_name": "url-original",
+        "description": "Unmodified original url as seen in the event source.\nNote that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path.\nThis field is meant to represent the URL as it was observed, complete or not.",
+        "example": "https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch",
+        "flat_name": "url.original",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "url.original.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "original",
+        "normalize": [],
+        "short": "Unmodified original url as seen in the event source.",
+        "type": "keyword"
+      },
+      "url.password": {
+        "dashed_name": "url-password",
+        "description": "Password of the request.",
+        "flat_name": "url.password",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "password",
+        "normalize": [],
+        "short": "Password of the request.",
+        "type": "keyword"
+      },
+      "url.path": {
+        "dashed_name": "url-path",
+        "description": "Path of the request, such as \"/search\".",
+        "flat_name": "url.path",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "path",
+        "normalize": [],
+        "short": "Path of the request, such as \"/search\".",
+        "type": "keyword"
+      },
+      "url.port": {
+        "dashed_name": "url-port",
+        "description": "Port of the request, such as 443.",
+        "example": 443,
+        "flat_name": "url.port",
+        "format": "string",
+        "level": "extended",
+        "name": "port",
+        "normalize": [],
+        "short": "Port of the request, such as 443.",
+        "type": "long"
+      },
+      "url.query": {
+        "dashed_name": "url-query",
+        "description": "The query field describes the query string of the request, such as \"q=elasticsearch\".\nThe `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.",
+        "flat_name": "url.query",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "query",
+        "normalize": [],
+        "short": "Query string of the request.",
+        "type": "keyword"
+      },
+      "url.registered_domain": {
+        "dashed_name": "url-registered-domain",
+        "description": "The highest registered url domain, stripped of the subdomain.\nFor example, the registered domain for \"foo.example.com\" is \"example.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".",
+        "example": "example.com",
+        "flat_name": "url.registered_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "registered_domain",
+        "normalize": [],
+        "short": "The highest registered url domain, stripped of the subdomain.",
+        "type": "keyword"
+      },
+      "url.scheme": {
+        "dashed_name": "url-scheme",
+        "description": "Scheme of the request, such as \"https\".\nNote: The `:` is not part of the scheme.",
+        "example": "https",
+        "flat_name": "url.scheme",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "scheme",
+        "normalize": [],
+        "short": "Scheme of the url.",
+        "type": "keyword"
+      },
+      "url.top_level_domain": {
+        "dashed_name": "url-top-level-domain",
+        "description": "The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is \"com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as \"co.uk\".",
+        "example": "co.uk",
+        "flat_name": "url.top_level_domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "top_level_domain",
+        "normalize": [],
+        "short": "The effective top level domain (com, org, net, co.uk).",
+        "type": "keyword"
+      },
+      "url.username": {
+        "dashed_name": "url-username",
+        "description": "Username of the request.",
+        "flat_name": "url.username",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "username",
+        "normalize": [],
+        "short": "Username of the request.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "url",
+    "prefix": "url.",
+    "short": "Fields that let you store URLs in various forms.",
+    "title": "URL",
+    "type": "group"
+  },
+  "user": {
+    "description": "The user fields describe information about the user that is relevant to the event.\nFields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.",
+    "fields": {
+      "user.domain": {
+        "dashed_name": "user-domain",
+        "description": "Name of the directory the user is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "user.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "short": "Name of the directory the user is a member of.",
+        "type": "keyword"
+      },
+      "user.email": {
+        "dashed_name": "user-email",
+        "description": "User email address.",
+        "flat_name": "user.email",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "email",
+        "normalize": [],
+        "short": "User email address.",
+        "type": "keyword"
+      },
+      "user.full_name": {
+        "dashed_name": "user-full-name",
+        "description": "User's full name, if available.",
+        "example": "Albert Einstein",
+        "flat_name": "user.full_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "user.full_name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full_name",
+        "normalize": [],
+        "short": "User's full name, if available.",
+        "type": "keyword"
+      },
+      "user.group.domain": {
+        "dashed_name": "user-group-domain",
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.",
+        "flat_name": "user.group.domain",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "domain",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the directory the group is a member of.",
+        "type": "keyword"
+      },
+      "user.group.id": {
+        "dashed_name": "user-group-id",
+        "description": "Unique identifier for the group on the system/platform.",
+        "flat_name": "user.group.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Unique identifier for the group on the system/platform.",
+        "type": "keyword"
+      },
+      "user.group.name": {
+        "dashed_name": "user-group-name",
+        "description": "Name of the group.",
+        "flat_name": "user.group.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "group",
+        "short": "Name of the group.",
+        "type": "keyword"
+      },
+      "user.hash": {
+        "dashed_name": "user-hash",
+        "description": "Unique user hash to correlate information for a user in anonymized form.\nUseful if `user.id` or `user.name` contain confidential information and cannot be used.",
+        "flat_name": "user.hash",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "hash",
+        "normalize": [],
+        "short": "Unique user hash to correlate information for a user in anonymized form.",
+        "type": "keyword"
+      },
+      "user.id": {
+        "dashed_name": "user-id",
+        "description": "Unique identifier of the user.",
+        "flat_name": "user.id",
+        "ignore_above": 1024,
+        "level": "core",
+        "name": "id",
+        "normalize": [],
+        "short": "Unique identifier of the user.",
+        "type": "keyword"
+      },
+      "user.name": {
+        "dashed_name": "user-name",
+        "description": "Short name or login of the user.",
+        "example": "albert",
+        "flat_name": "user.name",
+        "ignore_above": 1024,
+        "level": "core",
+        "multi_fields": [
+          {
+            "flat_name": "user.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "short": "Short name or login of the user.",
+        "type": "keyword"
+      },
+      "user.roles": {
+        "dashed_name": "user-roles",
+        "description": "Array of user roles at the time of the event.",
+        "example": "[\"kibana_admin\", \"reporting_user\"]",
+        "flat_name": "user.roles",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "roles",
+        "normalize": [
+          "array"
+        ],
+        "short": "Array of user roles at the time of the event.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "user",
+    "nestings": [
+      "user.group"
+    ],
+    "prefix": "user.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "user",
+          "at": "client",
+          "full": "client.user"
+        },
+        {
+          "as": "user",
+          "at": "destination",
+          "full": "destination.user"
+        },
+        {
+          "as": "user",
+          "at": "host",
+          "full": "host.user"
+        },
+        {
+          "as": "user",
+          "at": "server",
+          "full": "server.user"
+        },
+        {
+          "as": "user",
+          "at": "source",
+          "full": "source.user"
+        }
+      ],
+      "top_level": true
+    },
+    "reused_here": [
+      {
+        "full": "user.group",
+        "schema_name": "group",
+        "short": "User's group relevant to the event."
+      }
+    ],
+    "short": "Fields to describe the user relevant to the event.",
+    "title": "User",
+    "type": "group"
+  },
+  "user_agent": {
+    "description": "The user_agent fields normally come from a browser request.\nThey often show up in web service logs coming from the parsed user agent string.",
+    "fields": {
+      "user_agent.device.name": {
+        "dashed_name": "user-agent-device-name",
+        "description": "Name of the device.",
+        "example": "iPhone",
+        "flat_name": "user_agent.device.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "device.name",
+        "normalize": [],
+        "short": "Name of the device.",
+        "type": "keyword"
+      },
+      "user_agent.name": {
+        "dashed_name": "user-agent-name",
+        "description": "Name of the user agent.",
+        "example": "Safari",
+        "flat_name": "user_agent.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Name of the user agent.",
+        "type": "keyword"
+      },
+      "user_agent.original": {
+        "dashed_name": "user-agent-original",
+        "description": "Unparsed user_agent string.",
+        "example": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",
+        "flat_name": "user_agent.original",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "user_agent.original.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "original",
+        "normalize": [],
+        "short": "Unparsed user_agent string.",
+        "type": "keyword"
+      },
+      "user_agent.os.family": {
+        "dashed_name": "user-agent-os-family",
+        "description": "OS family (such as redhat, debian, freebsd, windows).",
+        "example": "debian",
+        "flat_name": "user_agent.os.family",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "family",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "OS family (such as redhat, debian, freebsd, windows).",
+        "type": "keyword"
+      },
+      "user_agent.os.full": {
+        "dashed_name": "user-agent-os-full",
+        "description": "Operating system name, including the version or code name.",
+        "example": "Mac OS Mojave",
+        "flat_name": "user_agent.os.full",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "user_agent.os.full.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "full",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system name, including the version or code name.",
+        "type": "keyword"
+      },
+      "user_agent.os.kernel": {
+        "dashed_name": "user-agent-os-kernel",
+        "description": "Operating system kernel version as a raw string.",
+        "example": "4.4.0-112-generic",
+        "flat_name": "user_agent.os.kernel",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "kernel",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system kernel version as a raw string.",
+        "type": "keyword"
+      },
+      "user_agent.os.name": {
+        "dashed_name": "user-agent-os-name",
+        "description": "Operating system name, without the version.",
+        "example": "Mac OS X",
+        "flat_name": "user_agent.os.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "user_agent.os.name.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "name",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system name, without the version.",
+        "type": "keyword"
+      },
+      "user_agent.os.platform": {
+        "dashed_name": "user-agent-os-platform",
+        "description": "Operating system platform (such centos, ubuntu, windows).",
+        "example": "darwin",
+        "flat_name": "user_agent.os.platform",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "platform",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system platform (such centos, ubuntu, windows).",
+        "type": "keyword"
+      },
+      "user_agent.os.version": {
+        "dashed_name": "user-agent-os-version",
+        "description": "Operating system version as a raw string.",
+        "example": "10.14.1",
+        "flat_name": "user_agent.os.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "original_fieldset": "os",
+        "short": "Operating system version as a raw string.",
+        "type": "keyword"
+      },
+      "user_agent.version": {
+        "dashed_name": "user-agent-version",
+        "description": "Version of the user agent.",
+        "example": 12.0,
+        "flat_name": "user_agent.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version",
+        "normalize": [],
+        "short": "Version of the user agent.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "user_agent",
+    "nestings": [
+      "user_agent.os"
+    ],
+    "prefix": "user_agent.",
+    "reused_here": [
+      {
+        "full": "user_agent.os",
+        "schema_name": "os",
+        "short": "OS fields contain information about the operating system."
+      }
+    ],
+    "short": "Fields to describe a browser user_agent string.",
+    "title": "User agent",
+    "type": "group"
+  },
+  "vlan": {
+    "description": "The VLAN fields are used to identify 802.1q tag(s) of a packet, as well as ingress and egress VLAN associations of an observer in relation to a specific packet or connection.\nNetwork.vlan fields are used to record a single VLAN tag, or the outer tag in the case of q-in-q encapsulations, for a packet or connection as observed, typically provided by a network sensor (e.g. Zeek, Wireshark) passively reporting on traffic.\nNetwork.inner VLAN fields are used to report inner q-in-q 802.1q tags (multiple 802.1q encapsulations) as observed, typically provided by a network sensor  (e.g. Zeek, Wireshark) passively reporting on traffic. Network.inner VLAN fields should only be used in addition to network.vlan fields to indicate q-in-q tagging.\nObserver.ingress and observer.egress VLAN values are used to record observer specific information when observer events contain discrete ingress and egress VLAN information, typically provided by firewalls, routers, or load balancers.",
+    "fields": {
+      "vlan.id": {
+        "dashed_name": "vlan-id",
+        "description": "VLAN ID as reported by the observer.",
+        "example": 10,
+        "flat_name": "vlan.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "short": "VLAN ID as reported by the observer.",
+        "type": "keyword"
+      },
+      "vlan.name": {
+        "dashed_name": "vlan-name",
+        "description": "Optional VLAN name as reported by the observer.",
+        "example": "outside",
+        "flat_name": "vlan.name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "name",
+        "normalize": [],
+        "short": "Optional VLAN name as reported by the observer.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "vlan",
+    "prefix": "vlan.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "vlan",
+          "at": "observer.ingress",
+          "full": "observer.ingress.vlan"
+        },
+        {
+          "as": "vlan",
+          "at": "observer.egress",
+          "full": "observer.egress.vlan"
+        },
+        {
+          "as": "vlan",
+          "at": "network",
+          "full": "network.vlan"
+        },
+        {
+          "as": "vlan",
+          "at": "network.inner",
+          "full": "network.inner.vlan"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "Fields to describe observed VLAN information.",
+    "title": "VLAN",
+    "type": "group"
+  },
+  "vulnerability": {
+    "description": "The vulnerability fields describe information about a vulnerability that is relevant to an event.",
+    "fields": {
+      "vulnerability.category": {
+        "dashed_name": "vulnerability-category",
+        "description": "The type of system or architecture that the vulnerability affects. These may be platform-specific (for example, Debian or SUSE) or general (for example, Database or Firewall). For example (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys vulnerability categories])\nThis field must be an array.",
+        "example": "[\"Firewall\"]",
+        "flat_name": "vulnerability.category",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "category",
+        "normalize": [
+          "array"
+        ],
+        "short": "Category of a vulnerability.",
+        "type": "keyword"
+      },
+      "vulnerability.classification": {
+        "dashed_name": "vulnerability-classification",
+        "description": "The classification of the vulnerability scoring system. For example (https://www.first.org/cvss/)",
+        "example": "CVSS",
+        "flat_name": "vulnerability.classification",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "classification",
+        "normalize": [],
+        "short": "Classification of the vulnerability.",
+        "type": "keyword"
+      },
+      "vulnerability.description": {
+        "dashed_name": "vulnerability-description",
+        "description": "The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])",
+        "example": "In macOS before 2.12.6, there is a vulnerability in the RPC...",
+        "flat_name": "vulnerability.description",
+        "ignore_above": 1024,
+        "level": "extended",
+        "multi_fields": [
+          {
+            "flat_name": "vulnerability.description.text",
+            "name": "text",
+            "norms": false,
+            "type": "text"
+          }
+        ],
+        "name": "description",
+        "normalize": [],
+        "short": "Description of the vulnerability.",
+        "type": "keyword"
+      },
+      "vulnerability.enumeration": {
+        "dashed_name": "vulnerability-enumeration",
+        "description": "The type of identifier used for this vulnerability. For example (https://cve.mitre.org/about/)",
+        "example": "CVE",
+        "flat_name": "vulnerability.enumeration",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "enumeration",
+        "normalize": [],
+        "short": "Identifier of the vulnerability.",
+        "type": "keyword"
+      },
+      "vulnerability.id": {
+        "dashed_name": "vulnerability-id",
+        "description": "The identification (ID) is the number portion of a vulnerability entry. It includes a unique identification number for the vulnerability. For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities and Exposure CVE ID]",
+        "example": "CVE-2019-00001",
+        "flat_name": "vulnerability.id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "id",
+        "normalize": [],
+        "short": "ID of the vulnerability.",
+        "type": "keyword"
+      },
+      "vulnerability.reference": {
+        "dashed_name": "vulnerability-reference",
+        "description": "A resource that provides additional information, context, and mitigations for the identified vulnerability.",
+        "example": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111",
+        "flat_name": "vulnerability.reference",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "reference",
+        "normalize": [],
+        "short": "Reference of the vulnerability.",
+        "type": "keyword"
+      },
+      "vulnerability.report_id": {
+        "dashed_name": "vulnerability-report-id",
+        "description": "The report or scan identification number.",
+        "example": 20191018.0001,
+        "flat_name": "vulnerability.report_id",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "report_id",
+        "normalize": [],
+        "short": "Scan identification number.",
+        "type": "keyword"
+      },
+      "vulnerability.scanner.vendor": {
+        "dashed_name": "vulnerability-scanner-vendor",
+        "description": "The name of the vulnerability scanner vendor.",
+        "example": "Tenable",
+        "flat_name": "vulnerability.scanner.vendor",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "scanner.vendor",
+        "normalize": [],
+        "short": "Name of the scanner vendor.",
+        "type": "keyword"
+      },
+      "vulnerability.score.base": {
+        "dashed_name": "vulnerability-score-base",
+        "description": "Scores can range from 0.0 to 10.0, with 10.0 being the most severe.\nBase scores cover an assessment for exploitability metrics (attack vector, complexity, privileges, and user interaction), impact metrics (confidentiality, integrity, and availability), and scope. For example (https://www.first.org/cvss/specification-document)",
+        "example": 5.5,
+        "flat_name": "vulnerability.score.base",
+        "level": "extended",
+        "name": "score.base",
+        "normalize": [],
+        "short": "Vulnerability Base score.",
+        "type": "float"
+      },
+      "vulnerability.score.environmental": {
+        "dashed_name": "vulnerability-score-environmental",
+        "description": "Scores can range from 0.0 to 10.0, with 10.0 being the most severe.\nEnvironmental scores cover an assessment for any modified Base metrics, confidentiality, integrity, and availability requirements. For example (https://www.first.org/cvss/specification-document)",
+        "example": 5.5,
+        "flat_name": "vulnerability.score.environmental",
+        "level": "extended",
+        "name": "score.environmental",
+        "normalize": [],
+        "short": "Vulnerability Environmental score.",
+        "type": "float"
+      },
+      "vulnerability.score.temporal": {
+        "dashed_name": "vulnerability-score-temporal",
+        "description": "Scores can range from 0.0 to 10.0, with 10.0 being the most severe.\nTemporal scores cover an assessment for code maturity, remediation level, and confidence. For example (https://www.first.org/cvss/specification-document)",
+        "flat_name": "vulnerability.score.temporal",
+        "level": "extended",
+        "name": "score.temporal",
+        "normalize": [],
+        "short": "Vulnerability Temporal score.",
+        "type": "float"
+      },
+      "vulnerability.score.version": {
+        "dashed_name": "vulnerability-score-version",
+        "description": "The National Vulnerability Database (NVD) provides qualitative severity rankings of \"Low\", \"Medium\", and \"High\" for CVSS v2.0 base score ranges in addition to the severity ratings for CVSS v3.0 as they are defined in the CVSS v3.0 specification.\nCVSS is owned and managed by FIRST.Org, Inc. (FIRST), a US-based non-profit organization, whose mission is to help computer security incident response teams across the world. For example (https://nvd.nist.gov/vuln-metrics/cvss)",
+        "example": 2.0,
+        "flat_name": "vulnerability.score.version",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "score.version",
+        "normalize": [],
+        "short": "CVSS version.",
+        "type": "keyword"
+      },
+      "vulnerability.severity": {
+        "dashed_name": "vulnerability-severity",
+        "description": "The severity of the vulnerability can help with metrics and internal prioritization regarding remediation. For example (https://nvd.nist.gov/vuln-metrics/cvss)",
+        "example": "Critical",
+        "flat_name": "vulnerability.severity",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "severity",
+        "normalize": [],
+        "short": "Severity of the vulnerability.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "vulnerability",
+    "prefix": "vulnerability.",
+    "short": "Fields to describe the vulnerability relevant to an event.",
+    "title": "Vulnerability",
+    "type": "group"
+  },
+  "x509": {
+    "description": "This implements the common core fields for x509 certificates. This information is likely logged with TLS sessions, digital signatures found in executable binaries, S/MIME information in email bodies, or analysis of files on disk. When only a single certificate is logged in an event, it should be nested under `file`. When hashes of the DER-encoded certificate are available, the `hash` data set should be populated as well (e.g. `file.hash.sha256`). For events that contain certificate information for both sides of the connection, the x509 object could be nested under the respective side of the connection information (e.g. `tls.server.x509`).",
+    "fields": {
+      "x509.alternative_names": {
+        "dashed_name": "x509-alternative-names",
+        "description": "List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.",
+        "example": "*.elastic.co",
+        "flat_name": "x509.alternative_names",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "alternative_names",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of subject alternative names (SAN).",
+        "type": "keyword"
+      },
+      "x509.issuer.common_name": {
+        "dashed_name": "x509-issuer-common-name",
+        "description": "List of common name (CN) of issuing certificate authority.",
+        "example": "Example SHA2 High Assurance Server CA",
+        "flat_name": "x509.issuer.common_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.common_name",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of common name (CN) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "x509.issuer.country": {
+        "dashed_name": "x509-issuer-country",
+        "description": "List of country (C) codes",
+        "example": "US",
+        "flat_name": "x509.issuer.country",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.country",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of country (C) codes",
+        "type": "keyword"
+      },
+      "x509.issuer.distinguished_name": {
+        "dashed_name": "x509-issuer-distinguished-name",
+        "description": "Distinguished name (DN) of issuing certificate authority.",
+        "example": "C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",
+        "flat_name": "x509.issuer.distinguished_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.distinguished_name",
+        "normalize": [],
+        "short": "Distinguished name (DN) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "x509.issuer.locality": {
+        "dashed_name": "x509-issuer-locality",
+        "description": "List of locality names (L)",
+        "example": "Mountain View",
+        "flat_name": "x509.issuer.locality",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.locality",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of locality names (L)",
+        "type": "keyword"
+      },
+      "x509.issuer.organization": {
+        "dashed_name": "x509-issuer-organization",
+        "description": "List of organizations (O) of issuing certificate authority.",
+        "example": "Example Inc",
+        "flat_name": "x509.issuer.organization",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.organization",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of organizations (O) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "x509.issuer.organizational_unit": {
+        "dashed_name": "x509-issuer-organizational-unit",
+        "description": "List of organizational units (OU) of issuing certificate authority.",
+        "example": "www.example.com",
+        "flat_name": "x509.issuer.organizational_unit",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.organizational_unit",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of organizational units (OU) of issuing certificate authority.",
+        "type": "keyword"
+      },
+      "x509.issuer.state_or_province": {
+        "dashed_name": "x509-issuer-state-or-province",
+        "description": "List of state or province names (ST, S, or P)",
+        "example": "California",
+        "flat_name": "x509.issuer.state_or_province",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "issuer.state_or_province",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of state or province names (ST, S, or P)",
+        "type": "keyword"
+      },
+      "x509.not_after": {
+        "dashed_name": "x509-not-after",
+        "description": "Time at which the certificate is no longer considered valid.",
+        "example": "2020-07-16T03:15:39+00:00",
+        "flat_name": "x509.not_after",
+        "level": "extended",
+        "name": "not_after",
+        "normalize": [],
+        "short": "Time at which the certificate is no longer considered valid.",
+        "type": "date"
+      },
+      "x509.not_before": {
+        "dashed_name": "x509-not-before",
+        "description": "Time at which the certificate is first considered valid.",
+        "example": "2019-08-16T01:40:25+00:00",
+        "flat_name": "x509.not_before",
+        "level": "extended",
+        "name": "not_before",
+        "normalize": [],
+        "short": "Time at which the certificate is first considered valid.",
+        "type": "date"
+      },
+      "x509.public_key_algorithm": {
+        "dashed_name": "x509-public-key-algorithm",
+        "description": "Algorithm used to generate the public key.",
+        "example": "RSA",
+        "flat_name": "x509.public_key_algorithm",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "public_key_algorithm",
+        "normalize": [],
+        "short": "Algorithm used to generate the public key.",
+        "type": "keyword"
+      },
+      "x509.public_key_curve": {
+        "dashed_name": "x509-public-key-curve",
+        "description": "The curve used by the elliptic curve public key algorithm. This is algorithm specific.",
+        "example": "nistp521",
+        "flat_name": "x509.public_key_curve",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "public_key_curve",
+        "normalize": [],
+        "short": "The curve used by the elliptic curve public key algorithm. This is algorithm specific.",
+        "type": "keyword"
+      },
+      "x509.public_key_exponent": {
+        "dashed_name": "x509-public-key-exponent",
+        "description": "Exponent used to derive the public key. This is algorithm specific.",
+        "doc_values": false,
+        "example": 65537,
+        "flat_name": "x509.public_key_exponent",
+        "index": false,
+        "level": "extended",
+        "name": "public_key_exponent",
+        "normalize": [],
+        "short": "Exponent used to derive the public key. This is algorithm specific.",
+        "type": "long"
+      },
+      "x509.public_key_size": {
+        "dashed_name": "x509-public-key-size",
+        "description": "The size of the public key space in bits.",
+        "example": 2048,
+        "flat_name": "x509.public_key_size",
+        "level": "extended",
+        "name": "public_key_size",
+        "normalize": [],
+        "short": "The size of the public key space in bits.",
+        "type": "long"
+      },
+      "x509.serial_number": {
+        "dashed_name": "x509-serial-number",
+        "description": "Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters.",
+        "example": "55FBB9C7DEBF09809D12CCAA",
+        "flat_name": "x509.serial_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "serial_number",
+        "normalize": [],
+        "short": "Unique serial number issued by the certificate authority.",
+        "type": "keyword"
+      },
+      "x509.signature_algorithm": {
+        "dashed_name": "x509-signature-algorithm",
+        "description": "Identifier for certificate signature algorithm. We recommend using names found in Go Lang Crypto library. See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353.",
+        "example": "SHA256-RSA",
+        "flat_name": "x509.signature_algorithm",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "signature_algorithm",
+        "normalize": [],
+        "short": "Identifier for certificate signature algorithm.",
+        "type": "keyword"
+      },
+      "x509.subject.common_name": {
+        "dashed_name": "x509-subject-common-name",
+        "description": "List of common names (CN) of subject.",
+        "example": "shared.global.example.net",
+        "flat_name": "x509.subject.common_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.common_name",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of common names (CN) of subject.",
+        "type": "keyword"
+      },
+      "x509.subject.country": {
+        "dashed_name": "x509-subject-country",
+        "description": "List of country (C) code",
+        "example": "US",
+        "flat_name": "x509.subject.country",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.country",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of country (C) code",
+        "type": "keyword"
+      },
+      "x509.subject.distinguished_name": {
+        "dashed_name": "x509-subject-distinguished-name",
+        "description": "Distinguished name (DN) of the certificate subject entity.",
+        "example": "C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",
+        "flat_name": "x509.subject.distinguished_name",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.distinguished_name",
+        "normalize": [],
+        "short": "Distinguished name (DN) of the certificate subject entity.",
+        "type": "keyword"
+      },
+      "x509.subject.locality": {
+        "dashed_name": "x509-subject-locality",
+        "description": "List of locality names (L)",
+        "example": "San Francisco",
+        "flat_name": "x509.subject.locality",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.locality",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of locality names (L)",
+        "type": "keyword"
+      },
+      "x509.subject.organization": {
+        "dashed_name": "x509-subject-organization",
+        "description": "List of organizations (O) of subject.",
+        "example": "Example, Inc.",
+        "flat_name": "x509.subject.organization",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.organization",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of organizations (O) of subject.",
+        "type": "keyword"
+      },
+      "x509.subject.organizational_unit": {
+        "dashed_name": "x509-subject-organizational-unit",
+        "description": "List of organizational units (OU) of subject.",
+        "flat_name": "x509.subject.organizational_unit",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.organizational_unit",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of organizational units (OU) of subject.",
+        "type": "keyword"
+      },
+      "x509.subject.state_or_province": {
+        "dashed_name": "x509-subject-state-or-province",
+        "description": "List of state or province names (ST, S, or P)",
+        "example": "California",
+        "flat_name": "x509.subject.state_or_province",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "subject.state_or_province",
+        "normalize": [
+          "array"
+        ],
+        "short": "List of state or province names (ST, S, or P)",
+        "type": "keyword"
+      },
+      "x509.version_number": {
+        "dashed_name": "x509-version-number",
+        "description": "Version of x509 format.",
+        "example": 3,
+        "flat_name": "x509.version_number",
+        "ignore_above": 1024,
+        "level": "extended",
+        "name": "version_number",
+        "normalize": [],
+        "short": "Version of x509 format.",
+        "type": "keyword"
+      }
+    },
+    "group": 2,
+    "name": "x509",
+    "prefix": "x509.",
+    "reusable": {
+      "expected": [
+        {
+          "as": "x509",
+          "at": "file",
+          "full": "file.x509"
+        },
+        {
+          "as": "x509",
+          "at": "tls.client",
+          "full": "tls.client.x509"
+        },
+        {
+          "as": "x509",
+          "at": "tls.server",
+          "full": "tls.server.x509"
+        }
+      ],
+      "top_level": false
+    },
+    "short": "These fields contain x509 certificate metadata.",
+    "title": "x509 Certificate",
+    "type": "group"
+  }
+}

--- a/rules/apm/apm_403_response_to_a_post.toml
+++ b/rules/apm/apm_403_response_to_a_post.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/apm/apm_405_response_method_not_allowed.toml
+++ b/rules/apm/apm_405_response_method_not_allowed.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/apm/apm_null_user_agent.toml
+++ b/rules/apm/apm_null_user_agent.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/apm/apm_sqlmap_user_agent.toml
+++ b/rules/apm/apm_sqlmap_user_agent.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/aws/collection_cloudtrail_logging_created.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/10"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/16"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -8,8 +8,8 @@ updated_date = "2020/07/28"
 author = ["Elastic"]
 description = """
 Identifies a high number of failed attempts to assume an AWS Identity and Access Management (IAM) role. IAM roles are
-used to delegate access to users or services. An adversary may attempt to enumerate IAM roles in order to determine if
-a role exists before attempting to assume or hijack the discovered role.
+used to delegate access to users or services. An adversary may attempt to enumerate IAM roles in order to determine if a
+role exists before attempting to assume or hijack the discovered role.
 """
 from = "now-20m"
 index = ["filebeat-*"]
@@ -50,3 +50,4 @@ reference = "https://attack.mitre.org/tactics/TA0006/"
 [rule.threshold]
 field = ""
 value = 25
+

--- a/rules/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/aws/credential_access_iam_user_addition_to_group.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/04"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -46,8 +46,6 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
+++ b/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/06"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/26"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/10"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/15"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/aws/defense_evasion_config_service_rule_deletion.toml
@@ -1,19 +1,19 @@
 [metadata]
 creation_date = "2020/06/26"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies attempts to delete an AWS Config Service rule. An adversary may tamper with Config rules in order to
-reduce visibiltiy into the security posture of an account and / or its workload instances.
+Identifies attempts to delete an AWS Config Service rule. An adversary may tamper with Config rules in order to reduce
+visibiltiy into the security posture of an account and / or its workload instances.
 """
 false_positives = [
     """
-    Privileged IAM users with security responsibilities may be expected to make changes to the Config rules in order
-    to align with local security policies and requirements. Automation, orchestration, and security tools may also make
+    Privileged IAM users with security responsibilities may be expected to make changes to the Config rules in order to
+    align with local security policies and requirements. Automation, orchestration, and security tools may also make
     changes to the Config service, where they are used to automate setup or configuration of AWS accounts. Other kinds
     of user or service contexts do not commonly make changes to this service.
     """,
@@ -52,3 +52,4 @@ reference = "https://attack.mitre.org/techniques/T1089/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/16"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/15"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/26"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/28"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/27"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/aws/defense_evasion_waf_acl_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/09"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -48,3 +48,4 @@ reference = "https://attack.mitre.org/techniques/T1089/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/aws/execution_via_system_manager.toml
+++ b/rules/aws/execution_via_system_manager.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/06"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -49,8 +49,6 @@ reference = "https://attack.mitre.org/techniques/T1064/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/24"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -51,3 +51,4 @@ reference = "https://attack.mitre.org/techniques/T1537/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0010/"
+

--- a/rules/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/aws/impact_cloudtrail_logging_updated.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/10"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -48,8 +48,6 @@ reference = "https://attack.mitre.org/techniques/T1492/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_group_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -51,8 +51,6 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/20"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -51,8 +51,6 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/aws/impact_ec2_disable_ebs_encryption.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/05"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/aws/impact_iam_deactivate_mfa_device.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/26"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/impact_iam_group_deletion.toml
+++ b/rules/aws/impact_iam_group_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/impact_rds_cluster_deletion.toml
+++ b/rules/aws/impact_rds_cluster_deletion.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/aws/impact_rds_instance_cluster_stoppage.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/20"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/initial_access_console_login_root.toml
+++ b/rules/aws/initial_access_console_login_root.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/11"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -46,8 +46,6 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/initial_access_password_recovery.toml
+++ b/rules/aws/initial_access_password_recovery.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/02"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/aws/persistence_ec2_network_acl_creation.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/04"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/persistence_iam_group_creation.toml
+++ b/rules/aws/persistence_iam_group_creation.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/06/05"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/aws/persistence_rds_cluster_creation.toml
+++ b/rules/aws/persistence_rds_cluster_creation.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/20"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -53,8 +53,6 @@ reference = "https://attack.mitre.org/techniques/T1108/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/06"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -47,3 +47,4 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/06"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 

--- a/rules/linux/credential_access_tcpdump_activity.toml
+++ b/rules/linux/credential_access_tcpdump_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/24"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 
@@ -43,3 +43,4 @@ reference = "https://attack.mitre.org/techniques/T1089/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/27"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/17"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/17"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
+++ b/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/04"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/defense_evasion_disable_selinux_attempt.toml
+++ b/rules/linux/defense_evasion_disable_selinux_attempt.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/22"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/defense_evasion_file_deletion_via_shred.toml
+++ b/rules/linux/defense_evasion_file_deletion_via_shred.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/27"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/defense_evasion_file_mod_writable_dir.toml
+++ b/rules/linux/defense_evasion_file_mod_writable_dir.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/17"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 
@@ -52,3 +52,4 @@ reference = "https://attack.mitre.org/techniques/T1027/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/29"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 
@@ -60,3 +60,4 @@ reference = "https://attack.mitre.org/techniques/T1158/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/linux/defense_evasion_kernel_module_removal.toml
+++ b/rules/linux/defense_evasion_kernel_module_removal.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/24"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 
@@ -58,3 +58,4 @@ reference = "https://attack.mitre.org/techniques/T1215/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/linux/discovery_kernel_module_enumeration.toml
+++ b/rules/linux/discovery_kernel_module_enumeration.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/23"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/discovery_virtual_machine_fingerprinting.toml
+++ b/rules/linux/discovery_virtual_machine_fingerprinting.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/27"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 
@@ -50,3 +50,4 @@ reference = "https://attack.mitre.org/techniques/T1082/"
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/linux/discovery_whoami_commmand.toml
+++ b/rules/linux/discovery_whoami_commmand.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/execution_perl_tty_shell.toml
+++ b/rules/linux/execution_perl_tty_shell.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/16"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/15"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/lateral_movement_telnet_network_activity_external.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_external.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/23"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/lateral_movement_telnet_network_activity_internal.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_internal.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/23"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_hping_activity.toml
+++ b/rules/linux/linux_hping_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_iodine_activity.toml
+++ b/rules/linux/linux_iodine_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_mknod_activity.toml
+++ b/rules/linux/linux_mknod_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_netcat_network_connection.toml
+++ b/rules/linux/linux_netcat_network_connection.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_nmap_activity.toml
+++ b/rules/linux/linux_nmap_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_nping_activity.toml
+++ b/rules/linux/linux_nping_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_process_started_in_temp_directory.toml
+++ b/rules/linux/linux_process_started_in_temp_directory.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_socat_activity.toml
+++ b/rules/linux/linux_socat_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/linux_strace_activity.toml
+++ b/rules/linux/linux_strace_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/persistence_kernel_module_activity.toml
+++ b/rules/linux/persistence_kernel_module_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/persistence_shell_activity_by_web_server.toml
+++ b/rules/linux/persistence_shell_activity_by_web_server.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/23"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/23"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/linux/privilege_escalation_sudoers_file_mod.toml
+++ b/rules/linux/privilege_escalation_sudoers_file_mod.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/04/13"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/ml/ml_cloudtrail_error_message_spike.toml
+++ b/rules/ml/ml_cloudtrail_error_message_spike.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/13"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/13"
 
@@ -35,3 +35,4 @@ rule_id = "78d3d8d9-b476-451d-a9e0-7a5addd70670"
 severity = "low"
 tags = ["AWS", "Elastic", "ML"]
 type = "machine_learning"
+

--- a/rules/ml/ml_cloudtrail_rare_error_code.toml
+++ b/rules/ml/ml_cloudtrail_rare_error_code.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/13"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/13"
 
@@ -35,3 +35,4 @@ rule_id = "19de8096-e2b0-4bd8-80c9-34a820813fff"
 severity = "low"
 tags = ["AWS", "Elastic", "ML"]
 type = "machine_learning"
+

--- a/rules/ml/ml_cloudtrail_rare_method_by_city.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_city.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/13"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/13"
 
@@ -37,3 +37,4 @@ rule_id = "809b70d3-e2c3-455e-af1b-2626a5a1a276"
 severity = "low"
 tags = ["AWS", "Elastic", "ML"]
 type = "machine_learning"
+

--- a/rules/ml/ml_cloudtrail_rare_method_by_country.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_country.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/13"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/13"
 
@@ -37,3 +37,4 @@ rule_id = "dca28dee-c999-400f-b640-50a081cc0fd1"
 severity = "low"
 tags = ["AWS", "Elastic", "ML"]
 type = "machine_learning"
+

--- a/rules/ml/ml_cloudtrail_rare_method_by_user.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_user.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/13"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/13"
 
@@ -36,3 +36,4 @@ rule_id = "ac706eae-d5ec-4b14-b4fd-e8ba8086f0e1"
 severity = "low"
 tags = ["AWS", "Elastic", "ML"]
 type = "machine_learning"
+

--- a/rules/ml/ml_linux_anomalous_network_activity.toml
+++ b/rules/ml/ml_linux_anomalous_network_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_linux_anomalous_network_port_activity.toml
+++ b/rules/ml/ml_linux_anomalous_network_port_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_linux_anomalous_network_service.toml
+++ b/rules/ml/ml_linux_anomalous_network_service.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_linux_anomalous_network_url_activity.toml
+++ b/rules/ml/ml_linux_anomalous_network_url_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_linux_anomalous_process_all_hosts.toml
+++ b/rules/ml/ml_linux_anomalous_process_all_hosts.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_linux_anomalous_user_name.toml
+++ b/rules/ml/ml_linux_anomalous_user_name.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_packetbeat_dns_tunneling.toml
+++ b/rules/ml/ml_packetbeat_dns_tunneling.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_packetbeat_rare_dns_question.toml
+++ b/rules/ml/ml_packetbeat_rare_dns_question.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_packetbeat_rare_server_domain.toml
+++ b/rules/ml/ml_packetbeat_rare_server_domain.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 
@@ -16,10 +16,10 @@ command-and-control communication.
 """
 false_positives = [
     """
-    Web activity that occurs rarely in small quantities can trigger this alert. Possible examples are browsing
-    technical support or vendor URLs that are used very sparsely. A user who visits a new and unique web destination may
-    trigger this alert when the activity is sparse. Web applications that generate URLs unique to a transaction may
-    trigger this when they are used sparsely. Web domains can be excluded in cases such as these.
+    Web activity that occurs rarely in small quantities can trigger this alert. Possible examples are browsing technical
+    support or vendor URLs that are used very sparsely. A user who visits a new and unique web destination may trigger
+    this alert when the activity is sparse. Web applications that generate URLs unique to a transaction may trigger this
+    when they are used sparsely. Web domains can be excluded in cases such as these.
     """,
 ]
 from = "now-45m"

--- a/rules/ml/ml_packetbeat_rare_urls.toml
+++ b/rules/ml/ml_packetbeat_rare_urls.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 
@@ -19,10 +19,10 @@ which are part of common Internet background traffic.
 """
 false_positives = [
     """
-    Web activity that occurs rarely in small quantities can trigger this alert. Possible examples are browsing
-    technical support or vendor URLs that are used very sparsely. A user who visits a new and unique web destination may
-    trigger this alert when the activity is sparse. Web applications that generate URLs unique to a transaction may
-    trigger this when they are used sparsely. Web domains can be excluded in cases such as these.
+    Web activity that occurs rarely in small quantities can trigger this alert. Possible examples are browsing technical
+    support or vendor URLs that are used very sparsely. A user who visits a new and unique web destination may trigger
+    this alert when the activity is sparse. Web applications that generate URLs unique to a transaction may trigger this
+    when they are used sparsely. Web domains can be excluded in cases such as these.
     """,
 ]
 from = "now-45m"

--- a/rules/ml/ml_packetbeat_rare_user_agent.toml
+++ b/rules/ml/ml_packetbeat_rare_user_agent.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_rare_process_by_host_linux.toml
+++ b/rules/ml/ml_rare_process_by_host_linux.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_rare_process_by_host_windows.toml
+++ b/rules/ml/ml_rare_process_by_host_windows.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_suspicious_login_activity.toml
+++ b/rules/ml/ml_suspicious_login_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_windows_anomalous_network_activity.toml
+++ b/rules/ml/ml_windows_anomalous_network_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_windows_anomalous_path_activity.toml
+++ b/rules/ml/ml_windows_anomalous_path_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_windows_anomalous_process_all_hosts.toml
+++ b/rules/ml/ml_windows_anomalous_process_all_hosts.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 
@@ -15,7 +15,7 @@ or many hosts in a fleet.
 false_positives = [
     """
     A newly installed program or one that runs rarely as part of a monthly or quarterly workflow could trigger this
-alert.
+    alert.
     """,
 ]
 from = "now-45m"
@@ -37,3 +37,4 @@ rule_id = "6e40d56f-5c0e-4ac6-aece-bee96645b172"
 severity = "low"
 tags = ["Elastic", "ML", "Windows"]
 type = "machine_learning"
+

--- a/rules/ml/ml_windows_anomalous_process_creation.toml
+++ b/rules/ml/ml_windows_anomalous_process_creation.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 
@@ -17,9 +17,8 @@ a method of detecting new and emerging malware that is not yet recognized by ant
 """
 false_positives = [
     """
-    Users running scripts in the course of technical support operations of software upgrades could trigger this alert.
-    A newly installed program or one that runs rarely as part of a monthly or quarterly workflow could trigger this
-    alert.
+    Users running scripts in the course of technical support operations of software upgrades could trigger this alert. A
+    newly installed program or one that runs rarely as part of a monthly or quarterly workflow could trigger this alert.
     """,
 ]
 from = "now-45m"

--- a/rules/ml/ml_windows_anomalous_script.toml
+++ b/rules/ml/ml_windows_anomalous_script.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_windows_anomalous_service.toml
+++ b/rules/ml/ml_windows_anomalous_service.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_windows_anomalous_user_name.toml
+++ b/rules/ml/ml_windows_anomalous_user_name.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_windows_rare_user_runas_event.toml
+++ b/rules/ml/ml_windows_rare_user_runas_event.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/ml/ml_windows_rare_user_type10_remote_login.toml
+++ b/rules/ml/ml_windows_rare_user_type10_remote_login.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/network/command_and_control_dns_directly_to_the_internet.toml
+++ b/rules/network/command_and_control_dns_directly_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -54,3 +54,4 @@ reference = "https://attack.mitre.org/techniques/T1043/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_ftp_file_transfer_protocol_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_ftp_file_transfer_protocol_activity_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -63,3 +63,4 @@ reference = "https://attack.mitre.org/techniques/T1048/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0010/"
+

--- a/rules/network/command_and_control_irc_internet_relay_chat_protocol_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_irc_internet_relay_chat_protocol_activity_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -62,3 +62,4 @@ reference = "https://attack.mitre.org/techniques/T1048/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_nat_traversal_port_activity.toml
+++ b/rules/network/command_and_control_nat_traversal_port_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -47,3 +47,4 @@ reference = "https://attack.mitre.org/techniques/T1043/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_port_26_activity.toml
+++ b/rules/network/command_and_control_port_26_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -60,3 +60,4 @@ reference = "https://attack.mitre.org/techniques/T1048/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_port_8000_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_port_8000_activity_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -49,3 +49,4 @@ reference = "https://attack.mitre.org/techniques/T1043/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_pptp_point_to_point_tunneling_protocol_activity.toml
+++ b/rules/network/command_and_control_pptp_point_to_point_tunneling_protocol_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -46,3 +46,4 @@ reference = "https://attack.mitre.org/techniques/T1043/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_proxy_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_proxy_port_activity_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -15,11 +15,12 @@ false_positives = [
     """
     Some proxied applications may use these ports but this usually occurs in local traffic using private IPs which this
     rule does not match. Proxies are widely used as a security technology but in enterprise environments this is usually
-    local traffic which this rule does not match. If desired, internet proxy services using these ports can be added to allowlists. Some screen recording applications may use these ports. Proxy port activity involving an unusual source or
-    destination may be more suspicious. Some cloud environments may use this port when VPNs or direct connects are not
-    in use and cloud instances are accessed across the Internet. Because these ports are in the ephemeral range, this
-    rule may false under certain conditions such as when a NATed web server replies to a client which has used a port in
-    the range by coincidence. In this case, such servers can be excluded if desired.
+    local traffic which this rule does not match. If desired, internet proxy services using these ports can be added to
+    allowlists. Some screen recording applications may use these ports. Proxy port activity involving an unusual source
+    or destination may be more suspicious. Some cloud environments may use this port when VPNs or direct connects are
+    not in use and cloud instances are accessed across the Internet. Because these ports are in the ephemeral range,
+    this rule may false under certain conditions such as when a NATed web server replies to a client which has used a
+    port in the range by coincidence. In this case, such servers can be excluded if desired.
     """,
 ]
 index = ["filebeat-*", "packetbeat-*"]
@@ -51,3 +52,4 @@ reference = "https://attack.mitre.org/techniques/T1043/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_rdp_remote_desktop_protocol_from_the_internet.toml
+++ b/rules/network/command_and_control_rdp_remote_desktop_protocol_from_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -75,3 +75,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/network/command_and_control_smtp_to_the_internet.toml
+++ b/rules/network/command_and_control_smtp_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -59,3 +59,4 @@ reference = "https://attack.mitre.org/techniques/T1048/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0010/"
+

--- a/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -48,3 +48,4 @@ reference = "https://attack.mitre.org/techniques/T1043/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_ssh_secure_shell_from_the_internet.toml
+++ b/rules/network/command_and_control_ssh_secure_shell_from_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -75,3 +75,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/network/command_and_control_ssh_secure_shell_to_the_internet.toml
+++ b/rules/network/command_and_control_ssh_secure_shell_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -50,3 +50,4 @@ reference = "https://attack.mitre.org/techniques/T1043/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_telnet_port_activity.toml
+++ b/rules/network/command_and_control_telnet_port_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -72,3 +72,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0011"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_tor_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_tor_activity_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -60,3 +60,4 @@ reference = "https://attack.mitre.org/techniques/T1188/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_vnc_virtual_network_computing_from_the_internet.toml
+++ b/rules/network/command_and_control_vnc_virtual_network_computing_from_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -61,3 +61,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/network/command_and_control_vnc_virtual_network_computing_to_the_internet.toml
+++ b/rules/network/command_and_control_vnc_virtual_network_computing_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -49,3 +49,4 @@ reference = "https://attack.mitre.org/techniques/T1219/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/initial_access_rdp_remote_desktop_protocol_to_the_internet.toml
+++ b/rules/network/initial_access_rdp_remote_desktop_protocol_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -62,3 +62,4 @@ reference = "https://attack.mitre.org/techniques/T1048/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0010/"
+

--- a/rules/network/initial_access_rpc_remote_procedure_call_from_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_from_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -41,3 +41,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0011"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -41,3 +41,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0011"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/initial_access_smb_windows_file_sharing_activity_to_the_internet.toml
+++ b/rules/network/initial_access_smb_windows_file_sharing_activity_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/02"
 
@@ -53,3 +53,4 @@ reference = "https://attack.mitre.org/techniques/T1048/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0010/"
+

--- a/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -42,3 +42,4 @@ reference = "https://attack.mitre.org/techniques/T1111/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/okta/credential_access_okta_brute_force_or_password_spraying.toml
+++ b/rules/okta/credential_access_okta_brute_force_or_password_spraying.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/16"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -11,7 +11,12 @@ Identifies a high number of failed Okta user authentication attempts from a sing
 of a brute force or password spraying attack. An adversary may attempt a brute force or password spraying attack to
 obtain unauthorized access to user accounts.
 """
-false_positives = ["Automated processes that attempt to authenticate using expired credentials and unbounded retries may lead to false positives."]
+false_positives = [
+    """
+    Automated processes that attempt to authenticate using expired credentials and unbounded retries may lead to false
+    positives.
+    """,
+]
 index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
@@ -48,3 +53,4 @@ reference = "https://attack.mitre.org/tactics/TA0006/"
 [rule.threshold]
 field = "source.ip"
 value = 25
+

--- a/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -48,3 +48,4 @@ reference = "https://attack.mitre.org/techniques/T1531/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+

--- a/rules/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/okta/impact_possible_okta_dos_attack.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -47,3 +47,4 @@ reference = "https://attack.mitre.org/techniques/T1499/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+

--- a/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -43,8 +43,6 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -57,8 +55,6 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -71,8 +67,6 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -85,3 +79,4 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/okta/okta_attempt_to_deactivate_okta_mfa_rule.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_mfa_rule.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -34,3 +34,4 @@ type = "query"
 query = '''
 event.module:okta and event.dataset:okta.system and event.action:policy.rule.deactivate
 '''
+

--- a/rules/okta/okta_attempt_to_delete_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/28"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -35,3 +35,4 @@ type = "query"
 query = '''
 event.module:okta and event.dataset:okta.system and event.action:policy.lifecycle.delete
 '''
+

--- a/rules/okta/okta_attempt_to_modify_okta_mfa_rule.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_mfa_rule.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -34,3 +34,4 @@ type = "query"
 query = '''
 event.module:okta and event.dataset:okta.system and event.action:(policy.rule.update or policy.rule.delete)
 '''
+

--- a/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -35,3 +35,4 @@ type = "query"
 query = '''
 event.module:okta and event.dataset:okta.system and event.action:(zone.update or zone.deactivate or zone.delete or network_zone.rule.disabled or zone.remove_blacklist)
 '''
+

--- a/rules/okta/okta_attempt_to_modify_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -35,3 +35,4 @@ type = "query"
 query = '''
 event.module:okta and event.dataset:okta.system and event.action:policy.lifecycle.update
 '''
+

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/01"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -34,3 +34,4 @@ type = "query"
 query = '''
 event.module:okta and event.dataset:okta.system and event.action:(application.policy.sign_on.update or application.policy.sign_on.rule.delete)
 '''
+

--- a/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
+++ b/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -29,3 +29,4 @@ type = "query"
 query = '''
 event.module:okta and event.dataset:okta.system and event.action:security.threat.detected
 '''
+

--- a/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -48,3 +48,4 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -49,3 +49,4 @@ reference = "https://attack.mitre.org/techniques/T1136/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/20"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -48,3 +48,4 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/okta/persistence_attempt_to_deactivate_okta_policy.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_okta_policy.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -49,3 +49,4 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/05/21"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/28"
 
@@ -48,3 +48,4 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/promotions/elastic_endpoint.toml
+++ b/rules/promotions/elastic_endpoint.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/08"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/08"
 

--- a/rules/promotions/endpoint_adversary_behavior_detected.toml
+++ b/rules/promotions/endpoint_adversary_behavior_detected.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_cred_dumping_detected.toml
+++ b/rules/promotions/endpoint_cred_dumping_detected.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_cred_dumping_prevented.toml
+++ b/rules/promotions/endpoint_cred_dumping_prevented.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_cred_manipulation_detected.toml
+++ b/rules/promotions/endpoint_cred_manipulation_detected.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_cred_manipulation_prevented.toml
+++ b/rules/promotions/endpoint_cred_manipulation_prevented.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_exploit_detected.toml
+++ b/rules/promotions/endpoint_exploit_detected.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_exploit_prevented.toml
+++ b/rules/promotions/endpoint_exploit_prevented.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_malware_detected.toml
+++ b/rules/promotions/endpoint_malware_detected.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_malware_prevented.toml
+++ b/rules/promotions/endpoint_malware_prevented.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_permission_theft_detected.toml
+++ b/rules/promotions/endpoint_permission_theft_detected.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_permission_theft_prevented.toml
+++ b/rules/promotions/endpoint_permission_theft_prevented.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_process_injection_detected.toml
+++ b/rules/promotions/endpoint_process_injection_detected.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_process_injection_prevented.toml
+++ b/rules/promotions/endpoint_process_injection_prevented.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_ransomware_detected.toml
+++ b/rules/promotions/endpoint_ransomware_detected.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/endpoint_ransomware_prevented.toml
+++ b/rules/promotions/endpoint_ransomware_prevented.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/08"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/08"
 

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/19"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/credential_access_credential_dumping_msbuild.toml
+++ b/rules/windows/credential_access_credential_dumping_msbuild.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_cve_2020_0601.toml
+++ b/rules/windows/defense_evasion_cve_2020_0601.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/19"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/19"
 

--- a/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
+++ b/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
+++ b/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 
@@ -23,7 +23,7 @@ type = "query"
 
 query = '''
 event.category:process and event.type:(start or process_started) and
-  (pe.original_file_name:MSBuild.exe or winlog.event_data.OriginalFileName:MSBuild.exe) and
+  (process.pe.original_file_name:MSBuild.exe or winlog.event_data.OriginalFileName:MSBuild.exe) and
   not process.name: MSBuild.exe
 '''
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 
@@ -45,3 +45,4 @@ reference = "https://attack.mitre.org/techniques/T1500/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
+++ b/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/windows/defense_evasion_injection_msbuild.toml
+++ b/rules/windows/defense_evasion_injection_msbuild.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/03/25"
 

--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/16"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_vssadmin.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_vssadmin.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/discovery_process_discovery_via_tasklist_command.toml
+++ b/rules/windows/discovery_process_discovery_via_tasklist_command.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
+++ b/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_command_shell_started_by_powershell.toml
+++ b/rules/windows/execution_command_shell_started_by_powershell.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_local_service_commands.toml
+++ b/rules/windows/execution_local_service_commands.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_msbuild_making_network_connections.toml
+++ b/rules/windows/execution_msbuild_making_network_connections.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_mshta_making_network_connections.toml
+++ b/rules/windows/execution_mshta_making_network_connections.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_psexec_lateral_movement_command.toml
+++ b/rules/windows/execution_psexec_lateral_movement_command.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_script_executing_powershell.toml
+++ b/rules/windows/execution_script_executing_powershell.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_suspicious_ms_office_child_process.toml
+++ b/rules/windows/execution_suspicious_ms_office_child_process.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/execution_suspicious_ms_outlook_child_process.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/30"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_unusual_dns_service_children.toml
+++ b/rules/windows/execution_unusual_dns_service_children.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/16"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/16"
 
@@ -57,3 +57,4 @@ reference = "https://attack.mitre.org/techniques/T1133/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/execution_unusual_dns_service_file_writes.toml
+++ b/rules/windows/execution_unusual_dns_service_file_writes.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/16"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/16"
 
@@ -46,3 +46,4 @@ reference = "https://attack.mitre.org/techniques/T1133/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/execution_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/execution_unusual_network_connection_via_rundll32.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_unusual_process_network_connection.toml
+++ b/rules/windows/execution_unusual_process_network_connection.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/execution_via_compiled_html_file.toml
+++ b/rules/windows/execution_via_compiled_html_file.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/windows/execution_via_net_com_assemblies.toml
+++ b/rules/windows/execution_via_net_com_assemblies.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/25"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/lateral_movement_dns_server_overflow.toml
+++ b/rules/windows/lateral_movement_dns_server_overflow.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/07/16"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/07/16"
 
@@ -56,3 +56,4 @@ reference = "https://attack.mitre.org/techniques/T1210/"
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
+

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/persistence_local_scheduled_task_commands.toml
+++ b/rules/windows/persistence_local_scheduled_task_commands.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/persistence_via_application_shimming.toml
+++ b/rules/windows/persistence_via_application_shimming.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.4.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/02/18"
 

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/03/17"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-ecs_version = ["1.5.0"]
+ecs_version = ["1.6.0"]
 maturity = "production"
 updated_date = "2020/08/03"
 


### PR DESCRIPTION
## Issues
None

## Summary
Added ECS schema for 1.6.0 and refreshed master (2.0.0). Also updated all rule metadata to use the new 1.6.0 schema for validation.

One rule was updated to use a revised field from changes in 1.6.0

### Details
commands run

```python
from detection_rules import rule_loader

rules = rule_loader.load_rules().values()

for rule in rules:
    rule.metadata['ecs_version'] = ['1.6.0']
    rule.save(as_rule=True)    
```