### PR TITLE
Loosen query DSL filter schema validation

### DIFF
--- a/detection_rules/schemas/v7_8.py
+++ b/detection_rules/schemas/v7_8.py
@@ -58,7 +58,7 @@ class Filters(jsl.Document):
     exists = jsl.DocumentField(FilterExists)
     meta = jsl.DocumentField(FilterMetadata)
     state = jsl.DocumentField(FilterState, name='$state')
-    query = jsl.DocumentField(FilterQuery)
+    query = jsl.DictField()
 
 
 class Threat(jsl.Document):


### PR DESCRIPTION
## Issues
From [this community slack thread](https://elasticstack.slack.com/archives/C016E72DWDS/p1611144454021300?thread_ts=1611138771.016300&cid=C016E72DWDS) by @SHolzhauer 

> Not sure what is wrong here.
> Adding the filter works with a script, this does what I need, tnx @ James Spiteri [Elastic Security Solutions Lead]
> I am now running into a TOML/JSON validation issue. I have added the following to the TOML file:
> 
    [[rule.filters]]
    [rule.filters.query.bool.filter.script.script]
    source = "doc['@timestamp'].value.getHour() > 0 && doc['@timestamp'].value.getHour() < 7 || doc['@timestamp'].value.getHour() > 21"
    lang = "painless"
> Running the test command or `kibana-upload` it fails with an error:
> 
    ERROR tests/test_mappings.py - jsonschema.exceptions.ValidationError: Additional properties are not allowed ('bool' was unexpected)
> Playing around with the formatting doesn't seem to make a difference.
> The weird thing to me is that when converting the TOML to JSON and taking the rule part, using curl to create a rule > through the api it is accepted and the rule works. Anyone see what is wrong here?

## Summary
I think we were overly strict, so this loosens the logic.