### PR TITLE
[New Rule] Attempt to Modify an Okta Application

### DIFF
--- a/rules/okta/okta_attempt_to_modify_okta_application.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_application.toml
@@ -1,0 +1,37 @@
+[metadata]
+creation_date = "2020/11/06"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/06"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects attempts to modify an Okta application. An adversary may attempt to modify, deactivate, or delete an Okta
+application in order to weaken an organization's security controls or disrupt their business operations.
+"""
+false_positives = [
+    """
+    Consider adding exceptions to this rule to filter false positives if your organization's Okta applications are
+    regularly modified and the behavior is expected.
+    """,
+]
+index = ["filebeat-*", "logs-okta*"]
+language = "kuery"
+license = "Elastic License"
+name = "Attempt to Modify an Okta Application"
+note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://developer.okta.com/docs/reference/api/system-log/",
+    "https://developer.okta.com/docs/reference/api/event-types/",
+]
+risk_score = 21
+rule_id = "c74fd275-ab2c-4d49-8890-e2943fa65c09"
+severity = "low"
+tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+type = "query"
+
+query = '''
+event.dataset:okta.system and event.action:application.lifecycle.update
+'''
+

--- a/rules/okta/okta_attempt_to_modify_okta_application.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_application.toml
@@ -22,6 +22,7 @@ license = "Elastic License"
 name = "Attempt to Modify an Okta Application"
 note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
 references = [
+    "https://help.okta.com/en/prod/Content/Topics/Apps/Apps_Apps.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",
 ]
@@ -34,4 +35,3 @@ type = "query"
 query = '''
 event.dataset:okta.system and event.action:application.lifecycle.update
 '''
-


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #492 

## Summary
Detects attempts to modify an Okta application. An adversary may attempt to modify, deactivate, or delete an Okta application in order to weaken an organization's security controls or disrupt their business operations.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
