### PR TITLE
[Rule Tuning] Update from event.code to event.category

### DIFF
--- a/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
+++ b/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/02/18"
+updated_date = "2020/09/30"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ tags = ["Elastic", "Windows"]
 type = "query"
 
 query = '''
-event.code:1 and process.name:(MSBuild.exe or msxsl.exe)
+event.category:process and event.type:(start or process_started) and process.name:(MSBuild.exe or msxsl.exe)
 '''
 
 

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/02/18"
+updated_date = "2020/09/30"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,7 @@ tags = ["Elastic", "Windows"]
 type = "query"
 
 query = '''
-event.code:1 and process.name:fltMC.exe
+event.category:process and event.type:(start or process_started) and process.name:fltMC.exe
 '''
 
 

--- a/rules/windows/discovery_process_discovery_via_tasklist_command.toml
+++ b/rules/windows/discovery_process_discovery_via_tasklist_command.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/02/18"
+updated_date = "2020/09/30"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,7 @@ tags = ["Elastic", "Windows"]
 type = "query"
 
 query = '''
-event.code:1 and process.name:tasklist.exe
+event.category:process and event.type:(start or process_started) and process.name:tasklist.exe
 '''
 
 

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/02/18"
+updated_date = "2020/09/30"
 
 [rule]
 author = ["Elastic"]
@@ -27,7 +27,7 @@ tags = ["Elastic", "Windows"]
 type = "query"
 
 query = '''
-process.name:whoami.exe and event.code:1
+event.category:process and event.type:(start or process_started) and process.name:whoami.exe
 '''
 
 

--- a/rules/windows/execution_via_compiled_html_file.toml
+++ b/rules/windows/execution_via_compiled_html_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/02/18"
+updated_date = "2020/09/30"
 
 [rule]
 author = ["Elastic"]
@@ -29,7 +29,7 @@ tags = ["Elastic", "Windows"]
 type = "query"
 
 query = '''
-event.code:1 and process.name:hh.exe
+event.category:process and event.type:(start or process_started) and process.name:hh.exe
 '''
 
 

--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/08/12"
+updated_date = "2020/09/30"
 
 [rule]
 author = ["Elastic"]
@@ -22,7 +22,7 @@ tags = ["Elastic", "Windows"]
 type = "query"
 
 query = '''
-event.code:1 and process.parent.name:winlogon.exe and not process.name:(atbroker.exe or displayswitch.exe or magnify.exe or narrator.exe or osk.exe or sethc.exe or utilman.exe)
+event.category:process and event.type:(start or process_started) and process.parent.name:winlogon.exe and not process.name:(atbroker.exe or displayswitch.exe or magnify.exe or narrator.exe or osk.exe or sethc.exe or utilman.exe)
 '''
 
 

--- a/rules/windows/persistence_via_application_shimming.toml
+++ b/rules/windows/persistence_via_application_shimming.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/02/18"
+updated_date = "2020/09/30"
 
 [rule]
 author = ["Elastic"]
@@ -22,7 +22,7 @@ tags = ["Elastic", "Windows"]
 type = "query"
 
 query = '''
-event.code:1 and process.name:sdbinst.exe
+event.category:process and event.type:(start or process_started) and process.name:sdbinst.exe
 '''
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->


## Summary
This PR updates all the rules that use `event.code:1` and replaces it with `event.category:process and event.type:(start or process_started)` instead. 

Other than `event.code:1`, I saw no other instances of that field in other rules. 

We should also consider removing a couple noisy rules, like `Whoami Process Activity` and `Process Discovery via Tasklist` and account for them in a more robust EQL discovery sequence and/or convert to a ML job.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
