### PR TITLE
[New Rule] O365 Exchange Safe Attachment Rule Disabled

### DIFF
--- a/rules/o365/defense_evasion_o365_exchange_safe_attach_rule_disabled.toml
+++ b/rules/o365/defense_evasion_o365_exchange_safe_attach_rule_disabled.toml
@@ -7,9 +7,9 @@ updated_date = "2020/11/19"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when a Safe Attachment rule is disabled in Office 365. Safe Attachment rules can extend malware protections
+Identifies when a safe attachment rule is disabled in Office 365. Safe attachment rules can extend malware protections
 to include routing all messages and attachments without a known malware signature to a special hypervisor environment.
-An adversary or malicious insider may disable a Safe Attachment rule to exfiltrate data or evade defenses.
+An adversary or insider threat may disable a safe attachment rule to exfiltrate data or evade defenses.
 """
 false_positives = [
     """

--- a/rules/o365/defense_evasion_o365_exchange_safe_attach_rule_disabled.toml
+++ b/rules/o365/defense_evasion_o365_exchange_safe_attach_rule_disabled.toml
@@ -1,0 +1,52 @@
+[metadata]
+creation_date = "2020/11/19"
+ecs_version = ["1.6.0"]
+maturity = "production"
+updated_date = "2020/11/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when a Safe Attachment rule is disabled in Office 365. Safe Attachment rules can extend malware protections
+to include routing all messages and attachments without a known malware signature to a special hypervisor environment.
+An adversary or malicious insider may disable a Safe Attachment rule to exfiltrate data or evade defenses.
+"""
+false_positives = [
+    """
+    A safe attachment rule may be disabled by a system or network administrator. Verify that the configuration change
+    was expected. Exceptions can be added to this rule to filter expected behavior.
+    """,
+]
+from = "now-30m"
+index = ["filebeat-*"]
+language = "kuery"
+license = "Elastic License"
+name = "O365 Exchange Safe Attachment Rule Disabled"
+note = "The O365 Fleet integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-safeattachmentrule?view=exchange-ps",
+]
+risk_score = 21
+rule_id = "03024bd9-d23f-4ec1-8674-3cf1a21e130b"
+severity = "low"
+tags = ["Elastic", "Cloud", "Office 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+type = "query"
+
+query = '''
+event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:"Disable-SafeAttachmentRule" and event.outcome:success
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #525 

## Summary
Identifies when a Safe Attachment rule is disabled in Office 365. Safe Attachment rules can extend malware protections to include routing all messages and attachments without a known malware signature to a special hypervisor environment. An adversary or malicious insider may disable a Safe Attachment rule to exfiltrate data or evade defenses.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
