### PR TITLE
[New Rule] Google Workspace MFA Enrollment Disabled

### DIFF
--- a/rules/google-workspace/google_workspace_mfa_enrollment_disabled.toml
+++ b/rules/google-workspace/google_workspace_mfa_enrollment_disabled.toml
@@ -1,0 +1,43 @@
+[metadata]
+creation_date = "2020/11/17"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/17"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when multi-factor authentication (MFA) enrollment is disabled for Google Workspace users. An adversary may
+disable MFA enrollment in order to weaken an organization’s security controls.
+"""
+false_positives = [
+    """
+    MFA policies and requirements may be modified by system administrators. Verify that the configuration change was
+    expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-130m"
+index = ["filebeat-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License"
+name = "Google Workspace MFA Enrollment Disabled"
+note = """### Important Information Regarding Google Workspace Event Lag Times
+- As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
+- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
+- By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
+- See the following references for further information.
+  - https://support.google.com/a/answer/7061566
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-gsuite.html"""
+references = ["https://support.google.com/a/answer/9176657?hl=en#"]
+risk_score = 47
+rule_id = "1c15030f-c106-40af-92c6-31c5136e8c07"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:gsuite.admin and event.provider:admin and event.category:iam and event.action:ENFORCE_STRONG_AUTHENTICATION and gsuite.admin.new_value:false
+'''
+


### PR DESCRIPTION
## Issues
Resolves #515 

## Summary

Detects when multi-factor authentication (MFA) enrollment is disabled for Google Workspace users. An adversary may disable MFA enrollment in order to weaken an organization’s security controls.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
