### PR TITLE
[Rule Tuning] Unusual File Modification by dns.exe

### DIFF
--- a/rules/windows/execution_unusual_dns_service_file_writes.toml
+++ b/rules/windows/execution_unusual_dns_service_file_writes.toml
@@ -30,7 +30,8 @@ timeline_id = "76e52245-7519-4251-91ab-262fb1a1728c"
 type = "query"
 
 query = '''
-event.category:file and process.name:dns.exe and
+event.category:file and process.name:dns.exe and 
+  event.type:(creation or deletion or change) and
   not file.name:dns.log
 '''
 


### PR DESCRIPTION
## Issues
resolves #471 

## Summary
Tune rule to add `event.type` in order to avoid FP's for `access` events (Sysmon 18).