### PR TITLE
[New Rule] Searching for Saved Credentials via VaultCmd

### DIFF
--- a/rules/windows/credential_access_saved_creds_vaultcmd.toml
+++ b/rules/windows/credential_access_saved_creds_vaultcmd.toml
@@ -1,0 +1,47 @@
+[metadata]
+creation_date = "2021/01/19"
+maturity = "production"
+updated_date = "2021/01/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Windows Credential Manager allows you to create, view, or delete saved credentials for signing into websites,
+connected applications, and networks. An adversary may abuse this to list or dump credentials stored in the Credential
+Manager for saved usernames and passwords. This may also be performed in preparation of lateral movement.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License"
+name = "Searching for Saved Credentials via VaultCmd"
+references = [
+    "https://medium.com/threatpunter/detecting-adversary-tradecraft-with-image-load-event-logging-and-eql-8de93338c16",
+    "https://rastamouse.me/blog/rdp-jump-boxes/",
+]
+risk_score = 47
+rule_id = "be8afaed-4bcd-4e0a-b5f9-5562003dde81"
+severity = "medium"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+type = "eql"
+
+query = '''
+process where event.type in ("start", "process_started") and
+  (process.pe.original_file_name:"vaultcmd.exe" or process.name:"vaultcmd.exe") and
+  process.args:"/list*"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1003"
+name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #840 

## Summary
Windows Credential Manager allows you to create, view, or delete saved credentials for signing into websites, connected applications, and networks. An adversary may abuse this to list or dump credentials stored in the Credential Manager for saved usernames and passwords. This may also be performed in preparation of lateral movement.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
