### PR TITLE
[New Rule] Potential Persistence via Time Provider Modification

### DIFF
--- a/rules/windows/persistence_time_provider_mod.toml
+++ b/rules/windows/persistence_time_provider_mod.toml
@@ -1,0 +1,51 @@
+[metadata]
+creation_date = "2021/01/19"
+maturity = "production"
+updated_date = "2021/01/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Windows operating systems are utilizing the time provider architecture in order to obtain accurate time stamps from
+other network devices or clients in the network. Time providers are implemented in the form of a DLL file which resides
+in System32 folder. The service W32Time initiates during the startup of Windows and loads w32time.dll. Adversaries may
+abuse this architecture to establish persistence, specifically by registering and enabling a malicious DLL as a time
+provider.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License"
+name = "Potential Persistence via Time Provider Modification"
+references = ["https://pentestlab.blog/2019/10/22/persistence-time-providers/"]
+risk_score = 47
+rule_id = "14ed1aa9-ebfd-4cf9-a463-0ac59ec55204"
+severity = "medium"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+type = "eql"
+
+query = '''
+registry where event.type:"change" and
+  registry.path:"HKLM\\SYSTEM\\*ControlSet*\\Services\\W32Time\\TimeProviders\\*" and
+  registry.data.strings:"*.dll"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1547"
+name = "Boot or Logon Autostart Execution"
+reference = "https://attack.mitre.org/techniques/T1547/"
+[[rule.threat.technique.subtechnique]]
+id = "T1547.003"
+name = "Time Providers"
+reference = "https://attack.mitre.org/techniques/T1547/003/"
+
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
resolves #853 

## Summary
Windows operating systems are utilizing the time provider architecture in order to obtain accurate time stamps from other network devices or clients in the network. Time providers are implemented in the form of a DLL file which resides in System32 folder. The service W32Time initiates during the startup of Windows and loads w32time.dll. Adversaries may abuse this architecture to establish persistence, specifically by registering and enabling a malicious DLL as a time provider.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
