### PR TITLE
[Rule Tuning] Use cidrMatch for eql rules checking multiple IPs

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -76,7 +76,8 @@ class Rule(object):
             if self.contents['language'] == 'kuery':
                 return kql.parse(self.query)
             elif self.contents['language'] == 'eql':
-                with eql.parser.elasticsearch_syntax:
+                # TODO: remove once py-eql supports ipv6 for cidrmatch
+                with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions:
                     return eql.parse_query(self.query)
 
     @property
@@ -125,7 +126,8 @@ class Rule(object):
         query = rule_contents.get('query')
         language = rule_contents.get('language')
         if language in ('kuery', 'eql'):
-            with eql.parser.elasticsearch_syntax:
+            # TODO: remove once py-eql supports ipv6 for cidrmatch
+            with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions:
                 parsed = kql.parse(query) if language == 'kuery' else eql.parse_query(query)
 
             return sorted(set(str(f) for f in parsed if isinstance(f, (eql.ast.Field, kql.ast.Field))))
@@ -205,7 +207,8 @@ class Rule(object):
     @cached
     def _validate_eql(ecs_versions, indexes, query, name):
         # validate against all specified schemas or the latest if none specified
-        with eql.parser.elasticsearch_syntax:
+        # TODO: remove once py-eql supports ipv6 for cidrmatch
+        with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions:
             parsed = eql.parse_query(query)
 
         beat_types = [index.split("-")[0] for index in indexes if "beat-*" in index]
@@ -223,7 +226,8 @@ class Rule(object):
 
         for schema in schemas:
             try:
-                with ecs.KqlSchema2Eql(schema), eql.parser.elasticsearch_syntax:
+                # TODO: remove once py-eql supports ipv6 for cidrmatch
+                with ecs.KqlSchema2Eql(schema), eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions:
                     eql.parse_query(query)
 
             except eql.EqlTypeMismatchError:

--- a/rules/linux/lateral_movement_telnet_network_activity_external.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_external.toml
@@ -34,7 +34,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name == "telnet" and event.type == "start"]
   [network where process.name == "telnet" and
-    not cidrMatch(destination.ip, "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
+    not cidrmatch(destination.ip, "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
                                   "192.168.0.0/16", "FE80::/10", "::1/128")]
 '''
 

--- a/rules/linux/lateral_movement_telnet_network_activity_external.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_external.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -34,7 +34,8 @@ query = '''
 sequence by process.entity_id
   [process where process.name == "telnet" and event.type == "start"]
   [network where process.name == "telnet" and
-    destination.ip not in ("127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10", "::1/128")]
+    not cidrMatch(destination.ip, "127.0.0.0/8", "10.0.0.0/8", "172.16.0.0/12",
+                                  "192.168.0.0/16", "FE80::/10", "::1/128")]
 '''
 
 

--- a/rules/linux/lateral_movement_telnet_network_activity_internal.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_internal.toml
@@ -34,8 +34,8 @@ query = '''
 sequence by process.entity_id
   [process where process.name == "telnet" and event.type == "start"]
   [network where process.name == "telnet" and
-    cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10") and
-    not cidrMatch(destination.ip, "127.0.0.0/8", "::1/128")]
+    cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10") and
+    not cidrmatch(destination.ip, "127.0.0.0/8", "::1/128")]
 '''
 
 

--- a/rules/linux/lateral_movement_telnet_network_activity_internal.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_internal.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -34,8 +34,8 @@ query = '''
 sequence by process.entity_id
   [process where process.name == "telnet" and event.type == "start"]
   [network where process.name == "telnet" and
-    destination.ip in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10") and
-    destination.ip not in ("127.0.0.0/8", "::1/128")]
+    cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "FE80::/10") and
+    not cidrMatch(destination.ip, "127.0.0.0/8", "::1/128")]
 '''
 
 

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/19"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "certutil.exe" and event.type == "start"]
   [network where process.name : "certutil.exe" and
-    destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+    cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "certutil.exe" and event.type == "start"]
   [network where process.name : "certutil.exe" and
-    cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+    cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "certutil.exe" and event.type == "start"]
   [network where process.name : "certutil.exe" and
-    cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+    not cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 
@@ -42,4 +42,3 @@ reference = "https://attack.mitre.org/techniques/T1105/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
-

--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -30,7 +30,7 @@ sequence by process.entity_id
      event.type == "start"]
   [network where (process.name : "expand.exe" or process.name : "extrac.exe" or
                  process.name : "ieexec.exe" or process.name : "makecab.exe") and
-     cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -30,7 +30,7 @@ sequence by process.entity_id
      event.type == "start"]
   [network where (process.name : "expand.exe" or process.name : "extrac.exe" or
                  process.name : "ieexec.exe" or process.name : "makecab.exe") and
-     destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -30,7 +30,7 @@ sequence by process.entity_id
      event.type == "start"]
   [network where (process.name : "expand.exe" or process.name : "extrac.exe" or
                  process.name : "ieexec.exe" or process.name : "makecab.exe") and
-     cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 
@@ -58,4 +58,3 @@ reference = "https://attack.mitre.org/techniques/T1218/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
-

--- a/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
+++ b/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -32,7 +32,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "cmd.exe" and event.type == "start"]
   [network where process.name : "cmd.exe" and
-     destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
+++ b/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
@@ -32,7 +32,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "cmd.exe" and event.type == "start"]
   [network where process.name : "cmd.exe" and
-     not cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -27,7 +27,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "hh.exe" and event.type == "start"]
   [network where process.name : "hh.exe" and
-     destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
@@ -27,7 +27,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "hh.exe" and event.type == "start"]
   [network where process.name : "hh.exe" and
-     not cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_msbuild_making_network_connections.toml
+++ b/rules/windows/execution_msbuild_making_network_connections.toml
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "MSBuild.exe" and event.type == "start"]
   [network where process.name : "MSBuild.exe" and
-     not cidrMatch(destination.ip, "127.0.0.1", "::1")]
+     not cidrmatch(destination.ip, "127.0.0.1", "::1")]
 '''
 
 

--- a/rules/windows/execution_msbuild_making_network_connections.toml
+++ b/rules/windows/execution_msbuild_making_network_connections.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "MSBuild.exe" and event.type == "start"]
   [network where process.name : "MSBuild.exe" and
-     destination.ip not in ("127.0.0.1", "::1")]
+     not cidrMatch(destination.ip, "127.0.0.1", "::1")]
 '''
 
 

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "msxsl.exe" and event.type == "start"]
   [network where process.name : "msxsl.exe" and
-     destination.ip not in ("10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "msxsl.exe" and event.type == "start"]
   [network where process.name : "msxsl.exe" and
-     not cidrMatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrmatch(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -35,7 +35,7 @@ sequence by process.entity_id
      event.type == "start"]
   [network where (process.name : "regsvr32.exe" or process.name : "regsvr64.exe" or
                   process.name : "RegAsm.exe" or process.name : "RegSvcs.exe") and
-     not cidrMatch(destination.ip, "10.0.0.0/8", "169.254.169.254", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrmatch(destination.ip, "10.0.0.0/8", "169.254.169.254", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -35,7 +35,7 @@ sequence by process.entity_id
      event.type == "start"]
   [network where (process.name : "regsvr32.exe" or process.name : "regsvr64.exe" or
                   process.name : "RegAsm.exe" or process.name : "RegSvcs.exe") and
-     destination.ip not in ("10.0.0.0/8", "169.254.169.254", "172.16.0.0/12", "192.168.0.0/16")]
+     not cidrMatch(destination.ip, "10.0.0.0/8", "169.254.169.254", "172.16.0.0/12", "192.168.0.0/16")]
 '''
 
 

--- a/rules/windows/execution_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/execution_unusual_network_connection_via_rundll32.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "rundll32.exe" and event.type == "start"]
   [network where process.name : "rundll32.exe" and
-     destination.ip not in ("10.0.0.0/8",  "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8")]
+     not cidrMatch(destination.ip, "10.0.0.0/8",  "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8")]
 '''
 
 

--- a/rules/windows/execution_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/execution_unusual_network_connection_via_rundll32.toml
@@ -26,7 +26,7 @@ query = '''
 sequence by process.entity_id
   [process where process.name : "rundll32.exe" and event.type == "start"]
   [network where process.name : "rundll32.exe" and
-     not cidrMatch(destination.ip, "10.0.0.0/8",  "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8")]
+     not cidrmatch(destination.ip, "10.0.0.0/8",  "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8")]
 '''
 
 

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -28,7 +28,7 @@ query = '''
 sequence by process.entity_id
   [process where event.type == "start" and process.pid != 4]
   [network where destination.port == 445 and process.pid != 4 and
-     not cidrMatch(destination.ip, "127.0.0.1", "::1")]
+     not cidrmatch(destination.ip, "127.0.0.1", "::1")]
 '''
 
 

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/10/29"
 
 [rule]
 author = ["Elastic"]
@@ -28,7 +28,7 @@ query = '''
 sequence by process.entity_id
   [process where event.type == "start" and process.pid != 4]
   [network where destination.port == 445 and process.pid != 4 and
-     destination.ip not in ("127.0.0.1", "::1")]
+     not cidrMatch(destination.ip, "127.0.0.1", "::1")]
 '''
 
 


### PR DESCRIPTION
## Issues
None

## Summary
EQL currently does not support comparing `ip` fields using `in`, so all EQL rules checking for multiple IP addresses using the convention `*.ip in ( ... )` must be converted to use `cidrMatch()` (or individual comparisons).