### PR TITLE
[New Rule] Application Added to Google Workspace Domain

### DIFF
--- a/rules/google-workspace/application_added_to_google_workspace_domain.toml
+++ b/rules/google-workspace/application_added_to_google_workspace_domain.toml
@@ -12,7 +12,7 @@ an organization’s Google Workspace domain in order to maintain a presence in t
 """
 false_positives = [
     """
-    Apps can be added to a Google Workspace domain by system administrators. Verify that the configuration change was
+    Applications can be added to a Google Workspace domain by system administrators. Verify that the configuration change was
     expected. Exceptions can be added to this rule to filter expected behavior.
     """,
 ]

--- a/rules/google-workspace/application_added_to_google_workspace_domain.toml
+++ b/rules/google-workspace/application_added_to_google_workspace_domain.toml
@@ -7,7 +7,7 @@ updated_date = "2020/11/17"
 [rule]
 author = ["Elastic"]
 description = """
-Detects when a Google marketplace app is added to the Google Workspace domain. An adversary may add a malicious app to
+Detects when a Google marketplace application is added to the Google Workspace domain. An adversary may add a malicious application to
 an organization’s Google Workspace domain in order to maintain a presence in their target’s organization and steal data.
 """
 false_positives = [
@@ -40,4 +40,3 @@ type = "query"
 query = '''
 event.dataset:gsuite.admin and event.provider:admin and event.category:iam and event.action:ADD_APPLICATION
 '''
-

--- a/rules/google-workspace/application_added_to_google_workspace_domain.toml
+++ b/rules/google-workspace/application_added_to_google_workspace_domain.toml
@@ -1,0 +1,43 @@
+[metadata]
+creation_date = "2020/11/17"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/17"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when a Google marketplace app is added to the Google Workspace domain. An adversary may add a malicious app to
+an organization’s Google Workspace domain in order to maintain a presence in their target’s organization and steal data.
+"""
+false_positives = [
+    """
+    Apps can be added to a Google Workspace domain by system administrators. Verify that the configuration change was
+    expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-130m"
+index = ["filebeat-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License"
+name = "Application Added to Google Workspace Domain"
+note = """### Important Information Regarding Google Workspace Event Lag Times
+- As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
+- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
+- By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
+- See the following references for further information.
+  - https://support.google.com/a/answer/7061566
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html"""
+references = ["https://support.google.com/a/answer/6328701?hl=en#"]
+risk_score = 47
+rule_id = "785a404b-75aa-4ffd-8be5-3334a5a544dd"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:gsuite.admin and event.provider:admin and event.category:iam and event.action:ADD_APPLICATION
+'''
+


### PR DESCRIPTION
## Issues
Resolves #512 

## Summary

Detects when a Google marketplace app is added to the Google Workspace domain. An adversary may add a malicious app to an organization’s Google Workspace domain in order to maintain a presence in their target’s organization and steal data.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
