### PR TITLE
[New Rule] O365 Exchange Transport Rule Modification

### DIFF
--- a/rules/o365/exfiltration_o365_exchange_transport_rule_mod.toml
+++ b/rules/o365/exfiltration_o365_exchange_transport_rule_mod.toml
@@ -13,7 +13,7 @@ insider may modify a transport rule to exfiltrate data or evade defenses.
 """
 false_positives = [
     """
-    A new transport rule may be modified by a system or network administrator. Verify that the configuration change was
+    A transport rule may be modified by a system or network administrator. Verify that the configuration change was
     expected. Exceptions can be added to this rule to filter expected behavior.
     """,
 ]

--- a/rules/o365/exfiltration_o365_exchange_transport_rule_mod.toml
+++ b/rules/o365/exfiltration_o365_exchange_transport_rule_mod.toml
@@ -1,0 +1,54 @@
+[metadata]
+creation_date = "2020/11/19"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when a transport rule has been disabled or deleted in Office 365. Mail flow rules (also known as transport
+rules) are used to identify and take action on messages that flow through your organization. An adversary or malicious
+insider may modify a transport rule to exfiltrate data or evade defenses.
+"""
+false_positives = [
+    """
+    A new transport rule may be modified by a system or network administrator. Verify that the configuration change was
+    expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-30m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "O365 Exchange Transport Rule Modification"
+note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-transportrule?view=exchange-ps",
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-transportrule?view=exchange-ps",
+    "https://docs.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules",
+]
+risk_score = 47
+rule_id = "272a6484-2663-46db-a532-ef734bf9a796"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Office 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:("Remove-TransportRule" or "Disable-TransportRule") and event.outcome:success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1537"
+name = "Transfer Data to Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1537/"
+
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"
+

--- a/rules/o365/exfiltration_o365_exchange_transport_rule_mod.toml
+++ b/rules/o365/exfiltration_o365_exchange_transport_rule_mod.toml
@@ -8,8 +8,8 @@ updated_date = "2020/11/19"
 author = ["Elastic"]
 description = """
 Identifies when a transport rule has been disabled or deleted in Office 365. Mail flow rules (also known as transport
-rules) are used to identify and take action on messages that flow through your organization. An adversary or malicious
-insider may modify a transport rule to exfiltrate data or evade defenses.
+rules) are used to identify and take action on messages that flow through your organization. An adversary or insider
+threat may modify a transport rule to exfiltrate data or evade defenses.
 """
 false_positives = [
     """

--- a/rules/windows/command_and_control_common_webservices.toml
+++ b/rules/windows/command_and_control_common_webservices.toml
@@ -1,0 +1,77 @@
+[metadata]
+creation_date = "2020/11/04"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+Adversaries may implement command and control communications that use common web services in order to hide their
+activity. This attack technique is typically targeted to an organization and uses web services common to the victim network which allows the adversary to blend into legitimate traffic.
+activity. These popular services are typically targeted since they have most likely been used before a compromise and
+allow adversaries to blend in the network.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License"
+name = "Connection to Commonly Abused Web Services"
+risk_score = 21
+rule_id = "66883649-f908-4a5b-a1e0-54090a1d3a32"
+severity = "low"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
+type = "eql"
+
+query = '''
+network where network.protocol == "dns" and
+             /* Add new WebSvc domains here */
+              wildcard(dns.question.name, "*.githubusercontent.*",
+                                          "*.pastebin.*",
+                                          "*drive.google.*",
+                                          "*docs.live.*",
+                                          "*api.dropboxapi.*",
+                                          "*dropboxusercontent.*",
+                                          "*onedrive.*",
+                                          "*4shared.*",
+                                          "*.file.io",
+                                          "*filebin.net",
+                                          "*slack-files.com",
+                                          "*ghostbin.*",
+                                          "*ngrok.*",
+                                          "*portmap.*",
+                                          "*serveo.net",
+                                          "*localtunnel.me",
+                                          "*pagekite.me",
+                                          "*localxpose.io",
+                                          "*notabug.org"
+                      ) and
+                          /* Insert noisy false positives here */
+              not process.name in ("MicrosoftEdgeCP.exe",
+                                    "MicrosoftEdge.exe",
+                                    "iexplore.exe",
+                                    "chrome.exe",
+                                    "msedge.exe",
+                                    "opera.exe",
+                                    "firefox.exe",
+                                    "Dropbox.exe",
+                                    "slack.exe",
+                                    "svchost.exe",
+                                    "thunderbird.exe",
+                                    "outlook.exe",
+                                    "OneDrive.exe")
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1102"
+name = "Web Service"
+reference = "https://attack.mitre.org/techniques/T1102/"
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #505 

## Summary
Identifies when a transport rule has been disabled or deleted in Office 365. Mail flow rules (also known as transport rules) are used to identify and take action on messages that flow through your organization. An adversary or malicious insider may modify a transport rule to exfiltrate data or evade defenses.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
