### PR TITLE
[New Rule] O365 Exchange Malware Filter Policy Deletion

### DIFF
--- a/rules/o365/defense_evasion_o365_exchange_malware_filter_policy_deletion.toml
+++ b/rules/o365/defense_evasion_o365_exchange_malware_filter_policy_deletion.toml
@@ -9,7 +9,7 @@ author = ["Elastic"]
 description = """
 Identifies when a malware filter policy has been deleted in Office 365. A malware filter policy is used to alert
 administrators that an internal user sent a message that contained malware. This may indicate an account or machine
-compromise, that would need to be investigated. Deletion of a malware filter policy may be done to evade detection.
+compromise that would need to be investigated. Deletion of a malware filter policy may be done to evade detection.
 """
 false_positives = [
     """

--- a/rules/o365/defense_evasion_o365_exchange_malware_filter_policy_deletion.toml
+++ b/rules/o365/defense_evasion_o365_exchange_malware_filter_policy_deletion.toml
@@ -1,0 +1,52 @@
+[metadata]
+creation_date = "2020/11/19"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when a malware filter policy has been deleted in Office 365. A malware filter policy is used to alert
+administrators that an internal user sent a message that contained malware. This may indicate an account or machine
+compromise, that would need to be investigated. Deletion of a malware filter policy may be done to evade detection.
+"""
+false_positives = [
+    """
+    A malware filter policy may be deleted by a system or network administrator. Verify that the configuration change
+    was expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-30m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "O365 Exchange Malware Filter Policy Deletion"
+note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-malwarefilterpolicy?view=exchange-ps",
+]
+risk_score = 47
+rule_id = "d743ff2a-203e-4a46-a3e3-40512cfe8fbb"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Office 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:"Remove-MalwareFilterPolicy" and event.outcome:success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/command_and_control_common_webservices.toml
+++ b/rules/windows/command_and_control_common_webservices.toml
@@ -1,0 +1,77 @@
+[metadata]
+creation_date = "2020/11/04"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+Adversaries may implement command and control communications that use common web services in order to hide their
+activity. This attack technique is typically targeted to an organization and uses web services common to the victim network which allows the adversary to blend into legitimate traffic.
+activity. These popular services are typically targeted since they have most likely been used before a compromise and
+allow adversaries to blend in the network.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License"
+name = "Connection to Commonly Abused Web Services"
+risk_score = 21
+rule_id = "66883649-f908-4a5b-a1e0-54090a1d3a32"
+severity = "low"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
+type = "eql"
+
+query = '''
+network where network.protocol == "dns" and
+             /* Add new WebSvc domains here */
+              wildcard(dns.question.name, "*.githubusercontent.*",
+                                          "*.pastebin.*",
+                                          "*drive.google.*",
+                                          "*docs.live.*",
+                                          "*api.dropboxapi.*",
+                                          "*dropboxusercontent.*",
+                                          "*onedrive.*",
+                                          "*4shared.*",
+                                          "*.file.io",
+                                          "*filebin.net",
+                                          "*slack-files.com",
+                                          "*ghostbin.*",
+                                          "*ngrok.*",
+                                          "*portmap.*",
+                                          "*serveo.net",
+                                          "*localtunnel.me",
+                                          "*pagekite.me",
+                                          "*localxpose.io",
+                                          "*notabug.org"
+                      ) and
+                          /* Insert noisy false positives here */
+              not process.name in ("MicrosoftEdgeCP.exe",
+                                    "MicrosoftEdge.exe",
+                                    "iexplore.exe",
+                                    "chrome.exe",
+                                    "msedge.exe",
+                                    "opera.exe",
+                                    "firefox.exe",
+                                    "Dropbox.exe",
+                                    "slack.exe",
+                                    "svchost.exe",
+                                    "thunderbird.exe",
+                                    "outlook.exe",
+                                    "OneDrive.exe")
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1102"
+name = "Web Service"
+reference = "https://attack.mitre.org/techniques/T1102/"
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #503 

## Summary
Identifies when a malware filter policy has been deleted in Office 365. A malware filter policy is used to alert administrators that an internal user sent a message that contained malware. This may indicate an account or machine compromise, that would need to be investigated. Deletion of a malware filter policy may be done to evade detection.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
