### PR TITLE
[New Rule] Azure Automation Runbook Deleted

### DIFF
--- a/rules/azure/impact_azure_automation_runbook_deleted.toml
+++ b/rules/azure/impact_azure_automation_runbook_deleted.toml
@@ -1,0 +1,34 @@
+[metadata]
+creation_date = "2020/09/01"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/09/01"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when an Azure Automation runbook is deleted. An adversary may delete an Azure Automation runbook in order to
+disrupt atheir target's automated business operations or to remove a malicious runbook that was used for persistence.
+"""
+from = "now-25m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "Azure Automation Runbook Deleted"
+note = "The Azure Filebeat module must be enabled to use this rule."
+references = [
+    "https://powerzure.readthedocs.io/en/latest/Functions/operational.html#create-backdoor",
+    "https://github.com/hausec/PowerZure",
+    "https://posts.specterops.io/attacking-azure-azure-ad-and-introducing-powerzure-ca70b330511a",
+    "https://azure.microsoft.com/en-in/blog/azure-automation-runbook-management/",
+]
+risk_score = 21
+rule_id = "8ddab73b-3d15-4e5d-9413-47f05553c1d7"
+severity = "low"
+tags = ["Elastic", "Azure", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.module:azure and event.dataset:azure.activitylogs and event.category:Administrative and azure.activitylogs.operation_name:(MICROSOFT.AUTOMATION/AUTOMATIONACCOUNTS/RUNBOOKS/DELETE) and event.outcome:Success
+'''
+

--- a/rules/azure/impact_azure_automation_runbook_deleted.toml
+++ b/rules/azure/impact_azure_automation_runbook_deleted.toml
@@ -8,7 +8,7 @@ updated_date = "2020/09/01"
 author = ["Elastic"]
 description = """
 Identifies when an Azure Automation runbook is deleted. An adversary may delete an Azure Automation runbook in order to
-disrupt atheir target's automated business operations or to remove a malicious runbook that was used for persistence.
+disrupt their target's automated business operations or to remove a malicious runbook that was used for persistence.
 """
 from = "now-25m"
 index = ["filebeat-*"]
@@ -31,4 +31,3 @@ type = "query"
 query = '''
 event.module:azure and event.dataset:azure.activitylogs and event.category:Administrative and azure.activitylogs.operation_name:(MICROSOFT.AUTOMATION/AUTOMATIONACCOUNTS/RUNBOOKS/DELETE) and event.outcome:Success
 '''
-

--- a/rules/azure/impact_azure_automation_runbook_deleted.toml
+++ b/rules/azure/impact_azure_automation_runbook_deleted.toml
@@ -29,5 +29,5 @@ tags = ["Elastic", "Azure", "Continuous Monitoring", "SecOps", "Configuration Au
 type = "query"
 
 query = '''
-event.module:azure and event.dataset:azure.activitylogs and event.category:Administrative and azure.activitylogs.operation_name:(MICROSOFT.AUTOMATION/AUTOMATIONACCOUNTS/RUNBOOKS/DELETE) and event.outcome:Success
+event.module:azure and event.dataset:azure.activitylogs and event.category:Administrative and azure.activitylogs.operation_name:MICROSOFT.AUTOMATION/AUTOMATIONACCOUNTS/RUNBOOKS/DELETE and event.outcome:Success
 '''


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #117 

## Summary
Identifies when an Azure Automation runbook is deleted. An adversary may delete an Azure Automation runbook in order to disrupt atheir target's automated business operations or to remove a malicious runbook that was used for persistence.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
