### PR TITLE
[New Rule] Azure Active Directory PowerShell Sign-in

### DIFF
--- a/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
+++ b/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
@@ -34,8 +34,8 @@ type = "query"
 
 query = '''
 event.dataset:azure.signinlogs and
-azure.signinlogs.properties.app_display_name:"Azure Active Directory PowerShell" and
-azure.signinlogs.properties.token_issuer_type:AzureAD and event.outcome:(success or Success)
+  azure.signinlogs.properties.app_display_name:"Azure Active Directory PowerShell" and
+  azure.signinlogs.properties.token_issuer_type:AzureAD and event.outcome:(success or Success)
 '''
 
 

--- a/rules/azure/initial_access_azure_active_directory_powershell_signon.toml
+++ b/rules/azure/initial_access_azure_active_directory_powershell_signon.toml
@@ -1,0 +1,59 @@
+[metadata]
+creation_date = "2020/12/14"
+maturity = "production"
+updated_date = "2020/12/14"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies a sign-in using the Azure Active Directory PowerShell module. PowerShell for Azure Active Directory allows
+for managing settings from the command line, which is intended for users who are members of an admin role.
+"""
+false_positives = [
+    """
+    Sign-ins using PowerShell may be done by a system or network administrator. Verify whether the username, hostname,
+    and/or resource name should be signing into your environment. Sign-ins from unfamiliar users or hosts should be
+    investigated. If known behavior is causing false positives, it can be exempted from the rule.
+    """,
+]
+from = "now-25m"
+index = ["filebeat-*", "logs-azure.*"]
+language = "kuery"
+license = "Elastic License"
+name = "Sign-in via Azure Active Directory PowerShell"
+note = "The Azure Fleet Integration or Filebeat module must be enabled to use this rule."
+references = [
+    "https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/",
+    "https://docs.microsoft.com/en-us/microsoft-365/enterprise/connect-to-microsoft-365-powershell?view=o365-worldwide",
+]
+risk_score = 21
+rule_id = "a605c51a-73ad-406d-bf3a-f24cc41d5c97"
+severity = "low"
+tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+type = "query"
+
+query = '''
+event.dataset:azure.signinlogs and
+azure.signinlogs.properties.app_display_name:"Azure Active Directory PowerShell" and
+azure.signinlogs.properties.token_issuer_type:AzureAD and event.outcome:(success or Success)
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+[[rule.threat.technique.subtechnique]]
+id = "T1078.004"
+name = "Cloud Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/azure/initial_access_azure_active_directory_powershell_signon.toml
+++ b/rules/azure/initial_access_azure_active_directory_powershell_signon.toml
@@ -20,7 +20,7 @@ from = "now-25m"
 index = ["filebeat-*", "logs-azure.*"]
 language = "kuery"
 license = "Elastic License"
-name = "Sign-in via Azure Active Directory PowerShell"
+name = "Azure Active Directory PowerShell Sign-in"
 note = "The Azure Fleet Integration or Filebeat module must be enabled to use this rule."
 references = [
     "https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/",
@@ -51,9 +51,7 @@ name = "Cloud Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/004/"
 
 
-
 [rule.threat.tactic]
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
-


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #713 

## Summary
Identifies a sign-in using the Azure Active Directory PowerShell module. PowerShell for Azure Active Directory allows for managing settings from the command line, which is intended for users who are members of an admin role.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
