### PR TITLE
[New Rule] Google Workspace Admin Role Assigned to a User

### DIFF
--- a/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -1,0 +1,57 @@
+[metadata]
+creation_date = "2020/11/17"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/17"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when an admin role is assigned to a Google Workspace user. An adversary may assign an admin role to a user in
+order to elevate the permissions of another user account and persist in their target’s environment.
+"""
+false_positives = [
+    """
+    Google Workspace admin role assignments may be modified by system administrators. Verify that the configuration
+    change was expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-130m"
+index = ["filebeat-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License"
+name = "Google Workspace Admin Role Assigned to a User"
+note = """### Important Information Regarding Google Workspace Event Lag Times
+- As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
+- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
+- By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
+- See the following references for further information.
+  - https://support.google.com/a/answer/7061566
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html"""
+references = ["https://support.google.com/a/answer/172176?hl=en"]
+risk_score = 47
+rule_id = "68994a6c-c7ba-4e82-b476-26a26877adf6"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+type = "query"
+
+query = '''
+event.dataset:gsuite.admin and event.provider:admin and event.category:iam and event.action:ASSIGN_ROLE
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+


### PR DESCRIPTION
## Issues
Resolves #506 

## Summary

Detects when an admin role is assigned to a Google Workspace user. An adversary may assign an admin role to a user in order to elevate the permissions of another user account and persist in their target’s environment.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
