### PR TITLE
[Rule Tuning] Zoom Meeting with no Passcode to production

### DIFF
--- a/etc/non-ecs-schema.json
+++ b/etc/non-ecs-schema.json
@@ -9,5 +9,12 @@
   },
   "winlogbeat-*": {
     "winlog.event_data.OriginalFileName": "keyword"
+  },
+  "filebeat-*": {
+    "zoom": {
+      "meeting": {
+        "password": "keyword"
+      }
+    }
   }
 }

--- a/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
+++ b/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
@@ -1,8 +1,7 @@
 [metadata]
 creation_date = "2020/09/14"
 ecs_version = ["1.6.0"]
-maturity = "development"
-query_schema_validation = false
+maturity = "production"
 updated_date = "2020/10/26"
 
 [rule]
@@ -38,8 +37,8 @@ tags = [
 type = "query"
 
 query = '''
-event.type:creation and event.module:zoom and event.dataset:zoom.webhook
- and event.action:meeting.created and not zoom.meeting.password:*
+event.type:creation and event.module:zoom and event.dataset:zoom.webhook and
+  event.action:meeting.created and not zoom.meeting.password:*
 '''
 
 


### PR DESCRIPTION
## Issues
None

## Summary
Zoom module was added to filebeat in this [PR](https://github.com/elastic/beats/pull/20414/files), which will be released with 7.10. Because the beats module could not be validated at the time the rule was created, this was placed in development. I temporarily added the field to the `non-ecs-schema` for the time being and once beats 7.10 is released, we can refresh the consolidated schema and remove this.