### PR TITLE
Use pathlib module for easier handling of filesystem paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ celerybeat-schedule
 # virtualenv
 venv*/
 ENV/
+.venv*/*
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![Supported Python versions](https://img.shields.io/badge/python-3.7+-yellow.svg)
+![Unit Tests](https://github.com/elastic/detection-rules/workflows/Unit%20Tests/badge.svg)
+[![Chat](https://img.shields.io/badge/chat-%23security--detection--rules-blueviolet)](https://ela.st/slack)
+
 # Detection Rules
 
 Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine.

--- a/detection_rules/__main__.py
+++ b/detection_rules/__main__.py
@@ -4,13 +4,13 @@
 
 # coding=utf-8
 """Shell for detection-rules."""
-import os
+from pathlib import Path
 import click
 from .main import root
 
-CURR_DIR = os.path.dirname(os.path.abspath(__file__))
-CLI_DIR = os.path.dirname(CURR_DIR)
-ROOT_DIR = os.path.dirname(CLI_DIR)
+CURR_DIR = Path(__file__).parent
+CLI_DIR = CURR_DIR.parent
+ROOT_DIR = CLI_DIR.parent
 
 BANNER = r"""
 █▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄

--- a/detection_rules/attack.py
+++ b/detection_rules/attack.py
@@ -13,7 +13,7 @@ from .semver import Version
 from .utils import read_gzip, gzip_compress
 
 ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR.joinpath('etc')
+ETC_DIR = ROOT_DIR / 'etc'
 
 PLATFORMS = ['Windows', 'macOS', 'Linux']
 tactics_map = {}

--- a/detection_rules/attack.py
+++ b/detection_rules/attack.py
@@ -5,15 +5,11 @@
 """Mitre attack info."""
 
 import json
-from pathlib import Path
 import requests
 from collections import OrderedDict
 
 from .semver import Version
-from .utils import read_gzip, gzip_compress
-
-ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR / 'etc'
+from .utils import ETC_DIR, read_gzip, gzip_compress
 
 PLATFORMS = ['Windows', 'macOS', 'Linux']
 tactics_map = {}
@@ -100,7 +96,7 @@ def refresh_attack_data(save=True):
     compressed = gzip_compress(json.dumps(attack_data, sort_keys=True))
 
     if save:
-        new_path = ETC_DIR.joinpath(f'attack-v{latest_version}.json.gz')
+        new_path = ETC_DIR / f'attack-v{latest_version}.json.gz'
         with open(new_path, 'wb') as f:
             f.write(compressed)
 

--- a/detection_rules/beats.py
+++ b/detection_rules/beats.py
@@ -51,8 +51,9 @@ def download_latest_beats_schema():
                 # create a hierarchical structure
                 parsed[key] = decoded
                 branch = fs
-                directory, base_name = os.path.split(key)
-                for limb in directory.split(os.path.sep):
+                key = Path(key)
+                directory, base_name = key.parent, key.name
+                for limb in str(directory).split(os.path.sep):
                     branch = branch.setdefault("folders", {}).setdefault(limb, {})
 
                 branch.setdefault("files", {})[base_name] = decoded

--- a/detection_rules/beats.py
+++ b/detection_rules/beats.py
@@ -4,6 +4,7 @@
 
 """ECS Schemas management."""
 import os
+from pathlib import Path
 
 import kql
 import eql
@@ -11,7 +12,10 @@ import requests
 import yaml
 
 from .semver import Version
-from .utils import unzip, load_etc_dump, save_etc_dump, get_etc_path, cached
+from .utils import unzip, load_dump, save_etc_dump, cached
+
+ROOT_DIR = Path(__file__).parent.parent
+ETC_DIR = ROOT_DIR.joinpath('etc')
 
 
 def download_latest_beats_schema():
@@ -132,10 +136,10 @@ def get_beats_sub_schema(schema: dict, beat: str, module: str, *datasets: str):
 
 @cached
 def read_beats_schema():
-    beats_schemas = os.listdir(get_etc_path("beats_schemas"))
-    latest = max(beats_schemas, key=lambda b: Version(b.lstrip("v")))
+    beats_schemas = list(ETC_DIR.joinpath("beats_schemas").iterdir())
+    latest = max(beats_schemas, key=lambda b: Version(str(b).lstrip("v")))
 
-    return load_etc_dump("beats_schemas", latest)
+    return load_dump(ETC_DIR.joinpath("beats_schemas", latest))
 
 
 def get_schema_from_datasets(beats, modules, datasets):

--- a/detection_rules/beats.py
+++ b/detection_rules/beats.py
@@ -15,7 +15,7 @@ from .semver import Version
 from .utils import unzip, load_dump, save_etc_dump, cached
 
 ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR.joinpath('etc')
+ETC_DIR = ROOT_DIR / 'etc'
 
 
 def download_latest_beats_schema():

--- a/detection_rules/beats.py
+++ b/detection_rules/beats.py
@@ -4,7 +4,6 @@
 
 """ECS Schemas management."""
 import os
-from pathlib import Path
 
 import kql
 import eql
@@ -12,10 +11,7 @@ import requests
 import yaml
 
 from .semver import Version
-from .utils import unzip, load_dump, save_etc_dump, cached
-
-ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR / 'etc'
+from .utils import ETC_DIR, unzip, load_dump, save_etc_dump, cached
 
 
 def download_latest_beats_schema():
@@ -139,7 +135,7 @@ def read_beats_schema():
     beats_schemas = list(ETC_DIR.joinpath("beats_schemas").iterdir())
     latest = max(beats_schemas, key=lambda b: Version(str(b).lstrip("v")))
 
-    return load_dump(ETC_DIR.joinpath("beats_schemas", latest))
+    return load_dump(ETC_DIR / "beats_schemas" / latest)
 
 
 def get_schema_from_datasets(beats, modules, datasets):

--- a/detection_rules/beats.py
+++ b/detection_rules/beats.py
@@ -4,6 +4,7 @@
 
 """ECS Schemas management."""
 import os
+from pathlib import Path
 
 import kql
 import eql
@@ -33,7 +34,7 @@ def download_latest_beats_schema():
         base_directory = archive.namelist()[0]
 
         for name in archive.namelist():
-            if os.path.basename(name) in ("fields.yml", "fields.common.yml", "config.yml"):
+            if Path(name).name in ("fields.yml", "fields.common.yml", "config.yml"):
                 contents = archive.read(name)
 
                 # chop off the base directory name

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -20,7 +20,7 @@ from .packaging import PACKAGE_FILE, Package, manage_versions, RELEASE_DIR
 from .rule import Rule
 
 ROOT_DIR = Path(__file__).parent.parent
-RULES_DIR = ROOT_DIR.joinpath('rules')
+RULES_DIR = ROOT_DIR / 'rules'
 
 
 @root.group('dev')
@@ -120,7 +120,7 @@ def kibana_commit(ctx, local_repo, github_repo, ssh, kibana_directory, base_bran
     git_exe = shutil.which("git")
 
     package_name = load_dump(PACKAGE_FILE)['package']["name"]
-    release_dir = RELEASE_DIR.joinpath(package_name)
+    release_dir = RELEASE_DIR / package_name
     message = message or f"[Detection Rules] Add {package_name} rules"
 
     if not release_dir.exists():
@@ -149,13 +149,13 @@ def kibana_commit(ctx, local_repo, github_repo, ssh, kibana_directory, base_bran
         git("checkout", "-b", f"rules/{package_name}", show_output=True)
         git("rm", "-r", kibana_directory)
 
-        source_dir = release_dir.joinpath("rules")
-        target_dir = local_repo.joinpath(kibana_directory)
+        source_dir = release_dir / "rules"
+        target_dir = local_repo / kibana_directory
         target_dir.mkdir(parents=True)
 
         for name in source_dir.iterdir():
             _, ext = name.stem, name.suffix
-            path = source_dir.joinpath(name)
+            path = source_dir / name
 
             if ext in (".ts", ".json"):
                 shutil.copyfile(path, target_dir.joinpath(name))

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -30,7 +30,7 @@ def dev_group():
               help='Save version.lock.json file with updated rule versions in the package')
 def build_release(config_file, update_version_lock):
     """Assemble all the rules into Kibana-ready release files."""
-    config = load_dump(config_file)['package']
+    config = load_dump(str(config_file))['package']
     click.echo('[+] Building package {}'.format(config.get('name')))
     package = Package.from_config(config, update_version_lock=update_version_lock, verbose=True)
     package.save()

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -7,7 +7,6 @@ import io
 import json
 import os
 import shutil
-from pathlib import Path
 import subprocess
 
 import click
@@ -18,9 +17,7 @@ from .main import root
 from .misc import PYTHON_LICENSE, client_error
 from .packaging import PACKAGE_FILE, Package, manage_versions, RELEASE_DIR
 from .rule import Rule
-
-ROOT_DIR = Path(__file__).parent.parent
-RULES_DIR = ROOT_DIR / 'rules'
+from .utils import ROOT_DIR
 
 
 @root.group('dev')
@@ -107,7 +104,7 @@ def kibana_diff(rule_id, branch, threads):
 
 
 @dev_group.command("kibana-commit")
-@click.argument("local-repo", default=ROOT_DIR.joinpath("kibana"))
+@click.argument("local-repo", default=ROOT_DIR / "kibana")
 @click.option("--kibana-directory", "-d", help="Directory to overwrite in Kibana",
               default="x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules")
 @click.option("--base-branch", "-b", help="Base branch in Kibana", default="master")

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -6,6 +6,7 @@
 import io
 import json
 import os
+from pathlib import Path
 import shutil
 import subprocess
 
@@ -177,10 +178,10 @@ def license_check(ctx):
     failed = False
 
     for path in ROOT_DIR.rglob("*.py"):
-        if str(path).startswith('{}"/env/"'):
+        if 'env' in path.parts:
             continue
 
-        relative_path = os.path.relpath(path)
+        relative_path = Path(os.path.relpath(path))
 
         with io.open(path, "rt", encoding="utf-8") as f:
             contents = f.read()

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -5,8 +5,6 @@
 """CLI commands for internal detection_rules dev team."""
 import io
 import json
-import os
-from pathlib import Path
 import shutil
 import subprocess
 
@@ -181,8 +179,6 @@ def license_check(ctx):
         if 'env' in path.parts:
             continue
 
-        relative_path = Path(os.path.relpath(path))
-
         with io.open(path, "rt", encoding="utf-8") as f:
             contents = f.read()
 
@@ -195,6 +191,6 @@ def license_check(ctx):
                     click.echo("Missing license headers for:", err=True)
 
                 failed = True
-                click.echo(relative_path, err=True)
+                click.echo(path, err=True)
 
     ctx.exit(int(failed))

--- a/detection_rules/ecs.py
+++ b/detection_rules/ecs.py
@@ -4,8 +4,7 @@
 
 """ECS Schemas management."""
 import copy
-import glob
-import os
+from pathlib import Path
 
 import shutil
 import json
@@ -99,7 +98,7 @@ def get_max_version(include_master=False):
     versions = get_schema_map().keys()
 
     if include_master and any([v.startswith('master') for v in versions]):
-        return glob.glob(os.path.join(ECS_SCHEMAS_DIR, 'master*'))[0]
+        return list(ECS_SCHEMAS_DIR.glob('master*'))[0]
 
     return str(max([Version(v) for v in versions if not v.startswith('master')]))
 
@@ -223,7 +222,7 @@ def download_schemas(refresh_master=True, refresh_all=False, verbose=True):
         if not version or version < (1, 0, 1) or version in existing:
             continue
 
-        schema_dir = os.path.join(ECS_SCHEMAS_DIR, str(version))
+        schema_dir = ECS_SCHEMAS_DIR / str(version)
 
         with unzip(requests.get(release['zipball_url']).content) as archive:
             name_list = archive.namelist()
@@ -234,8 +233,8 @@ def download_schemas(refresh_master=True, refresh_all=False, verbose=True):
             saved = []
 
             for member in members:
-                file_name = os.path.basename(member)
-                os.makedirs(schema_dir, exist_ok=True)
+                file_name = Path(member).name
+                schema_dir.mkdir(parents=True, exist_ok=True)
 
                 # load as yaml, save as json
                 contents = yaml.safe_load(archive.read(member))
@@ -255,7 +254,7 @@ def download_schemas(refresh_master=True, refresh_all=False, verbose=True):
 
         # prepend with underscore so that we can differentiate the fact that this is a working master version
         #   but first clear out any existing masters, since we only ever want 1 at a time
-        existing_master = glob.glob(os.path.join(ECS_SCHEMAS_DIR, 'master_*'))
+        existing_master = list(ECS_SCHEMAS_DIR.glob('master_*'))
         for m in existing_master:
             shutil.rmtree(m, ignore_errors=True)
 

--- a/detection_rules/ecs.py
+++ b/detection_rules/ecs.py
@@ -20,9 +20,9 @@ from .semver import Version
 from .utils import unzip, load_dump, cached, save_etc_dump
 
 ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR.joinpath('etc')
+ETC_DIR = ROOT_DIR / 'etc'
 ETC_NAME = 'ecs_schemas'
-ECS_SCHEMAS_DIR = ETC_DIR.joinpath(ETC_NAME)
+ECS_SCHEMAS_DIR = ETC_DIR / ETC_NAME
 
 
 def add_field(schema, name, info):
@@ -151,7 +151,7 @@ def flatten(schema):
 @cached
 def get_non_ecs_schema():
     """Load non-ecs schema."""
-    return load_dump(ETC_DIR.joinpath('non-ecs-schema.json'))
+    return load_dump(ETC_DIR / 'non-ecs-schema.json')
 
 
 @cached

--- a/detection_rules/ecs.py
+++ b/detection_rules/ecs.py
@@ -6,7 +6,6 @@
 import copy
 import glob
 import os
-from pathlib import Path
 
 import shutil
 import json
@@ -17,10 +16,8 @@ import eql.types
 import yaml
 
 from .semver import Version
-from .utils import unzip, load_dump, cached, save_etc_dump
+from .utils import ETC_DIR, unzip, load_dump, cached, save_etc_dump
 
-ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR / 'etc'
 ETC_NAME = 'ecs_schemas'
 ECS_SCHEMAS_DIR = ETC_DIR / ETC_NAME
 
@@ -263,7 +260,7 @@ def download_schemas(refresh_master=True, refresh_all=False, verbose=True):
             shutil.rmtree(m, ignore_errors=True)
 
         master_dir = "master_{}".format(master_ver)
-        ETC_DIR.joinpath(ETC_NAME, master_dir).mkdir(exist_ok=True)
+        ECS_SCHEMAS_DIR.joinpath(master_dir).mkdir(exist_ok=True)
 
         save_etc_dump(master_schema, ETC_NAME, master_dir, "ecs_flat.json")
 

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -88,7 +88,7 @@ class Events(object):
         dump_dir = dump_dir or self._get_dump_dir(rta_name)
 
         for source, events in self.events.items():
-            path = os.path.join(dump_dir, source + '.jsonl')
+            path = dump_dir / source / '.jsonl'
             with open(path, 'w') as f:
                 f.writelines([json.dumps(e, sort_keys=True) + '\n' for e in events])
                 click.echo('{} events saved to: {}'.format(len(events), path))

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -5,7 +5,6 @@
 """Elasticsearch cli commands."""
 import json
 import os
-from pathlib import Path
 import time
 
 import click
@@ -13,10 +12,9 @@ from elasticsearch import AuthenticationException, Elasticsearch
 
 from .main import root
 from .misc import client_error, getdefault
-from .utils import format_command_options, normalize_timing_and_sort, unix_time_to_formatted
+from .utils import ROOT_DIR, format_command_options, normalize_timing_and_sort, unix_time_to_formatted
 from .rule_loader import get_rule, rta_mappings
 
-ROOT_DIR = Path(__file__).parent.parent
 COLLECTION_DIR = ROOT_DIR / 'collections'
 
 
@@ -56,7 +54,7 @@ class Events(object):
             return dump_dir
         else:
             time_str = time.strftime('%Y%m%dT%H%M%SL')
-            dump_dir = COLLECTION_DIR.joinpath(self.agent_hostname, time_str)
+            dump_dir = COLLECTION_DIR / self.agent_hostname / time_str
             dump_dir.mkdir(exist_ok=True)
             return dump_dir
 

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -5,6 +5,7 @@
 """Elasticsearch cli commands."""
 import json
 import os
+from pathlib import Path
 import time
 
 import click
@@ -12,10 +13,11 @@ from elasticsearch import AuthenticationException, Elasticsearch
 
 from .main import root
 from .misc import client_error, getdefault
-from .utils import format_command_options, normalize_timing_and_sort, unix_time_to_formatted, get_path
+from .utils import format_command_options, normalize_timing_and_sort, unix_time_to_formatted
 from .rule_loader import get_rule, rta_mappings
 
-COLLECTION_DIR = get_path('collections')
+ROOT_DIR = Path(__file__).parent.parent
+COLLECTION_DIR = ROOT_DIR .joinpath('collections')
 
 
 def get_es_client(user, password, elasticsearch_url=None, cloud_id=None, **kwargs):
@@ -49,13 +51,13 @@ class Events(object):
     def _get_dump_dir(self, rta_name=None):
         """Prepare and get the dump path."""
         if rta_name:
-            dump_dir = get_path('unit_tests', 'data', 'true_positives', rta_name)
-            os.makedirs(dump_dir, exist_ok=True)
+            dump_dir = ROOT_DIR.joinpath('unit_tests/data/true_positives', rta_name)
+            dump_dir.mkdir(exist_ok=True)
             return dump_dir
         else:
             time_str = time.strftime('%Y%m%dT%H%M%SL')
-            dump_dir = os.path.join(COLLECTION_DIR, self.agent_hostname, time_str)
-            os.makedirs(dump_dir, exist_ok=True)
+            dump_dir = COLLECTION_DIR.joinpath(self.agent_hostname, time_str)
+            dump_dir.mkdir(exist_ok=True)
             return dump_dir
 
     def evaluate_against_rule_and_update_mapping(self, rule_id, rta_name, verbose=True):

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -17,7 +17,7 @@ from .utils import format_command_options, normalize_timing_and_sort, unix_time_
 from .rule_loader import get_rule, rta_mappings
 
 ROOT_DIR = Path(__file__).parent.parent
-COLLECTION_DIR = ROOT_DIR .joinpath('collections')
+COLLECTION_DIR = ROOT_DIR / 'collections'
 
 
 def get_es_client(user, password, elasticsearch_url=None, cloud_id=None, **kwargs):
@@ -51,7 +51,7 @@ class Events(object):
     def _get_dump_dir(self, rta_name=None):
         """Prepare and get the dump path."""
         if rta_name:
-            dump_dir = ROOT_DIR.joinpath('unit_tests/data/true_positives', rta_name)
+            dump_dir = ROOT_DIR / 'unit_tests/data/true_positives' / rta_name
             dump_dir.mkdir(exist_ok=True)
             return dump_dir
         else:

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -6,7 +6,6 @@
 import glob
 import json
 import os
-from pathlib import Path
 import re
 
 import click
@@ -18,11 +17,7 @@ from .misc import client_error, nested_set, parse_config
 from .rule import Rule
 from .rule_formatter import toml_write
 from .schemas import CurrentSchema
-from .utils import clear_caches, load_rule_contents
-
-
-ROOT_DIR = Path(__file__).parent.parent
-RULES_DIR = ROOT_DIR / 'rules'
+from .utils import RULES_DIR, clear_caches, load_rule_contents
 
 
 @click.group('detection-rules', context_settings={'help_option_names': ['-h', '--help']})
@@ -72,7 +67,7 @@ def import_rules(infile, directory):
     for contents in rule_contents:
         base_path = contents.get('name') or contents.get('rule', {}).get('name')
         base_path = name_to_filename(base_path) if base_path else base_path
-        rule_path = os.path.join(RULES_DIR, base_path) if base_path else None
+        rule_path = RULES_DIR / base_path if base_path else None
         Rule.build(rule_path, required_only=True, save=True, verbose=True, **contents)
 
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -22,7 +22,7 @@ from .utils import clear_caches, load_rule_contents
 
 
 ROOT_DIR = Path(__file__).parent.parent
-RULES_DIR = ROOT_DIR.joinpath('rules')
+RULES_DIR = ROOT_DIR / 'rules'
 
 
 @click.group('detection-rules', context_settings={'help_option_names': ['-h', '--help']})

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -3,9 +3,9 @@
 # you may not use this file except in compliance with the Elastic License.
 
 """CLI commands for detection_rules."""
-import glob
 import json
 import os
+from pathlib import Path
 import re
 
 import click
@@ -51,7 +51,8 @@ def create_rule(path, config, required_only, rule_type):
 @click.option('--directory', '-d', type=click.Path(file_okay=False, exists=True), help='Load files from a directory')
 def import_rules(infile, directory):
     """Import rules from json, toml, or Kibana exported rule file(s)."""
-    rule_files = glob.glob(os.path.join(directory, '**', '*.*'), recursive=True) if directory else []
+    directory = Path(directory)
+    rule_files = list(directory.rglob('*.*')) if directory else []
     rule_files = sorted(set(rule_files + list(infile)))
 
     rule_contents = []

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -6,6 +6,7 @@
 import glob
 import json
 import os
+from pathlib import Path
 import re
 
 import click
@@ -17,10 +18,11 @@ from .misc import client_error, nested_set, parse_config
 from .rule import Rule
 from .rule_formatter import toml_write
 from .schemas import CurrentSchema
-from .utils import get_path, clear_caches, load_rule_contents
+from .utils import clear_caches, load_rule_contents
 
 
-RULES_DIR = get_path('rules')
+ROOT_DIR = Path(__file__).parent.parent
+RULES_DIR = ROOT_DIR.joinpath('rules')
 
 
 @click.group('detection-rules', context_settings={'help_option_names': ['-h', '--help']})

--- a/detection_rules/mappings.py
+++ b/detection_rules/mappings.py
@@ -20,7 +20,7 @@ class RtaMappings(object):
 
     def __init__(self):
         """Rta-mapping validation and prep."""
-        self.mapping = load_dump(ETC_DIR.joinpath('rule-mapping.yml'))  # type: dict
+        self.mapping = load_dump(str(ETC_DIR.joinpath('rule-mapping.yml')))  # type: dict
         self.validate()
 
         self._rta_mapping = defaultdict(list)

--- a/detection_rules/mappings.py
+++ b/detection_rules/mappings.py
@@ -15,7 +15,7 @@ class RtaMappings(object):
 
     def __init__(self):
         """Rta-mapping validation and prep."""
-        self.mapping = load_dump(ETC_DIR / 'rule-mapping.yml')  # type: dict
+        self.mapping = load_dump(str(ETC_DIR / 'rule-mapping.yml'))  # type: dict
         self.validate()
 
         self._rta_mapping = defaultdict(list)

--- a/detection_rules/mappings.py
+++ b/detection_rules/mappings.py
@@ -11,8 +11,8 @@ from .schemas import validate_rta_mapping
 from .utils import load_dump, save_etc_dump
 
 ROOT_DIR = Path(__file__).parent.parent
-RTA_DIR = ROOT_DIR.joinpath("rta")
-ETC_DIR = ROOT_DIR.joinpath("etc")
+RTA_DIR = ROOT_DIR / "rta"
+ETC_DIR = ROOT_DIR / "etc"
 
 
 class RtaMappings(object):

--- a/detection_rules/mappings.py
+++ b/detection_rules/mappings.py
@@ -20,7 +20,7 @@ class RtaMappings(object):
 
     def __init__(self):
         """Rta-mapping validation and prep."""
-        self.mapping = load_dump(str(ETC_DIR.joinpath('rule-mapping.yml')))  # type: dict
+        self.mapping = load_dump(ETC_DIR.joinpath('rule-mapping.yml'))  # type: dict
         self.validate()
 
         self._rta_mapping = defaultdict(list)

--- a/detection_rules/mappings.py
+++ b/detection_rules/mappings.py
@@ -4,15 +4,10 @@
 
 """RTA to rule mappings."""
 import os
-from pathlib import Path
 from collections import defaultdict
 
 from .schemas import validate_rta_mapping
-from .utils import load_dump, save_etc_dump
-
-ROOT_DIR = Path(__file__).parent.parent
-RTA_DIR = ROOT_DIR / "rta"
-ETC_DIR = ROOT_DIR / "etc"
+from .utils import RTA_DIR, ETC_DIR, load_dump, save_etc_dump
 
 
 class RtaMappings(object):
@@ -20,7 +15,7 @@ class RtaMappings(object):
 
     def __init__(self):
         """Rta-mapping validation and prep."""
-        self.mapping = load_dump(ETC_DIR.joinpath('rule-mapping.yml'))  # type: dict
+        self.mapping = load_dump(ETC_DIR / 'rule-mapping.yml')  # type: dict
         self.validate()
 
         self._rta_mapping = defaultdict(list)

--- a/detection_rules/mappings.py
+++ b/detection_rules/mappings.py
@@ -8,10 +8,11 @@ from pathlib import Path
 from collections import defaultdict
 
 from .schemas import validate_rta_mapping
-from .utils import load_etc_dump, save_etc_dump
+from .utils import load_dump, save_etc_dump
 
 ROOT_DIR = Path(__file__).parent.parent
 RTA_DIR = ROOT_DIR.joinpath("rta")
+ETC_DIR = ROOT_DIR.joinpath("etc")
 
 
 class RtaMappings(object):
@@ -19,7 +20,7 @@ class RtaMappings(object):
 
     def __init__(self):
         """Rta-mapping validation and prep."""
-        self.mapping = load_etc_dump('rule-mapping.yml')  # type: dict
+        self.mapping = load_dump(ETC_DIR.joinpath('rule-mapping.yml'))  # type: dict
         self.validate()
 
         self._rta_mapping = defaultdict(list)

--- a/detection_rules/mappings.py
+++ b/detection_rules/mappings.py
@@ -4,13 +4,14 @@
 
 """RTA to rule mappings."""
 import os
+from pathlib import Path
 from collections import defaultdict
 
 from .schemas import validate_rta_mapping
-from .utils import load_etc_dump, save_etc_dump, get_path
+from .utils import load_etc_dump, save_etc_dump
 
-
-RTA_DIR = get_path("rta")
+ROOT_DIR = Path(__file__).parent.parent
+RTA_DIR = ROOT_DIR.joinpath("rta")
 
 
 class RtaMappings(object):

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -231,7 +231,7 @@ def get_kibana_rules(*rule_paths, branch='master', verbose=True, threads=50):
 @cached
 def parse_config():
     """Parse a default config file."""
-    config_file = ROOT_DIR.joinpath('.detection-rules-cfg.json')
+    config_file = ROOT_DIR / '.detection-rules-cfg.json'
     config = {}
 
     if config_file.exists():

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -5,7 +5,6 @@
 """Misc support."""
 import json
 import os
-from pathlib import Path
 import re
 import time
 import uuid
@@ -13,9 +12,8 @@ import uuid
 import click
 import requests
 
-from .utils import cached
+from .utils import ROOT_DIR, cached
 
-ROOT_DIR = Path(__file__).parent.parent
 _CONFIG = {}
 
 LICENSE_HEADER = """

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -5,6 +5,7 @@
 """Misc support."""
 import json
 import os
+from pathlib import Path
 import re
 import time
 import uuid
@@ -12,8 +13,9 @@ import uuid
 import click
 import requests
 
-from .utils import cached, get_path
+from .utils import cached
 
+ROOT_DIR = Path(__file__).parent.parent
 _CONFIG = {}
 
 LICENSE_HEADER = """
@@ -229,10 +231,10 @@ def get_kibana_rules(*rule_paths, branch='master', verbose=True, threads=50):
 @cached
 def parse_config():
     """Parse a default config file."""
-    config_file = get_path('.detection-rules-cfg.json')
+    config_file = ROOT_DIR.joinpath('.detection-rules-cfg.json')
     config = {}
 
-    if os.path.exists(config_file):
+    if config_file.exists():
         with open(config_file) as f:
             config = json.load(f)
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -17,9 +17,10 @@ import click
 from . import rule_loader
 from .misc import JS_LICENSE
 from .rule import Rule  # noqa: F401
-from .utils import load_etc_dump, save_etc_dump
+from .utils import load_dump, save_etc_dump
 
 ROOT_DIR = Path(__file__).parent.parent
+ETC_DIR = ROOT_DIR.joinpath("etc")
 RELEASE_DIR = ROOT_DIR / "releases"
 PACKAGE_FILE = ROOT_DIR / "etc/packages.yml"
 NOTICE_FILE = ROOT_DIR / 'NOTICE.txt'
@@ -58,7 +59,7 @@ def manage_versions(rules: list, deprecated_rules: list = None, current_versions
     changed_rules = []
 
     if current_versions is None:
-        current_versions = load_etc_dump('version.lock.json')
+        current_versions = load_dump(ETC_DIR.joinpath('version.lock.json'))
 
     for rule in rules:
         # it is a new rule, so add it if specified, and add an initial version to the rule
@@ -87,7 +88,7 @@ def manage_versions(rules: list, deprecated_rules: list = None, current_versions
     rule_deprecations = {}
 
     if deprecated_rules:
-        rule_deprecations = load_etc_dump('deprecated_rules.json')
+        rule_deprecations = load_dump(ETC_DIR.joinpath('deprecated_rules.json'))
 
         deprecation_date = str(datetime.date.today())
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -20,7 +20,7 @@ from .rule import Rule  # noqa: F401
 from .utils import load_dump, save_etc_dump
 
 ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR.joinpath("etc")
+ETC_DIR = ROOT_DIR / "etc"
 RELEASE_DIR = ROOT_DIR / "releases"
 PACKAGE_FILE = ROOT_DIR / "etc/packages.yml"
 NOTICE_FILE = ROOT_DIR / 'NOTICE.txt'
@@ -59,7 +59,7 @@ def manage_versions(rules: list, deprecated_rules: list = None, current_versions
     changed_rules = []
 
     if current_versions is None:
-        current_versions = load_dump(ETC_DIR.joinpath('version.lock.json'))
+        current_versions = load_dump(ETC_DIR / 'version.lock.json')
 
     for rule in rules:
         # it is a new rule, so add it if specified, and add an initial version to the rule
@@ -88,7 +88,7 @@ def manage_versions(rules: list, deprecated_rules: list = None, current_versions
     rule_deprecations = {}
 
     if deprecated_rules:
-        rule_deprecations = load_dump(ETC_DIR.joinpath('deprecated_rules.json'))
+        rule_deprecations = load_dump(ETC_DIR / 'deprecated_rules.json')
 
         deprecation_date = str(datetime.date.today())
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -9,7 +9,6 @@ import hashlib
 import json
 import os
 import shutil
-from pathlib import Path
 from collections import defaultdict, OrderedDict
 
 import click
@@ -17,11 +16,8 @@ import click
 from . import rule_loader
 from .misc import JS_LICENSE
 from .rule import Rule  # noqa: F401
-from .utils import load_dump, save_etc_dump
+from .utils import ROOT_DIR, ETC_DIR, RELEASE_DIR, load_dump, save_etc_dump
 
-ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR / "etc"
-RELEASE_DIR = ROOT_DIR / "releases"
 PACKAGE_FILE = ROOT_DIR / "etc/packages.yml"
 NOTICE_FILE = ROOT_DIR / 'NOTICE.txt'
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -9,6 +9,7 @@ import hashlib
 import json
 import os
 import shutil
+from pathlib import Path
 from collections import defaultdict, OrderedDict
 
 import click
@@ -16,11 +17,12 @@ import click
 from . import rule_loader
 from .misc import JS_LICENSE
 from .rule import Rule  # noqa: F401
-from .utils import get_path, get_etc_path, load_etc_dump, save_etc_dump
+from .utils import load_etc_dump, save_etc_dump
 
-RELEASE_DIR = get_path("releases")
-PACKAGE_FILE = get_etc_path('packages.yml')
-NOTICE_FILE = get_path('NOTICE.txt')
+ROOT_DIR = Path(__file__).parent.parent
+RELEASE_DIR = ROOT_DIR / "releases"
+PACKAGE_FILE = ROOT_DIR / "etc/packages.yml"
+NOTICE_FILE = ROOT_DIR / 'NOTICE.txt'
 
 
 def filter_rule(rule: Rule, config_filter: dict, exclude_fields: dict) -> bool:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -7,7 +7,6 @@ import copy
 import hashlib
 import json
 import os
-from pathlib import Path
 
 import click
 import kql
@@ -17,10 +16,8 @@ from . import ecs, beats
 from .attack import tactics, build_threat_map_entry, technique_lookup
 from .rule_formatter import nested_normalize, toml_write
 from .schemas import CurrentSchema, TomlMetadata  # RULE_TYPES, metadata_schema, schema_validate, get_schema
-from .utils import clear_caches, cached
+from .utils import ROOT_DIR, clear_caches, cached
 
-
-ROOT_DIR = Path(__file__).parent.parent
 RULES_DIR = ROOT_DIR / "rules"
 _META_SCHEMA_REQ_DEFAULTS = {}
 
@@ -375,7 +372,7 @@ class Rule(object):
             if ecs_version:
                 metadata['ecs_version'] = ecs_version
 
-        suggested_path = os.path.join(RULES_DIR, contents['name'])  # TODO: UPDATE BASED ON RULE STRUCTURE
+        suggested_path = RULES_DIR / contents['name']  # TODO: UPDATE BASED ON RULE STRUCTURE
         path = os.path.realpath(path or input('File path for rule [{}]: '.format(suggested_path)) or suggested_path)
 
         rule = None

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -7,6 +7,7 @@ import copy
 import hashlib
 import json
 import os
+from pathlib import Path
 
 import click
 import kql
@@ -16,10 +17,11 @@ from . import ecs, beats
 from .attack import tactics, build_threat_map_entry, technique_lookup
 from .rule_formatter import nested_normalize, toml_write
 from .schemas import CurrentSchema, TomlMetadata  # RULE_TYPES, metadata_schema, schema_validate, get_schema
-from .utils import get_path, clear_caches, cached
+from .utils import clear_caches, cached
 
 
-RULES_DIR = get_path("rules")
+ROOT_DIR = Path(__file__).parent.parent
+RULES_DIR = ROOT_DIR / "rules"
 _META_SCHEMA_REQ_DEFAULTS = {}
 
 

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -7,7 +7,6 @@ import functools
 import glob
 import io
 import os
-from pathlib import Path
 import re
 from collections import OrderedDict
 
@@ -19,8 +18,6 @@ from .rule import RULES_DIR, Rule
 from .schemas import CurrentSchema
 from .utils import cached
 
-ROOT_DIR = Path(__file__).parent.parent
-RTA_DIR = ROOT_DIR / "rta"
 FILE_PATTERN = r'^([a-z0-9_])+\.(json|toml)$'
 
 

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -7,6 +7,7 @@ import functools
 import glob
 import io
 import os
+from pathlib import Path
 import re
 from collections import OrderedDict
 
@@ -16,10 +17,10 @@ import pytoml
 from .mappings import RtaMappings
 from .rule import RULES_DIR, Rule
 from .schemas import CurrentSchema
-from .utils import get_path, cached
+from .utils import cached
 
-
-RTA_DIR = get_path("rta")
+ROOT_DIR = Path(__file__).parent.parent
+RTA_DIR = ROOT_DIR / "rta"
 FILE_PATTERN = r'^([a-z0-9_])+\.(json|toml)$'
 
 

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -41,14 +41,9 @@ def get_json_iter(f):
     return data
 
 
-def get_etc_path(*paths):
-    """Load a file from the etc/ folder."""
-    return ETC_DIR.joinpath(*paths)
-
-
 def save_etc_dump(contents, *path, **kwargs):
     """Load a json/yml/toml file from the etc/ folder."""
-    path = get_etc_path(*path)
+    path = ETC_DIR.joinpath(path)
     _, ext = path.parent, path.suffix
     sort_keys = kwargs.pop('sort_keys', True)
     indent = kwargs.pop('indent', 2)

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -43,7 +43,7 @@ def get_json_iter(f):
 
 def save_etc_dump(contents, *path, **kwargs):
     """Save a json/yml/toml file to the etc/ folder."""
-    path = ETC_DIR.joinpath(path)
+    path = ETC_DIR / path
     _, ext = path.parent, path.suffix
     sort_keys = kwargs.pop('sort_keys', True)
     indent = kwargs.pop('indent', 2)

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -42,7 +42,7 @@ def get_json_iter(f):
 
 
 def save_etc_dump(contents, *path, **kwargs):
-    """Load a json/yml/toml file from the etc/ folder."""
+    """Save a json/yml/toml file to the etc/ folder."""
     path = ETC_DIR.joinpath(path)
     _, ext = path.parent, path.suffix
     sort_keys = kwargs.pop('sort_keys', True)
@@ -52,7 +52,8 @@ def save_etc_dump(contents, *path, **kwargs):
         with open(path, "wt") as f:
             json.dump(contents, f, cls=DateTimeEncoder, sort_keys=sort_keys, indent=indent, **kwargs)
     else:
-        return eql.utils.save_dump(contents, path)
+        # TODO Remove str when eql.utils.save_dump takes a Path object as input
+        return eql.utils.save_dump(contents, str(path))
 
 
 def gzip_compress(contents):

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -41,30 +41,9 @@ def get_json_iter(f):
     return data
 
 
-def get_path(*paths):
-    """Get a file by relative path."""
-    return ROOT_DIR.joinpath(*paths)
-
-
 def get_etc_path(*paths):
     """Load a file from the etc/ folder."""
     return ETC_DIR.joinpath(*paths)
-
-
-def get_etc_glob_path(*patterns):
-    """Load a file from the etc/ folder."""
-    return list(ETC_DIR.glob(*patterns))
-
-
-def get_etc_file(name, mode="r"):
-    """Load a file from the etc/ folder."""
-    with open(get_etc_path(name), mode) as f:
-        return f.read()
-
-
-def load_etc_dump(*path):
-    """Load a json/yml/toml file from the etc/ folder."""
-    return load_dump(str(get_etc_path(*path)))
 
 
 def save_etc_dump(contents, *path, **kwargs):

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -20,7 +20,10 @@ from eql.utils import load_dump, stream_json_lines
 
 CURR_DIR = Path(__file__).parent
 ROOT_DIR = CURR_DIR.parent
-ETC_DIR = ROOT_DIR / "etc"
+ETC_DIR = ROOT_DIR / 'etc'
+RULES_DIR = ROOT_DIR / 'rules'
+RTA_DIR = ROOT_DIR / 'rta'
+RELEASE_DIR = ROOT_DIR / "releases"
 
 
 class DateTimeEncoder(json.JSONEncoder):

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -46,7 +46,7 @@ def get_json_iter(f):
 
 def save_etc_dump(contents, *path, **kwargs):
     """Save a json/yml/toml file to the etc/ folder."""
-    path = ETC_DIR / path
+    path = ETC_DIR / Path(*path)
     _, ext = path.parent, path.suffix
     sort_keys = kwargs.pop('sort_keys', True)
     indent = kwargs.pop('indent', 2)

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -184,9 +184,9 @@ def clear_caches():
     _cache.clear()
 
 
-def load_rule_contents(rule_file: str, single_only=False) -> list:
+def load_rule_contents(rule_file: Path, single_only=False) -> list:
     """Load a rule file from multiple formats."""
-    _, extension = Path(rule_file).parent, Path(rule_file).suffix
+    _, extension = rule_file.parent, rule_file.suffix
 
     if extension in ('.ndjson', '.jsonl'):
         # kibana exported rule object is ndjson with the export metadata on the last line

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -5,7 +5,6 @@
 """Test that all rules have valid metadata and syntax."""
 import json
 import os
-from pathlib import Path
 import re
 import sys
 import unittest
@@ -19,11 +18,8 @@ import pytoml
 from rta import get_ttp_names
 
 from detection_rules import attack, rule_loader
-from detection_rules.utils import load_dump
+from detection_rules.utils import ETC_DIR, load_dump
 from detection_rules.rule import Rule
-
-ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR / 'etc'
 
 
 class TestValidRules(unittest.TestCase):

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -5,6 +5,7 @@
 """Test that all rules have valid metadata and syntax."""
 import json
 import os
+from pathlib import Path
 import re
 import sys
 import unittest
@@ -18,8 +19,11 @@ import pytoml
 from rta import get_ttp_names
 
 from detection_rules import attack, rule_loader
-from detection_rules.utils import load_etc_dump
+from detection_rules.utils import load_dump
 from detection_rules.rule import Rule
+
+ROOT_DIR = Path(__file__).parent.parent
+ETC_DIR = ROOT_DIR.joinpath("etc")
 
 
 class TestValidRules(unittest.TestCase):
@@ -100,7 +104,7 @@ class TestValidRules(unittest.TestCase):
     @rule_loader.mock_loader
     def test_production_rules_have_rta(self):
         """Ensure that all production rules have RTAs."""
-        mappings = load_etc_dump('rule-mapping.yml')
+        mappings = load_dump(ETC_DIR.joinpath('rule-mapping.yml'))
 
         ttp_names = get_ttp_names()
 

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -23,7 +23,7 @@ from detection_rules.utils import load_dump
 from detection_rules.rule import Rule
 
 ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR.joinpath("etc")
+ETC_DIR = ROOT_DIR / 'etc'
 
 
 class TestValidRules(unittest.TestCase):
@@ -104,7 +104,7 @@ class TestValidRules(unittest.TestCase):
     @rule_loader.mock_loader
     def test_production_rules_have_rta(self):
         """Ensure that all production rules have RTAs."""
-        mappings = load_dump(ETC_DIR.joinpath('rule-mapping.yml'))
+        mappings = load_dump(ETC_DIR / 'rule-mapping.yml')
 
         ttp_names = get_ttp_names()
 

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -9,7 +9,11 @@ import warnings
 
 from . import get_data_files, get_fp_data_files
 from detection_rules import rule_loader
-from detection_rules.utils import combine_sources, evaluate, load_etc_dump
+from detection_rules.utils import combine_sources, evaluate, load_dump
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).parent.parent
+ETC_DIR = ROOT_DIR.joinpath("etc")
 
 
 class TestMappings(unittest.TestCase):
@@ -27,7 +31,7 @@ class TestMappings(unittest.TestCase):
     def test_true_positives(self):
         """Test that expected results return against true positives."""
         mismatched_ecs = []
-        mappings = load_etc_dump('rule-mapping.yml')
+        mappings = load_dump(ETC_DIR.joinpath('rule-mapping.yml'))
 
         for rule in rule_loader.get_production_rules():
             if rule.type == 'query' and rule.contents['language'] == 'kuery':

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -13,7 +13,7 @@ from detection_rules.utils import combine_sources, evaluate, load_dump
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR.joinpath("etc")
+ETC_DIR = ROOT_DIR / 'etc'
 
 
 class TestMappings(unittest.TestCase):
@@ -31,7 +31,7 @@ class TestMappings(unittest.TestCase):
     def test_true_positives(self):
         """Test that expected results return against true positives."""
         mismatched_ecs = []
-        mappings = load_dump(ETC_DIR.joinpath('rule-mapping.yml'))
+        mappings = load_dump(ETC_DIR / 'rule-mapping.yml')
 
         for rule in rule_loader.get_production_rules():
             if rule.type == 'query' and rule.contents['language'] == 'kuery':

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -9,11 +9,7 @@ import warnings
 
 from . import get_data_files, get_fp_data_files
 from detection_rules import rule_loader
-from detection_rules.utils import combine_sources, evaluate, load_dump
-from pathlib import Path
-
-ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR / 'etc'
+from detection_rules.utils import ETC_DIR, combine_sources, evaluate, load_dump
 
 
 class TestMappings(unittest.TestCase):

--- a/tests/test_toml_formatter.py
+++ b/tests/test_toml_formatter.py
@@ -5,19 +5,21 @@
 import copy
 import json
 import os
+from pathlib import Path
 import pytoml
 import unittest
-from detection_rules.utils import get_etc_path
 from detection_rules import rule_loader
 from detection_rules.rule_formatter import nested_normalize, toml_write
 
+ROOT_DIR = Path(__file__).parent.parent
+ETC_DIR = ROOT_DIR.joinpath('etc')
 
 tmp_file = 'tmp_file.toml'
 
 
 class TestRuleTomlFormatter(unittest.TestCase):
     """Test that the cutom toml formatting is not compromising the integrity of the data."""
-    with open(get_etc_path('test_toml.json'), 'r') as f:
+    with open(ETC_DIR.joinpath('test_toml.json'), 'r') as f:
         test_data = json.load(f)
 
     def compare_formatted(self, data, callback=None, kwargs=None):

--- a/tests/test_toml_formatter.py
+++ b/tests/test_toml_formatter.py
@@ -12,14 +12,14 @@ from detection_rules import rule_loader
 from detection_rules.rule_formatter import nested_normalize, toml_write
 
 ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR.joinpath('etc')
+ETC_DIR = ROOT_DIR / 'etc'
 
 tmp_file = 'tmp_file.toml'
 
 
 class TestRuleTomlFormatter(unittest.TestCase):
     """Test that the cutom toml formatting is not compromising the integrity of the data."""
-    with open(ETC_DIR.joinpath('test_toml.json'), 'r') as f:
+    with open(ETC_DIR / 'test_toml.json', 'r') as f:
         test_data = json.load(f)
 
     def compare_formatted(self, data, callback=None, kwargs=None):

--- a/tests/test_toml_formatter.py
+++ b/tests/test_toml_formatter.py
@@ -5,14 +5,11 @@
 import copy
 import json
 import os
-from pathlib import Path
 import pytoml
 import unittest
 from detection_rules import rule_loader
 from detection_rules.rule_formatter import nested_normalize, toml_write
-
-ROOT_DIR = Path(__file__).parent.parent
-ETC_DIR = ROOT_DIR / 'etc'
+from detection_rules.utils import ETC_DIR
 
 tmp_file = 'tmp_file.toml'
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Pending

## Summary
Use `pathlib` module for easier handling of object-oriented filesystem paths and readability.

I converted a couple of paths to strings to avoid errors in `eql.utils`.

Work in progress. I could apply this to other modules.

Also adding `.venv*/*` to `.gitignore`, as some people prefer to create a virtualenv using the `.venv` prefix. E.g. `.venv` or `.venv37`

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
