### PR TITLE
[Rule Tuning] AWS Root Login Without MFA

### DIFF
--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/06"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/08/31"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -12,7 +12,7 @@ practices indicate that the root user should be protected by MFA.
 """
 false_positives = [
     """
-    Some organizations allow login with the root user without MFA, however this is not considered best practice by AWS
+    Some organizations allow login with the root user without MFA, however, this is not considered best practice by AWS
     and increases the risk of compromised credentials.
     """,
 ]

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -24,9 +24,9 @@ license = "Elastic License"
 name = "AWS Root Login Without MFA"
 note = "The AWS Filebeat module must be enabled to use this rule."
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]
-risk_score = 21
+risk_score = 73
 rule_id = "bc0c6f0d-dab0-47a3-b135-0925f0a333bc"
-severity = "low"
+severity = "high"
 tags = ["AWS", "Elastic", "SecOps", "Identity and Access", "Continuous Monitoring"]
 type = "query"
 

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-aws*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License"


### PR DESCRIPTION
## Issue(s)
resolves #224 

## Description

Updates the severity and risk score for the `AWS Root Login Without MFA` rule.

## Checklists
Use ~~strikethroughs~~ to remove items which are not applicable to this issue.

### For submitter
- [x] Verify all query fields co-exist in a single event source (*beats) or annotated otherwise
  -- Query field process.name.text doesn't currently exist in endgame-* eventing data, but does exist for winlogbeats, and is case insensitive.
- [x] Verify all query fields co-exist within a single ECS version and annotated the minimum version
  -- 1.4.0
- [x] Verified the query detects the intended event(s)
  - detonate
  - search in _discover_
  - trigger as a custom signal
- [x] Create rule using `create-rule`
- [x] Verify and convert to standard linting (`toml-lint -f <rule-file>`)
- [x] Run tests using `pytest -x -v unit_tests` or `make test`
- [x] Internal search to determine noise and FP


### For reviewers
- [ ] Verify existing rule for activity doesn't exist as a siem or endpoint rule (unless intentionally specified in issue)
- [ ] Verify all query fields co-exist in a single event source (*beats) or annotated otherwise
- [ ] Verify all query fields co-exist within a single ECS version and annotated the minimum version
- [ ] Internal search to determine noise and FP
- [ ] Verify metadata accuracy and spelling
