### PR TITLE
[New Rule] Administrator Role Assigned to Okta User

### DIFF
--- a/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -20,7 +20,7 @@ false_positives = [
 index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License"
-name = "Administrator Role Assigned to Okta User"
+name = "Administrator Role Assigned to an Okta User"
 note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm",

--- a/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -23,9 +23,9 @@ license = "Elastic License"
 name = "Administrator Role Assigned to Okta User"
 note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
 references = [
+    "https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",
-    "https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm",
 ]
 risk_score = 47
 rule_id = "f06414a6-f2a4-466d-8eba-10f85e8abf71"

--- a/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -1,0 +1,53 @@
+[metadata]
+creation_date = "2020/11/06"
+ecs_version = ["1.6.0"]
+maturity = "development"
+updated_date = "2020/11/06"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when an administrator role is assigned to an Okta user. An adversary may attempt to assign an administrator
+role to an Okta user in order to assign additional permissions to a user account and maintain access to their target's
+environment.
+"""
+false_positives = [
+    """
+    Administrator roles may be assigned to Okta users by a Super Admin user. Verify that the behavior was expected.
+    Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+index = ["filebeat-*", "logs-okta*"]
+language = "kuery"
+license = "Elastic License"
+name = "Administrator Role Assigned to Okta User"
+note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://developer.okta.com/docs/reference/api/system-log/",
+    "https://developer.okta.com/docs/reference/api/event-types/",
+    "https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm",
+]
+risk_score = 47
+rule_id = "f06414a6-f2a4-466d-8eba-10f85e8abf71"
+severity = "medium"
+tags = ["Elastic", "Okta", "SecOps", "Monitoring", "Continuous Monitoring"]
+type = "query"
+
+query = '''
+event.dataset:okta.system and event.action:user.account.privilege.grant
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 ecs_version = ["1.6.0"]
-maturity = "development"
+maturity = "production"
 updated_date = "2020/11/06"
 
 [rule]
@@ -50,4 +50,3 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #397 

## Summary
Identifies when an administrator role is assigned to an Okta user. An adversary may attempt to assign an administrator role to an Okta user in order to assign additional permissions to a user account and maintain access to their target's environment.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
