### PR TITLE
Add test commands to search and survey rule hits

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -111,11 +111,11 @@ Usage: detection_rules es [OPTIONS] COMMAND [ARGS]...
   Commands for integrating with Elasticsearch.
 
 Options:
-  -e, --elasticsearch-url TEXT
+  -et, --timeout INTEGER        Timeout for elasticsearch client
+  -ep, --es-password TEXT
+  -eu, --es-user TEXT
   --cloud-id TEXT
-  -u, --es-user TEXT
-  -p, --es-password TEXT
-  -t, --timeout INTEGER         Timeout for elasticsearch client
+  -e, --elasticsearch-url TEXT
   -h, --help                    Show this message and exit.
 
 Commands:
@@ -130,12 +130,12 @@ Usage: detection_rules kibana [OPTIONS] COMMAND [ARGS]...
   Commands for integrating with Kibana.
 
 Options:
-  -k, --kibana-url TEXT
+  --space TEXT                 Kibana space
+  -kp, --kibana-password TEXT
+  -ku, --kibana-user TEXT
   --cloud-id TEXT
-  -u, --kibana-user TEXT
-  -p, --kibana-password TEXT
-  -t, --timeout INTEGER       Timeout for kibana client
-  -h, --help                  Show this message and exit.
+  -k, --kibana-url TEXT
+  -h, --help                   Show this message and exit.
 
 Commands:
   upload-rule  Upload a list of rule .toml files to Kibana.
@@ -153,11 +153,11 @@ python -m detection_rules kibana upload-rule -h
 
 Kibana client:
 Options:
-  -k, --kibana-url TEXT
+  --space TEXT                 Kibana space
+  -kp, --kibana-password TEXT
+  -ku, --kibana-user TEXT
   --cloud-id TEXT
-  -u, --kibana-user TEXT
-  -p, --kibana-password TEXT
-  -t, --timeout INTEGER       Timeout for kibana client
+  -k, --kibana-url TEXT
 
 Usage: detection_rules kibana upload-rule [OPTIONS] TOML_FILES...
 

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -401,10 +401,9 @@ def rule_survey(ctx: click.Context, query, date_range, dump_file, hide_zero_coun
     else:
         click.echo(table)
 
-    if dump_file:
-        os.makedirs(get_path('surveys'), exist_ok=True)
-        with open(dump_file, 'w') as f:
-            json.dump(details, f, indent=2, sort_keys=True)
+    os.makedirs(get_path('surveys'), exist_ok=True)
+    with open(dump_file, 'w') as f:
+        json.dump(details, f, indent=2, sort_keys=True)
 
     return survey_results
 

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -215,7 +215,7 @@ def test_group():
 
 @test_group.command('event-search')
 @click.argument('query')
-@click.option('--index', '-i', multiple=True, required=True, help='Index(es) to search against ("*": for all indexes)')
+@click.option('--index', '-i', multiple=True, help='Index patterns to search against')
 @click.option('--eql/--lucene', '-e/-l', 'language', default=None, help='Query language used (default: kql)')
 @click.option('--date-range', '-d', type=(str, str), default=('now-7d', 'now'), help='Date range to scope search')
 @click.option('--count', '-c', is_flag=True, help='Return count of results only')
@@ -227,6 +227,7 @@ def event_search(query, index, language, date_range, count, max_results, verbose
                  elasticsearch_client: Elasticsearch = None):
     """Search using a query against an Elasticsearch instance."""
     start_time, end_time = date_range
+    index = index or ('*',)
     language_used = "kql" if language is None else "eql" if language is True else "lucene"
     collector = CollectEvents(elasticsearch_client, max_results)
 

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -273,7 +273,12 @@ def rule_event_search(ctx, rule_file, rule_id, date_range, count, max_results, v
             click.echo(f'Searching rule: {rule.name}')
 
         rule_lang = rule.contents.get('language')
-        language = None if rule_lang == 'kuery' else True if rule_lang == 'eql' else "lucene"
+        if rule_lang == 'kuery':
+            language = None
+        elif rule_lang == 'eql':
+            language = True
+        else:
+            language = False
         ctx.invoke(event_search, query=rule.query, index=rule.contents.get('index', '*'), language=language,
                    date_range=date_range, count=count, max_results=max_results, verbose=verbose,
                    elasticsearch_client=elasticsearch_client)

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -294,13 +294,13 @@ def rule_event_search(ctx, rule_file, rule_id, date_range, count, verbose, elast
     else:
         client_error('Must specify a rule file or rule ID')
 
-    if rule.contents.get('query') and rule.contents.get('language'):
+    if rule.contents.query and rule.contents.get('language'):
         if verbose:
             click.echo(f'Searching rule: {rule.name}')
 
         rule_lang = rule.contents.get('language')
         language = None if rule_lang == 'kuery' else True if rule_lang == 'eql' else "lucene"
-        ctx.invoke(event_search, query=rule.query, index=rule.contents.get('index', "*"), language=language,
+        ctx.invoke(event_search, query=rule.query, index=rule.contents.get('index', '*'), language=language,
                    date_range=date_range, count=count, verbose=verbose, elasticsearch_client=elasticsearch_client)
     else:
         client_error('Rule is not a query rule!')
@@ -311,7 +311,7 @@ def rule_event_search(ctx, rule_file, rule_id, date_range, count, verbose, elast
 @click.option('--date-range', '-d', type=(str, str), default=('now-7d', 'now'), help='Date range to scope search')
 @click.option('--dump-file', type=click.Path(dir_okay=False),
               default=get_path('surveys', f'{time.strftime("%Y%m%dT%H%M%SL")}.json'),
-              help='Save details of results (capped at 1000 results/rule) (warning: potentially resource intensive)')
+              help='Save details of results (capped at 1000 results/rule)')
 @click.option('--hide-zero-counts', '-z', is_flag=True, help='Exclude rules with zero hits from printing')
 @click.option('--hide-errors', '-e', is_flag=True, help='Exclude rules with errors from printing')
 @click.pass_context

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -10,17 +10,14 @@ import os
 import shutil
 import subprocess
 import time
-from collections import defaultdict
 
 import click
-import elasticsearch
 from elasticsearch import Elasticsearch
-from elasticsearch.client import AsyncSearchClient
 from eql import load_dump
 from kibana.connector import Kibana
 
 from . import rule_loader
-from .eswrap import add_range_to_dsl
+from .eswrap import CollectEvents, add_range_to_dsl
 from .main import root
 from .misc import PYTHON_LICENSE, add_client, client_error
 from .packaging import PACKAGE_FILE, Package, manage_versions, RELEASE_DIR
@@ -229,50 +226,23 @@ def test_group():
 def event_search(query, index, language, date_range, count, max_results, verbose=True,
                  elasticsearch_client: Elasticsearch = None):
     """Search using a query against an Elasticsearch instance."""
-    import kql
-
-    language_used = "kql" if language is None else "eql" if language is True else "lucene"
-
-    index_str = ','.join(index)
-    formatted_query = {'query': kql.to_dsl(query)} if language_used == 'kql' else \
-        {'query': query} if language_used == 'eql' else {'query': {'bool': {'filter': []}}}  # lucene
-
-    # add range to query - for dsl: add to filter, for lucene and eql: build new and add to body[filter]
     start_time, end_time = date_range
-    if language_used in ('kql', 'lucene'):
-        add_range_to_dsl(formatted_query['query']['bool'].setdefault('filter', []), start_time, end_time)
-    elif language_used == 'eql':
-        formatted_query['filter'] = {'bool': {'filter': [{'match_all': {}}]}}
-        add_range_to_dsl(formatted_query['filter']['bool']['filter'], start_time, end_time)
+    language_used = "kql" if language is None else "eql" if language is True else "lucene"
+    collector = CollectEvents(elasticsearch_client, max_results)
 
     if verbose:
-        click.echo(f'searching {index_str} from {start_time} to {end_time}')
-        click.echo(f'{language_used}: {formatted_query or query}')
-
-    results = []
-    if language_used == 'eql':
-        formatted_query['size'] = 1000 if count else max_results
-        results = elasticsearch_client.eql.search(body=formatted_query, index=index_str)['hits']
-        results = results.get('events') or results.get('sequences', [])
+        click.echo(f'searching {",".join(index)} from {start_time} to {end_time}')
+        click.echo(f'{language_used}: {query}')
 
     if count:
-        # EQL API has no count endpoint
-        if language_used == 'eql':
-            count = len(results)
-        else:
-            count = elasticsearch_client.count(body=formatted_query, index=index_str)
-            click.echo(f'Total results: {count["count"]}')
-
-        return count
+        results = collector.count(query, language_used, index, start_time, end_time)
+        click.echo(f'total results: {results}')
     else:
-        # EQL search results will pass through from above
-        if language_used != 'eql':
-            results = elasticsearch_client.search(body=formatted_query, q=query if language_used == 'lucene' else None,
-                                                  index=index_str, size=max_results)['hits']['hits']
-
-        click.echo(f'total results: {len(results)}')
+        results = collector.search(query, language_used, index, start_time, end_time, max_results)
+        click.echo(f'total results: {len(results)} (capped at {max_results})')
         click.echo_via_pager(json.dumps(results, indent=2, sort_keys=True))
-        return results
+
+    return results
 
 
 @test_group.command('rule-event-search')
@@ -280,10 +250,13 @@ def event_search(query, index, language, date_range, count, max_results, verbose
 @click.option('--rule-id', '-id')
 @click.option('--date-range', '-d', type=(str, str), default=('now-7d', 'now'), help='Date range to scope search')
 @click.option('--count', '-c', is_flag=True, help='Return count of results only')
+@click.option('--max-results', '-m', type=click.IntRange(1, 1000), default=100,
+              help='Max results to return (capped at 1000)')
 @click.option('--verbose', '-v', is_flag=True)
 @click.pass_context
 @add_client('elasticsearch')
-def rule_event_search(ctx, rule_file, rule_id, date_range, count, verbose, elasticsearch_client: Elasticsearch = None):
+def rule_event_search(ctx, rule_file, rule_id, date_range, count, max_results, verbose,
+                      elasticsearch_client: Elasticsearch = None):
     """Search using a rule file against an Elasticsearch instance."""
     rule = None
 
@@ -294,14 +267,15 @@ def rule_event_search(ctx, rule_file, rule_id, date_range, count, verbose, elast
     else:
         client_error('Must specify a rule file or rule ID')
 
-    if rule.contents.query and rule.contents.get('language'):
+    if rule.query and rule.contents.get('language'):
         if verbose:
             click.echo(f'Searching rule: {rule.name}')
 
         rule_lang = rule.contents.get('language')
         language = None if rule_lang == 'kuery' else True if rule_lang == 'eql' else "lucene"
         ctx.invoke(event_search, query=rule.query, index=rule.contents.get('index', '*'), language=language,
-                   date_range=date_range, count=count, verbose=verbose, elasticsearch_client=elasticsearch_client)
+                   date_range=date_range, count=count, max_results=max_results, verbose=verbose,
+                   elasticsearch_client=elasticsearch_client)
     else:
         client_error('Rule is not a query rule!')
 
@@ -319,7 +293,6 @@ def rule_event_search(ctx, rule_file, rule_id, date_range, count, verbose, elast
 def rule_survey(ctx: click.Context, query, date_range, dump_file, hide_zero_counts, hide_errors,
                 elasticsearch_client: Elasticsearch = None, kibana_client: Kibana = None):
     """Survey rule counts."""
-    import kql
     from eql.table import Table
     from kibana.resources import Signal
     from . import rule_loader
@@ -337,7 +310,10 @@ def rule_survey(ctx: click.Context, query, date_range, dump_file, hide_zero_coun
 
     click.echo(f'Running survey against {len(rules)} rules')
     click.echo(f'Saving detailed dump to: {dump_file}')
-    details = get_detailed_search_results(elasticsearch_client, rules, start_time, end_time)
+
+    collector = CollectEvents(elasticsearch_client)
+    details = collector.search_from_rule(*rules, start_time=start_time, end_time=end_time)
+    counts = collector.count_from_rule(*rules, start_time=start_time, end_time=end_time)
 
     # add alerts
     with kibana_client:
@@ -346,52 +322,18 @@ def rule_survey(ctx: click.Context, query, date_range, dump_file, hide_zero_coun
         alerts = {a['_source']['signal']['rule']['rule_id']: a['_source']
                   for a in Signal.search(range_dsl)['hits']['hits']}
 
-    for rule in rules:
-        rule_results = {'rule_id': rule.id, 'name': rule.name}
-        if not rule.contents.get('query'):
-            continue
-
-        index = ','.join(rule.contents['index'])
-        language = rule.contents.get('language')
-        is_kql = language == 'kuery'
-        is_lucene = language == 'lucene'
-        is_eql = language == 'eql'
-
-        # dsl filter for date ranges for lucene and eql (kql is already dsl and so will mutate filter)
-        range_dsl = {'query': {'bool': {'filter': []}}}
-        add_range_to_dsl(range_dsl['query']['bool']['filter'], start_time, end_time)
-
-        try:
-            if is_kql:
-                kql_query = kql.to_dsl(rule.query)
-                add_range_to_dsl(kql_query['bool'].setdefault('filter', []), start_time, end_time)
-                result = elasticsearch_client.count({'query': kql_query}, index=index)
-                rule_results['search_count'] = result['count']
-            elif is_lucene:
-                result = elasticsearch_client.count(body=range_dsl, q=rule.query, index=index)
-                rule_results['search_count'] = result['count']
-            elif is_eql:
-                # EQL API has no count endpoint, so just count results
-                rule_results['search_count'] = len(details[rule.id].get('results', []))
-        except elasticsearch.NotFoundError as e:
-            if e.error == 'index_not_found_exception':
-                rule_results['search_count'] = -1
-            else:
-                raise
-        except (elasticsearch.NotFoundError, elasticsearch.RequestError):
-            rule_results['search_count'] = -1
-
-        alert_count = len(alerts.get(rule.id, []))
+    for rule_id, count in counts.items():
+        alert_count = len(alerts.get(rule_id, []))
         if alert_count > 0:
-            rule_results['alert_count'] = alert_count
+            count['alert_count'] = alert_count
 
-        details[rule.id].update(rule_results)
+        details[rule_id].update(count)
 
-        search_count = rule_results['search_count']
+        search_count = count['search_count']
         if not alert_count and (hide_zero_counts and search_count == 0) or (hide_errors and search_count == -1):
             continue
 
-        survey_results.append(rule_results)
+        survey_results.append(count)
 
     fields = ['rule_id', 'name', 'search_count', 'alert_count']
     table = Table.from_list(fields, survey_results)
@@ -404,89 +346,5 @@ def rule_survey(ctx: click.Context, query, date_range, dump_file, hide_zero_coun
     os.makedirs(get_path('surveys'), exist_ok=True)
     with open(dump_file, 'w') as f:
         json.dump(details, f, indent=2, sort_keys=True)
-
-    return survey_results
-
-
-def get_detailed_search_results(client: Elasticsearch, rules, start_time, end_time, max_results=1000):
-    """Get detailed search results for rules."""
-    import kql
-    from .misc import nested_get
-
-    async_client = AsyncSearchClient(client)
-    survey_results = {}
-
-    def parse_unique_field_results(rule_type, unique_fields, search_results):
-        parsed_results = defaultdict(lambda: defaultdict(int))
-        hits = search_results['hits']['hits'] if rule_type != 'eql' else search_results.events
-        for hit in hits:
-            for field in unique_fields:
-                match = nested_get(hit['_source'], field)
-                match = ','.join(sorted(match)) if isinstance(match, list) else match
-                parsed_results[field][match] += 1
-        # if rule.type == eql, structure is different
-        return {'results': parsed_results} if parsed_results else {}
-
-    multi_search = []
-    multi_search_rules = []
-    async_searches = {}
-    eql_searches = {}
-
-    for rule in rules:
-        if not rule.contents.get('query'):
-            continue
-
-        index = ','.join(rule.contents['index'])
-
-        # dsl filter for date ranges for lucene and eql (kql is already dsl and so will mutate filter)
-        range_dsl = {'query': {'bool': {'filter': []}}}
-        add_range_to_dsl(range_dsl['query']['bool']['filter'], start_time, end_time)
-
-        # prep for searches: msearch for kql | async search for lucene | eql client search for eql
-        if rule.contents['language'] == 'kuery':
-            multi_search_rules.append(rule)
-            multi_search.append(json.dumps({'index': index}))
-            kql_query = kql.to_dsl(rule.query)
-            add_range_to_dsl(kql_query['bool'].setdefault('filter', []), start_time, end_time)
-            body = {'query': kql_query, 'size': max_results, 'track_total_hits': True}
-            multi_search.append(json.dumps(body))
-        elif rule.contents['language'] == 'lucene':
-            # wait for 0 to try and force async with no immediate results (not guaranteed)
-            result = async_client.submit(body=range_dsl, q=rule.query, index=index, wait_for_completion_timeout=0,
-                                         size=max_results, track_total_hits=True)
-            if result['is_running'] is True:
-                async_searches[rule] = result['id']
-            else:
-                survey_results[rule.id] = parse_unique_field_results(rule.type, rule.unique_fields, result['response'])
-        elif rule.contents['language'] == 'eql':
-            eql_body = {
-                'index': index,
-                'params': {'ignore_unavailable': 'true'},
-                'body': {'query': rule.query, 'size': max_results, 'filter': range_dsl['query']}
-            }
-            eql_searches[rule] = eql_body
-
-    # assemble search results
-    multi_search_results = client.msearch('\n'.join(multi_search) + '\n')
-    for index, result in enumerate(multi_search_results['responses']):
-        try:
-            rule = multi_search_rules[index]
-            survey_results[rule.id] = parse_unique_field_results(rule.type, rule.unique_fields, result)
-        except KeyError:
-            survey_results[multi_search_rules[index].id] = {'error_retrieving_results': True}
-
-    for rule, search_args in eql_searches.items():
-        try:
-            result = client.eql.search(**search_args)
-            survey_results[rule.id] = parse_unique_field_results(rule.type, rule.unique_fields, result)
-        except (elasticsearch.NotFoundError, elasticsearch.RequestError) as e:
-            if e.error in ('index_not_found_exception', 'verification_exception'):
-                survey_results[rule.id] = {'error_retrieving_results': True, 'error': e.info['error']['reason']}
-            else:
-                raise
-
-    for rule, async_id in async_searches.items():
-        result = async_client.get(async_id)['response']
-        survey_results[rule.id] = parse_unique_field_results(rule.type, rule.unique_fields, result)
 
     return survey_results

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -279,7 +279,7 @@ def rule_event_search(ctx, rule_file, rule_id, date_range, count, max_results, v
             language = True
         else:
             language = False
-        ctx.invoke(event_search, query=rule.query, index=rule.contents.get('index', '*'), language=language,
+        ctx.invoke(event_search, query=rule.query, index=rule.contents.get('index', ['*']), language=language,
                    date_range=date_range, count=count, max_results=max_results, verbose=verbose,
                    elasticsearch_client=elasticsearch_client)
     else:

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -198,7 +198,8 @@ class CollectEvents(object):
 
         def parse_unique_field_results(rule_type, unique_fields, search_results):
             parsed_results = defaultdict(lambda: defaultdict(int))
-            hits = search_results['hits']['hits'] if rule_type != 'eql' else search_results.events
+            hits = search_results['hits']
+            hits = hits['hits'] if rule_type != 'eql' else hits.get('events') or hits.get('sequences', [])
             for hit in hits:
                 for field in unique_fields:
                     match = nested_get(hit['_source'], field)

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -8,24 +8,29 @@ import os
 import time
 
 import click
-from elasticsearch import AuthenticationException, Elasticsearch
+import elasticsearch
+from elasticsearch import Elasticsearch
+from elasticsearch.client import AsyncSearchClient
+from eql.utils import load_dump
+
 
 from .main import root
 from .misc import client_error, getdefault
 from .utils import format_command_options, normalize_timing_and_sort, unix_time_to_formatted, get_path
+from .rule import Rule
 from .rule_loader import get_rule, rta_mappings
 
 COLLECTION_DIR = get_path('collections')
 
 
-def get_es_client(user, password, elasticsearch_url=None, cloud_id=None, **kwargs):
+def get_es_client(es_user, es_password, elasticsearch_url=None, cloud_id=None, **kwargs):
     """Get an auth-validated elsticsearch client."""
     assert elasticsearch_url or cloud_id, \
         'You must specify a host or cloud_id to authenticate to an elasticsearch instance'
 
     hosts = [elasticsearch_url] if elasticsearch_url else elasticsearch_url
 
-    client = Elasticsearch(hosts=hosts, cloud_id=cloud_id, http_auth=(user, password), **kwargs)
+    client = Elasticsearch(hosts=hosts, cloud_id=cloud_id, http_auth=(es_user, es_password), **kwargs)
     # force login to test auth
     client.info()
     return client
@@ -193,7 +198,7 @@ def es_group(ctx: click.Context, **es_kwargs):
         click.echo(format_command_options(ctx))
 
     else:
-        if not es_kwargs['cloud_id'] or es_kwargs['elasticsearch_url']:
+        if not (es_kwargs['cloud_id'] or es_kwargs['elasticsearch_url']):
             client_error("Missing required --cloud-id or --elasticsearch-url")
 
         # don't prompt for these until there's a cloud id or elasticsearch URL
@@ -203,7 +208,7 @@ def es_group(ctx: click.Context, **es_kwargs):
         try:
             client = get_es_client(use_ssl=True, **es_kwargs)
             ctx.obj['es'] = client
-        except AuthenticationException as e:
+        except elasticsearch.AuthenticationException as e:
             error_msg = f'Failed authentication for {es_kwargs.get("elasticsearch_url") or es_kwargs.get("cloud_id")}'
             client_error(error_msg, e, ctx=ctx, err=True)
 
@@ -236,3 +241,144 @@ def collect_events(ctx, agent_hostname, index, agent_type, rta_name, rule_id, vi
     except AssertionError as e:
         error_msg = 'No events collected! Verify events are streaming and that the agent-hostname is correct'
         client_error(error_msg, e, ctx=ctx)
+
+
+@es_group.command('event-search')
+@click.argument('query')
+@click.option('--index', '-i', multiple=True, required=True, help='Index(es) to search against ("*": for all indexes)')
+@click.option('--eql/--lucene', '-e/-l', 'language', default=None, help='Query language used (default: kql)')
+@click.option('--count', '-c', is_flag=True, help='Return count of results only')
+@click.option('--verbose', '-v', is_flag=True)
+@click.pass_context
+def event_search(ctx: click.Context, query, index, language, count, verbose):
+    """Search using a query against an Elasticsearch instance."""
+    import kql
+
+    client = ctx.obj['es']
+
+    language_used = "kql" if language is None else "eql" if language is True else "lucene"
+
+    index_str = ','.join(index)
+    formatted_query = {'query': kql.to_dsl(query)} if language_used == 'kql' else \
+        {'query': query} if language_used == 'eql' else None
+
+    if verbose:
+        click.echo(f'{language_used}: {formatted_query or query}')
+
+    if count:
+        count = client.count(body=formatted_query, index=index_str)
+        click.echo(f'Total results: {count["count"]}')
+        return count
+    else:
+        if language_used != 'eql':
+            results = client.search(body=formatted_query, q=query if language_used == 'lucene' else None,
+                                    index=index_str)
+        else:
+            results = client.eql.search(body=formatted_query, index=index_str)
+
+        click.echo_via_pager(json.dumps(results['hits']['events'], indent=2, sort_keys=True))
+        return results
+
+
+@es_group.command('rule-event-search')
+@click.argument('rule-file', type=click.Path(dir_okay=False), required=False)
+@click.option('--rule-id', '-id')
+@click.option('--count', '-c', is_flag=True, help='Return count of results only')
+@click.option('--verbose', '-v', is_flag=True)
+@click.pass_context
+def rule_event_search(ctx, rule_file, rule_id, count, verbose):
+    """Search using a rule file against an Elasticsearch instance."""
+    rule = None
+
+    if rule_id:
+        rule = get_rule(rule_id, verbose=False)
+    elif rule_file:
+        rule = Rule(rule_file, load_dump(rule_file))
+    else:
+        client_error('Must specify a rule file or rule ID')
+
+    if rule.contents.get('query') and rule.contents.get('language'):
+        if verbose:
+            click.echo(f'Searching rule: {rule.name}')
+
+        rule_lang = rule.contents.get('language')
+        language = None if rule_lang == 'kuery' else True if rule_lang == 'eql' else "lucene"
+        ctx.invoke(event_search, query=rule.query, index=rule.contents.get('index', "*"), language=language,
+                   count=count, verbose=verbose)
+    else:
+        client_error('Rule is not a query rule!')
+
+
+@es_group.command('rule-survey')
+@click.argument('query', required=False)
+@click.pass_context
+def rule_survey(ctx: click.Context, query):
+    """Survey rule counts."""
+    import kql
+    from . import rule_loader
+    from .main import search_rules
+    # from .kbwrap import get_authed_kibana_client
+
+    client: Elasticsearch = ctx.obj['es']
+    async_client = AsyncSearchClient(client)
+    survey_results = {}  # rule_id - rule_name: {search_count: #, alert_count: #}
+
+    rules = ctx.invoke(search_rules, query=query, verbose=False) if query else \
+        rule_loader.load_rules(verbose=False).values()
+
+    multi_search = []
+    multi_search_rule_str = []
+    async_searches = {}
+    eql_searches = {}
+
+    for rule in rules:
+        if not rule.contents.get('query'):
+            continue
+
+        index = ','.join(rule.contents['index'])
+        rule_str = f'{rule.id} - {rule.name}'
+
+        # prep for searches:
+        #   msearch for all kql searches
+        #   async search for all lucene searches
+        #   eql client for eql searches
+        if rule.contents['language'] == 'kuery':
+            multi_search_rule_str.append(rule_str)
+            multi_search.append(json.dumps({'index': index}))
+            multi_search.append(json.dumps({'query': kql.to_dsl(rule.query)}))
+        elif rule.contents['language'] == 'lucene':
+            result = async_client.submit(q=rule.query, index=index, wait_for_completion_timeout=0)
+            if result['is_running'] is True:
+                async_searches[rule_str] = result['id']
+            else:
+                survey_results[rule_str] = {'search_count': len(result['response']['hits']['hits'])}
+        elif rule.contents['language'] == 'eql':
+            eql_searches[rule_str] = {'index': index, 'body': {'query': rule.query}}
+
+    # assemble search results
+    multi_search_results = client.msearch('\n'.join(multi_search) + '\n')
+    # TODO: parse results to survey_results
+    for index, result in enumerate(multi_search_results['responses']):
+        try:
+            survey_results[multi_search_rule_str[index]] = {'search_count': len(result['hits']['hits'])}
+        except KeyError:
+            survey_results[multi_search_rule_str[index]] = {'search_count': -1}
+
+    for eql_rule, search_args in eql_searches.items():
+        try:
+            result = client.eql.search(**search_args)
+            survey_results[eql_rule] = {'search_count': result.count}
+        except elasticsearch.NotFoundError as e:
+            if e.error == 'index_not_found_exception':
+                survey_results[eql_rule] = {'search_count': -1}
+            else:
+                raise
+
+    for lucene_rule, async_id in async_searches.items():
+        result = async_client.get(async_id)
+        survey_results[lucene_rule] = {'search_count': len(result['response']['hits']['hits'])}
+
+    # add alerts
+    # alerts = ctx.invoke(list_alerts)
+
+    return

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -25,7 +25,7 @@ COLLECTION_DIR = get_path('collections')
 MATCH_ALL = {'bool': {'filter': [{'match_all': {}}]}}
 
 
-def get_authed_es_client(cloud_id=None, elasticsearch_url=None, es_user=None, es_password=None, ctx=None, **kwargs):
+def get_elasticsearch_client(cloud_id=None, elasticsearch_url=None, es_user=None, es_password=None, ctx=None, **kwargs):
     """Get an authenticated elasticsearch client."""
     if not (cloud_id or elasticsearch_url):
         client_error("Missing required --cloud-id or --elasticsearch-url")
@@ -349,7 +349,7 @@ def es_group(ctx: click.Context, **kwargs):
         click.echo(format_command_options(ctx))
 
     else:
-        ctx.obj['es'] = get_authed_es_client(ctx=ctx, **kwargs)
+        ctx.obj['es'] = get_elasticsearch_client(ctx=ctx, **kwargs)
 
 
 @es_group.command('collect-events')

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -6,18 +6,23 @@
 import json
 import os
 import time
+from collections import defaultdict
+from typing import Union
 
 import click
 import elasticsearch
 from elasticsearch import Elasticsearch
+from elasticsearch.client import AsyncSearchClient
 
-
+import kql
 from .main import root
 from .misc import add_params, client_error, elasticsearch_options
 from .utils import format_command_options, normalize_timing_and_sort, unix_time_to_formatted, get_path
+from .rule import Rule
 from .rule_loader import get_rule, rta_mappings
 
 COLLECTION_DIR = get_path('collections')
+MATCH_ALL = {'bool': {'filter': [{'match_all': {}}]}}
 
 
 def get_authed_es_client(cloud_id=None, elasticsearch_url=None, es_user=None, es_password=None, ctx=None, **kwargs):
@@ -46,12 +51,11 @@ def add_range_to_dsl(dsl_filter, start_time, end_time='now'):
     )
 
 
-class Events(object):
+class RtaEvents(object):
     """Events collected from Elasticsearch."""
 
-    def __init__(self, agent_hostname, events):
-        self.agent_hostname = agent_hostname
-        self.events = self._normalize_event_timing(events)
+    def __init__(self, events):
+        self.events: dict = self._normalize_event_timing(events)
 
     @staticmethod
     def _normalize_event_timing(events):
@@ -61,7 +65,8 @@ class Events(object):
 
         return events
 
-    def _get_dump_dir(self, rta_name=None):
+    @staticmethod
+    def _get_dump_dir(rta_name=None, host_id=None):
         """Prepare and get the dump path."""
         if rta_name:
             dump_dir = get_path('unit_tests', 'data', 'true_positives', rta_name)
@@ -69,7 +74,7 @@ class Events(object):
             return dump_dir
         else:
             time_str = time.strftime('%Y%m%dT%H%M%SL')
-            dump_dir = os.path.join(COLLECTION_DIR, self.agent_hostname, time_str)
+            dump_dir = os.path.join(COLLECTION_DIR, host_id or 'unknown_host', time_str)
             os.makedirs(dump_dir, exist_ok=True)
             return dump_dir
 
@@ -96,11 +101,11 @@ class Events(object):
         echo_fn = click.echo_via_pager if pager else click.echo
         echo_fn(json.dumps(self.events, indent=2 if pretty else None, sort_keys=True))
 
-    def save(self, rta_name=None, dump_dir=None):
+    def save(self, rta_name=None, dump_dir=None, host_id=None):
         """Save collected events."""
-        assert self.events, 'Nothing to save. Run Collector.run() method first'
+        assert self.events, 'Nothing to save. Run Collector.run() method first or verify logging'
 
-        dump_dir = dump_dir or self._get_dump_dir(rta_name)
+        dump_dir = dump_dir or self._get_dump_dir(rta_name=rta_name, host_id=host_id)
 
         for source, events in self.events.items():
             path = os.path.join(dump_dir, source + '.jsonl')
@@ -113,8 +118,8 @@ class CollectEvents(object):
     """Event collector for elastic stack."""
 
     def __init__(self, client, max_events=3000):
-        self.client = client
-        self.MAX_EVENTS = max_events
+        self.client: Elasticsearch = client
+        self.max_events = max_events
 
     def _build_timestamp_map(self, index_str):
         """Build a mapping of indexes to timestamp data formats."""
@@ -122,16 +127,17 @@ class CollectEvents(object):
         timestamp_map = {n: m['mappings'].get('properties', {}).get('@timestamp', {}) for n, m in mappings.items()}
         return timestamp_map
 
-    def _get_current_time(self, agent_hostname, index_str):
+    def _get_last_event_time(self, index_str, dsl=None):
         """Get timestamp of most recent event."""
-        # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html
-        timestamp_map = self._build_timestamp_map(index_str)
+        last_event = self.client.search(dsl, index_str, size=1, sort='@timestamp:desc')['hits']['hits']
+        if not last_event:
+            return
 
-        last_event = self._search_window(agent_hostname, index_str, start_time='now-1m', size=1, sort='@timestamp:desc')
-        last_event = last_event['hits']['hits'][0]
-
+        last_event = last_event[0]
         index = last_event['_index']
         timestamp = last_event['_source']['@timestamp']
+
+        timestamp_map = self._build_timestamp_map(index_str)
         event_date_format = timestamp_map[index].get('format', '').split('||')
 
         # there are many native supported date formats and even custom data formats, but most, including beats use the
@@ -142,44 +148,182 @@ class CollectEvents(object):
 
         return timestamp
 
-    def _search_window(self, agent_hostname, index_str, start_time, end_time='now', size=None, sort='@timestamp:asc',
-                       **match):
-        """Collect all events within a time window and parse by source."""
-        match = match.copy()
-        match.update({"agent.hostname": agent_hostname})
-        body = {"query": {"bool": {"filter": [
-            {"match": {"agent.hostname": agent_hostname}},
-            {"range": {"@timestamp": {"gt": start_time, "lte": end_time, "format": "strict_date_optional_time"}}}]
-        }}}
+    @staticmethod
+    def _prep_query(query, language, index, start_time=None, end_time=None):
+        """Prep a query for search."""
+        index_str = ','.join(index if isinstance(index, (list, tuple)) else index.split(','))
+        lucene_query = query if language == 'lucene' else None
 
-        if match:
-            body['query']['bool']['filter'].extend([{'match': {k: v}} for k, v in match.items()])
+        if language in ('kql', 'kuery'):
+            formatted_dsl = {'query': kql.to_dsl(query)}
+        elif language == 'eql':
+            formatted_dsl = {'query': query, 'filter': MATCH_ALL}
+        elif language == 'lucene':
+            formatted_dsl = {'query': {'bool': {'filter': []}}}
+        elif language == 'dsl':
+            formatted_dsl = {'query': query}
+        else:
+            raise ValueError('Unknown search language')
 
-        return self.client.search(index=index_str, body=body, size=size or self.MAX_EVENTS, sort=sort)
+        if start_time or end_time:
+            end_time = end_time or 'now'
+            dsl = formatted_dsl['filter']['bool']['filter'] if language == 'eql' else \
+                formatted_dsl['query']['bool'].setdefault('filter', [])
+            add_range_to_dsl(dsl, start_time, end_time)
+
+        return index_str, formatted_dsl, lucene_query
+
+    def search(self, query, language, index: Union[str, list] = '*', start_time=None, end_time=None, size=None,
+               **kwargs):
+        """Search an elasticsearch instance."""
+        index_str, formatted_dsl, lucene_query = self._prep_query(query=query, language=language, index=index,
+                                                                  start_time=start_time, end_time=end_time)
+        formatted_dsl.update(size=size or self.max_events)
+
+        if language == 'eql':
+            results = self.client.eql.search(body=formatted_dsl, index=index_str, **kwargs)['hits']
+            results = results.get('events') or results.get('sequences', [])
+        else:
+            results = self.client.search(body=formatted_dsl, q=lucene_query, index=index_str,
+                                         allow_no_indices=True, ignore_unavailable=True, **kwargs)['hits']['hits']
+
+        return results
+
+    def search_from_rule(self, *rules: Rule, start_time=None, end_time='now', size=None):
+        """Search an elasticsearch instance using a rule."""
+        from .misc import nested_get
+
+        async_client = AsyncSearchClient(self.client)
+        survey_results = {}
+
+        def parse_unique_field_results(rule_type, unique_fields, search_results):
+            parsed_results = defaultdict(lambda: defaultdict(int))
+            hits = search_results['hits']['hits'] if rule_type != 'eql' else search_results.events
+            for hit in hits:
+                for field in unique_fields:
+                    match = nested_get(hit['_source'], field)
+                    match = ','.join(sorted(match)) if isinstance(match, list) else match
+                    parsed_results[field][match] += 1
+            # if rule.type == eql, structure is different
+            return {'results': parsed_results} if parsed_results else {}
+
+        multi_search = []
+        multi_search_rules = []
+        async_searches = {}
+        eql_searches = {}
+
+        for rule in rules:
+            if not rule.query:
+                continue
+
+            index_str, formatted_dsl, lucene_query = self._prep_query(query=rule.query,
+                                                                      language=rule.contents.get('language'),
+                                                                      index=rule.contents.get('index', '*'),
+                                                                      start_time=start_time,
+                                                                      end_time=end_time)
+            formatted_dsl.update(size=size or self.max_events)
+
+            # prep for searches: msearch for kql | async search for lucene | eql client search for eql
+            if rule.contents['language'] == 'kuery':
+                multi_search_rules.append(rule)
+                multi_search.append(json.dumps(
+                    {'index': index_str, 'allow_no_indices': 'true', 'ignore_unavailable': 'true'}))
+                multi_search.append(json.dumps(formatted_dsl))
+            elif rule.contents['language'] == 'lucene':
+                # wait for 0 to try and force async with no immediate results (not guaranteed)
+                result = async_client.submit(body=formatted_dsl, q=rule.query, index=index_str,
+                                             allow_no_indices=True, ignore_unavailable=True,
+                                             wait_for_completion_timeout=0)
+                if result['is_running'] is True:
+                    async_searches[rule] = result['id']
+                else:
+                    survey_results[rule.id] = parse_unique_field_results(rule.type, rule.unique_fields,
+                                                                         result['response'])
+            elif rule.contents['language'] == 'eql':
+                eql_body = {
+                    'index': index_str,
+                    'params': {'ignore_unavailable': 'true', 'allow_no_indices': 'true'},
+                    'body': {'query': rule.query, 'filter': formatted_dsl['filter']}
+                }
+                eql_searches[rule] = eql_body
+
+        # assemble search results
+        multi_search_results = self.client.msearch('\n'.join(multi_search) + '\n')
+        for index, result in enumerate(multi_search_results['responses']):
+            try:
+                rule = multi_search_rules[index]
+                survey_results[rule.id] = parse_unique_field_results(rule.type, rule.unique_fields, result)
+            except KeyError:
+                survey_results[multi_search_rules[index].id] = {'error_retrieving_results': True}
+
+        for rule, search_args in eql_searches.items():
+            try:
+                result = self.client.eql.search(**search_args)
+                survey_results[rule.id] = parse_unique_field_results(rule.type, rule.unique_fields, result)
+            except (elasticsearch.NotFoundError, elasticsearch.RequestError) as e:
+                survey_results[rule.id] = {'error_retrieving_results': True, 'error': e.info['error']['reason']}
+
+        for rule, async_id in async_searches.items():
+            result = async_client.get(async_id)['response']
+            survey_results[rule.id] = parse_unique_field_results(rule.type, rule.unique_fields, result)
+
+        return survey_results
+
+    def count(self, query, language, index: Union[str, list], start_time=None, end_time='now'):
+        """Get a count of documents from elasticsearch."""
+        index_str, formatted_dsl, lucene_query = self._prep_query(query=query, language=language, index=index,
+                                                                  start_time=start_time, end_time=end_time)
+
+        # EQL API has no count endpoint
+        if language == 'eql':
+            results = self.search(query=query, language=language, index=index, start_time=start_time, end_time=end_time,
+                                  size=1000)
+            return len(results)
+        else:
+            return self.client.count(body=formatted_dsl, index=index_str, q=lucene_query, allow_no_indices=True,
+                                     ignore_unavailable=True)['count']
+
+    def count_from_rule(self, *rules, start_time=None, end_time='now'):
+        """Get a count of documents from elasticsearch using a rule."""
+        survey_results = {}
+
+        for rule in rules:
+            rule_results = {'rule_id': rule.id, 'name': rule.name}
+
+            if not rule.query:
+                continue
+
+            try:
+                rule_results['search_count'] = self.count(query=rule.query, language=rule.contents.get('language'),
+                                                          index=rule.contents.get('index', '*'), start_time=start_time,
+                                                          end_time=end_time)
+            except (elasticsearch.NotFoundError, elasticsearch.RequestError):
+                rule_results['search_count'] = -1
+
+            survey_results[rule.id] = rule_results
+
+        return survey_results
+
+
+class CollectRtaEvents(CollectEvents):
+    """Collect RTA events from elasticsearch."""
 
     @staticmethod
     def _group_events_by_type(events):
         """Group events by agent.type."""
         event_by_type = {}
 
-        for event in events['hits']['hits']:
+        for event in events:
             event_by_type.setdefault(event['_source']['agent']['type'], []).append(event['_source'])
 
         return event_by_type
 
-    def run(self, agent_hostname, indexes, verbose=True, **match):
+    def run(self, dsl, indexes, start_time):
         """Collect the events."""
-        index_str = ','.join(indexes)
-        start_time = self._get_current_time(agent_hostname, index_str)
-
-        if verbose:
-            click.echo('Setting start of event capture to: {}'.format(click.style(start_time, fg='yellow')))
-
-        click.pause('Press any key once detonation is complete ...')
-        time.sleep(5)
-        events = self._group_events_by_type(self._search_window(agent_hostname, index_str, start_time, **match))
-
-        return Events(agent_hostname, events)
+        results = self.search(dsl, language='dsl', index=indexes, start_time=start_time, end_time='now', size=5000,
+                              sort='@timestamp:asc')
+        events = self._group_events_by_type(results)
+        return RtaEvents(events)
 
 
 @root.command('normalize-data')
@@ -187,7 +331,7 @@ class CollectEvents(object):
 def normalize_data(events_file):
     """Normalize Elasticsearch data timestamps and sort."""
     file_name = os.path.splitext(os.path.basename(events_file.name))[0]
-    events = Events('_', {file_name: [json.loads(e) for e in events_file.readlines()]})
+    events = RtaEvents({file_name: [json.loads(e) for e in events_file.readlines()]})
     events.save(dump_dir=os.path.dirname(events_file.name))
 
 
@@ -208,22 +352,26 @@ def es_group(ctx: click.Context, **kwargs):
 
 
 @es_group.command('collect-events')
-@click.argument('agent-hostname')
+@click.argument('host-id')
+@click.option('--query', '-q', help='KQL query to scope search')
 @click.option('--index', '-i', multiple=True, help='Index(es) to search against (default: all indexes)')
-@click.option('--agent-type', '-a', help='Restrict results to a source type (agent.type) ex: auditbeat')
 @click.option('--rta-name', '-r', help='Name of RTA in order to save events directly to unit tests data directory')
 @click.option('--rule-id', help='Updates rule mapping in rule-mapping.yml file (requires --rta-name)')
 @click.option('--view-events', is_flag=True, help='Print events after saving')
 @click.pass_context
-def collect_events(ctx, agent_hostname, index, agent_type, rta_name, rule_id, view_events):
+def collect_events(ctx, host_id, query, index, rta_name, rule_id, view_events):
     """Collect events from Elasticsearch."""
-    match = {'agent.type': agent_type} if agent_type else {}
     client = ctx.obj['es']
+    dsl = kql.to_dsl(query) if query else MATCH_ALL
+    dsl['bool'].setdefault('filter', []).append({'bool': {'should': [{'match_phrase': {'host.id': host_id}}]}})
 
     try:
-        collector = CollectEvents(client)
-        events = collector.run(agent_hostname, index, **match)
-        events.save(rta_name)
+        collector = CollectRtaEvents(client)
+        start = time.time()
+        click.pause('Press any key once detonation is complete ...')
+        start_time = f'now-{round(time.time() - start) + 5}s'
+        events = collector.run(dsl, index or '*', start_time)
+        events.save(rta_name=rta_name, host_id=host_id)
 
         if rta_name and rule_id:
             events.evaluate_against_rule_and_update_mapping(rule_id, rta_name)

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -13,9 +13,6 @@ from .rule_loader import load_rule_files, load_rules
 from .utils import format_command_options
 
 
-MATCH_ALL = {'bool': {'filter': [{'match_all': {}}]}}
-
-
 def get_authed_kibana_client(cloud_id, kibana_url, kibana_user, kibana_password, **kwargs):
     """Get an authenticated Kibana client."""
     if not (cloud_id or kibana_url):
@@ -87,7 +84,7 @@ def upload_rule(ctx, toml_files):
 def search_alerts(ctx, query, date_range):
     """Search detection engine alerts with KQL."""
     from eql.table import Table
-    from .eswrap import add_range_to_dsl
+    from .eswrap import MATCH_ALL, add_range_to_dsl
 
     kibana = ctx.obj['kibana']
     start_time, end_time = date_range

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -13,7 +13,7 @@ from .rule_loader import load_rule_files, load_rules
 from .utils import format_command_options
 
 
-def get_authed_kibana_client(cloud_id, kibana_url, kibana_user, kibana_password, **kwargs):
+def get_kibana_client(cloud_id, kibana_url, kibana_user, kibana_password, **kwargs):
     """Get an authenticated Kibana client."""
     if not (cloud_id or kibana_url):
         client_error("Missing required --cloud-id or --kibana-url")
@@ -40,7 +40,7 @@ def kibana_group(ctx: click.Context, **kibana_kwargs):
         click.echo(format_command_options(ctx))
 
     else:
-        ctx.obj['kibana'] = get_authed_kibana_client(**kibana_kwargs)
+        ctx.obj['kibana'] = get_kibana_client(**kibana_kwargs)
 
 
 @kibana_group.command("upload-rule")

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -16,16 +16,16 @@ from .utils import format_command_options
 MATCH_ALL = {'bool': {'filter': [{'match_all': {}}]}}
 
 
-def get_authed_kibana_client(kibana_kwargs):
+def get_authed_kibana_client(cloud_id, kibana_url, kibana_user, kibana_password, **kwargs):
     """Get an authenticated Kibana client."""
-    if not (kibana_kwargs['cloud_id'] or kibana_kwargs['kibana_url']):
+    if not (cloud_id or kibana_url):
         client_error("Missing required --cloud-id or --kibana-url")
 
     # don't prompt for these until there's a cloud id or Kibana URL
-    kibana_user = kibana_kwargs.pop('kibana_user', None) or click.prompt("kibana_user")
-    kibana_password = kibana_kwargs.pop('kibana_password', None) or click.prompt("kibana_password", hide_input=True)
+    kibana_user = kibana_user or click.prompt("kibana_user")
+    kibana_password = kibana_password or click.prompt("kibana_password", hide_input=True)
 
-    with Kibana(**kibana_kwargs) as kibana:
+    with Kibana(cloud_id=cloud_id, kibana_url=kibana_url, **kwargs) as kibana:
         kibana.login(kibana_user, kibana_password)
         return kibana
 
@@ -43,7 +43,7 @@ def kibana_group(ctx: click.Context, **kibana_kwargs):
         click.echo(format_command_options(ctx))
 
     else:
-        ctx.obj['kibana'] = get_authed_kibana_client(kibana_kwargs)
+        ctx.obj['kibana'] = get_authed_kibana_client(**kibana_kwargs)
 
 
 @kibana_group.command("upload-rule")

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -274,8 +274,8 @@ def add_client(*client_type, add_to_ctx=True):
     """Wrapper to add authed client."""
     from elasticsearch import Elasticsearch, ElasticsearchException
     from kibana import Kibana
-    from .eswrap import get_authed_es_client
-    from .kbwrap import get_authed_kibana_client
+    from .eswrap import get_elasticsearch_client
+    from .kbwrap import get_kibana_client
 
     def _wrapper(func):
         client_ops_dict = {}
@@ -306,9 +306,9 @@ def add_client(*client_type, add_to_ctx=True):
                             elasticsearch_client.info():
                         pass
                     else:
-                        elasticsearch_client = get_authed_es_client(use_ssl=True, **es_client_args)
+                        elasticsearch_client = get_elasticsearch_client(use_ssl=True, **es_client_args)
                 except ElasticsearchException:
-                    elasticsearch_client = get_authed_es_client(use_ssl=True, **es_client_args)
+                    elasticsearch_client = get_elasticsearch_client(use_ssl=True, **es_client_args)
 
                 kwargs['elasticsearch_client'] = elasticsearch_client
                 if ctx and add_to_ctx:
@@ -322,9 +322,9 @@ def add_client(*client_type, add_to_ctx=True):
                         if kibana_client and isinstance(kibana_client, Kibana) and kibana_client.version:
                             pass
                         else:
-                            kibana_client = get_authed_kibana_client(**kibana_client_args)
+                            kibana_client = get_kibana_client(**kibana_client_args)
                 except (requests.HTTPError, AttributeError):
-                    kibana_client = get_authed_kibana_client(**kibana_client_args)
+                    kibana_client = get_kibana_client(**kibana_client_args)
 
                 kwargs['kibana_client'] = kibana_client
                 if ctx and add_to_ctx:

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -302,7 +302,7 @@ def add_client(*client_type, add_to_ctx=True):
                     ctx.obj['es'] = elasticsearch_client
 
             if 'kibana' in client_type:
-                kibana_client = get_authed_kibana_client(kibana_client_args)
+                kibana_client = get_authed_kibana_client(**kibana_client_args)
                 kwargs['kibana_client'] = kibana_client
                 if ctx and add_to_ctx:
                     ctx.obj['kibana'] = kibana_client

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -252,3 +252,14 @@ def format_command_options(ctx):
             formatter.write_dl(opts)
 
     return formatter.getvalue()
+
+
+def add_params(*params):
+    """Add parameters to a click command."""
+    def decorator(f):
+        if not hasattr(f, '__click_params__'):
+            f.__click_params__ = []
+        f.__click_params__.extend(params)
+        return f
+
+    return decorator

--- a/kibana/connector.py
+++ b/kibana/connector.py
@@ -62,7 +62,7 @@ class Kibana(object):
             uri = "s/{}/{}".format(self.space, uri)
         return f"{self.kibana_url}/{uri}"
 
-    def request(self, method, uri, params=None, data=None, error=True, verbose=True):
+    def request(self, method, uri, params=None, data=None, error=True, verbose=True, raw=False):
         """Perform a RESTful HTTP request with JSON responses."""
         params = params or {}
         url = self.url(uri)
@@ -83,7 +83,7 @@ class Kibana(object):
         if not response.content:
             return
 
-        return response.json()
+        return response.content if raw else response.json()
 
     def get(self, uri, params=None, data=None, error=True, **kwargs):
         """Perform an HTTP GET."""
@@ -133,7 +133,10 @@ class Kibana(object):
 
     def logout(self):
         """Quit the current session."""
-        # TODO: implement session logout
+        self.get('/logout', raw=True)
+        self.status = None
+        self.authenticated = False
+        self.session = requests.Session()
         self.elasticsearch = None
 
     def __del__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ requests==2.22.0
 Click==7.0
 PyYAML~=5.3
 eql~=0.9.5
-elasticsearch~=7.5.1
+elasticsearch~=7.9.1
+elasticsearch-dsl==7.2.1
 XlsxWriter==1.3.6
 
 # test deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Click==7.0
 PyYAML~=5.3
 eql~=0.9.5
 elasticsearch~=7.9.1
-elasticsearch-dsl==7.2.1
 XlsxWriter==1.3.6
 
 # test deps

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests==2.22.0
 Click==7.0
 PyYAML~=5.3
 eql~=0.9.5
-elasticsearch~=7.9.1
+elasticsearch~=7.9
 XlsxWriter==1.3.6
 
 # test deps

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ import time
 import unittest
 
 from detection_rules.utils import normalize_timing_and_sort, cached
-from detection_rules.eswrap import Events
+from detection_rules.eswrap import RtaEvents
 from detection_rules.ecs import get_kql_schema
 
 
@@ -56,7 +56,7 @@ class TestTimeUtils(unittest.TestCase):
         """Test that events are normalized properly within Events."""
         events_data = self.get_events()
         for date_format, events in events_data.items():
-            normalized = Events('_', {'winlogbeat': events})
+            normalized = RtaEvents({'winlogbeat': events})
             self.assert_sort(normalized.events['winlogbeat'], date_format)
 
     def test_schema_multifields(self):


### PR DESCRIPTION
## Issues
resolves #484

## Summary
Adds the following commands:

* `dev test`:
   - `event-search` - search elasticsearch with a specified query
   - `rule-event-search` - search elasticsearch by specifying a rule
   - `rule-survey` - run a survey against all rules specified by a `rule-search` filter and determine search and alert hits
* `kibana`
   - `search-alerts` - search alerts with kql

```console
python -m detection_rules dev test rule-survey --hide-zero-counts --hide-errors --date-range now-220d now
Loaded config file: .../.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

DEBUG MODE ENABLED
Running survey against 325 rules
Saving detailed dump to: surveys/20201106T014126L.json
===============================================================================================================================
 rule_id                                name                                                        search_count   alert_count 
===============================================================================================================================
 2bf78aa2-9c56-48de-b139-f169bf99cf86   Adobe Hijack Persistence                                               1    
 6ea71ff0-9e95-475b-9506-2580d1ce6154   DNS Activity to the Internet                                         552    
 f675872f-6d85-40a3-b502-c0d2ef101e92   Delete Volume USN Journal with Fsutil                                  1    
 4b438734-3793-4fda-bd42-ceeada0be8f9   Disable Windows Firewall Rules via Netsh                               2    
 9c260313-c811-4ec8-ab89-8f6530e0246c   Hosts File Modified                                                   31    
 afcce5ad-65de-4ed2-8516-5e093d3ac99a   Local Scheduled Task Commands                                          8    
 e8571d5f-bea1-46c2-9f56-998de2d3ed95   Local Service Commands                                               107   12 
 adb961e0-cb74-42a0-af9e-29fc41f88f5f   Netcat Network Activity                                                1    
 81cc58f5-8062-49a2-ba84-5cc4b4d31c40   Persistence via Kernel Module Modification                             1    
 68921d85-d0dc-48b3-865f-43291ca2c4f2   Persistence via TelemetryController Scheduled Task Hijack             23    
 7405ddf1-6c8e-41ce-818f-48bea6bcaed8   Potential Modification of Accessibility Binaries                      25    
 6ea41894-66c3-4df7-ad6b-2c5074eb3df8   Process Potentially Masquerading as WerFault                           1    
 b41a13c6-ba45-4bab-a534-df53d0cfed6a   Suspicious Endpoint Security Parent Process                            7    
 a624863f-a70d-417f-a7d2-7a404638d47f   Suspicious MS Office Child Process                                     0   12 
 fd7a6052-58fa-4397-93c3-4795249ccfa2   Svchost spawning Cmd                                                   2    
 c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9   Unusual File Modification by dns.exe                                 130    
 3b47900d-e793-49e8-968f-c90dc3526aa1   Unusual Parent Process for cmd.exe                                    64    
 35df0dd8-092d-4a83-88c1-5151a804f31b   Unusual Parent-Child Relationship                                      3    
 df959768-b0c9-4d45-988c-5606a2be8e5a   Unusual Process Execution - Temp                                     104    
===============================================================================================================================
```