### PR TITLE
Make threat.technique optional

### DIFF
--- a/detection_rules/attack.py
+++ b/detection_rules/attack.py
@@ -134,13 +134,15 @@ def build_threat_map_entry(tactic: str, *technique_ids: str) -> dict:
 
     entry = {
         'framework': 'MITRE ATT&CK',
-        'technique': sorted(tech_entries.values(), key=lambda x: x['id']),
         'tactic': {
             'id': tactic_id,
             'name': tactic,
             'reference': url_base.format(type='tactics', id=tactic_id)
         }
     }
+
+    if tech_entries:
+        entry['technique'] = sorted(tech_entries.values(), key=lambda x: x['id'])
 
     return entry
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -362,7 +362,7 @@ class Rule(object):
                 while click.confirm('add mitre tactic?'):
                     tactic = schema_prompt('mitre tactic name', type='string', enum=tactics, required=True)
                     technique_ids = schema_prompt(f'technique or sub-technique IDs for {tactic}', type='array',
-                                                  required=True, enum=list(technique_lookup))
+                                                  required=False, enum=list(technique_lookup)) or []
 
                     try:
                         threat_map.append(build_threat_map_entry(tactic, *technique_ids))

--- a/detection_rules/schemas/v7_11.py
+++ b/detection_rules/schemas/v7_11.py
@@ -24,7 +24,7 @@ class Threat711(Threat78):
         subtechnique = jsl.ArrayField(jsl.DocumentField(ThreatSubTechnique), required=False)
 
     # override the `technique` field definition
-    technique = jsl.ArrayField(jsl.DocumentField(ThreatTechnique), required=True)
+    technique = jsl.ArrayField(jsl.DocumentField(ThreatTechnique), required=False)
 
 
 class ApiSchema711(ApiSchema710):


### PR DESCRIPTION
## Issues
Related to #52 

## Summary
Kibana is making (https://github.com/elastic/kibana/pull/85481) threat.technique optional, similar to the decision for threat.technique.subtechnique. This updates the schema to reflect that.