### PR TITLE
[Rule Tuning] Update Okta rules to include Agent index pattern

### DIFF
--- a/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ description = """
 An adversary may attempt to bypass the Okta multi-factor authentication (MFA) policies configured for an organization in
 order to obtain unauthorized access to an application. This rule detects when an Okta MFA bypass attempt occurs.
 """
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempted Bypass of Okta MFA"

--- a/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
+++ b/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/19"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/08/19"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ force or password spraying attack to obtain unauthorized access to user accounts
 ensures that a user account is locked out after 10 failed authentication attempts.
 """
 from = "now-180m"
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempts to Brute Force an Okta User Account"

--- a/rules/okta/credential_access_okta_brute_force_or_password_spraying.toml
+++ b/rules/okta/credential_access_okta_brute_force_or_password_spraying.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/16"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     positives.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Okta Brute Force or Password Spraying Attack"

--- a/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/credential_access_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/19"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/08/19"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "High Number of Okta User Password Reset or Unlock Attempts"

--- a/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ false_positives = [
     positives.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Revoke Okta API Token"

--- a/rules/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/okta/impact_possible_okta_dos_attack.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ description = """
 An adversary may attempt to disrupt an organization's business operations by performing a denial of service (DoS) attack
 against its Okta infrastructure.
 """
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Possible Okta DoS Attack"

--- a/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ This rule detects when a user reports suspicious activity for their Okta account
 as they can help security teams identify when an adversary is attempting to gain access to their network.
 """
 false_positives = ["A user may report suspicious activity on their Okta account in error."]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Suspicious Activity Reported by Okta User"

--- a/rules/okta/okta_attempt_to_deactivate_okta_mfa_rule.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_mfa_rule.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ false_positives = [
     your organization.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Deactivate Okta MFA Rule"

--- a/rules/okta/okta_attempt_to_delete_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/28"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     organization.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Delete Okta Policy"

--- a/rules/okta/okta_attempt_to_modify_okta_mfa_rule.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_mfa_rule.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ false_positives = [
     organization.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Modify Okta MFA Rule"

--- a/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     regularly modified.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Modify Okta Network Zone"

--- a/rules/okta/okta_attempt_to_modify_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     organization.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Modify Okta Policy"

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/01"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ false_positives = [
     regularly modified or deleted in your organization.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Modification or Removal of an Okta Application Sign-On Policy"

--- a/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
+++ b/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ This rule detects when Okta ThreatInsight identifies a request from a malicious 
 IP addresses identified as malicious by Okta ThreatInsight can help security teams monitor for and respond to credential
 based attacks against their organization, such as brute force and password spraying attacks.
 """
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Threat Detected by Okta ThreatInsight"

--- a/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ false_positives = [
     to Okta groups in your organization.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Administrator Privileges Assigned to Okta Group"

--- a/rules/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     positives.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Create Okta API Token"

--- a/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/20"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ false_positives = [
     filter false positives.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Deactivate MFA for Okta User Account"

--- a/rules/okta/persistence_attempt_to_deactivate_okta_policy.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_okta_policy.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     positives.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Deactivate Okta Policy"

--- a/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/07/28"
+updated_date = "2020/09/15"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ false_positives = [
     regularly reset in your organization.
     """,
 ]
-index = ["filebeat-*"]
+index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
 name = "Attempt to Reset MFA Factors for Okta User Account"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
#255 

## Summary
This PR updates our prebuilt Okta rules to include the Elastic Agent index, `logs-okta*.

![image](https://user-images.githubusercontent.com/56409778/93244781-7d96e080-f747-11ea-8720-939a23724dcf.png)

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
