### PR TITLE
[New Rule] Azure Network Watcher Deletion

### DIFF
--- a/rules/azure/defense_evasion_network_watcher_deletion.toml
+++ b/rules/azure/defense_evasion_network_watcher_deletion.toml
@@ -1,0 +1,51 @@
+[metadata]
+creation_date = "2020/08/31"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/08/31"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies the deletion of a Network Watcher in Azure. Network Watchers are used to monitor, diagnose, view metrics, and
+enable or disable logs for resources in an Azure virtual network. An adversary may delete a Network Watcher in an
+attempt to evade defenses.
+"""
+false_positives = [
+    """
+    Network Watcher deletions may be done by a system or network administrator. Verify whether the username, hostname,
+    and/or resource name should be making changes in your environment. Network Watcher deletions from unfamiliar users
+    or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+    """,
+]
+from = "now-25m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "Azure Network Watcher Deletion"
+note = "The Azure Filebeat module must be enabled to use this rule."
+references = ["https://docs.microsoft.com/en-us/azure/network-watcher/network-watcher-monitoring-overview"]
+risk_score = 47
+rule_id = "323cb487-279d-4218-bcbd-a568efe930c6"
+severity = "medium"
+tags = ["Elastic", "Azure", "SecOps", "Continuous Monitoring", "Network"]
+type = "query"
+
+query = '''
+event.module:azure and event.dataset:azure.activitylogs and event.category:Administrative and azure.activitylogs.operation_name:MICROSOFT.NETWORK/NETWORKWATCHERS/DELETE and event.outcome:Success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1089"
+name = "Disabling Security Tools"
+reference = "https://attack.mitre.org/techniques/T1089/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+


### PR DESCRIPTION
## Issue(s)
resolves #197 

## Description

Identifies the deletion of a Network Watcher in Azure. Network Watchers are used to monitor, diagnose, view metrics, and enable or disable logs for resources in an Azure virtual network. An adversary may delete a Network Watcher in an attempt to evade defenses.

## Checklists
Use ~~strikethroughs~~ to remove items which are not applicable to this issue.

### For submitter
- [x] Verify all query fields co-exist in a single event source (*beats) or annotated otherwise
  -- Query field process.name.text doesn't currently exist in endgame-* eventing data, but does exist for winlogbeats, and is case insensitive.
- [x] Verify all query fields co-exist within a single ECS version and annotated the minimum version
  -- 1.4.0
- [ ] Verified the query detects the intended event(s)
  - detonate
  - search in _discover_
  - trigger as a custom signal
- [x] Create rule using `create-rule`
- [x] Verify and convert to standard linting (`toml-lint -f <rule-file>`)
- [x] Run tests using `pytest -x -v unit_tests` or `make test`
- [ ] Internal search to determine noise and FP


### For reviewers
- [ ] Verify existing rule for activity doesn't exist as a siem or endpoint rule (unless intentionally specified in issue)
- [ ] Verify all query fields co-exist in a single event source (*beats) or annotated otherwise
- [ ] Verify all query fields co-exist within a single ECS version and annotated the minimum version
- [ ] Internal search to determine noise and FP
- [ ] Verify metadata accuracy and spelling
