### PR TITLE
Add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Supported Python versions](https://img.shields.io/badge/python-3.7+-yellow.svg)](https://www.python.org/downloads/)
+[![Unit Tests](https://github.com/elastic/detection-rules/workflows/Unit%20Tests/badge.svg)](https://github.com/elastic/detection-rules/actions)
+[![Chat](https://img.shields.io/badge/chat-%23security--detection--rules-blueviolet)](https://ela.st/slack)
+
 # Detection Rules
 
 Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine.


### PR DESCRIPTION
## Issues
None

## Summary

Add badges to readme to show supported Python versions, status of workflow tests, and a link to the Elastic Community Slack workspace.

<img width="449" alt="image" src="https://user-images.githubusercontent.com/56409778/99802151-646a3180-2af4-11eb-8bac-31b469ea119c.png">

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
