### PR TITLE
[Rule Tuning] Adjust risk scores to align with severity

### DIFF
--- a/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
+++ b/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,7 @@ name = "Attempt to Remove File Quarantine Attribute"
 references = [
     "https://www.trendmicro.com/en_us/research/20/k/new-macos-backdoor-connected-to-oceanlotus-surfaces.html",
 ]
-risk_score = 43
+risk_score = 47
 rule_id = "f0b48bbc-549e-4bcf-8ee0-a7a72586c6a7"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Defense Evasion"]

--- a/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
+++ b/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/05"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -24,7 +24,7 @@ references = [
     "https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-suricata.html",
     "https://www.elastic.co/guide/en/beats/filebeat/7.9/filebeat-module-zeek.html",
 ]
-risk_score = 100
+risk_score = 99
 rule_id = "e7075e8d-a966-458e-a183-85cd331af255"
 severity = "critical"
 tags = [

--- a/rules/windows/command_and_control_iexplore_via_com.toml
+++ b/rules/windows/command_and_control_iexplore_via_com.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/28"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License"
 name = "Potential Command and Control via Internet Explorer"
-risk_score = 43
+risk_score = 47
 rule_id = "acd611f3-2b93-47b3-a0a3-7723bcc46f6d"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]

--- a/rules/windows/command_and_control_remote_file_copy_scripts.toml
+++ b/rules/windows/command_and_control_remote_file_copy_scripts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/29"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License"
 name = "Remote File Download via Script Interpreter"
-risk_score = 43
+risk_score = 47
 rule_id = "1d276579-3380-4095-ad38-e596a01bc64f"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]

--- a/rules/windows/credential_access_kerberoasting_unusual_process.toml
+++ b/rules/windows/credential_access_kerberoasting_unusual_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License"
 name = "Kerberos Traffic from Unusual Process"
-risk_score = 43
+risk_score = 47
 rule_id = "897dc6b5-b39f-432a-8d75-d3730d50c782"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]

--- a/rules/windows/defense_evasion_masquerading_trusted_directory.toml
+++ b/rules/windows/defense_evasion_masquerading_trusted_directory.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License"
 name = "Program Files Directory Masquerading"
-risk_score = 43
+risk_score = 47
 rule_id = "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]

--- a/rules/windows/execution_shared_modules_local_sxs_dll.toml
+++ b/rules/windows/execution_shared_modules_local_sxs_dll.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ license = "Elastic License"
 name = "Execution via local SxS Shared Module"
 note = "The SxS DotLocal folder is a legitimate feature that can be abused to hijack standard modules loading order by forcing an executable on the same application.exe.local folder to load a malicious DLL module from the same directory."
 references = ["https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-redirection"]
-risk_score = 43
+risk_score = 47
 rule_id = "a3ea12f3-0d4e-4667-8b44-4230c63f3c75"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]

--- a/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
+++ b/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/29"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License"
 name = "Suspicious Explorer Child Process"
-risk_score = 43
+risk_score = 47
 rule_id = "9a5b4e31-6cde-4295-9ff7-6be1b8567e1b"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]

--- a/rules/windows/lateral_movement_powershell_remoting_target.toml
+++ b/rules/windows/lateral_movement_powershell_remoting_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,7 @@ name = "Incoming Execution via PowerShell Remoting"
 references = [
     "https://docs.microsoft.com/en-us/powershell/scripting/learn/remoting/running-remote-commands?view=powershell-7.1",
 ]
-risk_score = 43
+risk_score = 47
 rule_id = "2772264c-6fb9-4d9d-9014-b416eed21254"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License"
 name = "RDP Enabled via Registry"
-risk_score = 43
+risk_score = 47
 rule_id = "58aa72ca-d968-4f34-b9f7-bea51d75eb50"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]

--- a/rules/windows/persistence_ms_office_addins_file.toml
+++ b/rules/windows/persistence_ms_office_addins_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/16"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ language = "eql"
 license = "Elastic License"
 name = "Persistence via Microsoft Office AddIns"
 references = ["https://labs.mwrinfosecurity.com/blog/add-in-opportunities-for-office-persistence/"]
-risk_score = 71
+risk_score = 73
 rule_id = "f44fa4b6-524c-4e87-8d9e-a32599e4fb7c"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]

--- a/rules/windows/persistence_ms_outlook_vba_template.toml
+++ b/rules/windows/persistence_ms_outlook_vba_template.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ references = [
     "https://www.mdsec.co.uk/2020/11/a-fresh-outlook-on-mail-based-persistence/",
     "https://www.linkedin.com/pulse/outlook-backdoor-using-vba-samir-b-/",
 ]
-risk_score = 43
+risk_score = 47
 rule_id = "397945f3-d39a-4e6f-8bcb-9656c2031438"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]

--- a/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
+++ b/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License"
 name = "Suspicious Execution via Scheduled Task"
-risk_score = 43
+risk_score = 47
 rule_id = "5d1d6907-0747-4d5d-9b24-e4a18853dc0a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]

--- a/rules/windows/privilege_escalation_printspooler_registry_copyfiles.toml
+++ b/rules/windows/privilege_escalation_printspooler_registry_copyfiles.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/26"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ references = [
     "https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Privilege%20Escalation/privesc_sysmon_cve_20201030_spooler.evtx",
     "https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2020-1030",
 ]
-risk_score = 74
+risk_score = 73
 rule_id = "bd7eefee-f671-494e-98df-f01daf9e5f17"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]

--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ references = [
     "https://voidsec.com/cve-2020-1337-printdemon-is-dead-long-live-printdemon/",
     "https://www.thezdi.com/blog/2020/7/8/cve-2020-1300-remote-code-execution-through-microsoft-windows-cab-files",
 ]
-risk_score = 74
+risk_score = 73
 rule_id = "5bb4a95d-5a08-48eb-80db-4c3a63ec78a8"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ license = "Elastic License"
 name = "Suspicious PrintSpooler SPL File Created"
 note = "Refer to CVEs, CVE-2020-1048 and CVE-2020-1337 for further information on the vulnerability and exploit. Verify that the relevant system is patched."
 references = ["https://safebreach.com/Post/How-we-bypassed-CVE-2020-1048-Patch-and-got-CVE-2020-1337"]
-risk_score = 74
+risk_score = 73
 rule_id = "a7ccae7b-9d2c-44b2-a061-98e5946971fa"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]

--- a/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
+++ b/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/26"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ language = "eql"
 license = "Elastic License"
 name = "Privilege Escalation via Windir Environment Variable"
 references = ["https://www.tiraniddo.dev/2017/05/exploiting-environment-variables-in.html"]
-risk_score = 71
+risk_score = 73
 rule_id = "d563aaba-2e72-462b-8658-3e5ea22db3a6"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]

--- a/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +15,7 @@ language = "eql"
 license = "Elastic License"
 name = "UAC Bypass Attempt with IEditionUpgradeManager Elevated COM Interface"
 references = ["https://github.com/hfiref0x/UACME"]
-risk_score = 71
+risk_score = 73
 rule_id = "b90cdde7-7e0d-4359-8bf0-2c112ce2008a"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]

--- a/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/26"
 maturity = "production"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +15,7 @@ language = "eql"
 license = "Elastic License"
 name = "UAC Bypass Attempt via Windows Directory Masquerading"
 references = ["https://medium.com/tenable-techblog/uac-bypass-by-mocking-trusted-directories-24a96675f6e"]
-risk_score = 71
+risk_score = 73
 rule_id = "290aca65-e94d-403b-ba0f-62f320e63f51"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]

--- a/rules/windows/privilege_escalation_uac_sdclt.toml
+++ b/rules/windows/privilege_escalation_uac_sdclt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "development"
-updated_date = "2020/01/28"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License"
 name = "Bypass UAC via Sdclt"
-risk_score = 21
+risk_score = 73
 rule_id = "9b54e002-034a-47ac-9307-ad12c03fa900"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]

--- a/rules/windows/privilege_escalation_wpad_exploitation.toml
+++ b/rules/windows/privilege_escalation_wpad_exploitation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "development"
-updated_date = "2021/01/20"
+updated_date = "2021/02/08"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +15,7 @@ index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License"
 name = "WPAD Service Exploit"
-risk_score = 21
+risk_score = 73
 rule_id = "ec328da1-d5df-482b-866c-4a435692b1f3"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
n/a

## Summary
Upon review, there are rules in `main` that don't follow our established risk score/severity mappings of - 

`low:21`, 
`medium:47`, 
`high:73`, 
`critical:99`

This PR adjusts the risk score values to align with the severity mapping.



## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
