### PR TITLE
[Rule Tuning] Remove duplicate rules after EQL conversion

### DIFF
--- a/rules/windows/defense_evasion_msbuild_beacon_sequence.toml
+++ b/rules/windows/defense_evasion_msbuild_beacon_sequence.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
-maturity = "production"
+maturity = "development"
 updated_date = "2020/10/27"
 
 [rule]
@@ -23,6 +23,8 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "eql"
 
 query = '''
+/* duplicate of MsBuild Making Network Connections - 0e79980b-4250-4a50-a509-69294c14e84b */
+
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name : "MSBuild.exe"]
   [network where process.name : "MSBuild.exe" and

--- a/rules/windows/defense_evasion_msxsl_beacon.toml
+++ b/rules/windows/defense_evasion_msxsl_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
-maturity = "production"
+maturity = "development"
 updated_date = "2020/10/28"
 
 [rule]
@@ -23,6 +23,8 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "eql"
 
 query = '''
+/* duplicate of Network Connection via MsXsl - b86afe07-0d98-4738-b15d-8d7465f95ff5 */
+
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name : "msxsl.exe"]
   [network where process.name : "msxsl.exe" and network.direction == "outgoing"]

--- a/rules/windows/defense_evasion_reg_beacon.toml
+++ b/rules/windows/defense_evasion_reg_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
-maturity = "production"
+maturity = "development"
 updated_date = "2020/10/28"
 
 [rule]
@@ -23,6 +23,8 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "eql"
 
 query = '''
+/* duplicate of Network Connection via Registration Utility - fb02b8d3-71ee-4af1-bacd-215d23f17efa */
+
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and
      (process.name : "RegAsm.exe" or process.name : "regsvcs.exe" or process.name : "regsvr32.exe")]

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
-maturity = "production"
+maturity = "development"
 updated_date = "2020/10/28"
 
 [rule]
@@ -23,6 +23,8 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "eql"
 
 query = '''
+/* Unusual Network Connection via RunDLL32 - 52aaab7b-b51c-441a-89ce-4387b3aea886 */
+
 sequence by process.entity_id with maxspan=2h
   [process where event.type in ("start", "process_started") and
                                     /* uncomment once in winlogbeat */

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -23,7 +23,7 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "eql"
 
 query = '''
-/* Unusual Network Connection via RunDLL32 - 52aaab7b-b51c-441a-89ce-4387b3aea886 */
+/* duplicate of Unusual Network Connection via RunDLL32 - 52aaab7b-b51c-441a-89ce-4387b3aea886 */
 
 sequence by process.entity_id with maxspan=2h
   [process where event.type in ("start", "process_started") and

--- a/rules/windows/execution_mshta_making_network_connections.toml
+++ b/rules/windows/execution_mshta_making_network_connections.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
-maturity = "production"
+maturity = "development"
 updated_date = "2020/10/28"
 
 [rule]
@@ -24,6 +24,8 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "eql"
 
 query = '''
+/* duplicate of Mshta Making Network Connections - c2d90150-0133-451c-a783-533e736c12d7 */
+
 sequence by process.entity_id
   [process where process.name : "mshta.exe" and event.type == "start"]
   [network where process.name : "mshta.exe"]

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/18"
 ecs_version = ["1.6.0"]
-maturity = "development"
+maturity = "production"
 updated_date = "2020/10/29"
 
 [rule]
@@ -23,8 +23,6 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "eql"
 
 query = '''
-/* duplicate of MsXsl Making Network Connections - 870d1753-1078-403e-92d4-735f142edcca */
-
 sequence by process.entity_id
   [process where process.name : "msxsl.exe" and event.type == "start"]
   [network where process.name : "msxsl.exe" and

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/18"
 ecs_version = ["1.6.0"]
-maturity = "production"
+maturity = "development"
 updated_date = "2020/10/29"
 
 [rule]
@@ -23,6 +23,8 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "eql"
 
 query = '''
+/* duplicate of MsXsl Making Network Connections - 870d1753-1078-403e-92d4-735f142edcca */
+
 sequence by process.entity_id
   [process where process.name : "msxsl.exe" and event.type == "start"]
   [network where process.name : "msxsl.exe" and

--- a/rules/windows/execution_wpad_exploitation.toml
+++ b/rules/windows/execution_wpad_exploitation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
-maturity = "production"
+maturity = "development"
 updated_date = "2020/10/27"
 
 [rule]
@@ -25,6 +25,7 @@ type = "eql"
 
 query = '''
 /* preference would be to use user.sid rather than domain+name, once it is available in ECS + datasources */
+/* didn't trigger successfully during testing */
 
 sequence with maxspan=5s
   [process where event.type in ("start", "process_started") and process.name : "svchost.exe" and

--- a/rules/windows/privilege_escalation_uac_sdclt.toml
+++ b/rules/windows/privilege_escalation_uac_sdclt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
-maturity = "production"
+maturity = "development"
 updated_date = "2020/10/27"
 
 [rule]
@@ -24,6 +24,7 @@ type = "eql"
 
 query = '''
 /* add winlogbeat-* when process.code_signature.* fields are populated */
+/* still needs testing, applicable binary was not available on test machine */
 
 sequence with maxspan=1m
   [process where event.type in ("start", "process_started") and process.name : "sdclt.exe" and


### PR DESCRIPTION
## Summary
Upon testing of EQL rules for 7.10, and after the conversion of various KQL rules to EQL, we noticed some rules that we're duplicative. This PR drops those rules to `development`. This will allow us to re-work the syntax or deprecate those rules in the future, without them going into production this release.  

**Duplicative rules:**
`MsBuild Network Connection Sequence`
`Network Connection via Mshta`
`MsXsl Making Network Connections`
`Registration Tool Making Network Connections`
`Unusual Network Connection Sequence via RunDLL32`

Two other rules need additional testing and will also be dropped to dev for 7.10 - 
`Bypass UAC via Sdclt`
`WPAD Service Exploit`

After dropping all these to development, that leaves us with a total of 24 EQL rules for 7.10.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
