### PR TITLE
[New Rule] O365 Exchange Malware Filter Rule Modification

### DIFF
--- a/rules/o365/defense_evasion_o365_exchange_malware_filter_rule_mod.toml
+++ b/rules/o365/defense_evasion_o365_exchange_malware_filter_rule_mod.toml
@@ -1,0 +1,52 @@
+[metadata]
+creation_date = "2020/11/19"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when a malware filter rule has been deleted or disabled in Office 365. An adversary or malicious insider may
+want to modify a malware filter rule to evade detection.
+"""
+false_positives = [
+    """
+    A malware filter rule may be deleted by a system or network administrator. Verify that the configuration change was
+    expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-30m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "O365 Exchange Malware Filter Rule Modification"
+note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-malwarefilterrule?view=exchange-ps",
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-malwarefilterrule?view=exchange-ps",
+]
+risk_score = 47
+rule_id = "ca79768e-40e1-4e45-a097-0e5fbc876ac2"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Office 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:("Remove-MalwareFilterRule" or "Disable-MalwareFilterRule") and event.outcome:success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #504 

## Summary
Identifies when a malware filter rule has been deleted or disabled in Office 365. An adversary or malicious insider may want to modify a malware filter rule to evade detection.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
