### PR TITLE
Remove duplicate PR job

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,8 +3,6 @@ name: Unit Tests
 on:
   push:
     branches: [ "*" ]
-  pull_request:
-    branches: [ "*" ]
 
 jobs:
   build:


### PR DESCRIPTION
## Issues
None

## Summary
I noticed that we build all branches and all PRs. This means that each PR will have two checks. That's unnecessary. Since we already build all branches, I think the PR builds are redundant, so I removed them.