### PR TITLE
[Rule Tuning] Exclude known false positive - WerFault.exe

### DIFF
--- a/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
+++ b/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
@@ -25,7 +25,8 @@ query = '''
 event.category:process and event.type:(start or process_started) and
   process.parent.name:svchost.exe and
   process.parent.args:(UsoSvc or usosvc) and
-  not process.name:(UsoClient.exe or usoclient.exe or MusNotification.exe or musnotification.exe or MusNotificationUx.exe or musnotificationux.exe)
+  not process.name:(UsoClient.exe or usoclient.exe or MusNotification.exe or musnotification.exe or MusNotificationUx.exe or musnotificationux.exe) and
+  not process.args: ("C:\WINDOWS\system32\WerFault.exe" or "c:\windows\system32\werfault.exe")
 '''
 
 


### PR DESCRIPTION

## Summary
Thoughts on ignoring Windows Error Reporting? I am concerned about using just process name as an attacker could simply do their homework and see what process names are being excluded. Hard coding the process.args will ensure the windows system32 file WerFault.exe is being called during normal activity.