### PR TITLE
Bump EQL dependency to 0.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ toml==0.10.0
 requests==2.22.0
 Click==7.0
 PyYAML~=5.3
-eql~=0.9.5
+eql~=0.9.6
 elasticsearch~=7.9
 XlsxWriter==1.3.6
 


### PR DESCRIPTION
## Issues
Related to https://github.com/endgameinc/eql/issues/43

## Summary
Updated the EQL dependency so we can use `field : ("wild*card", "...")` syntax for EQL.
