### PR TITLE
[New Rule] Google Workspace Password Policy Modified

### DIFF
--- a/rules/google-workspace/google_workspace_policy_modified.toml
+++ b/rules/google-workspace/google_workspace_policy_modified.toml
@@ -48,3 +48,4 @@ event.dataset:gsuite.admin and event.provider:admin and event.category:iam and
     "Password Management - Maximum password length"
   )
 '''
+

--- a/rules/google-workspace/google_workspace_policy_modified.toml
+++ b/rules/google-workspace/google_workspace_policy_modified.toml
@@ -1,0 +1,50 @@
+[metadata]
+creation_date = "2020/11/17"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/17"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when a Google Workspace password policy is modified. An adversary may attempt to modify a password policy in
+order to weaken an organization’s security controls.
+"""
+false_positives = [
+    """
+    Password policies may be modified by system administrators. Verify that the configuration change was expected.
+    Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-130m"
+index = ["filebeat-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License"
+name = "Google Workspace Password Policy Modified"
+note = """### Important Information Regarding Google Workspace Event Lag Times
+- As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
+- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
+- By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
+- See the following references for further information.
+  - https://support.google.com/a/answer/7061566
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html"""
+risk_score = 47
+rule_id = "a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+type = "query"
+
+query = '''
+event.dataset:gsuite.admin and event.provider:admin and event.category:iam and
+  event.action:(CHANGE_APPLICATION_SETTING or CREATE_APPLICATION_SETTING) and
+  gsuite.admin.setting.name:(
+    "Password Management - Enforce strong password" or
+    "Password Management - Password reset frequency" or
+    "Password Management - Enable password reuse" or
+    "Password Management - Enforce password policy at next login" or
+    "Password Management - Minimum password length" or
+    "Password Management - Maximum password length"
+  )
+'''


### PR DESCRIPTION
## Issues
Resolves #469 

## Summary

Detects when a Google Workspace password policy is modified. An adversary may attempt to modify a password policy in order to weaken an organization’s security controls.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
