### PR TITLE
[New Rule] Domain Added to Google Workspace Trusted Domains

### DIFF
--- a/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
@@ -1,0 +1,43 @@
+[metadata]
+creation_date = "2020/11/17"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/17"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when a domain is added to the list of trusted Google Workspace domains. An adversary may add a trusted domain in
+order to collect and exfiltrate data from their target’s organization with less restrictive security controls.
+"""
+false_positives = [
+    """
+    Trusted domains may be added by system administrators. Verify that the configuration change was expected. Exceptions
+    can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-130m"
+index = ["filebeat-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License"
+name = "Domain Added to Google Workspace Trusted Domains"
+note = """### Important Information Regarding Google Workspace Event Lag Times
+- As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
+- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
+- By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
+- See the following references for further information.
+  - https://support.google.com/a/answer/7061566
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html"""
+references = ["https://support.google.com/a/answer/6160020?hl=en"]
+risk_score = 73
+rule_id = "cf549724-c577-4fd6-8f9b-d1b8ec519ec0"
+severity = "high"
+tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:gsuite.admin and event.provider:admin and event.category:iam and event.action:ADD_TRUSTED_DOMAINS
+'''
+


### PR DESCRIPTION
## Issues
Resolves #513 

## Summary

Detects when a domain is added to the list of trusted Google Workspace domains. An adversary may add a trusted domain in order to collect and exfiltrate data from their target’s organization with less restrictive security controls.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
