### PR TITLE
[New Rule] O365 Exchange Safe Link Policy Disabled

### DIFF
--- a/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
+++ b/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
@@ -7,7 +7,7 @@ updated_date = "2020/11/18"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when Safe Links are disabled in Office 365. Safe Links for Office applications extend phishing protection to
+Identifies when Safe Link policy is disabled in Office 365. Safe Link policies for Office applications extend phishing protection to
 documents that contain hyperlinks, even after they have been delivered to a user.
 """
 false_positives = [
@@ -20,7 +20,7 @@ from = "now-30m"
 index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License"
-name = "O365 Exchange SafeLinks Disabled"
+name = "O365 Exchange Safe Link Policy Disabled"
 note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-safelinksrule?view=exchange-ps",

--- a/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
+++ b/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
@@ -29,7 +29,7 @@ references = [
 risk_score = 47
 rule_id = "a989fa1b-9a11-4dd8-a3e9-f0de9c6eb5f2"
 severity = "medium"
-tags = ["Elastic"]
+tags = ["Elastic", "Cloud", "Office 365", "Continuous Monioring", "SecOps", "Identity and Access"]
 type = "query"
 
 query = '''

--- a/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
+++ b/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
@@ -1,0 +1,52 @@
+[metadata]
+creation_date = "2020/11/18"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/18"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when Safe Links are disabled in Office 365. Safe Links for Office applications extend phishing protection to
+documents that contain hyperlinks, even after they have been delivered to a user.
+"""
+false_positives = [
+    """
+    Disabling safe links may be done by a system or network administrator. Verify that the configuration change was
+    expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-30m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "O365 Exchange SafeLinks Disabled"
+note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-safelinksrule?view=exchange-ps",
+    "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/atp-safe-links?view=o365-worldwide",
+]
+risk_score = 47
+rule_id = "a989fa1b-9a11-4dd8-a3e9-f0de9c6eb5f2"
+severity = "medium"
+tags = ["Elastic"]
+type = "query"
+
+query = '''
+event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:"Disable-SafeLinksRule" and event.outcome:success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1566"
+name = "Phishing"
+reference = "https://attack.mitre.org/techniques/T1566/"
+
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
+++ b/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
@@ -7,7 +7,7 @@ updated_date = "2020/11/18"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when Safe Link policy is disabled in Office 365. Safe Link policies for Office applications extend phishing
+Identifies when a Safe Link policy is disabled in Office 365. Safe Link policies for Office applications extend phishing
 protection to documents that contain hyperlinks, even after they have been delivered to a user.
 """
 false_positives = [

--- a/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
+++ b/rules/o365/initial_access_o365_exchange_safelinks_disabled.toml
@@ -7,8 +7,8 @@ updated_date = "2020/11/18"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when Safe Link policy is disabled in Office 365. Safe Link policies for Office applications extend phishing protection to
-documents that contain hyperlinks, even after they have been delivered to a user.
+Identifies when Safe Link policy is disabled in Office 365. Safe Link policies for Office applications extend phishing
+protection to documents that contain hyperlinks, even after they have been delivered to a user.
 """
 false_positives = [
     """


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #464 

## Summary
Identifies when a Safe Link policy is disabled in Office 365. Safe Link policies for Office applications extend phishing protection to documents that contain hyperlinks, even after they have been delivered to a user.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
