### PR TITLE
Add build-release to GH actions

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,6 +31,10 @@ jobs:
     - name: Python License Check
       run: |
         python -m detection_rules license-check
+        
+    - name: Build release package
+      run: |
+        python -m detection_rules build-release
 
     - name: Unit tests
       run: |


### PR DESCRIPTION
## Issues
None

## Summary
This adds `build-release` to be run as part of GH actions to ensure packaging mechanisms are also tested