### PR TITLE
[Bug] Fix 7.11 -> 7.10 ATT&CK downgrade logic for optional techiques

### DIFF
--- a/detection_rules/schemas/v7_11.py
+++ b/detection_rules/schemas/v7_11.py
@@ -39,16 +39,29 @@ class ApiSchema711(ApiSchema710):
         """Remove 7.11 additions from the rule."""
         # ignore when this method is inherited by subclasses
         if cls == ApiSchema711 and "threat" in document:
-            threat_field = list(document["threat"])
-            for threat in threat_field:
-                if "technique" in threat:
-                    threat["technique"] = [t.copy() for t in threat["technique"]]
+            v711_threats = document.get("threat", [])
+            v710_threats = []
 
-                    for technique in threat["technique"]:
-                        technique.pop("subtechnique", None)
+            for threat in v711_threats:
+                # drop tactic without threat
+                if "technique" not in threat:
+                    continue
+
+                threat = threat.copy()
+                threat["technique"] = [t.copy() for t in threat["technique"]]
+
+                # drop subtechniques
+                for technique in threat["technique"]:
+                    technique.pop("subtechnique", None)
+
+                v710_threats.append(threat)
 
             document = document.copy()
-            document["threat"] = threat_field
+            document.pop("threat")
+
+            # only add if the array is not empty
+            if len(v710_threats) > 0:
+                document["threat"] = v710_threats
 
         # now strip any any unrecognized properties
         return target_cls.strip_additional_properties(document, role)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -53,6 +53,14 @@ class TestSchemas(unittest.TestCase):
             "name": "PowerShell",
             "reference": "https://attack.mitre.org/techniques/T1059/001/"
         }]
+        cls.v711_kql["threat"].append({
+            "framework": "MITRE ATT&CK",
+            "tactic": {
+                "id": "TA0008",
+                "name": "Lateral Movement",
+                "reference": "https://attack.mitre.org/tactics/TA0008/"
+            },
+        })
 
         cls.versioned_rule = Rule("test.toml", copy.deepcopy(cls.v79_kql))
         cls.versioned_rule.contents["version"] = 10


### PR DESCRIPTION
## Issues
A user found that some of the latest Sunburst rules weren't working with Kibana upload. The biggest reason is the downgrade process from 7.11 to 7.10. 


## Summary
We still have an issue where some new EQL functionality won't work properly in the detection engine (e.g. `process.name : ("a", "b", "c")` syntax and `:` with wildcards aren't supported.

The ATT&CK subtechnique process seemed to be working, but I didn't update the downgrade process for optional techniques, which was new in #727.


We'll merge `7.11` into `main` after this is merged.
