### PR TITLE
[New Rule] O365 Exchange Transport Rule Creation

### DIFF
--- a/rules/o365/exfiltration_o365_exchange_transport_rule_creation.toml
+++ b/rules/o365/exfiltration_o365_exchange_transport_rule_creation.toml
@@ -8,7 +8,8 @@ updated_date = "2020/11/18"
 author = ["Elastic"]
 description = """
 Identifies a transport rule creation in Office 365. Exchange Online mail transport rules should be set to not forward
-email to domains outside of your organization. An adversary may create transport rules to exfiltrate data.
+email to domains outside of your organization as a best practice. An adversary may create transport rules to exfiltrate
+data.
 """
 false_positives = [
     """
@@ -22,7 +23,10 @@ language = "kuery"
 license = "Elastic License"
 name = "O365 Exchange Transport Rule Creation"
 note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
-references = ["https://docs.microsoft.com/en-us/powershell/module/exchange/new-transportrule?view=exchange-ps"]
+references = [
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/new-transportrule?view=exchange-ps",
+    "https://docs.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules",
+]
 risk_score = 47
 rule_id = "ff4dd44a-0ac6-44c4-8609-3f81bc820f02"
 severity = "medium"

--- a/rules/o365/exfiltration_o365_exchange_transport_rule_creation.toml
+++ b/rules/o365/exfiltration_o365_exchange_transport_rule_creation.toml
@@ -23,9 +23,9 @@ license = "Elastic License"
 name = "O365 Exchange Transport Rule Creation"
 note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
 references = ["https://docs.microsoft.com/en-us/powershell/module/exchange/new-transportrule?view=exchange-ps"]
-risk_score = 21
+risk_score = 47
 rule_id = "ff4dd44a-0ac6-44c4-8609-3f81bc820f02"
-severity = "low"
+severity = "medium"
 tags = ["Elastic", "Cloud", "Office 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
 type = "query"
 

--- a/rules/o365/exfiltration_o365_exchange_transport_rule_creation.toml
+++ b/rules/o365/exfiltration_o365_exchange_transport_rule_creation.toml
@@ -1,0 +1,49 @@
+[metadata]
+creation_date = "2020/11/18"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/18"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies a transport rule creation in Office 365. Exchange Online mail transport rules should be set to not forward
+email to domains outside of your organization. An adversary may create transport rules to exfiltrate data.
+"""
+false_positives = [
+    """
+    A new transport rule may be created by a system or network administrator. Verify that the configuration change was
+    expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-30m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "O365 Exchange Transport Rule Creation"
+note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
+references = ["https://docs.microsoft.com/en-us/powershell/module/exchange/new-transportrule?view=exchange-ps"]
+risk_score = 21
+rule_id = "ff4dd44a-0ac6-44c4-8609-3f81bc820f02"
+severity = "low"
+tags = ["Elastic", "Cloud", "Office 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:"New-TransportRule" and event.outcome:success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1537"
+name = "Transfer Data to Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1537/"
+
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #468 

## Summary
Identifies a transport rule creation in Office 365. Exchange Online mail transport rules should be set to not forward email to domains outside of your organization. An adversary may create transport rules to exfiltrate data.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
