### PR TITLE
[New Rule] Azure External Guest User Invitation

### DIFF
--- a/rules/azure/initial_access_external_guest_user_invite.toml
+++ b/rules/azure/initial_access_external_guest_user_invite.toml
@@ -50,3 +50,17 @@ id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
 
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/azure/initial_access_external_guest_user_invite.toml
+++ b/rules/azure/initial_access_external_guest_user_invite.toml
@@ -1,0 +1,52 @@
+[metadata]
+creation_date = "2020/08/31"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/08/31"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies an invitation to an external user in Azure Active Directory (AD). Azure AD is extended to include
+collaboration, allowing you to invite people from outside your organization to be guest users in your cloud account.
+Unless there is a business need to provide guest access to any user, avoid creating guest users. Guest users could
+potentially be overlooked indefinitely leading to a potential vulnerability.
+"""
+false_positives = [
+    """
+    Guest user invitations may be sent out by a system or network administrator. Verify whether the username, hostname,
+    and/or resource name should be making changes in your environment. Guest user invitations from unfamiliar users or
+    hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+    """,
+]
+from = "now-25m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "Azure External Guest User Invitation"
+note = "The Azure Filebeat module must be enabled to use this rule."
+references = ["https://docs.microsoft.com/en-us/azure/governance/policy/samples/cis-azure-1-1-0"]
+risk_score = 21
+rule_id = "141e9b3a-ff37-4756-989d-05d7cbf35b0e"
+severity = "low"
+tags = ["Elastic", "Azure", "SecOps", "Continuous Monitoring", "Identity and Access"]
+type = "query"
+
+query = '''
+event.module:azure and event.dataset:azure.auditlogs and event.category:AuditLogs and azure.auditlogs.operation_name:"Invite external user" and azure.auditlogs.properties.target_resources.*.display_name:guest and event.outcome:Success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/azure/initial_access_external_guest_user_invite.toml
+++ b/rules/azure/initial_access_external_guest_user_invite.toml
@@ -9,8 +9,8 @@ author = ["Elastic"]
 description = """
 Identifies an invitation to an external user in Azure Active Directory (AD). Azure AD is extended to include
 collaboration, allowing you to invite people from outside your organization to be guest users in your cloud account.
-Unless there is a business need to provision guest access, it is best practice avoid creating guest users. Guest users could
-potentially be overlooked indefinitely leading to a potential vulnerability.
+Unless there is a business need to provision guest access, it is best practice avoid creating guest users. Guest users
+could potentially be overlooked indefinitely leading to a potential vulnerability.
 """
 false_positives = [
     """
@@ -63,3 +63,4 @@ reference = "https://attack.mitre.org/techniques/T1078/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+


### PR DESCRIPTION
## Issue(s)
resolves #193 

## Description

Identifies an invitation to an external user in Azure Active Directory (AD). Azure AD is extended to include collaboration, allowing you to invite people from outside your organization to be guest users in your cloud account. Unless there is a business need to provide guest access to any user, avoid creating guest users. Guest users could potentially be overlooked indefinitely leading to a potential vulnerability.

## Checklists
Use ~~strikethroughs~~ to remove items which are not applicable to this issue.

### For submitter
- [x] Verify all query fields co-exist in a single event source (*beats) or annotated otherwise
  -- Query field process.name.text doesn't currently exist in endgame-* eventing data, but does exist for winlogbeats, and is case insensitive.
- [x] Verify all query fields co-exist within a single ECS version and annotated the minimum version
  -- 1.4.0
- [ ] Verified the query detects the intended event(s)
  - detonate
  - search in _discover_
  - trigger as a custom signal
- [x] Create rule using `create-rule`
- [x] Verify and convert to standard linting (`toml-lint -f <rule-file>`)
- [x] Run tests using `pytest -x -v unit_tests` or `make test`
- [ ] Internal search to determine noise and FP


### For reviewers
- [ ] Verify existing rule for activity doesn't exist as a siem or endpoint rule (unless intentionally specified in issue)
- [ ] Verify all query fields co-exist in a single event source (*beats) or annotated otherwise
- [ ] Verify all query fields co-exist within a single ECS version and annotated the minimum version
- [ ] Internal search to determine noise and FP
- [ ] Verify metadata accuracy and spelling
