### PR TITLE
[New Rule] Added user account

### DIFF
--- a/rules/cross-platform/user_account_created.toml
+++ b/rules/cross-platform/user_account_created.toml
@@ -1,0 +1,26 @@
+[metadata]
+creation_date = "2020/11/18"
+ecs_version = ["1.6.0"]
+maturity = "development"
+updated_date = "2020/11/18"
+
+[rule]
+author = ["Anabella Cristaldi"]
+description = """
+Identifies the creation of new users. This is sometimes done either by attackers to increase access to a system or a
+domain or by a legal admin and the activity needs to be audited when strong security regulations are in place.
+"""
+index = ["winlogbeat-*", "auditbeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "User Account Created"
+risk_score = 21
+rule_id = "73ccc727-dc70-4112-85f1-aa91f86548f0"
+severity = "low"
+tags = ["Windows", "Linux", "Elastic"]
+type = "query"
+
+query = '''
+event.category:iam and event.type:(creation and user) and event.outcome:success
+'''
+

--- a/rules/windows/defense_evasion_clearing_windows_security_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_security_logs.toml
@@ -6,15 +6,19 @@ updated_date = "2020/11/12"
 
 [rule]
 author = ["Anabella Cristaldi"]
-description = "Looks for events related to clearing security logs"
+description = "Identifies attempts to clear Windows Security log stores"
+from = "now-9m"
 index = ["winlogbeat-*"]
+interval = "6m"
 language = "kuery"
 license = "Elastic License"
+max_signals = 99
 name = "Clearing Windows Security Logs"
 risk_score = 21
-rule_id = "95ba057e-4a9c-41af-9dda-510516fdfbe4"
+rule_id = "45ac4800-840f-414c-b221-53dd36a5aaf7"
 severity = "low"
-tags = ["Windows"]
+tags = ["Windows", "Elastic"]
+to = "now-1s"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_clearing_windows_security_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_security_logs.toml
@@ -1,0 +1,23 @@
+[metadata]
+creation_date = "2020/11/12"
+ecs_version = ["1.6.0"]
+maturity = "development"
+updated_date = "2020/11/12"
+
+[rule]
+author = ["Anabella Cristaldi"]
+description = "Looks for events related to clearing security logs"
+index = ["winlogbeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "Clearing Windows Security Logs"
+risk_score = 21
+rule_id = "95ba057e-4a9c-41af-9dda-510516fdfbe4"
+severity = "low"
+tags = ["Windows"]
+type = "query"
+
+query = '''
+event.module:security and event.action:audit-log-cleared
+'''
+


### PR DESCRIPTION
## Summary
Detecting when an user is being created is important not only because it can be an indicator that the system is compromised and an attacker is trying to increase access to a system/domain but also when legal activities needs to be audited for compliance 
There is one detection rule for windows "User Account Creation" that is base on the analysis of process execution and process execution arguments.
This rule is cross-plataform and it is based on ECS event fields (category, type and outcome) and it works well for the standard winlogbeat logs, auditbeat logs and also for custom logs mapped into ECS (example Fortinet's logid 0100032132)

![image](https://user-images.githubusercontent.com/33020901/99556777-413f6500-29c2-11eb-91bf-674eb2ccbffe.png)


