### PR TITLE
[Rule Tuning] Update EQL rules for 7.10

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -76,7 +76,8 @@ class Rule(object):
             if self.contents['language'] == 'kuery':
                 return kql.parse(self.query)
             elif self.contents['language'] == 'eql':
-                return eql.parse_query(self.query)
+                with eql.parser.elasticsearch_syntax:
+                    return eql.parse_query(self.query)
 
     @property
     def filters(self):
@@ -124,7 +125,9 @@ class Rule(object):
         query = rule_contents.get('query')
         language = rule_contents.get('language')
         if language in ('kuery', 'eql'):
-            parsed = kql.parse(query) if language == 'kuery' else eql.parse_query(query)
+            with eql.parser.elasticsearch_syntax:
+                parsed = kql.parse(query) if language == 'kuery' else eql.parse_query(query)
+
             return sorted(set(str(f) for f in parsed if isinstance(f, (eql.ast.Field, kql.ast.Field))))
 
     @staticmethod
@@ -202,7 +205,9 @@ class Rule(object):
     @cached
     def _validate_eql(ecs_versions, indexes, query, name):
         # validate against all specified schemas or the latest if none specified
-        parsed = eql.parse_query(query)
+        with eql.parser.elasticsearch_syntax:
+            parsed = eql.parse_query(query)
+
         beat_types = [index.split("-")[0] for index in indexes if "beat-*" in index]
         beat_schema = beats.get_schema_from_eql(parsed, beat_types) if beat_types else None
 
@@ -218,7 +223,7 @@ class Rule(object):
 
         for schema in schemas:
             try:
-                with ecs.KqlSchema2Eql(schema):
+                with ecs.KqlSchema2Eql(schema), eql.parser.elasticsearch_syntax:
                     eql.parse_query(query)
 
             except eql.EqlTypeMismatchError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ toml==0.10.0
 requests==2.22.0
 Click==7.0
 PyYAML~=5.3
-eql~=0.9
+eql~=0.9.5
 elasticsearch~=7.5.1
 XlsxWriter==1.3.6
 

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -26,7 +26,7 @@ query = '''
 
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name : "installutil.exe"]
-  [network where event.type == "connection" and process.name == "installutil.exe" and network.direction == "outgoing"]
+  [network where event.type == "connection" and process.name : "installutil.exe" and network.direction == "outgoing"]
 '''
 
 

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -22,7 +22,7 @@ tags = ["Elastic", "Windows"]
 type = "eql"
 
 query = '''
-/* this can be done without a sequence however, this does include more info on the process */
+/* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
 
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name == "installutil.exe"]

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -25,7 +25,7 @@ query = '''
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
 
 sequence by process.entity_id
-  [process where event.type in ("start", "process_started") and process.name == "installutil.exe"]
+  [process where event.type in ("start", "process_started") and process.name : "installutil.exe"]
   [network where event.type == "connection" and process.name == "installutil.exe" and network.direction == "outgoing"]
 '''
 

--- a/rules/windows/defense_evasion_msbuild_beacon_sequence.toml
+++ b/rules/windows/defense_evasion_msbuild_beacon_sequence.toml
@@ -25,7 +25,7 @@ query = '''
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name : "MSBuild.exe"]
   [network where process.name : "MSBuild.exe" and
-     not (destination.address == "127.0.0.1" and source.address == "127.0.0.1")]
+     not (destination.ip == "127.0.0.1" and source.ip == "127.0.0.1")]
 '''
 
 

--- a/rules/windows/defense_evasion_msbuild_beacon_sequence.toml
+++ b/rules/windows/defense_evasion_msbuild_beacon_sequence.toml
@@ -23,8 +23,8 @@ type = "eql"
 
 query = '''
 sequence by process.entity_id
-  [process where event.type in ("start", "process_started") and process.name == "MSBuild.exe"]
-  [network where process.name == "MSBuild.exe" and
+  [process where event.type in ("start", "process_started") and process.name : "MSBuild.exe"]
+  [network where process.name : "MSBuild.exe" and
      not (destination.address == "127.0.0.1" and source.address == "127.0.0.1")]
 '''
 

--- a/rules/windows/defense_evasion_mshta_beacon.toml
+++ b/rules/windows/defense_evasion_mshta_beacon.toml
@@ -23,12 +23,12 @@ type = "eql"
 
 query = '''
 sequence by process.entity_id with maxspan=2h
-  [process where event.type in ("start", "process_started") and process.name == "mshta.exe" and
-     process.parent.name != "Microsoft.ConfigurationManagement.exe" and
-     process.parent.executable not in ("C:\\Amazon\\Amazon Assistant\\amazonAssistantService.exe",
-                                       "C:\\TeamViewer\\TeamViewer.exe") and
-     process.args != "ADSelfService_Enroll.hta"]
-  [network where process.name == "mshta.exe"]
+  [process where event.type in ("start", "process_started") and process.name : "mshta.exe" and
+     not process.parent.name : "Microsoft.ConfigurationManagement.exe" and
+     not (process.parent.executable : "C:\\Amazon\\Amazon Assistant\\amazonAssistantService.exe" or
+          process.parent.executable : "C:\\TeamViewer\\TeamViewer.exe") and
+     not process.args : "ADSelfService_Enroll.hta"]
+  [network where process.name : "mshta.exe"]
 '''
 
 

--- a/rules/windows/defense_evasion_msxsl_beacon.toml
+++ b/rules/windows/defense_evasion_msxsl_beacon.toml
@@ -23,8 +23,8 @@ type = "eql"
 
 query = '''
 sequence by process.entity_id
-  [process where event.type in ("start", "process_started") and process.name == "msxsl.exe"]
-  [network where event.type == "connection" and process.name == "msxsl.exe" and network.direction == "outgoing"]
+  [process where event.type in ("start", "process_started") and process.name : "msxsl.exe"]
+  [network where event.type == "connection" and process.name : "msxsl.exe" and network.direction == "outgoing"]
 '''
 
 

--- a/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+++ b/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
@@ -26,47 +26,47 @@ sequence by process.entity_id with maxspan=5m
   [process where event.type in ("start", "process_started") and
 
      /* known applocker bypasses */
-     process.name in ("bginfo.exe",
-                      "cdb.exe",
-                      "control.exe",
-                      "cmstp.exe",
-                      "csi.exe",
-                      "dnx.exe",
-                      "fsi.exe",
-                      "ieexec.exe",
-                      "iexpress.exe",
-                      "installutil.exe",
-                      "Microsoft.Workflow.Compiler.exe",
-                      "MSBuild.exe",
-                      "msdt.exe",
-                      "mshta.exe",
-                      "msiexec.exe",
-                      "msxsl.exe",
-                      "odbcconf.exe",
-                      "rcsi.exe",
-                      "regsvr32.exe",
-                      "xwizard.exe")]
+     (process.name : "bginfo.exe" or
+      process.name : "cdb.exe" or
+      process.name : "control.exe" or
+      process.name : "cmstp.exe" or
+      process.name : "csi.exe" or
+      process.name : "dnx.exe" or
+      process.name : "fsi.exe" or
+      process.name : "ieexec.exe" or
+      process.name : "iexpress.exe" or
+      process.name : "installutil.exe" or
+      process.name : "Microsoft.Workflow.Compiler.exe" or
+      process.name : "MSBuild.exe" or
+      process.name : "msdt.exe" or
+      process.name : "mshta.exe" or
+      process.name : "msiexec.exe" or
+      process.name : "msxsl.exe" or
+      process.name : "odbcconf.exe" or
+      process.name : "rcsi.exe" or
+      process.name : "regsvr32.exe" or
+      process.name : "xwizard.exe")]
   [network where event.type == "connection" and
-     process.name in ("bginfo.exe",
-                      "cdb.exe",
-                      "control.exe",
-                      "cmstp.exe",
-                      "csi.exe",
-                      "dnx.exe",
-                      "fsi.exe",
-                      "ieexec.exe",
-                      "iexpress.exe",
-                      "installutil.exe",
-                      "Microsoft.Workflow.Compiler.exe",
-                      "MSBuild.exe",
-                      "msdt.exe",
-                      "mshta.exe",
-                      "msiexec.exe",
-                      "msxsl.exe",
-                      "odbcconf.exe",
-                      "rcsi.exe",
-                      "regsvr32.exe",
-                      "xwizard.exe")]
+     (process.name : "bginfo.exe" or
+      process.name : "cdb.exe" or
+      process.name : "control.exe" or
+      process.name : "cmstp.exe" or
+      process.name : "csi.exe" or
+      process.name : "dnx.exe" or
+      process.name : "fsi.exe" or
+      process.name : "ieexec.exe" or
+      process.name : "iexpress.exe" or
+      process.name : "installutil.exe" or
+      process.name : "Microsoft.Workflow.Compiler.exe" or
+      process.name : "MSBuild.exe" or
+      process.name : "msdt.exe" or
+      process.name : "mshta.exe" or
+      process.name : "msiexec.exe" or
+      process.name : "msxsl.exe" or
+      process.name : "odbcconf.exe" or
+      process.name : "rcsi.exe" or
+      process.name : "regsvr32.exe" or
+      process.name : "xwizard.exe")]
 '''
 
 

--- a/rules/windows/defense_evasion_reg_beacon.toml
+++ b/rules/windows/defense_evasion_reg_beacon.toml
@@ -24,7 +24,7 @@ type = "eql"
 query = '''
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and
-     process.name in ("regasm.exe", "regsvcs.exe", "regsvr32.exe")]
+     process.name in ("RegAsm.exe", "regsvcs.exe", "regsvr32.exe")]
   [network where event.type == "connection" and process.name in ("regasm.exe", "regsvcs.exe", "regsvr32.exe")]
 until
   [process where event.type == "end" and process.name in ("regasm.exe", "regsvcs.exe", "regsvr32.exe")]

--- a/rules/windows/defense_evasion_reg_beacon.toml
+++ b/rules/windows/defense_evasion_reg_beacon.toml
@@ -24,10 +24,12 @@ type = "eql"
 query = '''
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and
-     process.name in ("RegAsm.exe", "regsvcs.exe", "regsvr32.exe")]
-  [network where event.type == "connection" and process.name in ("regasm.exe", "regsvcs.exe", "regsvr32.exe")]
+     (process.name : "RegAsm.exe" or process.name : "regsvcs.exe" or process.name : "regsvr32.exe")]
+  [network where event.type == "connection" and
+     (process.name : "RegAsm.exe" or process.name : "regsvcs.exe" or process.name : "regsvr32.exe")]
 until
-  [process where event.type == "end" and process.name in ("regasm.exe", "regsvcs.exe", "regsvr32.exe")]
+  [process where event.type == "end" and
+     (process.name : "RegAsm.exe" or process.name : "regsvcs.exe" or process.name : "regsvr32.exe")]
 '''
 
 

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -25,11 +25,7 @@ query = '''
 sequence with maxspan=1h
   [process where event.type in ("start", "process_started") and
      (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
-
-     /* zero arguments excluding the binary itself (and accounting for when the binary may not be logged in args) */
-     ((process.args == "rundll32.exe" and process.args_count == 1) or
-      (process.args != "rundll32.exe" and process.args_count == 0))
-
+     process.args_count < 2
   ] by process.entity_id
   [process where event.type in ("start", "process_started") and
      (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -24,7 +24,7 @@ type = "eql"
 query = '''
 sequence with maxspan=1h
   [process where event.type in ("start", "process_started") and
-     (process.name == "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
+     (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
 
      /* zero arguments excluding the binary itself (and accounting for when the binary may not be logged in args) */
      ((process.args == "rundll32.exe" and process.args_count == 1) or
@@ -32,7 +32,7 @@ sequence with maxspan=1h
 
   ] by process.entity_id
   [process where event.type in ("start", "process_started") and
-     (process.name == "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")
+     (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")
   ] by process.parent.entity_id
 '''
 

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -11,7 +11,7 @@ Identifies child processes of unusual instances of RunDLL32 where the command li
 RunDLL32 could indicate malicious activity.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License"
 name = "Unusual Child Processes of RunDLL32"

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -11,7 +11,7 @@ Identifies child processes of unusual instances of RunDLL32 where the command li
 RunDLL32 could indicate malicious activity.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License"
 name = "Unusual Child Processes of RunDLL32"
@@ -24,11 +24,13 @@ type = "eql"
 query = '''
 sequence with maxspan=1h
   [process where event.type in ("start", "process_started") and
-     (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
+                                    /* uncomment once in winlogbeat */
+     (process.name : "rundll32.exe" /* or process.pe.original_file_name == "RUNDLL32.EXE" */ ) and
      process.args_count < 2
   ] by process.entity_id
   [process where event.type in ("start", "process_started") and
-     (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")
+                                    /* uncomment once in winlogbeat */
+     (process.name : "rundll32.exe" /* or process.pe.original_file_name == "RUNDLL32.EXE" */ )
   ] by process.parent.entity_id
 '''
 

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -22,12 +22,9 @@ tags = ["Elastic", "Windows"]
 type = "eql"
 
 query = '''
-/* replace winlog.event_data.OriginalFileName with process.pe.original_file_name once field is available in winlogbeat */
-
 sequence with maxspan=1h
   [process where event.type in ("start", "process_started") and
-     (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe" or
-        winlog.event_data.OriginalFileName == "rundll32.exe") and
+     (process.name == "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
 
      /* zero arguments excluding the binary itself (and accounting for when the binary may not be logged in args) */
      ((process.args == "rundll32.exe" and process.args_count == 1) or
@@ -35,8 +32,7 @@ sequence with maxspan=1h
 
   ] by process.entity_id
   [process where event.type in ("start", "process_started") and
-     (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe" or
-        winlog.event_data.OriginalFileName == "rundll32.exe")
+     (process.name == "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")
   ] by process.parent.entity_id
 '''
 

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -25,11 +25,7 @@ query = '''
 sequence by process.entity_id with maxspan=2h
   [process where event.type in ("start", "process_started") and
      (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
-
-     /* zero arguments excluding the binary itself (and accounting for when the binary may not be logged in args) */
-     ((process.args == "rundll32.exe" and process.args_count == 1) or
-      (process.args != "rundll32.exe" and process.args_count == 0))]
-
+     process.args_count < 2]
   [network where event.type == "connection" and
      (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")]
 '''

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -11,7 +11,7 @@ Identifies unusual instances of Rundll32.exe making outbound network connections
 and may identify malicious DLLs.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License"
 name = "Unusual Network Connection Sequence via RunDLL32"

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -22,20 +22,16 @@ tags = ["Elastic", "Windows"]
 type = "eql"
 
 query = '''
-/* replace winlog.event_data.OriginalFileName with process.pe.original_file_name once field is available in winlogbeat */
-
 sequence by process.entity_id with maxspan=2h
   [process where event.type in ("start", "process_started") and
-     (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe" or
-        winlog.event_data.OriginalFileName == "rundll32.exe") and
+     (process.name == "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
 
      /* zero arguments excluding the binary itself (and accounting for when the binary may not be logged in args) */
      ((process.args == "rundll32.exe" and process.args_count == 1) or
       (process.args != "rundll32.exe" and process.args_count == 0))]
 
   [network where event.type == "connection" and
-     (process.name == "rundll32.exe" or process.pe.original_file_name == "rundll32.exe" or
-        winlog.event_data.OriginalFileName == "rundll32.exe")]
+     (process.name == "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")]
 '''
 
 

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -11,7 +11,7 @@ Identifies unusual instances of Rundll32.exe making outbound network connections
 and may identify malicious DLLs.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License"
 name = "Unusual Network Connection Sequence via RunDLL32"
@@ -24,10 +24,12 @@ type = "eql"
 query = '''
 sequence by process.entity_id with maxspan=2h
   [process where event.type in ("start", "process_started") and
-     (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
+                                    /* uncomment once in winlogbeat */
+     (process.name : "rundll32.exe" /* or process.pe.original_file_name == "RUNDLL32.EXE" */ ) and
      process.args_count < 2]
   [network where event.type == "connection" and
-     (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")]
+                                     /* uncomment once in winlogbeat */
+     (process.name : "rundll32.exe" /* or process.pe.original_file_name == "RUNDLL32.EXE" */ )]
 '''
 
 

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -24,14 +24,14 @@ type = "eql"
 query = '''
 sequence by process.entity_id with maxspan=2h
   [process where event.type in ("start", "process_started") and
-     (process.name == "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
+     (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
 
      /* zero arguments excluding the binary itself (and accounting for when the binary may not be logged in args) */
      ((process.args == "rundll32.exe" and process.args_count == 1) or
       (process.args != "rundll32.exe" and process.args_count == 0))]
 
   [network where event.type == "connection" and
-     (process.name == "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")]
+     (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE")]
 '''
 
 

--- a/rules/windows/defense_evasion_suspicious_scrobj_load.toml
+++ b/rules/windows/defense_evasion_suspicious_scrobj_load.toml
@@ -11,7 +11,7 @@ Identifies scrobj.dll loaded into unusual Microsoft processes. This usually mean
 executed in the target process.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License"
 name = "Windows Suspicious Script Object Execution"
@@ -24,7 +24,6 @@ type = "eql"
 query = '''
 sequence by process.entity_id with maxspan=2m
   [process where event.type in ("start", "process_started") and
-     /* process.code_signature.* fields need to be populated for 7.10 */
      process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true and
      process.name not in ("cscript.exe",
                           "iexplore.exe",

--- a/rules/windows/defense_evasion_suspicious_scrobj_load.toml
+++ b/rules/windows/defense_evasion_suspicious_scrobj_load.toml
@@ -27,15 +27,15 @@ query = '''
 sequence by process.entity_id with maxspan=2m
   [process where event.type in ("start", "process_started") and
      process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true and
-     process.name not in ("cscript.exe",
-                          "iexplore.exe",
-                          "MicrosoftEdge.exe",
-                          "msiexec.exe",
-                          "smartscreen.exe",
-                          "taskhostw.exe",
-                          "w3wp.exe",
-                          "wscript.exe")]
-  [library where event.type == "start" and file.name == "scrobj.dll"]
+     not (process.name : "cscript.exe" or
+          process.name : "iexplore.exe" or
+          process.name : "MicrosoftEdge.exe" or
+          process.name : "msiexec.exe" or
+          process.name : "smartscreen.exe" or
+          process.name : "taskhostw.exe" or
+          process.name : "w3wp.exe" or
+          process.name : "wscript.exe")]
+  [library where event.type == "start" and file.name : "scrobj.dll"]
 '''
 
 

--- a/rules/windows/defense_evasion_suspicious_scrobj_load.toml
+++ b/rules/windows/defense_evasion_suspicious_scrobj_load.toml
@@ -11,7 +11,7 @@ Identifies scrobj.dll loaded into unusual Microsoft processes. This usually mean
 executed in the target process.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License"
 name = "Windows Suspicious Script Object Execution"
@@ -26,7 +26,8 @@ query = '''
 
 sequence by process.entity_id with maxspan=2m
   [process where event.type in ("start", "process_started") and
-     process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true and
+     /* uncomment once in winlogbeat */
+     /* process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true and */
      not (process.name : "cscript.exe" or
           process.name : "iexplore.exe" or
           process.name : "MicrosoftEdge.exe" or

--- a/rules/windows/defense_evasion_suspicious_wmi_script.toml
+++ b/rules/windows/defense_evasion_suspicious_wmi_script.toml
@@ -25,8 +25,8 @@ query = '''
 sequence by process.entity_id with maxspan=2m
 [process where event.type in ("start", "process_started") and
    (process.name : "WMIC.exe" or process.pe.original_file_name == "wmic.exe") and
-   (process.args:"format*:*" or process.args:"/format*:*" or process.args:"*-format*:*") and
-   not process.command_line:"* /format:table *"]
+   wildcard(process.args, "format*:*", "/format*:*", "*-format*:*") and
+   not wildcard(process.command_line, "* /format:table *")]
 [library where event.type == "start" and file.name in ("jscript.dll", "vbscript.dll")]
 '''
 

--- a/rules/windows/defense_evasion_suspicious_wmi_script.toml
+++ b/rules/windows/defense_evasion_suspicious_wmi_script.toml
@@ -24,7 +24,7 @@ type = "eql"
 query = '''
 sequence by process.entity_id with maxspan=2m
 [process where event.type in ("start", "process_started") and
-   (process.name == "WMIC.exe" or process.pe.original_file_name == "wmic.exe") and
+   (process.name : "WMIC.exe" or process.pe.original_file_name == "wmic.exe") and
    (process.args:"format*:*" or process.args:"/format*:*" or process.args:"*-format*:*") and
    not process.command_line:"* /format:table *"]
 [library where event.type == "start" and file.name in ("jscript.dll", "vbscript.dll")]

--- a/rules/windows/defense_evasion_suspicious_wmi_script.toml
+++ b/rules/windows/defense_evasion_suspicious_wmi_script.toml
@@ -22,15 +22,11 @@ tags = ["Elastic", "Windows"]
 type = "eql"
 
 query = '''
-/* lots of wildcards in the args
-   need to verify args cleanup is accurate
-*/
-
 sequence by process.entity_id with maxspan=2m
 [process where event.type in ("start", "process_started") and
-   (process.name == "wmic.exe" or process.pe.original_file_name == "wmic.exe") and
-   wildcard(process.args, "format*:*", "/format*:*", "*-format*:*") and
-   not process.args in ("/format:table", "/format:table") or wildcard(process.args, "format*:*")]
+   (process.name == "WMIC.exe" or process.pe.original_file_name == "wmic.exe") and
+   (process.args:"format*:*" or process.args:"/format*:*" or process.args:"*-format*:*") and
+   not process.command_line:"* /format:table *"]
 [library where event.type == "start" and file.name in ("jscript.dll", "vbscript.dll")]
 '''
 

--- a/rules/windows/execution_ms_office_written_file.toml
+++ b/rules/windows/execution_ms_office_written_file.toml
@@ -24,14 +24,14 @@ type = "eql"
 query = '''
 sequence with maxspan=2h
   [file where event.type != "delete" and file.extension == "exe" and
-     process.name in ("winword.exe",
-                      "excel.exe",
-                      "outlook.exe",
-                      "powerpnt.exe",
+     process.name in ("WINWORD.EXE",
+                      "EXCEL.EXE",
+                      "OUTLOOK.EXE",
+                      "POWERPNT.EXE",
                       "eqnedt32.exe",
                       "fltldr.exe",
-                      "mspub.exe",
-                      "msaccess.exe")
+                      "MSPUB.EXE",
+                      "MSACCESS.EXE")
   ] by host.id, file.path
   [process where event.type in ("start", "process_started")] by host.id, process.executable
 '''

--- a/rules/windows/execution_ms_office_written_file.toml
+++ b/rules/windows/execution_ms_office_written_file.toml
@@ -23,15 +23,15 @@ type = "eql"
 
 query = '''
 sequence with maxspan=2h
-  [file where event.type != "delete" and file.extension == "exe" and
-     process.name in ("WINWORD.EXE",
-                      "EXCEL.EXE",
-                      "OUTLOOK.EXE",
-                      "POWERPNT.EXE",
-                      "eqnedt32.exe",
-                      "fltldr.exe",
-                      "MSPUB.EXE",
-                      "MSACCESS.EXE")
+  [file where event.type != "delete" and file.extension : "exe" and
+     (process.name : "WINWORD.EXE" or
+      process.name : "EXCEL.EXE" or
+      process.name : "OUTLOOK.EXE" or
+      process.name : "POWERPNT.EXE" or
+      process.name : "eqnedt32.exe" or
+      process.name : "fltldr.exe" or
+      process.name : "MSPUB.EXE" or
+      process.name : "MSACCESS.EXE")
   ] by host.id, file.path
   [process where event.type in ("start", "process_started")] by host.id, process.executable
 '''

--- a/rules/windows/execution_ms_office_written_file.toml
+++ b/rules/windows/execution_ms_office_written_file.toml
@@ -23,7 +23,7 @@ type = "eql"
 
 query = '''
 sequence with maxspan=2h
-  [file where event.type != "delete" and file.extension : "exe" and
+  [file where event.type != "deletion" and file.extension : "exe" and
      (process.name : "WINWORD.EXE" or
       process.name : "EXCEL.EXE" or
       process.name : "OUTLOOK.EXE" or

--- a/rules/windows/execution_pdf_written_file.toml
+++ b/rules/windows/execution_pdf_written_file.toml
@@ -24,12 +24,12 @@ type = "eql"
 query = '''
 sequence with maxspan=2h
   [file where event.type != "delete" and file.extension == "exe" and
-     process.name in ("acrord32.exe", "rdrcef.exe", "foxitphantomPDF.exe", "foxitreader.exe") and
-     file.name not in ("foxitphantomPDF.exe",
+     process.name in ("AcroRd32.exe", "rdrcef.exe", "FoxitPhantomPDF.exe", "FoxitReader.exe") and
+     file.name not in ("FoxitPhantomPDF.exe",
                        "FoxitPhantomPDFUpdater.exe",
-                       "foxitreader.exe",
+                       "FoxitReader.exe",
                        "FoxitReaderUpdater.exe",
-                       "acrord32.exe",
+                       "AcroRd32.exe",
                        "rdrcef.exe")
   ] by host.id, file.path
   [process where event.type in ("start", "process_started")] by host.id, process.executable

--- a/rules/windows/execution_pdf_written_file.toml
+++ b/rules/windows/execution_pdf_written_file.toml
@@ -23,7 +23,7 @@ type = "eql"
 
 query = '''
 sequence with maxspan=2h
-  [file where event.type != "delete" and file.extension : "exe" and
+  [file where event.type != "deletion" and file.extension : "exe" and
      (process.name : "AcroRd32.exe" or
       process.name : "rdrcef.exe" or
       process.name : "FoxitPhantomPDF.exe" or

--- a/rules/windows/execution_pdf_written_file.toml
+++ b/rules/windows/execution_pdf_written_file.toml
@@ -23,14 +23,17 @@ type = "eql"
 
 query = '''
 sequence with maxspan=2h
-  [file where event.type != "delete" and file.extension == "exe" and
-     process.name in ("AcroRd32.exe", "rdrcef.exe", "FoxitPhantomPDF.exe", "FoxitReader.exe") and
-     file.name not in ("FoxitPhantomPDF.exe",
-                       "FoxitPhantomPDFUpdater.exe",
-                       "FoxitReader.exe",
-                       "FoxitReaderUpdater.exe",
-                       "AcroRd32.exe",
-                       "rdrcef.exe")
+  [file where event.type != "delete" and file.extension : "exe" and
+     (process.name : "AcroRd32.exe" or
+      process.name : "rdrcef.exe" or
+      process.name : "FoxitPhantomPDF.exe" or
+      process.name : "FoxitReader.exe") and
+     not (file.name : "FoxitPhantomPDF.exe" or
+          file.name : "FoxitPhantomPDFUpdater.exe" or
+          file.name : "FoxitReader.exe" or
+          file.name : "FoxitReaderUpdater.exe" or
+          file.name : "AcroRd32.exe" or
+          file.name : "rdrcef.exe")
   ] by host.id, file.path
   [process where event.type in ("start", "process_started")] by host.id, process.executable
 '''

--- a/rules/windows/execution_wpad_exploitation.toml
+++ b/rules/windows/execution_wpad_exploitation.toml
@@ -26,16 +26,16 @@ query = '''
 /* preference would be to use user.sid rather than domain+name, once it is available in ECS + datasources */
 
 sequence with maxspan=5s
-  [process where event.type in ("start", "process_started") and process.name == "svchost.exe" and
+  [process where event.type in ("start", "process_started") and process.name : "svchost.exe" and
      user.domain == "NT AUTHORITY" and user.name == "LOCAL SERVICE"] by process.entity_id
-  [network where network.protocol == "dns" and process.name == "svchost.exe" and
-     dns.question.name == "wpad" and process.name == "svchost.exe"] by process.entity_id
-  [network where event.type == "connection" and process.name == "svchost.exe"
+  [network where network.protocol == "dns" and process.name : "svchost.exe" and
+     dns.question.name : "wpad" and process.name : "svchost.exe"] by process.entity_id
+  [network where event.type == "connection" and process.name : "svchost.exe"
      and network.direction == "outgoing" and destination.port == 80] by process.entity_id
-  [library where event.type == "start" and process.name == "svchost.exe" and
-     file.name == "jscript.dll" and process.name == "svchost.exe"] by process.entity_id
+  [library where event.type == "start" and process.name : "svchost.exe" and
+     file.name : "jscript.dll" and process.name : "svchost.exe"] by process.entity_id
   [process where event.type in ("start", "process_started") and
-     process.parent.name == "svchost.exe"] by process.parent.entity_id
+     process.parent.name : "svchost.exe"] by process.parent.entity_id
 '''
 
 

--- a/rules/windows/execution_wpad_exploitation.toml
+++ b/rules/windows/execution_wpad_exploitation.toml
@@ -12,7 +12,7 @@ the local network or upstream DNS traffic can inject malicious JavaScript to the
 system compromise.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License"
 name = "WPAD Service Exploit"

--- a/rules/windows/lateral_movement_cmd_service.toml
+++ b/rules/windows/lateral_movement_cmd_service.toml
@@ -22,13 +22,14 @@ tags = ["Elastic", "Windows"]
 type = "eql"
 
 query = '''
-/* dependent on a wildcard for remote path */
-
 sequence by process.entity_id with maxspan=1m
   [process where event.type in ("start", "process_started") and
      (process.name == "sc.exe" or process.pe.original_file_name == "sc.exe") and
-     wildcard(process.args, "\\\\*") and wildcard(process.args, "binPath*", "binpath*") and
-     process.args in ("create", "config", "failure", "start")]
+                                                   /* case insensitive */
+      process.command_line:"* \\\\* binPath=*" and process.args:"create" or
+                                                   process.args:"config" or
+                                                   process.args:"failure" or
+                                                   process.args:"start"]
   [network where event.type == "connection" and process.name == "sc.exe" and destination.address != "127.0.0.1"]
 '''
 

--- a/rules/windows/lateral_movement_cmd_service.toml
+++ b/rules/windows/lateral_movement_cmd_service.toml
@@ -11,7 +11,7 @@ Identifies use of sc.exe to create, modify, or start services on remote hosts. T
 lateral movement but will be noisy if commonly done by admins.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License"
 name = "Service Command Lateral Movement"
@@ -24,7 +24,8 @@ type = "eql"
 query = '''
 sequence by process.entity_id with maxspan=1m
   [process where event.type in ("start", "process_started") and
-     (process.name == "sc.exe" or process.pe.original_file_name == "sc.exe") and
+                               /* uncomment once in winlogbeat */
+     (process.name == "sc.exe" /* or process.pe.original_file_name == "sc.exe" */ ) and
                                                    /* case insensitive */
       wildcard(process.args, "\\\\*") and wildcard(process.args, "binPath=*", "binpath=*") and 
       (process.args : "create" or

--- a/rules/windows/lateral_movement_cmd_service.toml
+++ b/rules/windows/lateral_movement_cmd_service.toml
@@ -26,10 +26,11 @@ sequence by process.entity_id with maxspan=1m
   [process where event.type in ("start", "process_started") and
      (process.name == "sc.exe" or process.pe.original_file_name == "sc.exe") and
                                                    /* case insensitive */
-      process.command_line:"* \\\\* binPath=*" and process.args:"create" or
-                                                   process.args:"config" or
-                                                   process.args:"failure" or
-                                                   process.args:"start"]
+      wildcard(process.args, "\\\\*") and wildcard(process.args, "binPath=*", "binpath=*") and 
+      (process.args : "create" or
+       process.args : "config" or
+       process.args : "failure" or
+       process.args : "start")]
   [network where event.type == "connection" and process.name : "sc.exe" and destination.address != "127.0.0.1"]
 '''
 

--- a/rules/windows/lateral_movement_cmd_service.toml
+++ b/rules/windows/lateral_movement_cmd_service.toml
@@ -31,7 +31,7 @@ sequence by process.entity_id with maxspan=1m
        process.args : "config" or
        process.args : "failure" or
        process.args : "start")]
-  [network where event.type == "connection" and process.name : "sc.exe" and destination.address != "127.0.0.1"]
+  [network where event.type == "connection" and process.name : "sc.exe" and destination.ip != "127.0.0.1"]
 '''
 
 

--- a/rules/windows/lateral_movement_cmd_service.toml
+++ b/rules/windows/lateral_movement_cmd_service.toml
@@ -30,7 +30,7 @@ sequence by process.entity_id with maxspan=1m
                                                    process.args:"config" or
                                                    process.args:"failure" or
                                                    process.args:"start"]
-  [network where event.type == "connection" and process.name == "sc.exe" and destination.address != "127.0.0.1"]
+  [network where event.type == "connection" and process.name : "sc.exe" and destination.address != "127.0.0.1"]
 '''
 
 

--- a/rules/windows/persistence_app_compat_shim.toml
+++ b/rules/windows/persistence_app_compat_shim.toml
@@ -22,8 +22,6 @@ tags = ["Elastic", "Windows"]
 type = "eql"
 
 query = '''
-/* dependent on wildcard for registry.value */
-
 sequence by process.entity_id with maxspan=5m
   [process where event.type in ("start", "process_started") and
      not (process.name == "sdbinst.exe" and process.parent.name == "msiexec.exe")]

--- a/rules/windows/persistence_app_compat_shim.toml
+++ b/rules/windows/persistence_app_compat_shim.toml
@@ -24,7 +24,7 @@ type = "eql"
 query = '''
 sequence by process.entity_id with maxspan=5m
   [process where event.type in ("start", "process_started") and
-     not (process.name == "sdbinst.exe" and process.parent.name == "msiexec.exe")]
+     not (process.name : "sdbinst.exe" and process.parent.name : "msiexec.exe")]
   [registry where event.type in ("creation", "change") and
      wildcard(registry.path, "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom\\*.sdb")]
 '''

--- a/rules/windows/privilege_escalation_uac_sdclt.toml
+++ b/rules/windows/privilege_escalation_uac_sdclt.toml
@@ -11,7 +11,7 @@ Identifies User Account Control (UAC) bypass via sdclt.exe. Attackers bypass UAC
 elevated permissions.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License"
 name = "Bypass UAC via Sdclt"
@@ -26,7 +26,8 @@ query = '''
 
 sequence with maxspan=1m
   [process where event.type in ("start", "process_started") and process.name : "sdclt.exe" and
-     process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true and
+     /* uncomment once in winlogbeat */
+     /* process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true and */
      process.args : "/kickoffelev"
   ] by process.entity_id
   [process where event.type in ("start", "process_started") and process.parent.name : "sdclt.exe" and

--- a/rules/windows/privilege_escalation_uac_sdclt.toml
+++ b/rules/windows/privilege_escalation_uac_sdclt.toml
@@ -25,15 +25,15 @@ query = '''
 /* add winlogbeat-* when process.code_signature.* fields are populated */
 
 sequence with maxspan=1m
-  [process where event.type in ("start", "process_started") and process.name == "sdclt.exe" and
+  [process where event.type in ("start", "process_started") and process.name : "sdclt.exe" and
      process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true and
-     process.args == "/kickoffelev"
+     process.args : "/kickoffelev"
   ] by process.entity_id
-  [process where event.type in ("start", "process_started") and process.parent.name == "sdclt.exe" and
-     process.executable not in ("C:\\Windows\\System32\\sdclt.exe",
-                                "C:\\Windows\\System32\\control.exe",
-                                "C:\\Windows\\SysWOW64\\sdclt.exe",
-                                "C:\\Windows\\SysWOW64\\control.exe")
+  [process where event.type in ("start", "process_started") and process.parent.name : "sdclt.exe" and
+     not (process.executable : "C:\\Windows\\System32\\sdclt.exe" or
+          process.executable : "C:\\Windows\\System32\\control.exe" or
+          process.executable : "C:\\Windows\\SysWOW64\\sdclt.exe" or
+          process.executable : "C:\\Windows\\SysWOW64\\control.exe")
   ] by process.parent.entity_id
 '''
 

--- a/rules/windows/privilege_escalation_uac_sdclt.toml
+++ b/rules/windows/privilege_escalation_uac_sdclt.toml
@@ -11,7 +11,7 @@ Identifies User Account Control (UAC) bypass via sdclt.exe. Attackers bypass UAC
 elevated permissions.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License"
 name = "Bypass UAC via Sdclt"
@@ -24,7 +24,6 @@ type = "eql"
 query = '''
 sequence with maxspan=1m
   [process where event.type in ("start", "process_started") and process.name == "sdclt.exe" and
-     /* process.code_signature.* fields need to be populated for 7.10 */
      process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true and
      process.args == "/kickoffelev"
   ] by process.entity_id


### PR DESCRIPTION
## Issues
dependent on endgameinc/eql/pull/41
resolves #396

## Summary
Updates EQL rules to reflect changes in EQL implementation and syntax. Rules were also tuned to adapt to missing fields in respective data sources (or the indexes were removed). EQL searches are strict and will fail if a field does not exist in the mapping