### PR TITLE
[New Rule] Azure Service Principal Addition

### DIFF
--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -7,7 +7,7 @@ updated_date = "2020/12/14"
 author = ["Elastic"]
 description = """
 Identifies when a new service principal is added in Azure. An application, hosted service, or automated tool that
-accesses or modify resources needs an identity created. This identity is known as a service principal. For security
+accesses or modify resources need an identity created. This identity is known as a service principal. For security
 reasons, it's always recommended to use service principals with automated tools rather than allowing them to log in with
 a user identity.
 """

--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -1,0 +1,59 @@
+[metadata]
+creation_date = "2020/12/14"
+maturity = "production"
+updated_date = "2020/12/14"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when a new service principal is added in Azure. An application, hosted service, or automated tool that
+accesses or modify resources needs an identity created. This identity is known as a service principal. For security
+reasons, it's always recommended to use service principals with automated tools rather than allowing them to log in with
+a user identity.
+"""
+false_positives = [
+    """
+    A service principal may be created by a system or network administrator. Verify whether the username, hostname,
+    and/or resource name should be making changes in your environment. Service principal additions from unfamiliar users
+    or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
+    """,
+]
+from = "now-25m"
+index = ["filebeat-*", "logs-azure.*"]
+language = "kuery"
+license = "Elastic License"
+name = "Azure Service Principal Addition"
+note = "The Azure Fleet Integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/",
+    "https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal",
+]
+risk_score = 47
+rule_id = "60b6b72f-0fbc-47e7-9895-9ba7627a8b50"
+severity = "medium"
+tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+type = "query"
+
+query = '''
+event.dataset:azure.auditlogs and azure.auditlogs.operation_name:"Add service principal" and event.outcome:(success or Success)
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1550"
+name = "Use Alternate Authentication Material"
+reference = "https://attack.mitre.org/techniques/T1550/"
+[[rule.threat.technique.subtechnique]]
+id = "T1550.001"
+name = "Application Access Token"
+reference = "https://attack.mitre.org/techniques/T1550/001/"
+
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -55,3 +55,4 @@ reference = "https://attack.mitre.org/techniques/T1550/001/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -51,9 +51,7 @@ name = "Application Access Token"
 reference = "https://attack.mitre.org/techniques/T1550/001/"
 
 
-
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-

--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -7,7 +7,7 @@ updated_date = "2020/12/14"
 author = ["Elastic"]
 description = """
 Identifies when a new service principal is added in Azure. An application, hosted service, or automated tool that
-accesses or modify resources need an identity created. This identity is known as a service principal. For security
+accesses or modifies resources needs an identity created. This identity is known as a service principal. For security
 reasons, it's always recommended to use service principals with automated tools rather than allowing them to log in with
 a user identity.
 """


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #715 

## Summary
Identifies when a new service principal is added in Azure. An application, hosted service, or automated tool that accesses or modify resources need an identity created. This identity is known as a service principal. For security reasons, it's always recommended to use service principals with automated tools rather than allowing them to log in with a user identity.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
