### PR TITLE
Remove connection type from endpoint network rules

### DIFF
--- a/rules/linux/lateral_movement_telnet_network_activity_external.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_external.toml
@@ -32,8 +32,8 @@ type = "eql"
 
 query = '''
 sequence by process.entity_id
-  [process where process.name : "telnet" and event.type == "start"]
-  [network where process.name : "telnet" and
+  [process where process.name == "telnet" and event.type == "start"]
+  [network where process.name == "telnet" and
     destination.ip not in ("127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10", "::1/128")]
 '''
 
@@ -50,4 +50,3 @@ reference = "https://attack.mitre.org/techniques/T1021/"
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
-

--- a/rules/linux/lateral_movement_telnet_network_activity_external.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_external.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -30,8 +30,10 @@ tags = ["Elastic", "Host", "Linux", "Threat Detection", "Lateral Movement"]
 type = "eql"
 
 query = '''
-network where process.name : "telnet" and
-  destination.ip not in ("127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10", "::1/128")
+sequence by process.entity_id
+  [process where process.name : "telnet" and event.type == "start"]
+  [network where process.name : "telnet" and
+    destination.ip not in ("127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10", "::1/128")]
 '''
 
 

--- a/rules/linux/lateral_movement_telnet_network_activity_external.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_external.toml
@@ -20,19 +20,18 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Connection to External Network via Telnet"
 risk_score = 47
 rule_id = "e19e64ee-130e-4c07-961f-8a339f0b8362"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Lateral Movement"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:(connection or start) and
-  process.name:telnet and
-  not destination.ip:(127.0.0.0/8 or 10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16 or "FE80::/10" or "::1/128")
+network where process.name : "telnet" and
+  destination.ip not in ("127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10", "::1/128")
 '''
 
 

--- a/rules/linux/lateral_movement_telnet_network_activity_internal.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_internal.toml
@@ -20,20 +20,19 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Connection to Internal Network via Telnet"
 risk_score = 47
 rule_id = "1b21abcc-4d9f-4b08-a7f5-316f5f94b973"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Lateral Movement"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:(connection or start) and
-  process.name:telnet and
-  destination.ip:((10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16 or "FE80::/10") and
-                    not (127.0.0.0/8 or "::1/128"))
+network where process.name : "telnet" and
+  destination.ip in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10") and
+  destination.ip not in ("127.0.0.0/8", "::1/128")
 '''
 
 

--- a/rules/linux/lateral_movement_telnet_network_activity_internal.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_internal.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -30,9 +30,11 @@ tags = ["Elastic", "Host", "Linux", "Threat Detection", "Lateral Movement"]
 type = "eql"
 
 query = '''
-network where process.name : "telnet" and
-  destination.ip in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10") and
-  destination.ip not in ("127.0.0.0/8", "::1/128")
+sequence by process.entity_id
+  [process where process.name : "telnet" and event.type == "start"]
+  [network where process.name : "telnet" and
+    destination.ip in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10") and
+    destination.ip not in ("127.0.0.0/8", "::1/128")]
 '''
 
 

--- a/rules/linux/lateral_movement_telnet_network_activity_internal.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_internal.toml
@@ -32,8 +32,8 @@ type = "eql"
 
 query = '''
 sequence by process.entity_id
-  [process where process.name : "telnet" and event.type == "start"]
-  [network where process.name : "telnet" and
+  [process where process.name == "telnet" and event.type == "start"]
+  [network where process.name == "telnet" and
     destination.ip in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10") and
     destination.ip not in ("127.0.0.0/8", "::1/128")]
 '''
@@ -51,4 +51,3 @@ reference = "https://attack.mitre.org/techniques/T1021/"
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
-

--- a/rules/linux/linux_netcat_network_connection.toml
+++ b/rules/linux/linux_netcat_network_connection.toml
@@ -20,7 +20,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Netcat Network Activity"
 references = [
@@ -32,10 +32,13 @@ risk_score = 47
 rule_id = "adb961e0-cb74-42a0-af9e-29fc41f88f5f"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:(access or connection or start) and
-  process.name:(nc or ncat or netcat or netcat.openbsd or netcat.traditional)
+network where (process.name : "nc" or
+               process.name : "ncat" or
+               process.name : "netcat" or
+               process.name : "netcat.openbsd" or
+               process.name : "netcat.traditional")
 '''
 

--- a/rules/linux/linux_netcat_network_connection.toml
+++ b/rules/linux/linux_netcat_network_connection.toml
@@ -37,10 +37,9 @@ type = "eql"
 
 query = '''
 sequence by process.entity_id
-  [process where (process.name : "nc" or process.name : "ncat" or process.name : "netcat" or
-                  process.name : "netcat.openbsd" or process.name : "netcat.traditional") and
+  [process where (process.name == "nc" or process.name == "ncat" or process.name == "netcat" or
+                  process.name == "netcat.openbsd" or process.name == "netcat.traditional") and
      event.type == "start"]
-  [network where (process.name : "nc" or process.name : "ncat" or process.name : "netcat" or
-                  process.name : "netcat.openbsd" or process.name : "netcat.traditional")]
+  [network where (process.name == "nc" or process.name == "ncat" or process.name == "netcat" or
+                  process.name == "netcat.openbsd" or process.name == "netcat.traditional")]
 '''
-

--- a/rules/linux/linux_netcat_network_connection.toml
+++ b/rules/linux/linux_netcat_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -35,10 +35,11 @@ tags = ["Elastic", "Host", "Linux", "Threat Detection"]
 type = "eql"
 
 query = '''
-network where (process.name : "nc" or
-               process.name : "ncat" or
-               process.name : "netcat" or
-               process.name : "netcat.openbsd" or
-               process.name : "netcat.traditional")
+sequence by process.entity_id
+  [process where (process.name : "nc" or process.name : "ncat" or process.name : "netcat" or
+                  process.name : "netcat.openbsd" or process.name : "netcat.traditional") and
+     event.type == "start"]
+  [network where (process.name : "nc" or process.name : "ncat" or process.name : "netcat" or
+                  process.name : "netcat.openbsd" or process.name : "netcat.traditional")]
 '''
 

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -12,18 +12,18 @@ malware, from a remote URL.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Network Connection via Certutil"
 risk_score = 21
 rule_id = "3838e0e3-1850-4850-a411-2e8c5ba40ba8"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and process.name:certutil.exe and
-  not destination.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+network where process.name : "certutil.exe" and
+  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 '''
 
 

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/19"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,10 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
 type = "eql"
 
 query = '''
-network where process.name : "certutil.exe" and
-  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+sequence by process.entity_id
+  [process where process.name : "certutil.exe" and event.type == "start"]
+  [network where process.name : "certutil.exe" and
+    destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -26,7 +26,7 @@ query = '''
 
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name : "installutil.exe"]
-  [network where event.type == "connection" and process.name : "installutil.exe" and network.direction == "outgoing"]
+  [network where process.name : "installutil.exe" and network.direction == "outgoing"]
 '''
 
 

--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -13,19 +13,21 @@ application allowlists and signature validation.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Network Connection via Signed Binary"
 risk_score = 21
 rule_id = "63e65ec3-43b1-45b0-8f2d-45b34291dc44"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
-  process.name:(expand.exe or extrac.exe or ieexec.exe or makecab.exe) and
-  not destination.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+network where (process.name : "expand.exe" or
+               process.name : "extrac.exe" or
+               process.name : "ieexec.exe" or
+               process.name : "makecab.exe") and
+  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 '''
 
 

--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -23,11 +23,13 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 type = "eql"
 
 query = '''
-network where (process.name : "expand.exe" or
-               process.name : "extrac.exe" or
-               process.name : "ieexec.exe" or
-               process.name : "makecab.exe") and
-  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+sequence by process.entity_id
+  [process where (process.name : "expand.exe" or process.name : "extrac.exe" or
+                 process.name : "ieexec.exe" or process.name : "makecab.exe") and
+     event.type == "start"]
+  [network where (process.name : "expand.exe" or process.name : "extrac.exe" or
+                 process.name : "ieexec.exe" or process.name : "makecab.exe") and
+     destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/defense_evasion_msxsl_beacon.toml
+++ b/rules/windows/defense_evasion_msxsl_beacon.toml
@@ -24,7 +24,7 @@ type = "eql"
 query = '''
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name : "msxsl.exe"]
-  [network where event.type == "connection" and process.name : "msxsl.exe" and network.direction == "outgoing"]
+  [network where process.name : "msxsl.exe" and network.direction == "outgoing"]
 '''
 
 

--- a/rules/windows/defense_evasion_msxsl_beacon.toml
+++ b/rules/windows/defense_evasion_msxsl_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+++ b/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+++ b/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
@@ -46,7 +46,7 @@ sequence by process.entity_id with maxspan=5m
       process.name : "rcsi.exe" or
       process.name : "regsvr32.exe" or
       process.name : "xwizard.exe")]
-  [network where event.type == "connection" and
+  [network where
      (process.name : "bginfo.exe" or
       process.name : "cdb.exe" or
       process.name : "control.exe" or

--- a/rules/windows/defense_evasion_reg_beacon.toml
+++ b/rules/windows/defense_evasion_reg_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_reg_beacon.toml
+++ b/rules/windows/defense_evasion_reg_beacon.toml
@@ -25,7 +25,7 @@ query = '''
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and
      (process.name : "RegAsm.exe" or process.name : "regsvcs.exe" or process.name : "regsvr32.exe")]
-  [network where event.type == "connection" and
+  [network where
      (process.name : "RegAsm.exe" or process.name : "regsvcs.exe" or process.name : "regsvr32.exe")]
 until
   [process where event.type == "end" and

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -28,9 +28,7 @@ sequence with maxspan=1h
      (process.name : "rundll32.exe" /* or process.pe.original_file_name == "RUNDLL32.EXE" */ ) and
      process.args_count < 2
   ] by process.entity_id
-  [process where event.type in ("start", "process_started") and
-                                    /* uncomment once in winlogbeat */
-     (process.name : "rundll32.exe" /* or process.pe.original_file_name == "RUNDLL32.EXE" */ )
+  [process where event.type in ("start", "process_started") and process.parent.name : "rundll32.exe"
   ] by process.parent.entity_id
 '''
 

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -27,7 +27,7 @@ sequence by process.entity_id with maxspan=2h
                                     /* uncomment once in winlogbeat */
      (process.name : "rundll32.exe" /* or process.pe.original_file_name == "RUNDLL32.EXE" */ ) and
      process.args_count < 2]
-  [network where event.type == "connection" and
+  [network where
                                      /* uncomment once in winlogbeat */
      (process.name : "rundll32.exe" /* or process.pe.original_file_name == "RUNDLL32.EXE" */ )]
 '''

--- a/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
+++ b/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -28,8 +28,10 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where process.name : "cmd.exe" and
-  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+sequence by process.entity_id
+  [process where process.name : "cmd.exe" and event.type == "start"]
+  [network where process.name : "cmd.exe" and
+     destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
+++ b/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
@@ -18,19 +18,18 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Command Prompt Network Connection"
 risk_score = 21
 rule_id = "89f9a4b0-9f8f-4ee0-8823-c4751a6d6696"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
-  process.name:cmd.exe and
-  not destination.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+network where process.name : "cmd.exe" and
+  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 '''
 
 

--- a/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -23,8 +23,10 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where process.name : "hh.exe" and
-  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+sequence by process.entity_id
+  [process where process.name : "hh.exe" and event.type == "start"]
+  [network where process.name : "hh.exe" and
+     destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
@@ -13,19 +13,18 @@ program (hh.exe).
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Network Connection via Compiled HTML File"
 risk_score = 21
 rule_id = "b29ee2be-bf99-446c-ab1a-2dc0183394b8"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
-  process.name:hh.exe and
-  not destination.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+network where process.name : "hh.exe" and
+  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 '''
 
 

--- a/rules/windows/execution_msbuild_making_network_connections.toml
+++ b/rules/windows/execution_msbuild_making_network_connections.toml
@@ -12,19 +12,18 @@ leveraged by adversaries to execute code and evade detection.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "MsBuild Making Network Connections"
 risk_score = 47
 rule_id = "0e79980b-4250-4a50-a509-69294c14e84b"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
- process.name:MSBuild.exe and
- not destination.ip:(127.0.0.1 or "::1")
+network where process.name : "MSBuild.exe" and
+ destination.ip not in ("127.0.0.1", "::1")
 '''
 
 

--- a/rules/windows/execution_msbuild_making_network_connections.toml
+++ b/rules/windows/execution_msbuild_making_network_connections.toml
@@ -22,8 +22,10 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where process.name : "MSBuild.exe" and
- destination.ip not in ("127.0.0.1", "::1")
+sequence by process.entity_id
+  [process where process.name : "MSBuild.exe" and event.type == "start"]
+  [network where process.name : "MSBuild.exe" and
+     destination.ip not in ("127.0.0.1", "::1")]
 '''
 
 

--- a/rules/windows/execution_mshta_making_network_connections.toml
+++ b/rules/windows/execution_mshta_making_network_connections.toml
@@ -12,7 +12,7 @@ by adversaries to execute malicious scripts and evade detection.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Network Connection via Mshta"
 references = ["https://www.fireeye.com/blog/threat-research/2017/05/cyber-espionage-apt32.html"]
@@ -20,10 +20,10 @@ risk_score = 47
 rule_id = "a4ec1382-4557-452b-89ba-e413b22ed4b8"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and process.name:mshta.exe
+network where process.name : "mshta.exe"
 '''
 
 

--- a/rules/windows/execution_mshta_making_network_connections.toml
+++ b/rules/windows/execution_mshta_making_network_connections.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,9 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where process.name : "mshta.exe"
+sequence by process.entity_id
+  [process where process.name : "mshta.exe" and event.type == "start"]
+  [network where process.name : "mshta.exe"]
 '''
 
 

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -12,19 +12,18 @@ by adversaries to execute malicious scripts and evade detection.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Network Connection via MsXsl"
 risk_score = 21
 rule_id = "b86afe07-0d98-4738-b15d-8d7465f95ff5"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
-  process.name:msxsl.exe and
-  not destination.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+network where process.name : "msxsl.exe" and
+  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
 '''
 
 

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,10 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where process.name : "msxsl.exe" and
-  destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+sequence by process.entity_id
+  [process where process.name : "msxsl.exe" and event.type == "start"]
+  [network where process.name : "msxsl.exe" and
+     destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_psexec_lateral_movement_command.toml
+++ b/rules/windows/execution_psexec_lateral_movement_command.toml
@@ -18,17 +18,17 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "PsExec Network Connection"
 risk_score = 21
 rule_id = "55d551c6-333b-4665-ab7e-5d14a59715ce"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and process.name:PsExec.exe
+network where process.name : "PsExec.exe"
 '''
 
 

--- a/rules/windows/execution_psexec_lateral_movement_command.toml
+++ b/rules/windows/execution_psexec_lateral_movement_command.toml
@@ -28,7 +28,9 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where process.name : "PsExec.exe"
+sequence by process.entity_id
+  [process where process.name : "PsExec.exe" and event.type == "start"]
+  [network where process.name : "PsExec.exe"]
 '''
 
 

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -18,19 +18,21 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Network Connection via Registration Utility"
 risk_score = 21
 rule_id = "fb02b8d3-71ee-4af1-bacd-215d23f17efa"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
-  process.name:(regsvr32.exe or regsvr64.exe or RegAsm.exe or RegSvcs.exe) and
-  not destination.ip:(10.0.0.0/8 or 169.254.169.254 or 172.16.0.0/12 or 192.168.0.0/16)
+network where (process.name : "regsvr32.exe" or
+                process.name : "regsvr64.exe" or
+                process.name : "RegAsm.exe" or
+                process.name : "RegSvcs.exe") and
+  destination.ip not in ("10.0.0.0/8", "169.254.169.254", "172.16.0.0/12", "192.168.0.0/16")
 '''
 
 

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -28,11 +28,13 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where (process.name : "regsvr32.exe" or
-                process.name : "regsvr64.exe" or
-                process.name : "RegAsm.exe" or
-                process.name : "RegSvcs.exe") and
-  destination.ip not in ("10.0.0.0/8", "169.254.169.254", "172.16.0.0/12", "192.168.0.0/16")
+sequence by process.entity_id
+  [process where (process.name : "regsvr32.exe" or process.name : "regsvr64.exe" or
+                  process.name : "RegAsm.exe" or process.name : "RegSvcs.exe") and
+     event.type == "start"]
+  [network where (process.name : "regsvr32.exe" or process.name : "regsvr64.exe" or
+                  process.name : "RegAsm.exe" or process.name : "RegSvcs.exe") and
+     destination.ip not in ("10.0.0.0/8", "169.254.169.254", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/execution_unusual_network_connection_via_rundll32.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,10 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where process.name : "rundll32.exe" and
-  destination.ip not in ("10.0.0.0/8",  "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8")
+sequence by process.entity_id
+  [process where process.name : "rundll32.exe" and event.type == "start"]
+  [network where process.name : "rundll32.exe" and
+     destination.ip not in ("10.0.0.0/8",  "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8")]
 '''
 
 

--- a/rules/windows/execution_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/execution_unusual_network_connection_via_rundll32.toml
@@ -12,19 +12,18 @@ and may identify malicious DLLs.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Unusual Network Connection via RunDLL32"
 risk_score = 21
 rule_id = "52aaab7b-b51c-441a-89ce-4387b3aea886"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
-  process.name:rundll32.exe and
-  not destination.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16 or 127.0.0.0/8)
+network where process.name : "rundll32.exe" and
+  destination.ip not in ("10.0.0.0/8",  "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8")
 '''
 
 

--- a/rules/windows/execution_unusual_process_network_connection.toml
+++ b/rules/windows/execution_unusual_process_network_connection.toml
@@ -12,19 +12,28 @@ applications are often leveraged by adversaries to execute code and evade detect
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Unusual Process Network Connection"
 risk_score = 21
 rule_id = "610949a1-312f-4e04-bb55-3a79b8c95267"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
-  process.name:(Microsoft.Workflow.Compiler.exe or bginfo.exe or cdb.exe or cmstp.exe or csi.exe or dnx.exe or
-                fsi.exe or ieexec.exe or iexpress.exe or odbcconf.exe or rcsi.exe or xwizard.exe)
+network where (process.name : "Microsoft.Workflow.Compiler.exe" or
+               process.name : "bginfo.exe" or
+               process.name : "cdb.exe" or
+               process.name : "cmstp.exe" or
+               process.name : "csi.exe" or
+               process.name : "dnx.exe" or
+               process.name : "fsi.exe" or
+               process.name : "ieexec.exe" or
+               process.name : "iexpress.exe" or
+               process.name : "odbcconf.exe" or
+               process.name : "rcsi.exe" or
+               process.name : "xwizard.exe")
 '''
 
 

--- a/rules/windows/execution_unusual_process_network_connection.toml
+++ b/rules/windows/execution_unusual_process_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -22,18 +22,32 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 type = "eql"
 
 query = '''
-network where (process.name : "Microsoft.Workflow.Compiler.exe" or
-               process.name : "bginfo.exe" or
-               process.name : "cdb.exe" or
-               process.name : "cmstp.exe" or
-               process.name : "csi.exe" or
-               process.name : "dnx.exe" or
-               process.name : "fsi.exe" or
-               process.name : "ieexec.exe" or
-               process.name : "iexpress.exe" or
-               process.name : "odbcconf.exe" or
-               process.name : "rcsi.exe" or
-               process.name : "xwizard.exe")
+sequence by process.entity_id
+  [process where (process.name : "Microsoft.Workflow.Compiler.exe" or
+                  process.name : "bginfo.exe" or
+                  process.name : "cdb.exe" or
+                  process.name : "cmstp.exe" or
+                  process.name : "csi.exe" or
+                  process.name : "dnx.exe" or
+                  process.name : "fsi.exe" or
+                  process.name : "ieexec.exe" or
+                  process.name : "iexpress.exe" or
+                  process.name : "odbcconf.exe" or
+                  process.name : "rcsi.exe" or
+                  process.name : "xwizard.exe") and
+     event.type == "start"]
+  [network where (process.name : "Microsoft.Workflow.Compiler.exe" or
+                  process.name : "bginfo.exe" or
+                  process.name : "cdb.exe" or
+                  process.name : "cmstp.exe" or
+                  process.name : "csi.exe" or
+                  process.name : "dnx.exe" or
+                  process.name : "fsi.exe" or
+                  process.name : "ieexec.exe" or
+                  process.name : "iexpress.exe" or
+                  process.name : "odbcconf.exe" or
+                  process.name : "rcsi.exe" or
+                  process.name : "xwizard.exe")]
 '''
 
 

--- a/rules/windows/execution_wpad_exploitation.toml
+++ b/rules/windows/execution_wpad_exploitation.toml
@@ -30,7 +30,7 @@ sequence with maxspan=5s
      user.domain == "NT AUTHORITY" and user.name == "LOCAL SERVICE"] by process.entity_id
   [network where network.protocol == "dns" and process.name : "svchost.exe" and
      dns.question.name : "wpad" and process.name : "svchost.exe"] by process.entity_id
-  [network where event.type == "connection" and process.name : "svchost.exe"
+  [network where process.name : "svchost.exe"
      and network.direction == "outgoing" and destination.port == 80] by process.entity_id
   [library where event.type == "start" and process.name : "svchost.exe" and
      file.name : "jscript.dll" and process.name : "svchost.exe"] by process.entity_id

--- a/rules/windows/lateral_movement_cmd_service.toml
+++ b/rules/windows/lateral_movement_cmd_service.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_cmd_service.toml
+++ b/rules/windows/lateral_movement_cmd_service.toml
@@ -32,7 +32,7 @@ sequence by process.entity_id with maxspan=1m
        process.args : "config" or
        process.args : "failure" or
        process.args : "start")]
-  [network where event.type == "connection" and process.name : "sc.exe" and destination.ip != "127.0.0.1"]
+  [network where process.name : "sc.exe" and destination.ip != "127.0.0.1"]
 '''
 
 

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/10/28"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,10 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
 type = "eql"
 
 query = '''
-network where destination.port == 445 and
-  process.pid != 4 and
-  destination.ip not in ("127.0.0.1", "::1")
+sequence by process.entity_id
+  [process where event.type == "start" and process.pid != 4]
+  [network where destination.port == 445 and process.pid != 4 and
+     destination.ip not in ("127.0.0.1", "::1")]
 '''
 
 

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -14,20 +14,19 @@ suspicious user-level processes moving laterally.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
 name = "Direct Outbound SMB Connection"
 risk_score = 47
 rule_id = "c82c7d8f-fb9e-4874-a4bd-fd9e3f9becf1"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:connection and
-  destination.port:445 and
-  not process.pid:4 and
-  not destination.ip:(127.0.0.1 or "::1")
+network where destination.port == 445 and
+  process.pid != 4 and
+  destination.ip not in ("127.0.0.1", "::1")
 '''
 
 


### PR DESCRIPTION
## Issues
resolves #419

## Summary
Modified all rules using the index `logs-endpoint.events.*` (or `winlogbeat-*` which can be compatible with endpoint) that were using `event.type:connection` for network events.

For just about all of these modified rules, the use of `event.type` was used to limit the number of alerts by restricting to only a subset of network events. Even with the `event.type` defined, the rules would still trigger many alerts. The best way to limit this is to use an `eql` sequence off the process `start` event, which would limit it to a single alert.

Also, see the issue for inconsistencies across the two data sources.