### PR TITLE
[New Rule] O365 Exchange Anti-Phish Policy Deletion

### DIFF
--- a/rules/o365/initial_access_o365_exchange_anti_phish_policy_deletion.toml
+++ b/rules/o365/initial_access_o365_exchange_anti_phish_policy_deletion.toml
@@ -27,9 +27,9 @@ references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-antiphishpolicy?view=exchange-ps",
     "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/set-up-anti-phishing-policies?view=o365-worldwide",
 ]
-risk_score = 21
+risk_score = 47
 rule_id = "d68eb1b5-5f1c-4b6d-9e63-5b6b145cd4aa"
-severity = "low"
+severity = "medium"
 tags = ["Elastic", "Cloud", "Office 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
 type = "query"
 

--- a/rules/o365/initial_access_o365_exchange_anti_phish_policy_deletion.toml
+++ b/rules/o365/initial_access_o365_exchange_anti_phish_policy_deletion.toml
@@ -1,0 +1,53 @@
+[metadata]
+creation_date = "2020/11/19"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies the deletion of an anti-phishing policy in Office 365. By default, Office 365 includes built-in features that
+help protect users from phishing attacks. Anti-phishing polices increase this protection by refining settings to better
+detect and prevent attacks.
+"""
+false_positives = [
+    """
+    An anti-phishing policy may be deleted by a system or network administrator. Verify that the configuration change
+    was expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-30m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "O365 Exchange Anti-Phish Policy Deletion"
+note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-antiphishpolicy?view=exchange-ps",
+    "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/set-up-anti-phishing-policies?view=o365-worldwide",
+]
+risk_score = 21
+rule_id = "d68eb1b5-5f1c-4b6d-9e63-5b6b145cd4aa"
+severity = "low"
+tags = ["Elastic", "Cloud", "Office 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:"Remove-AntiPhishPolicy" and event.outcome:success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1566"
+name = "Phishing"
+reference = "https://attack.mitre.org/techniques/T1566/"
+
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #479 

## Summary
Identifies the deletion of an anti-phishing policy in Office 365. By default, Office 365 includes built-in features that help protect users from phishing attacks. Anti-phishing polices increase this protection by refining settings to better detect and prevent attacks.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
