### PR TITLE
Add support for threat match rule type

### DIFF
--- a/detection_rules/schemas/v7_10.py
+++ b/detection_rules/schemas/v7_10.py
@@ -16,17 +16,17 @@ THREAT_MATCH = "threat_match"
 class ApiSchema710(ApiSchema79):
     """Schema for siem rule in API format."""
 
-    class ThreatEntries(jsl.Document):
+    class ThreatMatchEntries(jsl.Document):
         """Threat match rule entries."""
 
-        class ThreatEntry(jsl.Document):
+        class ThreatMatchEntry(jsl.Document):
             """Threat match rule mapping entry."""
 
             field = jsl.StringField(required=True)
             type = jsl.StringField(default='mapping', enum='mapping', required=True)
             value = jsl.StringField(required=True)
 
-        entries = jsl.ArrayField(jsl.DocumentField(ThreatEntry, required=True), min_items=1)
+        entries = jsl.ArrayField(jsl.DocumentField(ThreatMatchEntry, required=True), min_items=1)
 
     STACK_VERSION = "7.10"
     RULE_TYPES = ApiSchema79.RULE_TYPES + [EQL]
@@ -51,7 +51,7 @@ class ApiSchema710(ApiSchema79):
         tm_scope.index = jsl.ArrayField(jsl.StringField(), required=False)
         tm_scope.query = jsl.StringField(required=True)
         tm_scope.threat_query = jsl.StringField(default='*:*', required=True)
-        tm_scope.threat_mapping = jsl.ArrayField(jsl.DocumentField(ThreatEntries, required=True), min_items=1)
+        tm_scope.threat_mapping = jsl.ArrayField(jsl.DocumentField(ThreatMatchEntries, required=True), min_items=1)
         tm_scope.threat_language = jsl.StringField(enum=['kuery', 'lucene'], required=True, default=EQL)
         tm_scope.threat_index = jsl.ArrayField(jsl.StringField(required=True), min_items=1)
 

--- a/detection_rules/schemas/v7_10.py
+++ b/detection_rules/schemas/v7_10.py
@@ -10,10 +10,23 @@ from .v7_9 import ApiSchema79
 
 # rule types
 EQL = "eql"
+THREAT_MATCH = "threat_match"
 
 
 class ApiSchema710(ApiSchema79):
     """Schema for siem rule in API format."""
+
+    class ThreatEntries(jsl.Document):
+        """Threat match rule entries."""
+
+        class ThreatEntry(jsl.Document):
+            """Threat match rule mapping entry."""
+
+            field = jsl.StringField(required=True)
+            type = jsl.StringField(default='mapping', enum='mapping', required=True)
+            value = jsl.StringField(required=True)
+
+        entries = jsl.ArrayField(jsl.DocumentField(ThreatEntry, required=True), min_items=1)
 
     STACK_VERSION = "7.10"
     RULE_TYPES = ApiSchema79.RULE_TYPES + [EQL]
@@ -31,6 +44,23 @@ class ApiSchema710(ApiSchema79):
         eql_scope.query = jsl.StringField(required=True)
         eql_scope.language = jsl.StringField(enum=[EQL], required=True, default=EQL)
         eql_scope.type = jsl.StringField(enum=[EQL], required=True)
+
+    with jsl.Scope(THREAT_MATCH) as tm_scope:
+        tm_scope.type = jsl.StringField(enum=THREAT_MATCH, required=True)
+        tm_scope.language = jsl.StringField(enum=['kuery', 'lucene'], required=True, default=EQL)
+        tm_scope.index = jsl.ArrayField(jsl.StringField(), required=False)
+        tm_scope.query = jsl.StringField(required=True)
+        tm_scope.threat_query = jsl.StringField(default='*:*', required=True)
+        tm_scope.threat_mapping = jsl.ArrayField(jsl.DocumentField(ThreatEntries, required=True), min_items=1)
+        tm_scope.threat_language = jsl.StringField(enum=['kuery', 'lucene'], required=True, default=EQL)
+        tm_scope.threat_index = jsl.ArrayField(jsl.StringField(required=True), min_items=1)
+
+        # API items not defined here
+        #   filters: filtersOrUndefined,
+        #   savedId: savedIdOrUndefined,
+        #   threatFilters: filtersOrUndefined,
+        #   concurrentSearches: concurrentSearchesOrUndefined,
+        #   itemsPerSearch: itemsPerSearchOrUndefined,
 
     with jsl.Scope(jsl.DEFAULT_ROLE) as default_scope:
         default_scope.type = type

--- a/detection_rules/schemas/v7_8.py
+++ b/detection_rules/schemas/v7_8.py
@@ -14,8 +14,10 @@ INTERVAL_PATTERN = r'\d+[mshd]'
 MITRE_URL_PATTERN = r'https://attack.mitre.org/{type}/T[A-Z0-9]+/'
 
 
-# kibana/.../siem/server/lib/detection_engine/routes/schemas/add_prepackaged_rules_schema.ts
-#                           /detection_engine/routes/schemas/schemas.ts
+# kibana/.../security_solution/server/lib/detection_engine/routes/schemas/add_prepackaged_rules_schema.ts
+#                                        /detection_engine/routes/schemas/schemas.ts
+#                                        /detection_engine/schemas/rule_schemas.ts
+
 # rule_id is required here
 # output_index is not allowed (and instead the space index must be used)
 # immutable defaults to true instead of to false and if it is there can only be true


### PR DESCRIPTION
## Issues
Resolves #305 
Related to # https://github.com/elastic/elasticsearch/issues/64746

## Summary
Adds support for threat_match rules.

### TODO
- [x] verify fields/schema
- [ ] add support to CLI rule builder (plus read list from file)
- [x] check for opportunities/needs to add unit test and/or validate fields