### PR TITLE
[Rule Tuning] Remove all rule timelines

### DIFF
--- a/rules/linux/credential_access_tcpdump_activity.toml
+++ b/rules/linux/credential_access_tcpdump_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 21
 rule_id = "7a137d76-ce3d-48e2-947d-2747796a78c0"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Credential Access"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/24"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "125417b8-d3df-479f-8418-12d7e034fee3"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/27"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "2f8a1226-5720-437d-9c20-e0029deb6194"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/17"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 21
 rule_id = "debff20a-46bc-4a4d-bae5-5cdd14222795"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/17"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 21
 rule_id = "97f22dab-84e8-409d-955e-dacd1d31670b"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
+++ b/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/04"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "7bcbb3ac-e533-41ad-a612-d6c3bf666aba"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_disable_selinux_attempt.toml
+++ b/rules/linux/defense_evasion_disable_selinux_attempt.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/22"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "eb9eb8ba-a983-41d9-9c93-a1c05112ca5e"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_file_deletion_via_shred.toml
+++ b/rules/linux/defense_evasion_file_deletion_via_shred.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/27"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "a1329140-8de3-4445-9f87-908fb6d824f4"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_file_mod_writable_dir.toml
+++ b/rules/linux/defense_evasion_file_mod_writable_dir.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -25,8 +25,6 @@ risk_score = 21
 rule_id = "9f9a2a82-93a8-4b1a-8778-1780895626d4"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/17"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 21
 rule_id = "a9198571-b135-4a76-b055-e3e5a476fd83"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/29"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,6 @@ risk_score = 47
 rule_id = "b9666521-4742-49ce-9ddc-b8e84c35acae"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_kernel_module_removal.toml
+++ b/rules/linux/defense_evasion_kernel_module_removal.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/24"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,6 @@ risk_score = 73
 rule_id = "cd66a5af-e34b-4bb0-8931-57d0a043f2ef"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/discovery_kernel_module_enumeration.toml
+++ b/rules/linux/discovery_kernel_module_enumeration.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 47
 rule_id = "2d8043ed-5bda-4caf-801c-c1feb7410504"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Discovery"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/discovery_virtual_machine_fingerprinting.toml
+++ b/rules/linux/discovery_virtual_machine_fingerprinting.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/27"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 73
 rule_id = "5b03c9fb-9945-4d2f-9568-fd690fee3fba"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Discovery"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/discovery_whoami_commmand.toml
+++ b/rules/linux/discovery_whoami_commmand.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -25,8 +25,6 @@ risk_score = 21
 rule_id = "120559c6-5e24-49f4-9e30-8ffe697df6b9"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Discovery"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/execution_perl_tty_shell.toml
+++ b/rules/linux/execution_perl_tty_shell.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/16"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 73
 rule_id = "05e5a668-7b51-4a67-93ab-e9af405c9ef3"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/15"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 73
 rule_id = "d76b02ef-fc95-4001-9297-01cb7412232f"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/lateral_movement_telnet_network_activity_external.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_external.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,6 @@ risk_score = 47
 rule_id = "e19e64ee-130e-4c07-961f-8a339f0b8362"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Lateral Movement"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/linux/lateral_movement_telnet_network_activity_internal.toml
+++ b/rules/linux/lateral_movement_telnet_network_activity_internal.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,6 @@ risk_score = 47
 rule_id = "1b21abcc-4d9f-4b08-a7f5-316f5f94b973"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Lateral Movement"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/linux/linux_hping_activity.toml
+++ b/rules/linux/linux_hping_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 73
 rule_id = "90169566-2260-4824-b8e4-8615c3b4ed52"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_iodine_activity.toml
+++ b/rules/linux/linux_iodine_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 73
 rule_id = "041d4d41-9589-43e2-ba13-5680af75ebc2"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_mknod_activity.toml
+++ b/rules/linux/linux_mknod_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -28,8 +28,6 @@ risk_score = 21
 rule_id = "61c31c14-507f-4627-8c31-072556b89a9c"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_netcat_network_connection.toml
+++ b/rules/linux/linux_netcat_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -32,8 +32,6 @@ risk_score = 47
 rule_id = "adb961e0-cb74-42a0-af9e-29fc41f88f5f"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/linux/linux_nmap_activity.toml
+++ b/rules/linux/linux_nmap_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -28,8 +28,6 @@ risk_score = 21
 rule_id = "c87fca17-b3a9-4e83-b545-f30746c53920"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_nping_activity.toml
+++ b/rules/linux/linux_nping_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 47
 rule_id = "0d69150b-96f8-467c-a86d-a67a3378ce77"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_process_started_in_temp_directory.toml
+++ b/rules/linux/linux_process_started_in_temp_directory.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 47
 rule_id = "df959768-b0c9-4d45-988c-5606a2be8e5a"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_socat_activity.toml
+++ b/rules/linux/linux_socat_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,6 @@ risk_score = 47
 rule_id = "cd4d5754-07e1-41d4-b9a5-ef4ea6a0a126"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_strace_activity.toml
+++ b/rules/linux/linux_strace_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 21
 rule_id = "d6450d4e-81c6-46a3-bd94-079886318ed5"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/persistence_kernel_module_activity.toml
+++ b/rules/linux/persistence_kernel_module_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -25,8 +25,6 @@ risk_score = 21
 rule_id = "81cc58f5-8062-49a2-ba84-5cc4b4d31c40"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/persistence_shell_activity_by_web_server.toml
+++ b/rules/linux/persistence_shell_activity_by_web_server.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -23,8 +23,6 @@ risk_score = 47
 rule_id = "231876e7-4d1f-4d63-a47c-47dd1acdc1cb"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 21
 rule_id = "3a86e085-094c-412d-97ff-2439731e59cb"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Privilege Escalation"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/23"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 21
 rule_id = "8a1b0278-0f9a-487d-96bd-d4833298e87a"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Privilege Escalation"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/macos/credential_access_compress_credentials_keychains.toml
+++ b/rules/macos/credential_access_compress_credentials_keychains.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -21,8 +21,6 @@ risk_score = 73
 rule_id = "96e90768-c3b7-4df6-b5d9-6237f8bc36a8"
 severity = "high"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Credential Access"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/macos/credential_access_kerberosdump_kcc.toml
+++ b/rules/macos/credential_access_kerberosdump_kcc.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "ad88231f-e2ab-491c-8fc6-64746da26cfe"
 severity = "high"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Credential Access"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
+++ b/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "5ae4e6f8-d1bf-40fa-96ba-e29645e1e4dc"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Lateral Movement"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_cobalt_strike_beacon.toml
+++ b/rules/network/command_and_control_cobalt_strike_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/06"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -30,8 +30,6 @@ risk_score = 73
 rule_id = "cf53f532-9cc9-445a-9ae7-fced307ec53c"
 severity = "high"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_dns_directly_to_the_internet.toml
+++ b/rules/network/command_and_control_dns_directly_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -33,8 +33,6 @@ risk_score = 47
 rule_id = "6ea71ff0-9e95-475b-9506-2580d1ce6154"
 severity = "medium"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_download_rar_powershell_from_internet.toml
+++ b/rules/network/command_and_control_download_rar_powershell_from_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -31,8 +31,6 @@ risk_score = 47
 rule_id = "ff013cb4-274d-434a-96bb-fe15ddd3ae92"
 severity = "medium"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/06"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -28,8 +28,6 @@ risk_score = 73
 rule_id = "4a4e23cf-78a2-449c-bac3-701924c269d3"
 severity = "high"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_ftp_file_transfer_protocol_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_ftp_file_transfer_protocol_activity_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -30,8 +30,6 @@ risk_score = 21
 rule_id = "87ec6396-9ac4-4706-bcf0-2ebb22002f43"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_halfbaked_beacon.toml
+++ b/rules/network/command_and_control_halfbaked_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/06"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,6 @@ risk_score = 73
 rule_id = "2e580225-2a58-48ef-938b-572933be06fe"
 severity = "high"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_irc_internet_relay_chat_protocol_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_irc_internet_relay_chat_protocol_activity_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,6 @@ risk_score = 47
 rule_id = "c6474c34-4953-447a-903e-9fcb7b6661aa"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_nat_traversal_port_activity.toml
+++ b/rules/network/command_and_control_nat_traversal_port_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -28,8 +28,6 @@ risk_score = 21
 rule_id = "a9cb3641-ff4b-4cdc-a063-b4b8d02a67c7"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_port_26_activity.toml
+++ b/rules/network/command_and_control_port_26_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,6 @@ risk_score = 21
 rule_id = "d7e62693-aab9-4f66-a21a-3d79ecdd603d"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_port_8000_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_port_8000_activity_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -28,8 +28,6 @@ risk_score = 21
 rule_id = "08d5d7e2-740f-44d8-aeda-e41f4263efaf"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_pptp_point_to_point_tunneling_protocol_activity.toml
+++ b/rules/network/command_and_control_pptp_point_to_point_tunneling_protocol_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,6 @@ risk_score = 21
 rule_id = "d2053495-8fe7-4168-b3df-dad844046be3"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_proxy_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_proxy_port_activity_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -31,8 +31,6 @@ risk_score = 47
 rule_id = "ad0e5e75-dd89-4875-8d0a-dfdc1828b5f3"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_rdp_remote_desktop_protocol_from_the_internet.toml
+++ b/rules/network/command_and_control_rdp_remote_desktop_protocol_from_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -30,8 +30,6 @@ risk_score = 47
 rule_id = "8c1bdde8-4204-45c0-9e0c-c85ca3902488"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_smtp_to_the_internet.toml
+++ b/rules/network/command_and_control_smtp_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 21
 rule_id = "67a9beba-830d-4035-bfe8-40b7e28f8ac4"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,6 @@ risk_score = 47
 rule_id = "139c7458-566a-410c-a5cd-f80238d6a5cd"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_ssh_secure_shell_from_the_internet.toml
+++ b/rules/network/command_and_control_ssh_secure_shell_from_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -30,8 +30,6 @@ risk_score = 47
 rule_id = "ea0784f0-a4d7-4fea-ae86-4baaf27a6f17"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_ssh_secure_shell_to_the_internet.toml
+++ b/rules/network/command_and_control_ssh_secure_shell_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,6 @@ risk_score = 21
 rule_id = "6f1500bc-62d7-4eb9-8601-7485e87da2f4"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_telnet_port_activity.toml
+++ b/rules/network/command_and_control_telnet_port_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,6 @@ risk_score = 47
 rule_id = "34fde489-94b0-4500-a76f-b8a157cf9269"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_tor_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_tor_activity_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,6 @@ risk_score = 47
 rule_id = "7d2c38d7-ede7-4bdf-b140-445906e6c540"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_vnc_virtual_network_computing_from_the_internet.toml
+++ b/rules/network/command_and_control_vnc_virtual_network_computing_from_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -28,8 +28,6 @@ risk_score = 73
 rule_id = "5700cb81-df44-46aa-a5d7-337798f53eb8"
 severity = "high"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_vnc_virtual_network_computing_to_the_internet.toml
+++ b/rules/network/command_and_control_vnc_virtual_network_computing_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -28,8 +28,6 @@ risk_score = 47
 rule_id = "3ad49c61-7adc-42c1-b788-732eda2f5abf"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/discovery_post_exploitation_public_ip_reconnaissance.toml
+++ b/rules/network/discovery_post_exploitation_public_ip_reconnaissance.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/04"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -30,8 +30,6 @@ risk_score = 21
 rule_id = "1d72d014-e2ab-4707-b056-9b96abe7b511"
 severity = "low"
 tags = ["Elastic", "Network", "Threat Detection", "Discovery"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_rdp_remote_desktop_protocol_to_the_internet.toml
+++ b/rules/network/initial_access_rdp_remote_desktop_protocol_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,6 @@ risk_score = 21
 rule_id = "e56993d2-759c-4120-984c-9ec9bb940fd5"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Initial Access"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_rpc_remote_procedure_call_from_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_from_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "143cb236-0956-4f42-a706-814bcaa0cf5a"
 severity = "high"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Initial Access"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "32923416-763a-4531-bb35-f33b9232ecdb"
 severity = "high"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Initial Access"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_smb_windows_file_sharing_activity_to_the_internet.toml
+++ b/rules/network/initial_access_smb_windows_file_sharing_activity_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "c82b2bd8-d701-420c-ba43-f11a155b681a"
 severity = "high"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Initial Access"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_unsecure_elasticsearch_node.toml
+++ b/rules/network/initial_access_unsecure_elasticsearch_node.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/11"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,6 @@ risk_score = 47
 rule_id = "31295df3-277b-4c56-a1fb-84e31b4222a9"
 severity = "medium"
 tags = ["Elastic", "Network", "Threat Detection", "Initial Access"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/elastic_endpoint.toml
+++ b/rules/promotions/elastic_endpoint.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/08"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ rule_id = "9a1a2dae-0b5f-4c3d-8305-a268d404c306"
 rule_name_override = "message"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/promotions/endpoint_adversary_behavior_detected.toml
+++ b/rules/promotions/endpoint_adversary_behavior_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "77a3c3df-8ec4-4da4-b758-878f551dee69"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_dumping_detected.toml
+++ b/rules/promotions/endpoint_cred_dumping_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "571afc56-5ed9-465d-a2a9-045f099f6e7e"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_dumping_prevented.toml
+++ b/rules/promotions/endpoint_cred_dumping_prevented.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "db8c33a8-03cd-4988-9e2c-d0a4863adb13"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_manipulation_detected.toml
+++ b/rules/promotions/endpoint_cred_manipulation_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "c0be5f31-e180-48ed-aa08-96b36899d48f"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_manipulation_prevented.toml
+++ b/rules/promotions/endpoint_cred_manipulation_prevented.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_exploit_detected.toml
+++ b/rules/promotions/endpoint_exploit_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "2003cdc8-8d83-4aa5-b132-1f9a8eb48514"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_exploit_prevented.toml
+++ b/rules/promotions/endpoint_exploit_prevented.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "2863ffeb-bf77-44dd-b7a5-93ef94b72036"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_malware_detected.toml
+++ b/rules/promotions/endpoint_malware_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 99
 rule_id = "0a97b20f-4144-49ea-be32-b540ecc445de"
 severity = "critical"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_malware_prevented.toml
+++ b/rules/promotions/endpoint_malware_prevented.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "3b382770-efbb-44f4-beed-f5e0a051b895"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_permission_theft_detected.toml
+++ b/rules/promotions/endpoint_permission_theft_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "c3167e1b-f73c-41be-b60b-87f4df707fe3"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_permission_theft_prevented.toml
+++ b/rules/promotions/endpoint_permission_theft_prevented.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "453f659e-0429-40b1-bfdb-b6957286e04b"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_process_injection_detected.toml
+++ b/rules/promotions/endpoint_process_injection_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "80c52164-c82a-402c-9964-852533d58be1"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_process_injection_prevented.toml
+++ b/rules/promotions/endpoint_process_injection_prevented.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "990838aa-a953-4f3e-b3cb-6ddf7584de9e"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_ransomware_detected.toml
+++ b/rules/promotions/endpoint_ransomware_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 99
 rule_id = "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd"
 severity = "critical"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_ransomware_prevented.toml
+++ b/rules/promotions/endpoint_ransomware_prevented.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "e3c5d5cb-41d5-4206-805c-f30561eae3ac"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timeline_id = "db366523-f1c6-4c1f-8731-6ce5ed9e5717"
-timeline_title = "Generic Endpoint Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/19"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "3838e0e3-1850-4850-a411-2e8c5ba40ba8"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
+++ b/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/03"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "15c0b7a7-9c34-4869-b25b-fa6518414899"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/03"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 47
 rule_id = "c6453e73-90eb-4fe7-a98c-cde7bbfc504a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
+++ b/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -17,8 +17,6 @@ risk_score = 47
 rule_id = "b25a7df2-120a-4db2-bd3f-3e4b86b24bee"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/credential_access_credential_dumping_msbuild.toml
+++ b/rules/windows/credential_access_credential_dumping_msbuild.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/13"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -24,8 +24,6 @@ risk_score = 73
 rule_id = "b83a7e96-2eb3-4edf-8346-427b6858d3bd"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
+++ b/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -21,8 +21,6 @@ risk_score = 73
 rule_id = "0564fb9d-90b9-4234-a411-82a546dc1343"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/credential_access_iis_connectionstrings_dumping.toml
+++ b/rules/windows/credential_access_iis_connectionstrings_dumping.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -25,8 +25,6 @@ risk_score = 73
 rule_id = "c25e9c87-95e1-4368-bfab-9fd34cf867ec"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/31"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 73
 rule_id = "ebb200e8-adf0-43f8-a0bb-4ee5b5d852c6"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 21
 rule_id = "4630d948-40d4-4cef-ac69-4002e29bc3db"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "d331bbe2-6db4-4941-80a5-8270db72eb61"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_code_injection_conhost.toml
+++ b/rules/windows/defense_evasion_code_injection_conhost.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/31"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "28896382-7d4f-4d50-9b72-67091901fd26"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
+++ b/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "f675872f-6d85-40a3-b502-c0d2ef101e92"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "581add16-df76-42bb-af8e-c979bfb39a59"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "4b438734-3793-4fda-bd42-ceeada0be8f9"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
+++ b/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 47
 rule_id = "201200f1-a99b-43fb-88ed-f65a45c4972c"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
+++ b/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "fd70c98a-c410-42dc-a2e3-761c71848acf"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 73
 rule_id = "c5dc3223-13a2-44a2-946c-e9dc0aa0449c"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae3"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae4"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae6"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
+++ b/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/03"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "1160dcdb-0a0a-4a79-91d8-9b84616edebd"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
+++ b/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_iis_httplogging_disabled.toml
+++ b/rules/windows/defense_evasion_iis_httplogging_disabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/14"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "ebf1adea-ccf2-4943-8b96-7ab11ca173a5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_injection_msbuild.toml
+++ b/rules/windows/defense_evasion_injection_msbuild.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae9"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "a13167f1-eec2-4015-9631-1fee60406dcf"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
+++ b/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/24"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "b41a13c6-ba45-4bab-a534-df53d0cfed6a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
+++ b/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/01"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "2e1e835d-01e5-48ca-b9fc-7a61f7f11902"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
+++ b/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/24"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -24,8 +24,6 @@ risk_score = 47
 rule_id = "ac5012b8-8da8-440b-aaaf-aedafdea2dff"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_masquerading_werfault.toml
+++ b/rules/windows/defense_evasion_masquerading_werfault.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/24"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -21,8 +21,6 @@ risk_score = 47
 rule_id = "6ea41894-66c3-4df7-ad6b-2c5074eb3df8"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "63e65ec3-43b1-45b0-8f2d-45b34291dc44"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/16"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "69c251fb-a5d6-4035-b5ec-40438bd829ff"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_msbuild_beacon_sequence.toml
+++ b/rules/windows/defense_evasion_msbuild_beacon_sequence.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "development"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "9dc6ed5d-62a9-4feb-a903-fafa1d33b8e9"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_mshta_beacon.toml
+++ b/rules/windows/defense_evasion_mshta_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "c2d90150-0133-451c-a783-533e736c12d7"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_msxsl_beacon.toml
+++ b/rules/windows/defense_evasion_msxsl_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "development"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "870d1753-1078-403e-92d4-735f142edcca"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+++ b/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "1fe3b299-fbb5-4657-a937-1d746f2c711a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_reg_beacon.toml
+++ b/rules/windows/defense_evasion_reg_beacon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "development"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "6d3456a5-4a42-49d1-aaf2-7b1fd475b2c6"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "f036953a-4615-4707-a1ca-dc53bf69dcd5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_rundll32_sequence.toml
+++ b/rules/windows/defense_evasion_rundll32_sequence.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "development"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "2b347f66-6739-4ae3-bd94-195036dde8b3"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_suspicious_scrobj_load.toml
+++ b/rules/windows/defense_evasion_suspicious_scrobj_load.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "4ed678a9-3a4f-41fb-9fea-f85a6e0a0dff"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_suspicious_wmi_script.toml
+++ b/rules/windows/defense_evasion_suspicious_wmi_script.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "7f370d54-c0eb-4270-ac5a-9a6020585dc6"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
+++ b/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/03"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "97aba1ef-6034-4bd3-8c1a-1e0996b27afa"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
+++ b/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/19"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 73
 rule_id = "e94262f2-c1e9-4d3f-a907-aeab16712e1a"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
+++ b/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/19"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 73
 rule_id = "de9bd7e0-49e9-4e92-a64d-53ade2e66af1"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -18,8 +18,6 @@ risk_score = 21
 rule_id = "06dceabf-adca-48af-ac79-ffdf4c3b1e9a"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_vssadmin.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_vssadmin.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 73
 rule_id = "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 73
 rule_id = "dc9c1f74-dac3-48e3-b47f-eb79db358f57"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "2856446a-34e6-435b-9fb5-f8f040bfa7ed"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/discovery_process_discovery_via_tasklist_command.toml
+++ b/rules/windows/discovery_process_discovery_via_tasklist_command.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 21
 rule_id = "cc16f774-59f9-462d-8b98-d27ccd4519ec"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -24,8 +24,6 @@ risk_score = 21
 rule_id = "ef862985-3f13-4262-a686-5f357bbb9bc2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
+++ b/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -25,8 +25,6 @@ risk_score = 21
 rule_id = "89f9a4b0-9f8f-4ee0-8823-c4751a6d6696"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_command_shell_started_by_powershell.toml
+++ b/rules/windows/execution_command_shell_started_by_powershell.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 21
 rule_id = "0f616aee-8161-4120-857e-742366f5eeb3"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 21
 rule_id = "fd7a6052-58fa-4397-93c3-4795249ccfa2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/21"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 47
 rule_id = "3b47900d-e793-49e8-968f-c90dc3526aa1"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_downloaded_shortcut_files.toml
+++ b/rules/windows/execution_downloaded_shortcut_files.toml
@@ -3,7 +3,7 @@ creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "development"
 query_schema_validation = false
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "6b1fd8e8-cefe-444c-bc4d-feaa2c497347"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_downloaded_url_file.toml
+++ b/rules/windows/execution_downloaded_url_file.toml
@@ -3,7 +3,7 @@ creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "development"
 query_schema_validation = false
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "cd82e3d6-1346-4afd-8f22-38388bbf34cb"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "b29ee2be-bf99-446c-ab1a-2dc0183394b8"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_local_service_commands.toml
+++ b/rules/windows/execution_local_service_commands.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "e8571d5f-bea1-46c2-9f56-998de2d3ed95"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_ms_office_written_file.toml
+++ b/rules/windows/execution_ms_office_written_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "0d8ad79f-9025-45d8-80c1-4f0cd3c5e8e5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_msbuild_making_network_connections.toml
+++ b/rules/windows/execution_msbuild_making_network_connections.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "0e79980b-4250-4a50-a509-69294c14e84b"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_mshta_making_network_connections.toml
+++ b/rules/windows/execution_mshta_making_network_connections.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "development"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 47
 rule_id = "a4ec1382-4557-452b-89ba-e413b22ed4b8"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_msxsl_network.toml
+++ b/rules/windows/execution_msxsl_network.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "b86afe07-0d98-4738-b15d-8d7465f95ff5"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_pdf_written_file.toml
+++ b/rules/windows/execution_pdf_written_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "1defdd62-cd8d-426e-a246-81a37751bb2b"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_psexec_lateral_movement_command.toml
+++ b/rules/windows/execution_psexec_lateral_movement_command.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -25,8 +25,6 @@ risk_score = 21
 rule_id = "55d551c6-333b-4665-ab7e-5d14a59715ce"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -25,8 +25,6 @@ risk_score = 21
 rule_id = "fb02b8d3-71ee-4af1-bacd-215d23f17efa"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_script_executing_powershell.toml
+++ b/rules/windows/execution_script_executing_powershell.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_suspicious_ms_office_child_process.toml
+++ b/rules/windows/execution_suspicious_ms_office_child_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "a624863f-a70d-417f-a7d2-7a404638d47f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/execution_suspicious_ms_outlook_child_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "32f4675e-6c49-4ace-80f9-97c9259dca2e"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/30"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "53a26770-9cbd-40c5-8b57-61d01a325e14"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_suspicious_psexesvc.toml
+++ b/rules/windows/execution_suspicious_psexesvc.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "e2f9fdf5-8076-45ad-9427-41e0e03dc9c2"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_unusual_dns_service_children.toml
+++ b/rules/windows/execution_unusual_dns_service_children.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/16"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -36,8 +36,6 @@ risk_score = 73
 rule_id = "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_unusual_dns_service_file_writes.toml
+++ b/rules/windows/execution_unusual_dns_service_file_writes.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/16"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 73
 rule_id = "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/execution_unusual_network_connection_via_rundll32.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "52aaab7b-b51c-441a-89ce-4387b3aea886"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_unusual_process_network_connection.toml
+++ b/rules/windows/execution_unusual_process_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "610949a1-312f-4e04-bb55-3a79b8c95267"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_via_compiled_html_file.toml
+++ b/rules/windows/execution_via_compiled_html_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,6 @@ risk_score = 21
 rule_id = "e3343ab9-4245-4715-b344-e11c56b0a47f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_via_hidden_shell_conhost.toml
+++ b/rules/windows/execution_via_hidden_shell_conhost.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/17"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 73
 rule_id = "05b358de-aa6d-4f6c-89e6-78f74018b43b"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_via_net_com_assemblies.toml
+++ b/rules/windows/execution_via_net_com_assemblies.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "47f09343-8d1f-4bb5-8bb0-00c9d18f5010"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 73
 rule_id = "4ed493fc-d637-4a36-80ff-ac84937e5461"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_wpad_exploitation.toml
+++ b/rules/windows/execution_wpad_exploitation.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "development"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "ec328da1-d5df-482b-866c-4a435692b1f3"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/lateral_movement_cmd_service.toml
+++ b/rules/windows/lateral_movement_cmd_service.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "d61cbcf8-1bc1-4cff-85ba-e7b21c5beedc"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -21,8 +21,6 @@ risk_score = 47
 rule_id = "c82c7d8f-fb9e-4874-a4bd-fd9e3f9becf1"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/lateral_movement_dns_server_overflow.toml
+++ b/rules/windows/lateral_movement_dns_server_overflow.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/16"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -36,8 +36,6 @@ risk_score = 47
 rule_id = "11013227-0301-4a8c-b150-4db924484475"
 severity = "medium"
 tags = ["Elastic", "Network", "Threat Detection", "Lateral Movement"]
-timeline_id = "91832785-286d-4ebe-b884-1a208d111a70"
-timeline_title = "Generic Network Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,8 +16,6 @@ risk_score = 21
 rule_id = "2bf78aa2-9c56-48de-b139-f169bf99cf86"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_app_compat_shim.toml
+++ b/rules/windows/persistence_app_compat_shim.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "c5ce48a6-7f57-4ee8-9313-3d0024caee10"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/persistence_gpo_schtask_service_creation.toml
+++ b/rules/windows/persistence_gpo_schtask_service_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/13"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 21
 rule_id = "c0429aa8-9974-42da-bfb6-53a0a515a145"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_local_scheduled_task_commands.toml
+++ b/rules/windows/persistence_local_scheduled_task_commands.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -17,8 +17,6 @@ risk_score = 21
 rule_id = "afcce5ad-65de-4ed2-8516-5e093d3ac99a"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "7405ddf1-6c8e-41ce-818f-48bea6bcaed8"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "0022d47d-39c7-4f69-a232-4fe9dc7a3acd"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "1aa9181a-492b-4c01-8b16-fa0735786b2b"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_via_application_shimming.toml
+++ b/rules/windows/persistence_via_application_shimming.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "fd4a992d-6130-4802-9ff8-829b89ae801f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
+++ b/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/17"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -22,8 +22,6 @@ risk_score = 73
 rule_id = "68921d85-d0dc-48b3-865f-43291ca2c4f2"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
+++ b/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/17"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,8 +20,6 @@ risk_score = 73
 rule_id = "265db8f5-fc73-4d0d-b434-6483b56372e2"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -24,8 +24,6 @@ risk_score = 74
 rule_id = "5bb4a95d-5a08-48eb-80db-4c3a63ec78a8"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -21,8 +21,6 @@ risk_score = 74
 rule_id = "a7ccae7b-9d2c-44b2-a061-98e5946971fa"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "1dcc51f6-ba26-49e7-9ef4-2655abb2361e"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/17"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''

--- a/rules/windows/privilege_escalation_uac_sdclt.toml
+++ b/rules/windows/privilege_escalation_uac_sdclt.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 ecs_version = ["1.6.0"]
 maturity = "development"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 21
 rule_id = "9b54e002-034a-47ac-9307-ad12c03fa900"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "eql"
 
 query = '''

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 ecs_version = ["1.6.0"]
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/11/03"
 
 [rule]
 author = ["Elastic"]
@@ -19,8 +19,6 @@ risk_score = 47
 rule_id = "35df0dd8-092d-4a83-88c1-5151a804f31b"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
-timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
-timeline_title = "Generic Process Timeline"
 type = "query"
 
 query = '''


### PR DESCRIPTION
## Issues
related to #453 
related to elastic/kibana/pull/82214 (see comments)

## Summary
Timeline templates are not showing in the most appropriate manner and so the functionality/templates should be reviewed and revised. This removes all timelines within rules until that is performed.