### PR TITLE
[New Rule] Google Workspace API Access Granted via Domain-Wide Delegation of Authority

### DIFF
--- a/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
+++ b/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
@@ -1,0 +1,58 @@
+[metadata]
+creation_date = "2020/11/12"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/12"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when a domain-wide delegation of authority is granted to a service account. Domain-wide delegation can be
+configured to grant third-party and internal applications to access the data of Google Workspace users. An adversary may
+configure domain-wide delegation to maintain access to their target’s data.
+"""
+false_positives = [
+    """
+    Domain-wide delegation of authority may be granted to service accounts by system administrators. Verify that the
+    configuration change was expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-130m"
+index = ["filebeat-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License"
+name = "Google Workspace API Access Granted via Domain-Wide Delegation of Authority"
+note = """### Important Information Regarding Google Workspace Event Lag Times
+- As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
+- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
+- By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
+- See the following references for further information.
+  - https://support.google.com/a/answer/7061566
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html"""
+references = ["https://developers.google.com/admin-sdk/directory/v1/guides/delegation"]
+risk_score = 47
+rule_id = "acbc8bb9-2486-49a8-8779-45fb5f9a93ee"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+type = "query"
+
+query = '''
+event.dataset:gsuite.admin and event.provider:admin and event.category:iam and event.action:AUTHORIZE_API_CLIENT_ACCESS
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+


### PR DESCRIPTION
## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #467

## Summary
Detects when a domain-wide delegation of authority is granted to a service account. Domain-wide delegation can be configured to grant third-party and internal applications to access the data of Google Workspace users. An adversary may configure domain-wide delegation to maintain access to their target’s data.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
