### PR TITLE
Lock versions for rule changes in v7.11.0

### DIFF
--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -1,13 +1,28 @@
 {
   "000047bb-b27a-47ec-8b62-ef1a5d2c9e19": {
-    "rule_name": "Attempt to Modify Okta MFA Rule",
-    "sha256": "f9bd8e6caeae611103938c373e4396b7cbfc29189f96b3e4032efd7afcc143ee",
-    "version": 2
+    "rule_name": "Attempt to Modify an Okta Policy Rule",
+    "sha256": "be6fbf2245a6365c6741b42f979b49c16c2d5f485f90365f4572ad17b1c6d266",
+    "version": 3
+  },
+  "00140285-b827-4aee-aa09-8113f58a08f3": {
+    "rule_name": "Potential Credential Access via Windows Utilities",
+    "sha256": "ed629ffafc2eda9866eea9b7538c947ed39f3caa91bc9318b7d8258962b8d58e",
+    "version": 1
   },
   "0022d47d-39c7-4f69-a232-4fe9dc7a3acd": {
     "rule_name": "System Shells via Services",
-    "sha256": "5f1f258d346ed8061345b2cdb728ab29e71335b3c401e9dc13235cdd8fba7ac0",
-    "version": 5
+    "sha256": "32aa5dae894539d46a474893aa8d053005b8b3875035989a8c43640d58d58644",
+    "version": 6
+  },
+  "03024bd9-d23f-4ec1-8674-3cf1a21e130b": {
+    "rule_name": "Microsoft 365 Exchange Safe Attachment Rule Disabled",
+    "sha256": "597de1037b8e935e00d29b0083b61f2f93e7ce6fab04637d0664a0c7b5a31b9a",
+    "version": 1
+  },
+  "035889c4-2686-4583-a7df-67f89c292f2c": {
+    "rule_name": "High Number of Process and/or Service Terminations",
+    "sha256": "675294fdab8938639d7813f80e9ed17a038d03d3d20b16462738ed18c86c0811",
+    "version": 1
   },
   "041d4d41-9589-43e2-ba13-5680af75ebc2": {
     "rule_name": "Potential DNS Tunneling via Iodine",
@@ -16,8 +31,8 @@
   },
   "0564fb9d-90b9-4234-a411-82a546dc1343": {
     "rule_name": "Microsoft IIS Service Account Password Dumped",
-    "sha256": "3ad71ce2d24f4fbf0ff051c5f322c321173231d333c6313321c24b050cee99ee",
-    "version": 1
+    "sha256": "1526b1ab6e956f6f27eb41d78ac30b6377a5d859920edb7dfd9401d5d8382ba3",
+    "version": 2
   },
   "05b358de-aa6d-4f6c-89e6-78f74018b43b": {
     "rule_name": "Conhost Spawned By Suspicious Parent Process",
@@ -29,15 +44,35 @@
     "sha256": "efe7bd02504d62b8781e6ffc70abc015bd4025c4b7fd67565e568841919b53e7",
     "version": 4
   },
+  "0635c542-1b96-4335-9b47-126582d2c19a": {
+    "rule_name": "Remote System Discovery Commands",
+    "sha256": "8174bab1329c416caecc97faa33aa7fcd688064d44f11b6ae47de85198c8c610",
+    "version": 1
+  },
   "06dceabf-adca-48af-ac79-ffdf4c3b1e9a": {
     "rule_name": "Potential Evasion via Filter Manager",
     "sha256": "03ac5cac28ca005e43bb065cac877fd834f2a5a1c4abe2d0e86b65dd9efbbcbd",
     "version": 4
   },
+  "074464f9-f30d-4029-8c03-0ed237fffec7": {
+    "rule_name": "Remote Desktop Enabled in Windows Firewall",
+    "sha256": "710d393f51db68c5cee8407ee3db8d9f769d91288c10a6f5f3506e46888d3fbc",
+    "version": 1
+  },
+  "082e3f8c-6f80-485c-91eb-5b112cb79b28": {
+    "rule_name": "Launch Agent Creation or Modification and Immediate Loading",
+    "sha256": "e528a87ea96507db3839017216ed364081e638391209af086b126d1de534f30c",
+    "version": 1
+  },
   "08d5d7e2-740f-44d8-aeda-e41f4263efaf": {
     "rule_name": "TCP Port 8000 Activity to the Internet",
-    "sha256": "eb9d27881cdd82877f5c79e587676c4708362bb9c1f3cc33bf2ff3c372f58296",
-    "version": 5
+    "sha256": "620150666b5a85765d458c0ad166e11af070c6df20475d5f60c6a8b667b0126d",
+    "version": 6
+  },
+  "09443c92-46b3-45a4-8f25-383b028b258d": {
+    "rule_name": "Process Termination followed by Deletion",
+    "sha256": "c5f205ff54c1d0e79f4b4750bf6a7a410a4c6541e53a51be0d8cb5e8cc8e67c6",
+    "version": 1
   },
   "0a97b20f-4144-49ea-be32-b540ecc445de": {
     "rule_name": "Malware - Detected - Endpoint Security",
@@ -49,6 +84,11 @@
     "sha256": "2c0ef448095688b59b12cdf6eaa8b1cf916845b1b9ca33e47412f87f855d493d",
     "version": 3
   },
+  "0c7ca5c2-728d-4ad9-b1c5-bbba83ecb1f4": {
+    "rule_name": "Peripheral Device Discovery",
+    "sha256": "cb51a32a4e8ce0e88271b31626be8e84c4f46d1e29e7b29a3afc611282c5470c",
+    "version": 1
+  },
   "0d69150b-96f8-467c-a86d-a67a3378ce77": {
     "rule_name": "Nping Process Activity",
     "sha256": "4bb206b502300c86a4e61297e3adff88d2986792f3ab900a0db31d29b589713b",
@@ -56,23 +96,23 @@
   },
   "0d8ad79f-9025-45d8-80c1-4f0cd3c5e8e5": {
     "rule_name": "Execution of File Written or Modified by Microsoft Office",
-    "sha256": "279c5672f7a5cf27f5c97c7becfc549d34a4483c7b12fbf88949ec9ab8b4fd22",
-    "version": 1
+    "sha256": "1c2093218988bd5075f751f889f33bf5951acd5b6eed596e7b16356c713992b4",
+    "version": 2
   },
   "0e5acaae-6a64-4bbc-adb8-27649c03f7e1": {
     "rule_name": "GCP Service Account Key Creation",
-    "sha256": "6f6d7dc29596f09dcc690be249eb63dafb013bc2a63bea2cf59acb3fa25e957a",
-    "version": 1
+    "sha256": "651ee1ba3e8d38e3b0650fb146070bc177ddb32abc744c2291ada7f993239c9a",
+    "version": 2
   },
   "0e79980b-4250-4a50-a509-69294c14e84b": {
     "rule_name": "MsBuild Making Network Connections",
-    "sha256": "31d9a8a7c66735189e7ff5948984f41e1041a7148f7d55b751aceff7ad660ef2",
-    "version": 5
+    "sha256": "49f28f634ed84feabea9a0466856d470b32de0629543625a47b810c023bf3f7d",
+    "version": 6
   },
   "0f616aee-8161-4120-857e-742366f5eeb3": {
     "rule_name": "PowerShell spawning Cmd",
-    "sha256": "eda1455bfca1e70643cf61c6349be1e9948d6711fd999e23683c739a5b5582aa",
-    "version": 5
+    "sha256": "a8d9fcd5f266c1c5bf85063d3e23006ff92faa1c844be75e69a56a22ae4add26",
+    "version": 6
   },
   "11013227-0301-4a8c-b150-4db924484475": {
     "rule_name": "Abnormally Large DNS Response",
@@ -81,7 +121,12 @@
   },
   "1160dcdb-0a0a-4a79-91d8-9b84616edebd": {
     "rule_name": "Potential DLL SideLoading via Trusted Microsoft Programs",
-    "sha256": "1d2aa3da7555b841e5ecbea83e7ee1a8c38bd9f604f69396dcedba77b2507a79",
+    "sha256": "42bd493577210bb3d458322e64dc3bfef8288024123681ff8a831d0d186582a4",
+    "version": 2
+  },
+  "1178ae09-5aff-460a-9f2f-455cd0ac4d8e": {
+    "rule_name": "UAC Bypass via Windows Firewall Snap-In Hijack",
+    "sha256": "8e6964722059775cf9281fe83d13ab053402a8bff97909f022214caea8d05a24",
     "version": 1
   },
   "120559c6-5e24-49f4-9e30-8ffe697df6b9": {
@@ -91,38 +136,48 @@
   },
   "125417b8-d3df-479f-8418-12d7e034fee3": {
     "rule_name": "Attempt to Disable IPTables or Firewall",
-    "sha256": "954073af18b76a19b827b05ef6809fbb44f532554dc57d267ca86882d04d9302",
-    "version": 4
+    "sha256": "87d42f9709d9399e1b79c6e7019210984844d88b6c851d8104d64ccdf606381d",
+    "version": 5
+  },
+  "12f07955-1674-44f7-86b5-c35da0a6f41a": {
+    "rule_name": "Suspicious Cmd Execution via WMI",
+    "sha256": "6b729a2dfa9c05431da196cc8d53b96e6cff8d20355ebda3c946832ac6570cd4",
+    "version": 1
   },
   "139c7458-566a-410c-a5cd-f80238d6a5cd": {
     "rule_name": "SQL Traffic to the Internet",
-    "sha256": "58162840d3e9478788b0da3fbfc63f6c9887ca97e9e9c2e02e83f833411d8309",
-    "version": 5
+    "sha256": "cd68668f3a89f96fddb995cff2dd1c34c45188cfb6f8684ba6945f23a2b024e2",
+    "version": 6
   },
   "141e9b3a-ff37-4756-989d-05d7cbf35b0e": {
     "rule_name": "Azure External Guest User Invitation",
-    "sha256": "6173211181d2fd70cc93738f4621a3e27b4c8c3e01fd396d2f05a34d6eb6df6f",
-    "version": 1
+    "sha256": "19f48e8f623fb68f35bbe6746f8fd4935f1b2f5e29dcc9072bdec16cf0171eba",
+    "version": 2
   },
   "143cb236-0956-4f42-a706-814bcaa0cf5a": {
     "rule_name": "RPC (Remote Procedure Call) from the Internet",
-    "sha256": "27ccce4c59e522e175b0b0c36484ad0dc4c3960a8e1a98df4584d2ed14eea6f4",
-    "version": 5
+    "sha256": "eaed9eb3b9f22c95ce23b56b78f56eab96752442afbe674da92c6d196a4fe8de",
+    "version": 6
   },
   "15c0b7a7-9c34-4869-b25b-fa6518414899": {
     "rule_name": "Remote File Download via Desktopimgdownldr Utility",
-    "sha256": "6e920e9127286ed497dc48b7a5f289178452156489699e5cb40a3116683cf324",
-    "version": 1
+    "sha256": "f82bd052efca4c7baef73d99dcb1b2a52fbe51229cdb460bbd9820c76ef4510f",
+    "version": 2
   },
   "16280f1e-57e6-4242-aa21-bb4d16f13b2f": {
     "rule_name": "Azure Automation Runbook Created or Modified",
-    "sha256": "6d28baddd53074b17e5fa12ac1c9ce3ce717a61967b0ecbe4bb45b8e52bdb1bc",
-    "version": 1
+    "sha256": "ad286a2be4535d1ffcf2283d3bf2ff4535f17ec5c9d863bcebd305e8ce8c98b4",
+    "version": 2
   },
   "169f3a93-efc7-4df2-94d6-0d9438c310d1": {
     "rule_name": "AWS IAM Group Creation",
-    "sha256": "8c529f3afdc74b3c7974570fe13a06db483a06d61dbd054f23da483edf630d7e",
-    "version": 2
+    "sha256": "199bf9973118ddd2f9d8af6c7a0d5ce2fcaaabe21d753225c08d1f9a58869c84",
+    "version": 3
+  },
+  "16a52c14-7883-47af-8745-9357803f0d4c": {
+    "rule_name": "Component Object Model Hijacking",
+    "sha256": "5e030748329745eeee71061e689ed93a163afb5e7facb86644773cff36b87b94",
+    "version": 1
   },
   "1781d055-5c66-4adf-9c59-fc0fa58336a5": {
     "rule_name": "Unusual Windows Username",
@@ -149,6 +204,11 @@
     "sha256": "9b5521dffd2429f28febd39b2e0c6854439e3020f4ea36dae83899321f987f80",
     "version": 3
   },
+  "17c7f6a5-5bc9-4e1f-92bf-13632d24384d": {
+    "rule_name": "Suspicious Execution - Short Program Name",
+    "sha256": "8ba6ec732352e58f2418f5189e0b79f202dc377af37c819839e66897147501b5",
+    "version": 1
+  },
   "17e68559-b274-4948-ad0b-f8415bb31126": {
     "rule_name": "Unusual Network Destination Domain Name",
     "sha256": "6e872b23e100ee779531cb816953fbf9c13e475e07b3ab4e52ecdef1e474e124",
@@ -156,18 +216,23 @@
   },
   "184dfe52-2999-42d9-b9d1-d1ca54495a61": {
     "rule_name": "GCP Logging Sink Modification",
-    "sha256": "2703485bd04f7b90892dd0a5fd2aafc77e2109c6c64340f47ece4b56a0f6d9fc",
-    "version": 1
+    "sha256": "76f5fb3584049eedd28cf7a96f175db16d5955ffacaa05e51a2fefe43084ef77",
+    "version": 2
   },
   "19de8096-e2b0-4bd8-80c9-34a820813fff": {
     "rule_name": "Rare AWS Error Code",
     "sha256": "ba1f3d9db01dd4ecac10bceae27c1686745f53fc59c9164cdda820d1ff955667",
     "version": 2
   },
+  "1a36cace-11a7-43a8-9a10-b497c5a02cd3": {
+    "rule_name": "Azure Application Credential Modification",
+    "sha256": "566fd428efb2f6d4eb7eda9abdec74a6b407ea38023cf089c04e8da344ef549e",
+    "version": 1
+  },
   "1aa8fa52-44a7-4dae-b058-f3333b91c8d7": {
     "rule_name": "AWS CloudTrail Log Suspended",
-    "sha256": "4691d9fb494b9ab1413375f4832bb68e4541a7a96907ede652102beae9b927fe",
-    "version": 2
+    "sha256": "1cbeedb8561afa64948fbe258e2718f4992802cc83809ce703e267504c5b727c",
+    "version": 3
   },
   "1aa9181a-492b-4c01-8b16-fa0735786b2b": {
     "rule_name": "User Account Creation",
@@ -181,7 +246,17 @@
   },
   "1c6a8c7a-5cb6-4a82-ba27-d5a5b8a40a38": {
     "rule_name": "Possible Consent Grant Attack via Azure-Registered Application",
-    "sha256": "f360fa061dda8c50993fc93f7fb9d1c3a7f070861b18c63cfffaeb7bab802d94",
+    "sha256": "ccd0f37317c399e36df84c0a458ee06b859ab7869995d8f26e542b3679ac0cf6",
+    "version": 2
+  },
+  "1cd01db9-be24-4bef-8e7c-e923f0ff78ab": {
+    "rule_name": "Incoming Execution via WinRM Remote Shell",
+    "sha256": "b6932e27a95974385f586931c228695347bfd04535e89f328976ff0db921235a",
+    "version": 1
+  },
+  "1d276579-3380-4095-ad38-e596a01bc64f": {
+    "rule_name": "Remote File Download via Script Interpreter",
+    "sha256": "4abb8480e4397d41ccad67d9f2aea6c629a9a089247d426bc92135e3073f83a7",
     "version": 1
   },
   "1d72d014-e2ab-4707-b056-9b96abe7b511": {
@@ -191,18 +266,18 @@
   },
   "1dcc51f6-ba26-49e7-9ef4-2655abb2361e": {
     "rule_name": "UAC Bypass via DiskCleanup Scheduled Task Hijack",
-    "sha256": "0adc0d3d12852872e3353b3be3bd0c586cef1dac4989a670954d3b9e8bcbefa9",
-    "version": 1
+    "sha256": "1832984e7f2bac120cdfa1bce9afb73503a975aa5bf582000608b056267b4dd4",
+    "version": 2
   },
   "1defdd62-cd8d-426e-a246-81a37751bb2b": {
     "rule_name": "Execution of File Written or Modified by PDF Reader",
-    "sha256": "8c1cf9330ffc9fdaa53a49674a3974cd90262ff7de7c0fefee99cc413a7b3be4",
-    "version": 1
+    "sha256": "aa68e54b0b1dab44af2dafcbdb5c36d1b2b9e6d5363b407789b653864158e52f",
+    "version": 2
   },
   "1e0b832e-957e-43ae-b319-db82d228c908": {
     "rule_name": "Azure Storage Account Key Regenerated",
-    "sha256": "d189965d46796d21054d909dfdc3cc2c2edb949bbd9c53fc71e9ba9501dd22d3",
-    "version": 1
+    "sha256": "b670982bd2cea96cca6babe74af50324bbe3474f43e6561fde640c8e3284d6cb",
+    "version": 2
   },
   "1e9fc667-9ff1-4b33-9f40-fefca8537eb0": {
     "rule_name": "Unusual Sudo Activity",
@@ -226,7 +301,12 @@
   },
   "201200f1-a99b-43fb-88ed-f65a45c4972c": {
     "rule_name": "Suspicious .NET Code Compilation",
-    "sha256": "3c266f628d45aaa310e2dec51dc18b57f257afc1885ec11d033a4187e9d38226",
+    "sha256": "64b587a8352b7bb14fdbb5176b6e3e5ad6d47335087d807cf59e0982141bf930",
+    "version": 2
+  },
+  "22599847-5d13-48cb-8872-5796fee8692b": {
+    "rule_name": "SUNBURST Command and Control Activity",
+    "sha256": "7a4f04aa1b58e764f3530e79089f90cf6a7636963425fa11485e40030542ea55",
     "version": 1
   },
   "227dc608-e558-43d9-b521-150772250bae": {
@@ -236,27 +316,52 @@
   },
   "231876e7-4d1f-4d63-a47c-47dd1acdc1cb": {
     "rule_name": "Potential Shell via Web Server",
-    "sha256": "6b38e8be014568c7786001c5974a1ce463d8f7f3e436e5df0a8c969ebc27d823",
-    "version": 6
+    "sha256": "c2c31e7d78f6434fa9cd3db2dd06ab36a1a81340338a41557e7b16a7a1dc7c9d",
+    "version": 7
   },
   "2326d1b2-9acf-4dee-bd21-867ea7378b4d": {
     "rule_name": "GCP Storage Bucket Permissions Modification",
-    "sha256": "1dc4803392cfaa78b483660dc16fac6fcdc0c940d413949557cb912ee27ad979",
+    "sha256": "e8335174cc297b2c5f189a4013f316ea437efb1b4a045ffbf046cc666e55e2f7",
+    "version": 2
+  },
+  "25224a80-5a4a-4b8a-991e-6ab390465c4f": {
+    "rule_name": "Lateral Movement via Startup Folder",
+    "sha256": "f707f3380372f319a10ff01815d201dd8ccf0f261956337c6ff838d41d76e478",
     "version": 1
   },
   "2636aa6c-88b5-4337-9c31-8d0192a8ef45": {
     "rule_name": "Azure Blob Container Access Level Modification",
-    "sha256": "a8eaa99d010397c8e118b375183047db902df793867c7bd8311adfc1eeb959b0",
-    "version": 1
+    "sha256": "6880cec014be2430a132b6a2468d10a2ab2c7816dafafcbca87201ec1505bcef",
+    "version": 2
   },
   "265db8f5-fc73-4d0d-b434-6483b56372e2": {
     "rule_name": "Persistence via Update Orchestrator Service Hijack",
-    "sha256": "dc25f66a2cd09edd7f601b26b29c51d34acc2f7419b666689d7d9974a4a4b157",
+    "sha256": "b8982d412aef4e25fcff6aa043f6672b65ef99f8d291ac5ef962a745b50bf8d2",
+    "version": 2
+  },
+  "26f68dba-ce29-497b-8e13-b4fde1db5a2d": {
+    "rule_name": "Attempts to Brute Force a Microsoft 365 User Account",
+    "sha256": "1678ed5e26e08ff3c4b51dea2cee32f9fb1275bc8042634dae096429511f64c1",
+    "version": 1
+  },
+  "272a6484-2663-46db-a532-ef734bf9a796": {
+    "rule_name": "Microsoft 365 Exchange Transport Rule Modification",
+    "sha256": "12d4eafa7f91342d743e0a51be51b3117990f359596bcc19965419bd74155ea7",
+    "version": 1
+  },
+  "2772264c-6fb9-4d9d-9014-b416eed21254": {
+    "rule_name": "Incoming Execution via PowerShell Remoting",
+    "sha256": "57b09eec9a69ad0e38e8e43010bf9c0937e1508d050755d0a480820c02f3434f",
     "version": 1
   },
   "2783d84f-5091-4d7d-9319-9fceda8fa71b": {
     "rule_name": "GCP Firewall Rule Modification",
-    "sha256": "f468d6672778eccf92ab3c49e47650a9ebbef4feb3bf5ef57fe854b0101f837c",
+    "sha256": "7cb9fa12872677397b5749bd9c678344728b3e13a30837e477262f653c8134a9",
+    "version": 2
+  },
+  "27f7c15a-91f8-4c3d-8b9e-1f99cc030a51": {
+    "rule_name": "Microsoft 365 Teams External Access Enabled",
+    "sha256": "dad571cede63daa41944ed5b2a5c542fccb3af6b554ccc696aa214d87d8e477d",
     "version": 1
   },
   "2856446a-34e6-435b-9fb5-f8f040bfa7ed": {
@@ -274,10 +379,15 @@
     "sha256": "29ec058f9603c19950c03bba6b7ab0bc8c8609966dc782f1481059b97f6d2564",
     "version": 1
   },
+  "290aca65-e94d-403b-ba0f-62f320e63f51": {
+    "rule_name": "UAC Bypass Attempt via Windows Directory Masquerading",
+    "sha256": "51616e4ec912d948fe113223c9c6bfdf36f5f3c164573c6e42adcf0bd6907186",
+    "version": 1
+  },
   "2bf78aa2-9c56-48de-b139-f169bf99cf86": {
     "rule_name": "Adobe Hijack Persistence",
-    "sha256": "55ab3cdeae88e42d8404c28f598eb416fc7de78206a9b80e38ac98abbb5df237",
-    "version": 5
+    "sha256": "d0eeeda2b5eb588e6edf406c4f468adf31d0d4ef850e92722601a214890e19e0",
+    "version": 6
   },
   "2d8043ed-5bda-4caf-801c-c1feb7410504": {
     "rule_name": "Enumeration of Kernel Modules",
@@ -286,23 +396,28 @@
   },
   "2e1e835d-01e5-48ca-b9fc-7a61f7f11902": {
     "rule_name": "Renamed AutoIt Scripts Interpreter",
-    "sha256": "5ad137862977f43fad9760347b3e8922e95874871ba0083be5ef1054135991ec",
-    "version": 1
+    "sha256": "e675b7f839446dad1cb5d44cbb903e5e137c1b97966ced2e1280a004cde07855",
+    "version": 2
   },
   "2e580225-2a58-48ef-938b-572933be06fe": {
     "rule_name": "Halfbaked Command and Control Beacon",
-    "sha256": "fe2712b9622cf77291f067c1a80170ba996bea2724f1f2e2239a71c4e9a9d172",
-    "version": 1
+    "sha256": "e77f63807a89e722a20622ea33c5f733afc0f90378e2c9876a99543fd2c18ee2",
+    "version": 2
   },
   "2f8a1226-5720-437d-9c20-e0029deb6194": {
     "rule_name": "Attempt to Disable Syslog Service",
-    "sha256": "93f733e8864d6a086ce2131e251f6e66158a635fcf588a8ef61ad1e286648863",
-    "version": 4
+    "sha256": "529e18561a1d32da00b5c9c40099b2757b511cd5c18bb6a52c60bab0dd3c02cf",
+    "version": 5
+  },
+  "2fba96c0-ade5-4bce-b92f-a5df2509da3f": {
+    "rule_name": "Startup Folder Persistence via Unsigned Process",
+    "sha256": "eddb73a664e938bfa193825a0de166c1ae4577d8e2f1ce732819db7f92bfc126",
+    "version": 1
   },
   "30562697-9859-4ae0-a8c5-dab45d664170": {
     "rule_name": "GCP Firewall Rule Creation",
-    "sha256": "bedb1bf60788bffebbe4160f2f7f48d8d1fdcfcb050166cee7d9a7deb794da48",
-    "version": 1
+    "sha256": "e994dbbf4d651d09a2adff62c38bb36abbc3e17f9537fd5a4bd50bd7aa586f3a",
+    "version": 2
   },
   "31295df3-277b-4c56-a1fb-84e31b4222a9": {
     "rule_name": "Inbound Connection to an Unsecure Elasticsearch Node",
@@ -311,83 +426,118 @@
   },
   "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62": {
     "rule_name": "Bypass UAC via Event Viewer",
-    "sha256": "e8a189f29d90e1a2bb295677cec25932884f2ef0d8cbaac015b8a4c02678fa3c",
-    "version": 4
+    "sha256": "226e22578802c0db22d1805860c39c3472f692b81f32e5e0923cd7850726f394",
+    "version": 5
   },
   "3202e172-01b1-4738-a932-d024c514ba72": {
     "rule_name": "GCP Pub/Sub Topic Deletion",
-    "sha256": "cee072c874203cd0812746b405aa3d5d28dbe4fbd2cd49ab04cf29bcbd795e3e",
-    "version": 1
+    "sha256": "5180237a6d223a39920f0e25b96c62d1021db9754e4bd088b743c98802a75c82",
+    "version": 2
   },
   "323cb487-279d-4218-bcbd-a568efe930c6": {
     "rule_name": "Azure Network Watcher Deletion",
-    "sha256": "f96fc5c64e1a81100fda85de8bd4ff271547c059ab4c22cb8aa58f1643b32fe4",
-    "version": 1
+    "sha256": "b61ac0124af599d2ed4d36f3e322e88c05316c3a8e4bd08fcc2dc66d78fe7dd9",
+    "version": 2
   },
   "32923416-763a-4531-bb35-f33b9232ecdb": {
     "rule_name": "RPC (Remote Procedure Call) to the Internet",
-    "sha256": "fdb02360ced00662199045a09224c9ac6156660aef6f1bda85cf299a1113ec94",
-    "version": 5
+    "sha256": "81e9194be578d1614c653e41b721efdffba8c2f991d0c00e8b3e99ba0fe50196",
+    "version": 6
+  },
+  "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14": {
+    "rule_name": "Program Files Directory Masquerading",
+    "sha256": "a6b409aa5c1a7cf56c20bd904dedd98c0637589d4f7fafd0e5abbc5b76b881ba",
+    "version": 1
   },
   "32f4675e-6c49-4ace-80f9-97c9259dca2e": {
     "rule_name": "Suspicious MS Outlook Child Process",
-    "sha256": "1a000d838130068a0ecdeca43014a2ea356323058d0347944492a26b569a934a",
-    "version": 5
+    "sha256": "ee650323541fc217097ebae5be9743116a3fc32b0781903b04357cd7e5ed6c4c",
+    "version": 6
   },
   "333de828-8190-4cf5-8d7c-7575846f6fe0": {
     "rule_name": "AWS IAM User Addition to Group",
-    "sha256": "8b3fa242c860a30e14510d25a9809c34b50727a60d9903438e27ef547ba2edc0",
-    "version": 2
+    "sha256": "4531d115b94f4e437c84390cdc1aa7e8ccd515a3630fd15dd6d22ee52ced30ee",
+    "version": 3
+  },
+  "33f306e8-417c-411b-965c-c2812d6d3f4d": {
+    "rule_name": "Remote File Download via PowerShell",
+    "sha256": "3f7622021f11c5c2649c14842643ecee2ece082c6e00228f579757cbdf1a5261",
+    "version": 1
   },
   "34fde489-94b0-4500-a76f-b8a157cf9269": {
     "rule_name": "Telnet Port Activity",
-    "sha256": "62226b26b71cbc35a084cde046d1d5ba78a2be5e580d592549a23468aaf07f50",
-    "version": 4
+    "sha256": "f459488b88d14180081713099b0032605424654fa3e612f49563ac766fbc7fee",
+    "version": 5
+  },
+  "3535c8bb-3bd5-40f4-ae32-b7cd589d5372": {
+    "rule_name": "Port Forwarding Rule Addition",
+    "sha256": "f64dfa87334a889830ca53e2b225d199e02231d66b9066081f42c1ab3111e12f",
+    "version": 1
   },
   "35df0dd8-092d-4a83-88c1-5151a804f31b": {
     "rule_name": "Unusual Parent-Child Relationship",
-    "sha256": "1ac1f22b69204183b001f43052dc594d7e644045ab127d94e0abb985192c0d15",
-    "version": 5
+    "sha256": "d4e4d3d9ca777e5e01cb04ea212ddfc7c68e57a22b73b6e06b9eef7e75c63838",
+    "version": 6
+  },
+  "36a8e048-d888-4f61-a8b9-0f9e2e40f317": {
+    "rule_name": "Suspicious ImagePath Service Creation",
+    "sha256": "672a594cc4b4f0c61f7fe5198f2698210a2fc1db74a48dfc049a1a5a3ece6b0f",
+    "version": 1
   },
   "37b0816d-af40-40b4-885f-bb162b3c88a9": {
     "rule_name": "Anomalous Kernel Module Activity",
-    "sha256": "be9a968918ecb1de60f64c0aa026e28eda3b6abf5832ab652eb32b7ab5b28073",
-    "version": 1
+    "sha256": "cd02c225183b6d5187a07bf67653afe3372de17dde89842143f115477aca31d7",
+    "version": 2
   },
   "37b211e8-4e2f-440f-86d8-06cc8f158cfa": {
     "rule_name": "AWS Execution via System Manager",
-    "sha256": "34930b0fc1fe02746abb468b9a279aedb61bc646104c54c72b06307f261aa59f",
-    "version": 2
+    "sha256": "bbd154f013487bf4fe024a94d1324ebdaeafb6c888cc30157268e08df1994dea",
+    "version": 3
   },
   "3805c3dc-f82c-4f8d-891e-63c24d3102b0": {
     "rule_name": "Attempted Bypass of Okta MFA",
-    "sha256": "da9d2dfce1dde913e81976b107b7d87f4d8deacc91269bb7ceee3375153a7f37",
-    "version": 2
+    "sha256": "e67a1aaa9d43641b3b423418015f78229dbf198b84e9c10f1dbee6548c878727",
+    "version": 3
   },
   "3838e0e3-1850-4850-a411-2e8c5ba40ba8": {
     "rule_name": "Network Connection via Certutil",
     "sha256": "def0708eb6e6a00bb2f17fb1fafee41d4e11f5e4385ca2ca08447724ff623f68",
     "version": 4
   },
+  "38948d29-3d5d-42e3-8aec-be832aaaf8eb": {
+    "rule_name": "Prompt for Credentials with OSASCRIPT",
+    "sha256": "bff999462d36e7706271a98328bb72001083af0b09cb9e3f8fb31b0021fc8946",
+    "version": 1
+  },
   "38e5acdd-5f20-4d99-8fe4-f0a1a592077f": {
     "rule_name": "User Added as Owner for Azure Service Principal",
-    "sha256": "0326cf943e8002b7250c2cac5ea432b445ec2d3392f4f0d128c7498af4cbcac6",
-    "version": 1
+    "sha256": "637089ce32c111f2bc450112dc43e77a0c191cc1ea49e6f0bf664309f913ecb9",
+    "version": 2
   },
   "39144f38-5284-4f8e-a2ae-e3fd628d90b0": {
     "rule_name": "AWS EC2 Network Access Control List Creation",
-    "sha256": "a054bdb16ea3b4206df475de2d32ad97ce6bb9a0f1ce60685fc9de355dac63a8",
-    "version": 2
+    "sha256": "79183338e96c2ffca1eeff36a0fda0b640854ad372fe3a599e26276401677c66",
+    "version": 3
+  },
+  "397945f3-d39a-4e6f-8bcb-9656c2031438": {
+    "rule_name": "Persistence via Microsoft Outlook VBA",
+    "sha256": "baa5488faf7b131d9587b945593517cf0d9641a088bebf675d75b20081f68bee",
+    "version": 1
+  },
+  "3a59fc81-99d3-47ea-8cd6-d48d561fca20": {
+    "rule_name": "Potential DNS Tunneling via NsLookup",
+    "sha256": "732ac08d2d07ec76126d378233aaa6ceaad8088afaa81e456854b8a71a3db361",
+    "version": 1
   },
   "3a86e085-094c-412d-97ff-2439731e59cb": {
     "rule_name": "Setgid Bit Set via chmod",
-    "sha256": "1daabd68272b1075354622fb803a78db173eea976714950f2314ac51bfac266b",
-    "version": 4
+    "sha256": "88f9b435053af9149607e76525202c778a18d68d443b39fa55d5abe389038f30",
+    "version": 5
   },
   "3ad49c61-7adc-42c1-b788-732eda2f5abf": {
     "rule_name": "VNC (Virtual Network Computing) to the Internet",
-    "sha256": "5418780f11b869e1dee170ddaef24842c18adb0b1c84427261cff4400fcc5c63",
-    "version": 5
+    "sha256": "2c04e5d522326cc744f1b49f8df15c4a76b74279207703af169a9fe62954370d",
+    "version": 6
   },
   "3b382770-efbb-44f4-beed-f5e0a051b895": {
     "rule_name": "Malware - Prevented - Endpoint Security",
@@ -399,6 +549,11 @@
     "sha256": "3956449a0683db5b1401aa8c3a1230cd21ebc628f1b1e700d4913b13744b0aeb",
     "version": 1
   },
+  "3bc6deaa-fbd4-433a-ae21-3e892f95624f": {
+    "rule_name": "NTDS or SAM Database File Copied",
+    "sha256": "6129832a37aaa5e17a84c8d54a07e74155c9a7e7e58622fae606eb7e5a9fdaa9",
+    "version": 1
+  },
   "3c7e32e6-6104-46d9-a06e-da0f8b5795a0": {
     "rule_name": "Unusual Linux Network Port Activity",
     "sha256": "b1d42eb05bc2bb9c5ca66aab76709e4f3aa79e9293af35f760905331f4fe3d43",
@@ -406,13 +561,28 @@
   },
   "3e002465-876f-4f04-b016-84ef48ce7e5d": {
     "rule_name": "AWS CloudTrail Log Updated",
-    "sha256": "58809561efd9fbbf3137f283d5db96b1ef0c2025772e1e1c292a8565bd62c8d6",
-    "version": 2
+    "sha256": "d5508e7625989a082fffb99c02bc4ef880943ee818c2230c81a221d68c3b4092",
+    "version": 3
+  },
+  "3ecbdc9e-e4f2-43fa-8cca-63802125e582": {
+    "rule_name": "Privilege Escalation via Named Pipe Impersonation",
+    "sha256": "b202446df1f2e4a0afeea4be08526355c5d5dbb62ea5551dc9808275199a1adb",
+    "version": 1
+  },
+  "3efee4f0-182a-40a8-a835-102c68a4175d": {
+    "rule_name": "Potential Password Spraying of Microsoft 365 User Accounts",
+    "sha256": "86bd2b4c6d0bc71a1b6510262a029195221c555fc4f67f094e93dc1879d04e93",
+    "version": 1
+  },
+  "403ef0d3-8259-40c9-a5b6-d48354712e49": {
+    "rule_name": "Unusual Persistence via Services Registry",
+    "sha256": "3e33a9f1d52b9b07a34917a0697c94254c0b86881343a9c65d91c5e86ffe0b9d",
+    "version": 1
   },
   "42bf698b-4738-445b-8231-c834ddefd8a0": {
     "rule_name": "Okta Brute Force or Password Spraying Attack",
-    "sha256": "ebd654004bde86bb1dab153f917ac139895ca478b9262553cffb12b52b040ff0",
-    "version": 2
+    "sha256": "fab4b7b457970b0ff1295a2fe4e230ca8221c8a4f5b6491512a62ae3d870d00f",
+    "version": 3
   },
   "4330272b-9724-4bc6-a3ca-f1532b81e5c2": {
     "rule_name": "Unusual Login Activity",
@@ -424,6 +594,11 @@
     "sha256": "75ab7209924df0f0f956fd6d1a9713461cbd51ae2b6e6ce2a1ff51eef35d7a82",
     "version": 4
   },
+  "440e2db4-bc7f-4c96-a068-65b78da59bde": {
+    "rule_name": "Shortcut File Written or Modified for Persistence",
+    "sha256": "e5bc69f2b78b0c6331ce9314de1fe11b771510bdcd43512ff48699785d0e05d1",
+    "version": 1
+  },
   "445a342e-03fb-42d0-8656-0367eb2dead5": {
     "rule_name": "Unusual Windows Path Activity",
     "sha256": "051a230879f4261f63624018cf932d319e6c4484457aa525a006d0d05facf1d3",
@@ -434,10 +609,15 @@
     "sha256": "de91fb70ece5386bf2fe4d065f50aa219516eff015f22534b5cd1b69064fe002",
     "version": 4
   },
+  "45d273fb-1dca-457d-9855-bcb302180c21": {
+    "rule_name": "Encrypting Files with WinRar or 7z",
+    "sha256": "422e05c31ffba0df8f3bae7faf300bfdadf97308441e829967edb08598f95598",
+    "version": 1
+  },
   "4630d948-40d4-4cef-ac69-4002e29bc3db": {
     "rule_name": "Adding Hidden File Attribute via Attrib",
-    "sha256": "67a356c25e202bc547e362a4fda70b93bfc37f0cf070b6f9874e1a81703685c7",
-    "version": 5
+    "sha256": "571ed6e2dbf42785996098630255b55ef5f0dee3f6ca705988bc216fd33d3439",
+    "version": 6
   },
   "46f804f5-b289-43d6-a881-9387cf594f75": {
     "rule_name": "Unusual Process For a Linux Host",
@@ -446,18 +626,28 @@
   },
   "47f09343-8d1f-4bb5-8bb0-00c9d18f5010": {
     "rule_name": "Execution via Regsvcs/Regasm",
-    "sha256": "3a8ea88b97a4902eece57b688d6777d31a512d7598c733553b513a39906b83a0",
-    "version": 4
+    "sha256": "e75e919b3bae2df1eed41952fc6f41dbcc36756b8f830ac594ef37b6d8f8919a",
+    "version": 5
+  },
+  "47f76567-d58a-4fed-b32b-21f571e28910": {
+    "rule_name": "Apple Script Execution followed by Network Connection",
+    "sha256": "c9c44540966b2d9592ad5f670eba6bd6ee29beba41798f2788fc66fd3c0f6c1d",
+    "version": 1
   },
   "4a4e23cf-78a2-449c-bac3-701924c269d3": {
     "rule_name": "Possible FIN7 DGA Command and Control Behavior",
-    "sha256": "73d5438ece3f10febd908003635768a86eee7e140294b352f0b18b1aa7c5a01b",
-    "version": 1
+    "sha256": "3fa7153a86cbc2ace7d71cfed53816495b74a6d6ee0094365420c17fa95c2957",
+    "version": 2
   },
   "4b438734-3793-4fda-bd42-ceeada0be8f9": {
     "rule_name": "Disable Windows Firewall Rules via Netsh",
-    "sha256": "c75227fe4928fdef60b18c6a7da28c56f73773a50ced7b35cb2ea29e654e2e98",
-    "version": 5
+    "sha256": "318527838ec562ffa5c4c1ccf7576ea36b934c2a9d0d08ba12ead4defdda2143",
+    "version": 6
+  },
+  "4bd1c1af-79d4-4d37-9efa-6e0240640242": {
+    "rule_name": "Unusual Process Execution Path - Alternate Data Stream",
+    "sha256": "d988671014362e73e19a8a61cf4d8271628b833daaa941b9e898366ccf0bcfc7",
+    "version": 1
   },
   "4d50a94f-2844-43fa-8395-6afbd5e1c5ef": {
     "rule_name": "AWS Management Console Brute Force of Root User Identity",
@@ -471,23 +661,43 @@
   },
   "4ed678a9-3a4f-41fb-9fea-f85a6e0a0dff": {
     "rule_name": "Windows Suspicious Script Object Execution",
-    "sha256": "cf8905f5bf0f2a7f38f283840d708231961dcc293a005f0f3469949f437c1d70",
+    "sha256": "575bb0ccbaf54a34b2a4967355a6aeabd8e1e1da541113896f9de5e4d02dbc8c",
+    "version": 2
+  },
+  "4fe9d835-40e1-452d-8230-17c147cafad8": {
+    "rule_name": "Execution via TSClient Mountpoint",
+    "sha256": "9290f46476c9f56f04b7b9aabeb75175375804c957088b0887618e8ce8b0e100",
+    "version": 1
+  },
+  "513f0ffd-b317-4b9c-9494-92ce861f22c7": {
+    "rule_name": "Registry Persistence via AppCert DLL",
+    "sha256": "317e55d046b33a23441d5ae5214e214792c050b26a514220a5a57177fcd328ba",
+    "version": 1
+  },
+  "514121ce-c7b6-474a-8237-68ff71672379": {
+    "rule_name": "Microsoft 365 Exchange DKIM Signing Configuration Disabled",
+    "sha256": "62ec84bd95359f43ab55b4e4f464aa612eff03d4717105c1cad0bf2f4ca207bc",
     "version": 1
   },
   "51859fa0-d86b-4214-bf48-ebb30ed91305": {
     "rule_name": "GCP Logging Sink Deletion",
-    "sha256": "53af759fc004066d5246fb1458a5ede7a6bf6ffeaf65edf7aa2a675fe33943b1",
+    "sha256": "179abd386f4a83ae3ff067a6ef71e77b481cefeb368301c6367d96990478ce39",
+    "version": 2
+  },
+  "51ce96fb-9e52-4dad-b0ba-99b54440fc9a": {
+    "rule_name": "Incoming DCOM Lateral Movement with MMC",
+    "sha256": "5e1b6224a46c6f4bac302f5a4b217ea1aa3c52fd980bf278b667f36cd3261083",
     "version": 1
   },
   "523116c0-d89d-4d7c-82c2-39e6845a78ef": {
     "rule_name": "AWS GuardDuty Detector Deletion",
-    "sha256": "af78d5bd0c65dfaeaebed1748d4394ef79cbd3ba10e52ccfdde2c11388622fb1",
-    "version": 2
+    "sha256": "03c8d3751e05c4bc6d2050a6e350b95e20b80a0fc370d29b7520aef0583c1702",
+    "version": 3
   },
   "52aaab7b-b51c-441a-89ce-4387b3aea886": {
     "rule_name": "Unusual Network Connection via RunDLL32",
-    "sha256": "974260b5ef9ddc2c76c33e68e87127ba7821f14955736d7c985458bd1b51a10e",
-    "version": 6
+    "sha256": "62f9a83f87a1646d277900c459415fe58eeb8c9dd0b803948689441ab0672d25",
+    "version": 7
   },
   "52afbdc5-db15-485e-bc24-f5707f820c4b": {
     "rule_name": "Unusual Linux Network Activity",
@@ -506,33 +716,38 @@
   },
   "5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de": {
     "rule_name": "Azure Diagnostic Settings Deletion",
-    "sha256": "a393a7c5077458d582e38d756fc330ee2fa0649195e1be10791907706aca79ae",
-    "version": 1
+    "sha256": "a8b4e48c52cd06a7dfae8677a8c2055b4bbe2171a3f66ff858e6db0a94637684",
+    "version": 2
   },
   "53a26770-9cbd-40c5-8b57-61d01a325e14": {
     "rule_name": "Suspicious PDF Reader Child Process",
     "sha256": "53f61925ba39298ed65f48eef2a47cdfacd39d5bfbb319d1d88ce18745b2836b",
     "version": 4
   },
+  "54902e45-3467-49a4-8abc-529f2c8cfb80": {
+    "rule_name": "Uncommon Registry Persistence Change",
+    "sha256": "09bf4205dee6d3b689bd2b6a6b8e43b2e4264ea34b10ea7094e4d783e98647db",
+    "version": 1
+  },
   "55d551c6-333b-4665-ab7e-5d14a59715ce": {
     "rule_name": "PsExec Network Connection",
-    "sha256": "51884c16fbcf771946f67df5e8c78a0ce21f3989f0689a81baf4425e23d23ce7",
-    "version": 5
+    "sha256": "135ac096e16bb4d0f7fda7f52b5fbae7cb80c49e8628cdd928800d9e3940d0e2",
+    "version": 6
   },
   "56557cde-d923-4b88-adee-c61b3f3b5dc3": {
     "rule_name": "Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)",
-    "sha256": "517f7d2386b522bb99be156a0b7ae7a344df063050798bd89ae8c70c4c90636f",
-    "version": 3
+    "sha256": "88c22b8c1d0da1fde8aa5bb68147c976d156c5d0b41581c7b2e7804682875b13",
+    "version": 4
   },
   "5663b693-0dea-4f2e-8275-f1ae5ff2de8e": {
     "rule_name": "GCP Logging Bucket Deletion",
-    "sha256": "e688c4b2d004ab9ec5533ad288c2b35b0fa114b55c17ffe29cc1a4ab9f9ed917",
-    "version": 1
+    "sha256": "2a09a46e4d41dfdb6032d04649fbd864a59aa9861bf2904a7f9a49c6fed0762b",
+    "version": 2
   },
   "5700cb81-df44-46aa-a5d7-337798f53eb8": {
     "rule_name": "VNC (Virtual Network Computing) from the Internet",
-    "sha256": "7d1754c5b2cbae32243e10d50d803ff077dfee6e1a871b68dff4935709c2c3fb",
-    "version": 5
+    "sha256": "a2ea2cb2026677826f160a04916fafeb90ea540d33892a4df8253121c3dc1d4a",
+    "version": 6
   },
   "571afc56-5ed9-465d-a2a9-045f099f6e7e": {
     "rule_name": "Credential Dumping - Detected - Endpoint Security",
@@ -541,12 +756,22 @@
   },
   "581add16-df76-42bb-af8e-c979bfb39a59": {
     "rule_name": "Deleting Backup Catalogs with Wbadmin",
-    "sha256": "ffe5c9b71b0dd6f06a0f30f1aabfd3aa41a4970a66718b832865e08956cc2ddb",
-    "version": 5
+    "sha256": "543592b4939c56351c5a38152ef4d04001547111f7beec7c24191bf85570366c",
+    "version": 6
+  },
+  "58aa72ca-d968-4f34-b9f7-bea51d75eb50": {
+    "rule_name": "RDP Enabled via Registry",
+    "sha256": "b0f105b512f1ebe64f70c5c3a5094cb3602906dd5b4dbaa0a9bd5c39998b435f",
+    "version": 1
   },
   "58ac2aa5-6718-427c-a845-5f3ac5af00ba": {
     "rule_name": "Zoom Meeting with no Passcode",
     "sha256": "cc04c68a382fb37bd26c5adb30a32d599bb5e1338a79d4c430ce5738b6a45d78",
+    "version": 1
+  },
+  "58bc134c-e8d2-4291-a552-b4b3e537c60b": {
+    "rule_name": "Lateral Tool Transfer",
+    "sha256": "94039776569f68c81b2596b9811ba52331323a57b2069a1060c42d8fcf601d03",
     "version": 1
   },
   "594e0cbf-86cc-45aa-9ff7-ff27db27d3ed": {
@@ -559,6 +784,11 @@
     "sha256": "bcf941f7244ac82c4700aaa98b51326165d8c561e6be7ea725a0372ac568c9e6",
     "version": 1
   },
+  "5a14d01d-7ac8-4545-914c-b687c2cf66b3": {
+    "rule_name": "UAC Bypass Attempt via Privileged IFileOperation COM Interface",
+    "sha256": "d4bd9acc538695bff422cdc9e4ac490996401fc395ff6b2d4d0823cfbdca5bc4",
+    "version": 1
+  },
   "5ae4e6f8-d1bf-40fa-96ba-e29645e1e4dc": {
     "rule_name": "Remote SSH Login Enabled via systemsetup Command",
     "sha256": "4231722b2c377f5fb4cb400e9418ad9b537ea08498dcfc356e3fa2dd8d79b86e",
@@ -566,8 +796,8 @@
   },
   "5aee924b-6ceb-4633-980e-1bde8cdb40c5": {
     "rule_name": "Potential Secure File Deletion via SDelete Utility",
-    "sha256": "5aedf26da80998a93c5e8ea4a6d3ca34eeb3e86d6159d22046df493a05f58733",
-    "version": 1
+    "sha256": "7dd120455eb0e2906f3ad016539d3bd4dd5df34bbb1e90bbb827b64c9ad930e2",
+    "version": 2
   },
   "5b03c9fb-9945-4d2f-9568-fd690fee3fba": {
     "rule_name": "Virtual Machine Fingerprinting",
@@ -581,78 +811,158 @@
   },
   "5beaebc1-cc13-4bfc-9949-776f9e0dc318": {
     "rule_name": "AWS WAF Rule or Rule Group Deletion",
-    "sha256": "024639b28d5d5780224af7cc80d32766cf470e7edb7449a5ba3b92065286b3ed",
-    "version": 2
+    "sha256": "0d2374203b38e327452c3c572da95594340a8610ecc4231b3f445b8ecd6a4239",
+    "version": 3
   },
   "5c983105-4681-46c3-9890-0c66d05e776b": {
     "rule_name": "Unusual Linux Process Discovery Activity",
     "sha256": "701bb83db4ee9988f602d8483da8fd2616afd8d5182f6caba81a678824382d69",
     "version": 1
   },
+  "5cd55388-a19c-47c7-8ec4-f41656c2fded": {
+    "rule_name": "Outbound Scheduled Task Activity via PowerShell",
+    "sha256": "9e8ee2abd46dc1f135f981e2df161ad295f37034b2caef627a87509b42868976",
+    "version": 1
+  },
+  "5d0265bf-dea9-41a9-92ad-48a8dcd05080": {
+    "rule_name": "Persistence via Login or Logout Hook",
+    "sha256": "4e88ca6458c7a271beefea95422cc2b97c7ba6731f400d6a97c932d3535ff4f0",
+    "version": 1
+  },
+  "5d1d6907-0747-4d5d-9b24-e4a18853dc0a": {
+    "rule_name": "Suspicious Execution via Scheduled Task",
+    "sha256": "14bcfde36556d11e476d3c9b6a667134b4a9895ab1e60ab21fcabe502dd5ff3c",
+    "version": 1
+  },
+  "5e552599-ddec-4e14-bad1-28aa42404388": {
+    "rule_name": "Microsoft 365 Teams Guest Access Enabled",
+    "sha256": "8a43bdd682722e1a831ca24d3b8aeb5138e73e8b464b7dc613174b62a1ead724",
+    "version": 1
+  },
   "60884af6-f553-4a6c-af13-300047455491": {
     "rule_name": "Azure Command Execution on Virtual Machine",
-    "sha256": "81cca8969edbf9334800c41f8a58e889da9e066798155b5058ebeab1b84cdaba",
+    "sha256": "322bebd844ffb21d830ab08eed67b26b3c45964f7dd93578520c641e668b7535",
+    "version": 2
+  },
+  "60b6b72f-0fbc-47e7-9895-9ba7627a8b50": {
+    "rule_name": "Azure Service Principal Addition",
+    "sha256": "c22c57b1e5bd8d490cfd1c79ad555b735f040598a0ef8bfa5789210cb476f5bf",
+    "version": 1
+  },
+  "60f3adec-1df9-4104-9c75-b97d9f078b25": {
+    "rule_name": "Microsoft 365 Exchange DLP Policy Removed",
+    "sha256": "574cfc55506404904910aa107eb70e4170d1db1cb4cc1b37f80a3c698e2d64e1",
     "version": 1
   },
   "610949a1-312f-4e04-bb55-3a79b8c95267": {
     "rule_name": "Unusual Process Network Connection",
-    "sha256": "6c2a5a4587e7180d2655cab2be0dfbbe26e16399b21bc1c4d0078a603e8744fa",
-    "version": 5
+    "sha256": "4b4462020136392da9adc5255f937664f218535edd5602e49fe21831a795bfd4",
+    "version": 6
   },
   "61c31c14-507f-4627-8c31-072556b89a9c": {
     "rule_name": "Mknod Process Activity",
     "sha256": "47dcac670430caeec4f2a3af82d5367c6a27dfa80aacfcc662e6dbbf9f3f3cb8",
     "version": 5
   },
+  "622ecb68-fa81-4601-90b5-f8cd661e4520": {
+    "rule_name": "Incoming DCOM Lateral Movement via MSHTA",
+    "sha256": "bc0f34f950e9e0160d34ca918e98ecae1b5ff9c07d1a04dd1c4e37cbb87b0e97",
+    "version": 1
+  },
   "63e65ec3-43b1-45b0-8f2d-45b34291dc44": {
     "rule_name": "Network Connection via Signed Binary",
-    "sha256": "f98344eaa71e80dba1f17dca8d33128da463ead2fe8025e320ad906456896ba9",
-    "version": 5
+    "sha256": "5d84c2fa70575d8f1b2136ec8618d3aaba781d6844314dcf1e8e9e6f333928d0",
+    "version": 6
   },
   "647fc812-7996-4795-8869-9c4ea595fe88": {
     "rule_name": "Anomalous Process For a Linux Population",
     "sha256": "906c854f64f56a381c73270b7974d2ea0285d8fc16e9f6c6121e54cef5d0e402",
     "version": 3
   },
+  "665e7a4f-c58e-4fc6-bc83-87a7572670ac": {
+    "rule_name": "WebServer Access Logs Deleted",
+    "sha256": "03dd8d2c3e9f6d1d719ef31e1cd4d40a46fd25d023399a1dadfbce43640ba910",
+    "version": 1
+  },
+  "66883649-f908-4a5b-a1e0-54090a1d3a32": {
+    "rule_name": "Connection to Commonly Abused Web Services",
+    "sha256": "d393849a40606e31a07adf06dd075984f3158fd858a797e4dca212bc61e98e2f",
+    "version": 1
+  },
   "6731fbf2-8f28-49ed-9ab9-9a918ceb5a45": {
-    "rule_name": "Attempt to Modify Okta Policy",
-    "sha256": "2b13a7bfc9ab1ce4408616930ddb7ebdb98077d050de77d6d09d57f97f473692",
-    "version": 2
+    "rule_name": "Attempt to Modify an Okta Policy",
+    "sha256": "3ec5aad58e1f18140fee7ae4ff11fd1faf068e7d0c351f1922efff21f1db296e",
+    "version": 3
   },
   "676cff2b-450b-4cf1-8ed2-c0c58a4a2dd7": {
     "rule_name": "Attempt to Revoke Okta API Token",
-    "sha256": "bdc8c0d1e3d8096b5c54d5da7e222cd6f976125b50ed8ef2d700232adc3cf4e8",
-    "version": 2
+    "sha256": "0ec5b61bbd833bbdfb5c64dac527df602f43863310c016c7791c3928db184464",
+    "version": 3
   },
   "67a9beba-830d-4035-bfe8-40b7e28f8ac4": {
     "rule_name": "SMTP to the Internet",
-    "sha256": "78e971361dc0678ea353fb79b86589c8b4cb26185eabe28d1159a11b30ef7e11",
-    "version": 5
+    "sha256": "88b2bc63cda4078953dc59855583991e5fa306c3c717928e496e92c2d3deef27",
+    "version": 6
+  },
+  "68113fdc-3105-4cdd-85bb-e643c416ef0b": {
+    "rule_name": "Query Registry via reg.exe",
+    "sha256": "0a2f0ded00af21047d20cc20185957362679bc9d0590e1cfaab1a9cfc9cf33d5",
+    "version": 1
+  },
+  "6839c821-011d-43bd-bd5b-acff00257226": {
+    "rule_name": "Image File Execution Options Injection",
+    "sha256": "d5b819c5e9a12fa9c10224e43f3822857f14a55eee98d3bb8e71af720d5d9965",
+    "version": 1
   },
   "6885d2ae-e008-4762-b98a-e8e1cd3a81e9": {
     "rule_name": "Threat Detected by Okta ThreatInsight",
-    "sha256": "6b7f276c62f4f7defb228e29ead53b282c0b46c4b991a6f95eff9e2c02f28185",
-    "version": 2
+    "sha256": "14a996f72274ed0db272c844a9fd9c4744821f902db93e015708a7e80666d78a",
+    "version": 3
   },
   "68921d85-d0dc-48b3-865f-43291ca2c4f2": {
     "rule_name": "Persistence via TelemetryController Scheduled Task Hijack",
-    "sha256": "67deb2c01f432ef5cef4abbacad33ccfe77ca28c7c03fb2bd62f3fe467a2a2ee",
+    "sha256": "90a6ba0e59d5d4104216c1e211f8db109530d5ceaa592082dbfe90ee70b1afd6",
+    "version": 2
+  },
+  "68994a6c-c7ba-4e82-b476-26a26877adf6": {
+    "rule_name": "Google Workspace Admin Role Assigned to a User",
+    "sha256": "9987dd62c2d729ed9a5414cd2aaf20f0da5f80166fc35210f5187f4f421f0f77",
+    "version": 1
+  },
+  "689b9d57-e4d5-4357-ad17-9c334609d79a": {
+    "rule_name": "Scheduled Task Created by a Windows Script",
+    "sha256": "b219c3f1ae863fc87d2555183a467eccaed16b9f09796f272c52db9db4925437",
     "version": 1
   },
   "68a7a5a5-a2fc-4a76-ba9f-26849de881b4": {
     "rule_name": "AWS CloudWatch Log Group Deletion",
-    "sha256": "61785ca726bc291dfecd41e6316d7b133caafbf334af721971cdd67355695552",
-    "version": 2
+    "sha256": "2b3f9d809c39c7486e0089b1360dca3ffad10c850bb658b535dfdf54725669dc",
+    "version": 3
+  },
+  "68d56fdc-7ffa-4419-8e95-81641bd6f845": {
+    "rule_name": "UAC Bypass via ICMLuaUtil Elevated COM Interface",
+    "sha256": "3b10d74eae99b1b9092bd8ee5135c7b05a6e5df78b231f9eeeefd61ac115a40f",
+    "version": 1
   },
   "69c251fb-a5d6-4035-b5ec-40438bd829ff": {
     "rule_name": "Modification of Boot Configuration",
-    "sha256": "c064c881d6f1609b35df3cdafdb95320bc3ace192c7ed1de7a7ed344f176578b",
-    "version": 4
+    "sha256": "b1d70ee5e38827d796c671f4f9348ae38783d2843d0358d587fbac034d91a07f",
+    "version": 5
   },
   "69c420e8-6c9e-4d28-86c0-8a2be2d1e78c": {
     "rule_name": "AWS IAM Password Recovery Requested",
     "sha256": "4e5b8c7586736f83e5cb879408c4821fb2c72e9276a1143e49349133b1a7c59a",
     "version": 2
+  },
+  "6a8ab9cc-4023-4d17-b5df-1a3e16882ce7": {
+    "rule_name": "Unusual Service Host Child Process - Childless Service",
+    "sha256": "5f6da8e7b09f7db8e52412b2ee44b56d6dce3a2ea408a8bc58f9a44fdd33d782",
+    "version": 1
+  },
+  "6aace640-e631-4870-ba8e-5fdda09325db": {
+    "rule_name": "Exporting Exchange Mailbox via PowerShell",
+    "sha256": "790f16dd11d3bf2d01e453ef495d2e0a2ae796d83936bdd327385fc3f0453d36",
+    "version": 1
   },
   "6d448b96-c922-4adb-b51c-b767f1ea5b76": {
     "rule_name": "Unusual Process For a Windows Host",
@@ -665,39 +975,54 @@
     "version": 3
   },
   "6ea41894-66c3-4df7-ad6b-2c5074eb3df8": {
-    "rule_name": "Process Potentially Masquerading as WerFault",
-    "sha256": "3f6823f24aa7d3c376af0f4b58a68210ddc1be1ce3d244454a4b2f375da0a397",
+    "rule_name": "Potential Windows Error Manager Masquerading",
+    "sha256": "7c9d7f37ae3388f4ce88cbabac925c158192140c5815d9bda106e88e7f9c01a5",
+    "version": 2
+  },
+  "6ea55c81-e2ba-42f2-a134-bccf857ba922": {
+    "rule_name": "Security Software Discovery using WMIC",
+    "sha256": "98db76428d1d6d8c1249a8220d772aeb20e89771aad6b5bc81ebd982e75beb8a",
     "version": 1
   },
   "6ea71ff0-9e95-475b-9506-2580d1ce6154": {
     "rule_name": "DNS Activity to the Internet",
-    "sha256": "f614e11a3d1ef4e2469ee8f91993834f5eeeb7151f1a9f5fc5953c6931cb251b",
-    "version": 5
+    "sha256": "993cdd705222f27c0d075f166b093394b5a4aa67d70bc0d93ea25c8b5e805de4",
+    "version": 6
   },
   "6f1500bc-62d7-4eb9-8601-7485e87da2f4": {
     "rule_name": "SSH (Secure Shell) to the Internet",
-    "sha256": "cf840e135ecaea5f8e140cf42780b329ec22d7a6623aa5899c30c8517c130a98",
-    "version": 5
+    "sha256": "43bc4ad3036356a6379efb90d28dfdded2c5f262a6ec734aa3f5f302eb4bb7fe",
+    "version": 6
+  },
+  "6f435062-b7fc-4af9-acea-5b1ead65c5a5": {
+    "rule_name": "Google Workspace Role Modified",
+    "sha256": "dcf3a00334259660c41d128e78f2c2640236abe078e179646057d9afed039105",
+    "version": 1
   },
   "7024e2a0-315d-4334-bb1a-441c593e16ab": {
     "rule_name": "AWS CloudTrail Log Deleted",
-    "sha256": "14a10983bf46224ad28045be57e2d518a7cf3d43125b7e3f29e4c97cfe36146f",
-    "version": 2
+    "sha256": "f542997e53c9f5ae4e21b5ee7efbcf2db6301fb9ceda302267c540131d12766f",
+    "version": 3
   },
   "7024e2a0-315d-4334-bb1a-552d604f27bc": {
     "rule_name": "AWS Config Service Tampering",
-    "sha256": "a3bdbd224ab0a123f86d4fa01299c2feb7a13d1a0419f9f9b08549447ec889c9",
-    "version": 2
+    "sha256": "3f6c5f5dd272de11ed7c4b62acd3e45df5c85676a93c9760d259c06be98a4161",
+    "version": 3
+  },
+  "71c5cb27-eca5-4151-bb47-64bc3f883270": {
+    "rule_name": "Suspicious RDP ActiveX Client Loaded",
+    "sha256": "7019144b339ec91a1f2c549e51ffb8454226e7d1d954002bef3940f8f89cadc4",
+    "version": 1
   },
   "729aa18d-06a6-41c7-b175-b65b739b1181": {
-    "rule_name": "Attempt to Reset MFA Factors for Okta User Account",
-    "sha256": "1b38f0fd69723da62fb95f3db4ed0bd0957ca81ca4cb4cd646595c7aa041a6fc",
-    "version": 2
+    "rule_name": "Attempt to Reset MFA Factors for an Okta User Account",
+    "sha256": "56a5d971043bcc6813ccef21f4786e1ae23536ab14d4603ce5f9931c1bed2083",
+    "version": 3
   },
   "7405ddf1-6c8e-41ce-818f-48bea6bcaed8": {
     "rule_name": "Potential Modification of Accessibility Binaries",
-    "sha256": "41ba9fab688006b8830dcebf0b6fa3bd6d9c0795f5eff98b6146246e16669656",
-    "version": 4
+    "sha256": "4be87ea9885598848d48eb5c18cc2ff5274309799d094acd8e52b22e13ee44f3",
+    "version": 5
   },
   "746edc4c-c54c-49c6-97a1-651223819448": {
     "rule_name": "Unusual DNS Activity",
@@ -709,20 +1034,30 @@
     "sha256": "ddc7ab73355be41f897b01ef0179d7f2e122f9e5e080842130db2d08cc80a7f7",
     "version": 4
   },
+  "76fd43b7-3480-4dd9-8ad7-8bd36bfad92f": {
+    "rule_name": "Potential Remote Desktop Tunneling Detected",
+    "sha256": "32b94f1aff46559949f5d74874fbe90d2a2e2bdf3ef83068a4ba5840ddf47e76",
+    "version": 1
+  },
   "774f5e28-7b75-4a58-b94e-41bf060fdd86": {
     "rule_name": "User Added as Owner for Azure Application",
-    "sha256": "9d4ef1ac3a3675b6655e21474a16855134f2d5b8302e42950aae847ba537eea2",
-    "version": 1
+    "sha256": "5a52d664d3a54596aa8e4cffbe1900e29523f76f56d5ad2047c69f5051bd3a32",
+    "version": 2
   },
   "77a3c3df-8ec4-4da4-b758-878f551dee69": {
     "rule_name": "Adversary Behavior - Detected - Endpoint Security",
     "sha256": "60af511ccd3ed511fec254c879279d5090ca084efa9c11bc4fb01690450b7180",
     "version": 4
   },
+  "785a404b-75aa-4ffd-8be5-3334a5a544dd": {
+    "rule_name": "Application Added to Google Workspace Domain",
+    "sha256": "7da09b4d92040751ddf82e0a7a876775307af621becf1620a5554ec18c1649c0",
+    "version": 1
+  },
   "7882cebf-6cf1-4de3-9662-213aa13e8b80": {
     "rule_name": "Azure Privilege Identity Management Role Modified",
-    "sha256": "f672108b81b8e824915fc077f2a2ff8aa2742c747520ad77422220b486168be3",
-    "version": 1
+    "sha256": "fb52de2ab58d972616850de33eb9aa35be646289b0abad14cd7d1c1aa17c6953",
+    "version": 2
   },
   "78d3d8d9-b476-451d-a9e0-7a5addd70670": {
     "rule_name": "Spike in AWS Error Messages",
@@ -731,28 +1066,38 @@
   },
   "792dd7a6-7e00-4a0a-8a9a-a7c24720b5ec": {
     "rule_name": "Azure Key Vault Modified",
-    "sha256": "80e882eea3c399356e7b5fabb453b957c42ca38493d65b1a33067a86ccb571bd",
-    "version": 1
+    "sha256": "6fa72b201f144df04b3655cbc0d7273dbfe868ade0cc7ebbc1a3086e4e6e9283",
+    "version": 2
   },
   "7a137d76-ce3d-48e2-947d-2747796a78c0": {
     "rule_name": "Network Sniffing via Tcpdump",
     "sha256": "a6d1f9bf40eb2be0f1afb3fe2823ad6b3ad5fd2e9e8d3633ba63c09a5a7553cb",
     "version": 5
   },
+  "7b08314d-47a0-4b71-ae4e-16544176924f": {
+    "rule_name": "File and Directory Discovery",
+    "sha256": "d2ba3d143210b919fddb482a33df43a8d880a7246eba8e1a6eb637cd8d7233d9",
+    "version": 1
+  },
+  "7b8bfc26-81d2-435e-965c-d722ee397ef1": {
+    "rule_name": "Windows Network Enumeration",
+    "sha256": "19e17f834104e04b4f86c1397f7e44d39a9c5aa6a6e7b8f7aa9dc64f393fb74c",
+    "version": 1
+  },
   "7bcbb3ac-e533-41ad-a612-d6c3bf666aba": {
     "rule_name": "Deletion of Bash Command Line History",
-    "sha256": "48766e4b23a04a163e73db18b29e2b272e5e1705f16054608a7b3076b7756ef6",
-    "version": 3
+    "sha256": "6c0e085bab042b2f97f4e9b7a8b753965e8df95cf9116216bd4c738b5cc7ab47",
+    "version": 4
   },
   "7ceb2216-47dd-4e64-9433-cddc99727623": {
     "rule_name": "GCP Service Account Creation",
-    "sha256": "0211c0df546c9bbd15ae769ec10645e0ca3b4f6a11b1fbf8729f2772e30cd6e3",
-    "version": 1
+    "sha256": "c3984837d03bd8964a042a3de20b2605f22b7ad68298d861e29d7f6d992623b0",
+    "version": 2
   },
   "7d2c38d7-ede7-4bdf-b140-445906e6c540": {
     "rule_name": "Tor Activity to the Internet",
-    "sha256": "a1ea165e21ebdf28f31f66bc5e139b7a76b53de45146934ace719a45b982c5d8",
-    "version": 5
+    "sha256": "685c420292df5f816146d2311d20930a92a9cd4c1bf83a001978b27fc10f5034",
+    "version": 6
   },
   "7f370d54-c0eb-4270-ac5a-9a6020585dc6": {
     "rule_name": "Suspicious WMIC XSL Script Execution",
@@ -771,23 +1116,43 @@
   },
   "81cc58f5-8062-49a2-ba84-5cc4b4d31c40": {
     "rule_name": "Persistence via Kernel Module Modification",
-    "sha256": "53857055ca08f9fae8e76f245b875d0c1052aa68192b6eee82e5dddf24d645e8",
-    "version": 5
+    "sha256": "000b7d6f15e6222587aa093137a9274ba9df2f7c8f9042677705c945ce52ea0c",
+    "version": 6
+  },
+  "852c1f19-68e8-43a6-9dce-340771fe1be3": {
+    "rule_name": "Suspicious PowerShell Engine ImageLoad",
+    "sha256": "6c77a9c90b0d38585e3ece485e95d00c1373e03bb21fdd132b166fdafb9d7390",
+    "version": 1
   },
   "8623535c-1e17-44e1-aa97-7a0699c3037d": {
     "rule_name": "AWS EC2 Network Access Control List Deletion",
-    "sha256": "547d0b2193b1da1702c595df23682395b5b62a857822c677492ae96fb3ae804a",
-    "version": 2
+    "sha256": "6302175f659f66b65a513111fa8716d3c534c476d2a72186d08499b9b37ebd99",
+    "version": 3
   },
   "867616ec-41e5-4edc-ada2-ab13ab45de8a": {
     "rule_name": "AWS IAM Group Deletion",
     "sha256": "405b47638ac6da7ea5fac975810240eb8e1af8a1f5c631161352f451fe52ba0d",
     "version": 2
   },
+  "871ea072-1b71-4def-b016-6278b505138d": {
+    "rule_name": "Enumeration of Administrator Accounts",
+    "sha256": "cb860fd7a221e6f146426f19bf688ec03504f828e012e5e7caf35a29c0eceb3b",
+    "version": 1
+  },
   "87ec6396-9ac4-4706-bcf0-2ebb22002f43": {
     "rule_name": "FTP (File Transfer Protocol) Activity to the Internet",
-    "sha256": "ba519701d197c99dbc5bd062369a427279fda93cbcfc55a50683926dffe4636c",
-    "version": 5
+    "sha256": "9fbd64aa4392d90265da1b892102ebb46bffd1aa36f7d306e585668347fced41",
+    "version": 6
+  },
+  "891cb88e-441a-4c3e-be2d-120d99fe7b0d": {
+    "rule_name": "Suspicious WMI Image Load from MS Office",
+    "sha256": "5201eadecdb48d9d66a4a97a149c5bcfa0b1e92e1381acd95a924b796edfb1d4",
+    "version": 1
+  },
+  "897dc6b5-b39f-432a-8d75-d3730d50c782": {
+    "rule_name": "Kerberos Traffic from Unusual Process",
+    "sha256": "8b7a072b62648e941e768d07169bbaea3f865b5b9323d9917247f21e1bca84b4",
+    "version": 1
   },
   "89f9a4b0-9f8f-4ee0-8823-c4751a6d6696": {
     "rule_name": "Command Prompt Network Connection",
@@ -796,17 +1161,27 @@
   },
   "8a1b0278-0f9a-487d-96bd-d4833298e87a": {
     "rule_name": "Setuid Bit Set via chmod",
-    "sha256": "9b88b5a2161f5262ef6c91e1ac017ab60d7ab48f57dd4ef41e4196a16685a816",
-    "version": 4
+    "sha256": "1faca8319a2cbc4d45cb4c3f6a0f51cb973105038ead2094083b5a7c231ac741",
+    "version": 5
+  },
+  "8a5c1e5f-ad63-481e-b53a-ef959230f7f1": {
+    "rule_name": "Attempt to Deactivate an Okta Network Zone",
+    "sha256": "a2f5c5f1618797d200ef635b548bcf14d2e1574f3eb840f3ba58ffe941c7e9f0",
+    "version": 1
   },
   "8c1bdde8-4204-45c0-9e0c-c85ca3902488": {
     "rule_name": "RDP (Remote Desktop Protocol) from the Internet",
-    "sha256": "829a3fc3b44b53556ab245cbd18dbe204f407c5e4f1eed4117ef6ce9a636efcc",
-    "version": 5
+    "sha256": "89d11db76a14823b4885cfcecf6aec506ed9c44dcc5187db8f14e8f158d98843",
+    "version": 6
   },
   "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45": {
     "rule_name": "Unusual Child Process of dns.exe",
-    "sha256": "eeeb6d9b82313d638b9e2021ef811b3b6bdb38acaa9e993db7216855b8427f33",
+    "sha256": "e77c3c77423aac5a2421d4bfcdb4e1a8d34bd0d6265cd11952584e67b3224c43",
+    "version": 2
+  },
+  "8c81e506-6e82-4884-9b9a-75d3d252f967": {
+    "rule_name": "Potential SharpRDP Behavior",
+    "sha256": "bf5fcfd9cd7226a093ca39837bc17517c032364a947c002339b22e141ee8da1a",
     "version": 1
   },
   "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd": {
@@ -816,13 +1191,18 @@
   },
   "8ddab73b-3d15-4e5d-9413-47f05553c1d7": {
     "rule_name": "Azure Automation Runbook Deleted",
-    "sha256": "7bbf8b21cbb86e24daf5c066d567a3deb5f0f417279379918c1e6b5d176baf2d",
+    "sha256": "398adb0364db4bfbb63d39f4d3764ae420c0bc4a22acaa6475211623314eda8e",
+    "version": 2
+  },
+  "8f919d4b-a5af-47ca-a594-6be59cd924a4": {
+    "rule_name": "Incoming DCOM Lateral Movement with ShellBrowserWindow or ShellWindows",
+    "sha256": "39a399aa526d2d2a43153510b8e38765f3c4daafc199cddd96183cef46562b50",
     "version": 1
   },
   "8fb75dda-c47a-4e34-8ecd-34facf7aad13": {
     "rule_name": "GCP Service Account Deletion",
-    "sha256": "d54dda99fd202de02e562c0a2e1e1d6c7db983129a86877ccc1052b4284b9e90",
-    "version": 1
+    "sha256": "87663b229ffa8dd57f68884c9b517a4ad39ba98ade4a6f15806e7ed2f1befd12",
+    "version": 2
   },
   "90169566-2260-4824-b8e4-8615c3b4ed52": {
     "rule_name": "Hping Process Activity",
@@ -836,13 +1216,13 @@
   },
   "9180ffdf-f3d0-4db3-bf66-7a14bcff71b8": {
     "rule_name": "GCP Virtual Private Cloud Route Creation",
-    "sha256": "616985d34abde83a443deb7035258ff363c05fb77083ea2103a0083651cd4d37",
-    "version": 1
+    "sha256": "1fffd1f3ae6bb70acfbdc7b372633bde676e163371fb6f2b288596cb0292c42a",
+    "version": 2
   },
   "91d04cd4-47a9-4334-ab14-084abe274d49": {
     "rule_name": "AWS WAF Access Control List Deletion",
-    "sha256": "14e441e365c89e773c4835b1891c9b6202d58f8caf21bb3133550241f6df8bfb",
-    "version": 2
+    "sha256": "aec7c8f0ec11d42cb4faaf633151ad4a5458c54708c066f552c00c6b21883607",
+    "version": 3
   },
   "91f02f01-969f-4167-8d77-07827ac4cee0": {
     "rule_name": "Unusual Web User Agent",
@@ -861,42 +1241,77 @@
   },
   "931e25a5-0f5e-4ae0-ba0d-9e94eff7e3a4": {
     "rule_name": "Sudoers File Modification",
-    "sha256": "f2a7fe82ef52f06900c135f2934ddbd89006d53d2699dddf5a02beab14ce5be8",
-    "version": 4
+    "sha256": "edcba80637996ba019eefaf5903814c68b7a203bea58f07d0003775f87a4587d",
+    "version": 5
   },
   "9395fd2c-9947-4472-86ef-4aceb2f7e872": {
     "rule_name": "AWS EC2 Flow Log Deletion",
-    "sha256": "029aa0e079e53acf76b87ad126e31b843845e3d60f9484327896ee0600fc0f73",
-    "version": 2
+    "sha256": "6029cac80714e83f3024113dbe9951502643ac487f2a12d673f6e1c334c6d811",
+    "version": 3
+  },
+  "93b22c0a-06a0-4131-b830-b10d5e166ff4": {
+    "rule_name": "Suspicious SolarWinds Child Process",
+    "sha256": "8a388bbca239377760166ba4e4f7a3b5fb8d74d8b8e83423bd02b5eeb96cb9ef",
+    "version": 1
+  },
+  "93c1ce76-494c-4f01-8167-35edfb52f7b1": {
+    "rule_name": "Encoded Executable Stored in the Registry",
+    "sha256": "a1b59cd14b175c430705b22a0f1c837dba4e9d326470ecf4a74c2268efcfa803",
+    "version": 1
+  },
+  "93e63c3e-4154-4fc6-9f86-b411e0987bbf": {
+    "rule_name": "Google Workspace Admin Role Deletion",
+    "sha256": "3bb70d74398ec3ca1b32067f347a4219cdfd427fe89621b7b8aa9ef2fe7043a4",
+    "version": 1
+  },
+  "954ee7c8-5437-49ae-b2d6-2960883898e9": {
+    "rule_name": "Remote Scheduled Task Creation",
+    "sha256": "dd83a9d7e1d24d5351b3c80bf0a9824ca7d1e07a85a3ff6a403f00351d22aff8",
+    "version": 1
   },
   "96b9f4ea-0e8c-435b-8d53-2096e75fcac5": {
     "rule_name": "Attempt to Create Okta API Token",
-    "sha256": "747be70c824774e29416044ec3f4474020851953ed98ecd89fba129cb9012a8f",
-    "version": 2
+    "sha256": "143160a8035bbd3e6df111157b3815c49de06189d89a22da01482c315d92f699",
+    "version": 3
   },
   "96e90768-c3b7-4df6-b5d9-6237f8bc36a8": {
     "rule_name": "Compression of Keychain Credentials Directories",
-    "sha256": "4635d2ec8707ebc29552340a5362c0649406c13a1052e578fe2e485e41c1ac57",
+    "sha256": "1f4a1949a64039ea8d55e0d19a4f750fc3e52f96f389b4839426cc438271732d",
+    "version": 2
+  },
+  "97314185-2568-4561-ae81-f3e480e5e695": {
+    "rule_name": "Microsoft 365 Exchange Anti-Phish Rule Modification",
+    "sha256": "b94acd2020fb45df725709165c4ca72568e6ba7bd13c50a8b42a246c6421139b",
     "version": 1
   },
   "97359fd8-757d-4b1d-9af1-ef29e4a8680e": {
     "rule_name": "GCP Storage Bucket Configuration Modification",
-    "sha256": "6e56f98fe82ce7e51249f69484813f6218f8d7554338267d030e45f72dad4810",
-    "version": 1
+    "sha256": "9060e6cc7731b8e0a8f18590c0b21345fc2732fbe238339a2b4dfad994438982",
+    "version": 2
   },
   "97aba1ef-6034-4bd3-8c1a-1e0996b27afa": {
     "rule_name": "Suspicious Zoom Child Process",
-    "sha256": "6fd98d23d27ed4a588b57c8b47ef8a5dca7229a3f126fcced7123dc90abf1eb1",
-    "version": 1
+    "sha256": "b8561f3a0d827325832ed2346b479513df07895503221bac51983673383954de",
+    "version": 2
   },
   "97f22dab-84e8-409d-955e-dacd1d31670b": {
     "rule_name": "Base64 Encoding/Decoding Activity",
-    "sha256": "ac2f2cd86ce416677f80f22d50079b1843e0b9f345192c361c9d004542a93af8",
-    "version": 4
+    "sha256": "14c8d3e3d6e63fce634dc9680d63cdc0a358e115c8e11d3335a88ddf7debb768",
+    "version": 5
+  },
+  "97fc44d3-8dae-4019-ae83-298c3015600f": {
+    "rule_name": "Startup or Run Key Registry Modification",
+    "sha256": "8664d569f36790398ed216cc68da6b55af545e88bc152ce42e687882673f4bba",
+    "version": 1
   },
   "9890ee61-d061-403d-9bf6-64934c51f638": {
     "rule_name": "GCP IAM Service Account Key Deletion",
-    "sha256": "6c242802a4d3630f2a6f598cf340080e1e3541f6f114c036720e381b864eaa98",
+    "sha256": "4b0cc6796a7a9e459d487f57f338c6d12dbd80aed917a4323cb5de8d180435a4",
+    "version": 2
+  },
+  "98995807-5b09-4e37-8a54-5cae5dc932d7": {
+    "rule_name": "Microsoft 365 Exchange Management Group Role Assignment",
+    "sha256": "166a57ae856cc4f3548926bed7f35c5aab8d0a52d0aa3e8da38e05133d8ebb00",
     "version": 1
   },
   "98fd7407-0bd5-5817-cda0-3fcc33113a56": {
@@ -914,45 +1329,70 @@
     "sha256": "8ec7416fc13c3cdde052cb4ffa8d26b6b2ac42862a6aa8422c5b703e87918188",
     "version": 2
   },
+  "9a5b4e31-6cde-4295-9ff7-6be1b8567e1b": {
+    "rule_name": "Suspicious Explorer Child Process",
+    "sha256": "df3197c7dbc849cfe2afe2cfbf8ed64ea00bc8cfce0bd713d6883dde8d2e5aaf",
+    "version": 1
+  },
+  "9aa0e1f6-52ce-42e1-abb3-09657cee2698": {
+    "rule_name": "Scheduled Tasks AT Command Enabled",
+    "sha256": "e6dd1917565689d121a222c996af2146eaa8dc7a096d5fafff9c2ce282828aed",
+    "version": 1
+  },
+  "9b6813a1-daf1-457e-b0e6-0bb4e55b8a4c": {
+    "rule_name": "Persistence via WMI Event Subscription",
+    "sha256": "97c4d5a146496b112ad9c7ba05d41d1bb72a153253d317abc78aaf058ec028e4",
+    "version": 1
+  },
   "9c260313-c811-4ec8-ab89-8f6530e0246c": {
     "rule_name": "Hosts File Modified",
-    "sha256": "b7a0d05c84c565ad1d095d6068c57dc1b5b01f0298957a919da1980bc510f047",
+    "sha256": "fbf1ed63ee10192094e425e3eb9d941fb5a6d0c6411400519ecec2175ebf61fd",
+    "version": 2
+  },
+  "9ccf3ce0-0057-440a-91f5-870c6ad39093": {
+    "rule_name": "Command Shell Activity Started via RunDLL32",
+    "sha256": "3352c204da15f5e6acfe7965c7f1d6b2e3b5248c7043bb2e7a209eda9615ab24",
     "version": 1
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1": {
     "rule_name": "Trusted Developer Application Usage",
-    "sha256": "b31831af6fec604a5aab2a0ed62e7b08a9e157c41d056b0e386bde1b9ed2ee21",
-    "version": 4
+    "sha256": "7a3412ac1f547c605d2973337db4396c84335c8597f26a29f0cd029519b54674",
+    "version": 5
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2": {
     "rule_name": "Microsoft Build Engine Started by a Script Process",
-    "sha256": "dffc77708e3d6fba2b5e28d6c89f30e8df0ecbc1b5641a7b015e72149d2f78b3",
-    "version": 4
+    "sha256": "076badcddc214367edbcab33b72564a70ccbc7a00327c9d43d0881abf021fa08",
+    "version": 5
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae3": {
     "rule_name": "Microsoft Build Engine Started by a System Process",
-    "sha256": "12f4e3265e07c977ee3305177f1f12be5621a262e3568d9f72e57b9e38014197",
-    "version": 4
+    "sha256": "3b3f4739eb659e42f97a0c061f5ba89f37060f6b2b838b9363d813991d09b436",
+    "version": 5
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae4": {
     "rule_name": "Microsoft Build Engine Using an Alternate Name",
-    "sha256": "10abec4736c39269af08446d3c15a49a3dbc44eb4d3ce29f90d09e419376bba4",
-    "version": 4
+    "sha256": "30df0fb4795c635659f6b787118792e8efa3f6c83fcd106240c44cc45cfa10cb",
+    "version": 5
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5": {
     "rule_name": "Microsoft Build Engine Loading Windows Credential Libraries",
-    "sha256": "621159d55407ee87e4aff6a835dffa6b8c1e06b524dadf20ae257683aaf54f37",
-    "version": 4
+    "sha256": "699faee1951f92fcc3d979de3cd88666af66530f6b69fd983a0c3de15355cdfb",
+    "version": 5
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae6": {
     "rule_name": "Microsoft Build Engine Started an Unusual Process",
-    "sha256": "4c00763e30cada84029f4a421f33e471cebc7a78a27437742459de1a5d4205ea",
-    "version": 4
+    "sha256": "29c43efb4d57ceeb47af9c9189d65dbb7da9a4e3af004e47ece0058b299c69dc",
+    "version": 5
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae9": {
     "rule_name": "Process Injection by the Microsoft Build Engine",
     "sha256": "a6dc309477c0ec0cf00a523e874e327fd4a21d5562cb15eba27a8d5f9c6eb0b3",
     "version": 3
+  },
+  "9d19ece6-c20e-481a-90c5-ccca596537de": {
+    "rule_name": "LaunchDaemon Creation or Modification and Immediate Loading",
+    "sha256": "97eb1480debfc4d14c82db4a2d76bcaf1e5b3c7e7fd04ffcfb458eb5dc804373",
+    "version": 1
   },
   "9d302377-d226-4e12-b54c-1906b5aec4f6": {
     "rule_name": "Unusual Linux Process Calling the Metadata Service",
@@ -971,22 +1411,27 @@
   },
   "a10d3d9d-0f65-48f1-8b25-af175e2594f5": {
     "rule_name": "GCP Pub/Sub Topic Creation",
-    "sha256": "a1d56fb9474be1a4b1b5dcb5eedccb7c89f31ee815d775fa9838c28d7e0f60a7",
-    "version": 1
+    "sha256": "1ee3cc3dc635379279ab4ec164112e0138896d5e16f973d4ca0f53bc40834266",
+    "version": 2
   },
   "a13167f1-eec2-4015-9631-1fee60406dcf": {
     "rule_name": "InstallUtil Process Making Network Connections",
-    "sha256": "16920ecbba408db6fa4105b8ea1dd3ab4730d1b62c8000347ddf221be4df5c13",
-    "version": 1
+    "sha256": "770756236699c90255ee512de436252e9aee5f134879f8125dbfbbdf0568d461",
+    "version": 2
   },
   "a1329140-8de3-4445-9f87-908fb6d824f4": {
     "rule_name": "File Deletion via Shred",
-    "sha256": "74e38c3265c880ffbb6f193e8c740f1144400811d45b68e751c1b4fca01a8225",
-    "version": 4
+    "sha256": "6e5685ce4d4f76055e01992c5f3b2f834708653eaeee82f67965738ee592f0c2",
+    "version": 5
   },
   "a17bcc91-297b-459b-b5ce-bc7460d8f82a": {
     "rule_name": "GCP Virtual Private Cloud Route Deletion",
-    "sha256": "8476d6b084c94e7d7b253063528aa0db568d7e00342501448f0c37f6d9307416",
+    "sha256": "53aeb11b780ae24e40d4884ebcc34ac56c98fd2c72951a38b72ea4491b157a10",
+    "version": 2
+  },
+  "a3ea12f3-0d4e-4667-8b44-4230c63f3c75": {
+    "rule_name": "Execution via local SxS Shared Module",
+    "sha256": "b40e8b2a1fbe1356f46d89e8e2ffad2775ae12dabf61c6c56d4aeb5c1eefd655",
     "version": 1
   },
   "a4ec1382-4557-452b-89ba-e413b22ed4b8": {
@@ -999,14 +1444,24 @@
     "sha256": "74c51426db3c534d8d7db0d289ab13c3af4c88760dc8e8ff366a455e39657c4e",
     "version": 2
   },
+  "a605c51a-73ad-406d-bf3a-f24cc41d5c97": {
+    "rule_name": "Azure Active Directory PowerShell Sign-in",
+    "sha256": "1b1038129eba695022215c9b87b49ef2b85573384b320b04232a18f60c3ea962",
+    "version": 1
+  },
   "a624863f-a70d-417f-a7d2-7a404638d47f": {
     "rule_name": "Suspicious MS Office Child Process",
-    "sha256": "7e63195829965edbc6c27d91816412cda8d314bd04e4d5c2730d7a2e6f67d3ae",
-    "version": 5
+    "sha256": "2a44865a315ce2796c4c626cb62df55873961063c023d4c0ee9ee416bc8cabbe",
+    "version": 6
   },
   "a7ccae7b-9d2c-44b2-a061-98e5946971fa": {
     "rule_name": "Suspicious PrintSpooler SPL File Created",
     "sha256": "ce67fcf560f3bc44bc8afac138a1d05d7529ee9f898e1da8188ac53c7762eb5c",
+    "version": 1
+  },
+  "a7e7bfa3-088e-4f13-b29e-3986e0e756b8": {
+    "rule_name": "Credential Acquisition via Registry Hive Dumping",
+    "sha256": "3f0fa31ea94c0ebef7875c570d743ca7b49c1357c13a218f4804158a4252f22f",
     "version": 1
   },
   "a87a4e42-1d82-44bd-b0bf-d9b7f91fb89e": {
@@ -1016,17 +1471,47 @@
   },
   "a9198571-b135-4a76-b055-e3e5a476fd83": {
     "rule_name": "Hex Encoding/Decoding Activity",
-    "sha256": "e5fd7c525f5724e259ab3727cb7f0d081648fb98ff3e8e641f8a92bf69b74f3b",
-    "version": 4
+    "sha256": "d5f70e91eea294b0aba75d327617bbacb898f6163649faa28c5e92204a3756ce",
+    "version": 5
+  },
+  "a989fa1b-9a11-4dd8-a3e9-f0de9c6eb5f2": {
+    "rule_name": "Microsoft 365 Exchange Safe Link Policy Disabled",
+    "sha256": "5678366a0a895f1f838be70b450cc5b13299a4b8de3d882e178b8b0cf134de81",
+    "version": 1
+  },
+  "a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73": {
+    "rule_name": "Google Workspace Password Policy Modified",
+    "sha256": "6ab1ea750113b4528f973d71f7ba55d9f1322704fac965e99a95ea81e7c90572",
+    "version": 1
+  },
+  "a9b05c3b-b304-4bf9-970d-acdfaef2944c": {
+    "rule_name": "Persistence via Hidden Run Key Detected",
+    "sha256": "61dd2fef1d6882b8bb49ee87f7966cee63609396ac718d490e4bebb9c0b51cba",
+    "version": 1
   },
   "a9cb3641-ff4b-4cdc-a063-b4b8d02a67c7": {
     "rule_name": "IPSEC NAT Traversal Port Activity",
-    "sha256": "bb9cfa0970a07d45ee0ad4b679f13098b0ea7ad00b0ad1c5fee7bc5b5aed3f19",
-    "version": 4
+    "sha256": "463300c77ba30a5d1f6bab1cbd87ed99eb8604828b8fd5490c232f00d72e8a61",
+    "version": 5
   },
   "aa8007f0-d1df-49ef-8520-407857594827": {
     "rule_name": "GCP IAM Custom Role Creation",
-    "sha256": "07b49066452b995e690709a179733747cee194b8b7744a2bf25441099069f1da",
+    "sha256": "2d8a912547e4c791bebd848bcee61454527b9d293caff47e494c72e0c071471a",
+    "version": 2
+  },
+  "aa895aea-b69c-4411-b110-8d7599634b30": {
+    "rule_name": "System Log File Deletion",
+    "sha256": "9b1ce89987303ce4f46efbe0b8c9ae58729c066ed20fa15a6c80cc690da89f09",
+    "version": 1
+  },
+  "aa9a274d-6b53-424d-ac5e-cb8ca4251650": {
+    "rule_name": "Remotely Started Services via RPC",
+    "sha256": "378f8ce524eee1aef24018a4a17eb55353559cc57adecc2b6a3ee1ffe71b8f2d",
+    "version": 1
+  },
+  "ab75c24b-2502-43a0-bf7c-e60e662c811e": {
+    "rule_name": "Remote Execution via File Shares",
+    "sha256": "b4742a5907688dfb96cac8284d71df61ec5430dfcce9653aa56c82bd8288a9c4",
     "version": 1
   },
   "abae61a8-c560-4dbd-acca-1e1438bff36b": {
@@ -1044,6 +1529,21 @@
     "sha256": "61030c4ed5783a5267a042417e8d7604e0b04eb36a6da6aaa8a630c10fcb0977",
     "version": 2
   },
+  "acbc8bb9-2486-49a8-8779-45fb5f9a93ee": {
+    "rule_name": "Google Workspace API Access Granted via Domain-Wide Delegation of Authority",
+    "sha256": "f870007577845c26dc14d371fd5b361c9a62fd3e81b259545f722b215d8acea6",
+    "version": 1
+  },
+  "acd611f3-2b93-47b3-a0a3-7723bcc46f6d": {
+    "rule_name": "Potential Command and Control via Internet Explorer",
+    "sha256": "85555d822707d421f4757e862b5cb505544cb9a451c4c2cf04fb4cec5df7d052",
+    "version": 1
+  },
+  "ace1e989-a541-44df-93a8-a8b0591b63c0": {
+    "rule_name": "Potential SSH Brute Force Detected",
+    "sha256": "95eee06042a8070b93d08264c73c46771db9bd046e90bacfbbabe54c8d7b4934",
+    "version": 1
+  },
   "acf738b5-b5b2-4acc-bad9-1e18ee234f40": {
     "rule_name": "Suspicious Managed Code Hosting Process",
     "sha256": "7d10ab696ba07deb10e38ef1fe5092ea27e5333c5929d80a86e5e04f1ccdc253",
@@ -1051,8 +1551,13 @@
   },
   "ad0e5e75-dd89-4875-8d0a-dfdc1828b5f3": {
     "rule_name": "Proxy Port Activity to the Internet",
-    "sha256": "7e5ade67ad526efd2c4b9b0c7c2d3ccd21e69ea1c97313253e10657587a46204",
-    "version": 5
+    "sha256": "6fb209a384be437b6dc787d0c427701f3cc1920aefe7258e79dbce4586d360f6",
+    "version": 6
+  },
+  "ad3f2807-2b3e-47d7-b282-f84acbbe14be": {
+    "rule_name": "Google Workspace Custom Admin Role Created",
+    "sha256": "e81156f6e1d2589b50aed1132c6fe51ad1240aa79f97748a0e229f26014083d9",
+    "version": 1
   },
   "ad88231f-e2ab-491c-8fc6-64746da26cfe": {
     "rule_name": "Kerberos Cached Credentials Dumping",
@@ -1069,6 +1574,11 @@
     "sha256": "287b40cfe49eb44710e1ea328cd189b3aa07e74c0ec3112d14be0363a4885d34",
     "version": 5
   },
+  "b0046934-486e-462f-9487-0d4cf9e429c6": {
+    "rule_name": "Timestomping using Touch Command",
+    "sha256": "f682c1280f269c6f20b67af7287419b0b993c116848367b74a44d8a961b83fd2",
+    "version": 1
+  },
   "b25a7df2-120a-4db2-bd3f-3e4b86b24bee": {
     "rule_name": "Remote File Copy via TeamViewer",
     "sha256": "f7ae1ed53d8f7949ac4eb5ddf819effa6b55f9cb859a0c66d13816ade0e2c6c2",
@@ -1076,8 +1586,8 @@
   },
   "b29ee2be-bf99-446c-ab1a-2dc0183394b8": {
     "rule_name": "Network Connection via Compiled HTML File",
-    "sha256": "cd21f3a8ea8c40effa4b5e949339ff2887003ed5c7ea1731fc221e50e4d5d701",
-    "version": 5
+    "sha256": "c745562b8799190c0796b1ea6f84e766130818f342c77b4842579ba216e29323",
+    "version": 6
   },
   "b347b919-665f-4aac-b9e8-68369bf2340c": {
     "rule_name": "Unusual Linux Username",
@@ -1086,63 +1596,88 @@
   },
   "b41a13c6-ba45-4bab-a534-df53d0cfed6a": {
     "rule_name": "Suspicious Endpoint Security Parent Process",
-    "sha256": "6c3d9fc5c0ea867f143ea48b8c802a43127c7c62b03e68270649f926fd10636f",
-    "version": 1
+    "sha256": "1a599980beade6259299e17a6a299186116e9015d6334710a597f570b74e2d7f",
+    "version": 2
   },
   "b4bb1440-0fcb-4ed1-87e5-b06d58efc5e9": {
-    "rule_name": "Attempt to Delete Okta Policy",
-    "sha256": "a44cc68d90849cfa6af1ebd8244a7e54b69c5296587d66e3e5b03e0dfed09eb7",
-    "version": 2
+    "rule_name": "Attempt to Delete an Okta Policy",
+    "sha256": "ef0b2fe5b56a6ae22af6845f5513286d41709f78a68f06610a24aa9c884f3032",
+    "version": 3
   },
   "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921": {
     "rule_name": "Volume Shadow Copy Deletion via VssAdmin",
-    "sha256": "13033cd627f0f9a86831dbf953919807a482349281a90cf5b5df94ce701154ff",
-    "version": 5
+    "sha256": "1ec687e814f560c6ebb3a8e6c8d6871126d6e3646b045428447733f14063f933",
+    "version": 6
+  },
+  "b64b183e-1a76-422d-9179-7b389513e74d": {
+    "rule_name": "Windows Script Interpreter Executing Process via WMI",
+    "sha256": "45cc14e84175cd9bd73d21cddb502b11bc2d6d9984edac3fdda44920ebb1f980",
+    "version": 1
   },
   "b6dce542-2b75-4ffb-b7d6-38787298ba9d": {
     "rule_name": "Azure Event Hub Authorization Rule Created or Updated",
-    "sha256": "1a8437015412d5d957d9fc92ddd8babf4e65740b4062cb5c940d92bfc5902d9e",
-    "version": 1
+    "sha256": "404d89d51dc0e6afc9470e7861bea3a4556be38c85a92a637c6ee893f64c1e3a",
+    "version": 2
   },
   "b719a170-3bdb-4141-b0e3-13e3cf627bfe": {
-    "rule_name": "Attempt to Deactivate Okta Policy",
-    "sha256": "53069a8b375432e7c5d72033d80f0cab138541ee5585a61bc6948320005fe9b0",
-    "version": 2
+    "rule_name": "Attempt to Deactivate an Okta Policy",
+    "sha256": "08414dfb73180ab7116050258b01c01225bf3fcf6c0c722a4ea71b1485482992",
+    "version": 3
   },
   "b8075894-0b62-46e5-977c-31275da34419": {
-    "rule_name": "Administrator Privileges Assigned to Okta Group",
-    "sha256": "80b17cdd3d0857c866078aad9ae531e4b28269e32ccc3017a54b5e4265afa7bc",
-    "version": 2
+    "rule_name": "Administrator Privileges Assigned to an Okta Group",
+    "sha256": "05c1f28999ada75cf2b12b483799455583321e12c3a500815eb8c56425725767",
+    "version": 3
   },
   "b83a7e96-2eb3-4edf-8346-427b6858d3bd": {
     "rule_name": "Creation or Modification of Domain Backup DPAPI private key",
-    "sha256": "86b511b0e0e45c157554e4e78f463045e0fc173a404a91a26e9a0a0478d2e8fd",
-    "version": 1
+    "sha256": "b21f9d6260efe5f5b4a126bfdc4c43c6bafd5d3d86a016a3bb3859fcd5908696",
+    "version": 2
   },
   "b86afe07-0d98-4738-b15d-8d7465f95ff5": {
     "rule_name": "Network Connection via MsXsl",
-    "sha256": "4086798c5555549c5ea0ffa2ca47aa6a9b0b147bced719401be931ba0fafdfbe",
-    "version": 4
+    "sha256": "b6730853dd499a1f5bdd7adce3dd750c04b5acb1ad52c08a818be52b790016c9",
+    "version": 5
+  },
+  "b90cdde7-7e0d-4359-8bf0-2c112ce2008a": {
+    "rule_name": "UAC Bypass Attempt with IEditionUpgradeManager Elevated COM Interface",
+    "sha256": "f4832ddf31a51c69210b2da2af5a78889cf7053b99eaabaf41a4bce7aaefa6d3",
+    "version": 1
   },
   "b9666521-4742-49ce-9ddc-b8e84c35acae": {
     "rule_name": "Creation of Hidden Files and Directories",
-    "sha256": "cdf9e3986bd64fcb42a8dab1fb1efe2cfa4c9f21d61d9040d6f5c029fb9ffd57",
-    "version": 3
+    "sha256": "064d074d49298a64c36f7bd92450c570074ab633d34fe4b5470a2c956b96d839",
+    "version": 4
+  },
+  "b9960fef-82c6-4816-befa-44745030e917": {
+    "rule_name": "SolarWinds Process Disabling Services via Registry",
+    "sha256": "81643150e39223d477c4123fbb81ffe5266c83f45f8ea8eb503db8674b344e06",
+    "version": 1
   },
   "ba342eb2-583c-439f-b04d-1fdd7c1417cc": {
     "rule_name": "Unusual Windows Network Activity",
     "sha256": "183bc920de288c25759da14909826873e441d5f97faf2b64f82ba501db10e2c8",
     "version": 3
   },
+  "baa5d22c-5e1c-4f33-bfc9-efa73bb53022": {
+    "rule_name": "Suspicious Image Load (taskschd.dll) from MS Office",
+    "sha256": "319ecab19b574f534575e0f3c3dd52e5ea27d14f469ce2b782895aad2b90c51b",
+    "version": 1
+  },
   "bb4fe8d2-7ae2-475c-8b5d-55b449e4264f": {
     "rule_name": "Azure Resource Group Deletion",
-    "sha256": "5c4ce8168ef1ecd41e25e9150be58267cff6315720ef7eeba94414c450e25323",
-    "version": 1
+    "sha256": "b5f1102902e0aa82b044f0318fe48c46913cc697fb211c998ff0241d96ab71e3",
+    "version": 2
   },
   "bb9b13b2-1700-48a8-a750-b43b0a72ab69": {
     "rule_name": "AWS EC2 Encryption Disabled",
-    "sha256": "177a92a76ad4d22d3a48e3f0d06ce47142fecd86a01c55692f7fbdcde0eee5e9",
-    "version": 2
+    "sha256": "5ac41e3ee65442e7438c687a5fbfda7bbc1de58f406d829d096217c041f0dc79",
+    "version": 3
+  },
+  "bbd1a775-8267-41fa-9232-20e5582596ac": {
+    "rule_name": "Microsoft 365 Teams Custom Application Interaction Allowed",
+    "sha256": "80b3d313db62358da59fc880599240dba855703161326e1418839c4d629dc5d8",
+    "version": 1
   },
   "bc0c6f0d-dab0-47a3-b135-0925f0a333bc": {
     "rule_name": "AWS Root Login Without MFA",
@@ -1151,23 +1686,28 @@
   },
   "bc0f2d83-32b8-4ae2-b0e6-6a45772e9331": {
     "rule_name": "GCP Storage Bucket Deletion",
-    "sha256": "bc4d7228992da82b9454e2415c12a20b8283df6d43ae9190e9c373fe4fb2ef9a",
-    "version": 1
+    "sha256": "bdee66cc159be2da8e14be6693cae29df3085298aa4712587bc243cf58f95c6e",
+    "version": 2
   },
   "bc48bba7-4a23-4232-b551-eca3ca1e3f20": {
     "rule_name": "Azure Conditional Access Policy Modified",
-    "sha256": "4abc25fb7a3101834bd455c11c5e0ab9e231d504a43955c92c7ce53cddd0407e",
-    "version": 1
+    "sha256": "ebe555d81187dfe879c5149586378c5400cd42e43e5f9c7f02b63bb71f8916f5",
+    "version": 2
   },
   "bca7d28e-4a48-47b1-adb7-5074310e9a61": {
     "rule_name": "GCP Service Account Disabled",
-    "sha256": "3e1c796dbbc11484030ecded8be8ef72d3d25e58ea8ff6ca9526241dad35ebbc",
+    "sha256": "3c4e6f366d741a7d224168ba9bfae6d2cc0657a11e64f6c509242be7e151ca23",
+    "version": 2
+  },
+  "bd7eefee-f671-494e-98df-f01daf9e5f17": {
+    "rule_name": "Suspicious Print Spooler Point and Print DLL",
+    "sha256": "cecd7d93e882686b0f78176c259b17b6b02185cb39a2df6b9d2307f25c0e91b5",
     "version": 1
   },
   "c0429aa8-9974-42da-bfb6-53a0a515a145": {
     "rule_name": "Creation or Modification of a new GPO Scheduled Task or Service",
-    "sha256": "8e94f612969a8dfe1fbb12cce0e38dfbbd077c1ff4dec40842cd316427718206",
-    "version": 1
+    "sha256": "dceb645c6c3c15126cdb4a62a95c94a06c2b9cc9e4e7fe18b3a0ba799a20cd89",
+    "version": 2
   },
   "c0be5f31-e180-48ed-aa08-96b36899d48f": {
     "rule_name": "Credential Manipulation - Detected - Endpoint Security",
@@ -1176,58 +1716,78 @@
   },
   "c25e9c87-95e1-4368-bfab-9fd34cf867ec": {
     "rule_name": "Microsoft IIS Connection Strings Decryption",
-    "sha256": "240d341265966cf1b1bb947936f662d93b4c747adfa34cba0b95dfc644470b5b",
-    "version": 1
+    "sha256": "a491defc8e242a9adcf085b40368e489e28be78d130ecca8ea5925111862c4d7",
+    "version": 2
   },
   "c28c4d8c-f014-40ef-88b6-79a1d67cd499": {
     "rule_name": "Unusual Linux Network Connection Discovery",
     "sha256": "505c5b266419774eaf329af4f0f25e9009c93211214858e730bb637bb665f62c",
     "version": 1
   },
+  "c292fa52-4115-408a-b897-e14f684b3cb7": {
+    "rule_name": "Persistence via Folder Action Script",
+    "sha256": "c3098f9a8ff4dbe6ddae14bf87cc3ae0dc3b2000ed09029b7b73ab7d3ae2c85b",
+    "version": 1
+  },
   "c2d90150-0133-451c-a783-533e736c12d7": {
     "rule_name": "Mshta Making Network Connections",
-    "sha256": "5db66dcfe74799e54b2b5ef01951e0574a72e5e498832e73d9657c1d6159f551",
-    "version": 1
+    "sha256": "27507954b3e3d4d61214f223d6afd52cc306b2726af409fdf5448619131f7aac",
+    "version": 2
   },
   "c3167e1b-f73c-41be-b60b-87f4df707fe3": {
     "rule_name": "Permission Theft - Detected - Endpoint Security",
     "sha256": "7b185258dbbaa2a9837362d5bb5f7551cfdf689ccbd0119140c1155c581dd80c",
     "version": 4
   },
+  "c4210e1c-64f2-4f48-b67e-b5a8ffe3aa14": {
+    "rule_name": "Mounting Hidden or WebDav Remote Shares",
+    "sha256": "d0e1e515a6f2b2e9163f44301afdb166de3872c7f64318fb9b8df0a7f6736909",
+    "version": 1
+  },
   "c58c3081-2e1d-4497-8491-e73a45d1a6d6": {
     "rule_name": "GCP Virtual Private Cloud Network Deletion",
-    "sha256": "10a715c19fe5fd4d26ba651a6e8abf09bdd47ff6548b5ec3a19f7a7348cd2d67",
-    "version": 1
+    "sha256": "cba970c966fc145de9fd1c6954fb498487c855b455191cb1119c0947e359b375",
+    "version": 2
   },
   "c5ce48a6-7f57-4ee8-9313-3d0024caee10": {
     "rule_name": "Installation of Custom Shim Databases",
-    "sha256": "258662654d35047e6c083c504add264471ace501d23b2de2dec064787da2a0bf",
-    "version": 1
+    "sha256": "6e3ffdadba05c9bab0bb5408eec0fccb6e415111cc005cee2389d35f3d87d1ee",
+    "version": 2
   },
   "c5dc3223-13a2-44a2-946c-e9dc0aa0449c": {
     "rule_name": "Microsoft Build Engine Started by an Office Application",
-    "sha256": "0d9f7b4502249bb186a8309f01658c0c5fb4544e4932c09d53a2848f031388fc",
-    "version": 4
+    "sha256": "a36e3ce490be6e3ecb40027634e19d4a9a020928db22ef0b1b7d67c53f967769",
+    "version": 5
   },
   "c6453e73-90eb-4fe7-a98c-cde7bbfc504a": {
     "rule_name": "Remote File Download via MpCmdRun",
-    "sha256": "ffe88afafce90b7655cde9e0e2ac48606946447ad2651aff3dea586ec8101fc5",
-    "version": 1
+    "sha256": "2892da630216ea0fee0b335395737baba55faf9461d2239a19cc48d5d7417686",
+    "version": 2
   },
   "c6474c34-4953-447a-903e-9fcb7b6661aa": {
     "rule_name": "IRC (Internet Relay Chat) Protocol Activity to the Internet",
-    "sha256": "7d84660c7417ccc8a28c5eb0eadf50067ceac388e16a69cbc3c6b32391cc7f78",
-    "version": 5
+    "sha256": "302dec5617303b5fc97a50c64f9d8af5f094d2725f69ec9b10edc556684ba2d9",
+    "version": 6
+  },
+  "c749e367-a069-4a73-b1f2-43a3798153ad": {
+    "rule_name": "Attempt to Delete an Okta Network Zone",
+    "sha256": "dae25bf8b915abd1ebfa02549df9de1cff58093ffde028c10ff25d946fc27a1f",
+    "version": 1
+  },
+  "c74fd275-ab2c-4d49-8890-e2943fa65c09": {
+    "rule_name": "Attempt to Modify an Okta Application",
+    "sha256": "5a0b8f4ce3a86a9bcc1a56f719262ae58a2ac9be112d9ea744cfe3e2ffdbd307",
+    "version": 1
   },
   "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9": {
     "rule_name": "Unusual File Modification by dns.exe",
-    "sha256": "fc9734ad191d97c69d6c2982b68741128c34feb931ba5711914698fad796064e",
-    "version": 1
+    "sha256": "feed274042000e8477e08585cba127c5c3f0abf7492986467af6fb789d353dea",
+    "version": 2
   },
   "c82b2bd8-d701-420c-ba43-f11a155b681a": {
     "rule_name": "SMB (Windows File Sharing) Activity to the Internet",
-    "sha256": "3ce14cabaf3406faaeae1ca507b7d6613a96fa5f1c773192cd7280d7849549fb",
-    "version": 5
+    "sha256": "dcabadc5473a10d79a9b66d8499da99622d1bf05bba1b13cfad0469c0de62ac5",
+    "version": 6
   },
   "c82c7d8f-fb9e-4874-a4bd-fd9e3f9becf1": {
     "rule_name": "Direct Outbound SMB Connection",
@@ -1244,6 +1804,16 @@
     "sha256": "0734e9a063c5bbf35c5b4b73c95544f1399e648c12d6396698015de1d5d392ef",
     "version": 4
   },
+  "ca79768e-40e1-4e45-a097-0e5fbc876ac2": {
+    "rule_name": "Microsoft 365 Exchange Malware Filter Rule Modification",
+    "sha256": "becf4796be38e87c8b61737c9a1786d4cf6f7af978d0c5a3d0a05e1b74a70eca",
+    "version": 1
+  },
+  "cad4500a-abd7-4ef3-b5d3-95524de7cfe1": {
+    "rule_name": "Google Workspace MFA Enforcement Disabled",
+    "sha256": "548489977f9e7b6629606ed2704f733dec091533a4e45ad55c9ca83ccc4c6d28",
+    "version": 1
+  },
   "cc16f774-59f9-462d-8b98-d27ccd4519ec": {
     "rule_name": "Process Discovery via Tasklist",
     "sha256": "9e2137223c6aa526dcc784ee7d6e74f1cb75d4aa50547430cbadaa6b617510a8",
@@ -1251,18 +1821,23 @@
   },
   "cc89312d-6f47-48e4-a87c-4977bd4633c3": {
     "rule_name": "GCP Pub/Sub Subscription Deletion",
-    "sha256": "49ed4db4edcbc1e642a8bf3a2b41c9ef8f073ba8df6d65fa5810b367098a1a3a",
-    "version": 1
+    "sha256": "be0ac88b8ae314e2f2f188f4d5c9d2be45380231a09af38c357b4829d1939e05",
+    "version": 2
   },
   "cc92c835-da92-45c9-9f29-b4992ad621a0": {
-    "rule_name": "Attempt to Deactivate Okta MFA Rule",
-    "sha256": "c9cd5d3b47f49d301599e07cecd5e6fa9c99406d7a72031b24e539a0fcbda0c9",
-    "version": 2
+    "rule_name": "Attempt to Deactivate an Okta Policy Rule",
+    "sha256": "346fbc298bd3a67f9c307e39b8670c959030d2325dd0208e870ed37bcb8f4467",
+    "version": 3
+  },
+  "ccc55af4-9882-4c67-87b4-449a7ae8079c": {
+    "rule_name": "Potential Process Herpaderping Attempt",
+    "sha256": "295e8b053ee6f7acf40105fdc9c1e9cf16689482d786246cb96eb0a9be078e8d",
+    "version": 1
   },
   "cd16fb10-0261-46e8-9932-a0336278cdbe": {
     "rule_name": "Modification or Removal of an Okta Application Sign-On Policy",
-    "sha256": "14b665fd8a4f4cf8354d1de879b354b6d364109df39bbbc9d6e7d72dbaca39c7",
-    "version": 2
+    "sha256": "6b5420121ddb4ff805a9953f6a58537d97b4f71b2162ead5b6ae11e3fc4557f0",
+    "version": 3
   },
   "cd4d5754-07e1-41d4-b9a5-ef4ea6a0a126": {
     "rule_name": "Socat Process Activity",
@@ -1276,28 +1851,58 @@
   },
   "cd66a5af-e34b-4bb0-8931-57d0a043f2ef": {
     "rule_name": "Kernel Module Removal",
-    "sha256": "bc00e1a16cb3ae247f1542e591c009d5178d4f317727286cdba81d9dcbfc0649",
-    "version": 4
+    "sha256": "436cd24e09346d4810af409e99f550c88c21aaa6e82071a9b823748f37a5217a",
+    "version": 5
   },
   "cd89602e-9db0-48e3-9391-ae3bf241acd8": {
-    "rule_name": "Attempt to Deactivate MFA for Okta User Account",
-    "sha256": "28934ffa02c0820ed6bd025db0696bdfd6861f462c563119938ae998c2c9910b",
-    "version": 2
+    "rule_name": "Attempt to Deactivate MFA for an Okta User Account",
+    "sha256": "9c731ed4d8cd911769ebb630ac37079bbbc4d00f625ee1763fdacbaaec766f43",
+    "version": 3
+  },
+  "ce64d965-6cb0-466d-b74f-8d2c76f47f05": {
+    "rule_name": "New ActiveSyncAllowedDeviceID Added via PowerShell",
+    "sha256": "71aa16970e9b9d4d2a8d474e2293a12eed62a29a397e332582a5c429b32c63be",
+    "version": 1
   },
   "cf53f532-9cc9-445a-9ae7-fced307ec53c": {
     "rule_name": "Cobalt Strike Command and Control Beacon",
-    "sha256": "174dd9bcdb9c581abc57c1e303c30f9ff0beadea51ed0ac2b3b753db1e9c354d",
+    "sha256": "547beccb9e948068f7f206f95c156d102b38063a4a26ef88d383ffc7af07e6d8",
+    "version": 2
+  },
+  "cf549724-c577-4fd6-8f9b-d1b8ec519ec0": {
+    "rule_name": "Domain Added to Google Workspace Trusted Domains",
+    "sha256": "94e51603e7092942ab70839b1dcde9c7c84b3e99b9c1af9afad933dcf749b668",
+    "version": 1
+  },
+  "cff92c41-2225-4763-b4ce-6f71e5bda5e6": {
+    "rule_name": "Execution from Unusual Directory - Command Line",
+    "sha256": "d2196383de3fd71431cea3a7022b3c5467f569669d0c3d397912aa6033afa7d1",
+    "version": 1
+  },
+  "d0e159cf-73e9-40d1-a9ed-077e3158a855": {
+    "rule_name": "Registry Persistence via AppInit DLL",
+    "sha256": "a547d65d3d5ecd73ca45fdcc069c8c2e9f70a3fafbe2bfc4e77c081b7a0bddd6",
     "version": 1
   },
   "d2053495-8fe7-4168-b3df-dad844046be3": {
     "rule_name": "PPTP (Point to Point Tunneling Protocol) Activity",
-    "sha256": "ab53f0fb3955a51235b78f098a4a2cbccfa4dfaa7921e0aeb304d67433739ac6",
-    "version": 4
+    "sha256": "a5bde03953114a8b422e0ddb20f05d27f827e6eee266010be21ad274054f9392",
+    "version": 5
   },
   "d331bbe2-6db4-4941-80a5-8270db72eb61": {
     "rule_name": "Clearing Windows Event Logs",
-    "sha256": "2b039bc6c610f5ccf1189f27592fde0d4574d769a80621ab0b8e971478a05124",
-    "version": 5
+    "sha256": "80c1831b191ed38004865c1dea80ea16e946845e34aad831d1aba8522df4b205",
+    "version": 6
+  },
+  "d461fac0-43e8-49e2-85ea-3a58fe120b4f": {
+    "rule_name": "Shell Execution via Apple Scripting",
+    "sha256": "20cce1e74b134378da1095bbe74784c7c83419746dd9e333c3d77af405448619",
+    "version": 1
+  },
+  "d48e1c13-4aca-4d1f-a7b1-a9161c0ad86f": {
+    "rule_name": "Attempt to Delete an Okta Application",
+    "sha256": "3fb886cd01f67f0c9c03be6492743853abd9eefb39e3a295273423149911205f",
+    "version": 1
   },
   "d49cc73f-7a16-4def-89ce-9fc7127d7820": {
     "rule_name": "Web Application Suspicious Activity: sqlmap User Agent",
@@ -1309,25 +1914,50 @@
     "sha256": "e0e46e6ee2027def12fd17f22fae998afd8c4a85057349c80869c06bf44b3f01",
     "version": 1
   },
+  "d563aaba-2e72-462b-8658-3e5ea22db3a6": {
+    "rule_name": "Privilege Escalation via Windir Environment Variable",
+    "sha256": "6522b3fcd566576a6a1e2c65c59ff9e624cf083f2097a89d95ac1b32bd9a58ba",
+    "version": 1
+  },
+  "d5d86bf5-cf0c-4c06-b688-53fdc072fdfd": {
+    "rule_name": "Attempt to Delete an Okta Policy Rule",
+    "sha256": "a6291f43b9a5a2838276347274b3e05f46d3251899e576310db871da2fe66a92",
+    "version": 1
+  },
   "d61cbcf8-1bc1-4cff-85ba-e7b21c5beedc": {
     "rule_name": "Service Command Lateral Movement",
-    "sha256": "1a08981a11ed6445bb228a70a38e170a437e4e923b81572aefe85c02df7224e6",
-    "version": 1
+    "sha256": "e66df2e2111657b7ee9cdd483f6f9611b4d76cb8924ee9fc415a41013c4afd26",
+    "version": 2
   },
   "d624f0ae-3dd1-4856-9aad-ccfe4d4bfa17": {
     "rule_name": "AWS CloudWatch Log Stream Deletion",
-    "sha256": "8696f975bcbe6973c5856d38f114bde75ded99c10d889c579f32bd5150e42161",
-    "version": 2
+    "sha256": "49611c41d6fe582c484c7a296b75e49bbea84a714e6dd7230e44d3179d0c1c66",
+    "version": 3
   },
   "d62b64a8-a7c9-43e5-aee3-15a725a794e7": {
     "rule_name": "GCP Pub/Sub Subscription Creation",
-    "sha256": "45924655d7ef740d37376aa63dfef35fc64a04924c56bf0e0aa514f52db93abb",
-    "version": 1
+    "sha256": "56291b3f724ed3a272022d9b290aea05d451d92df449c65cd5c8b454dbc8881d",
+    "version": 2
   },
   "d6450d4e-81c6-46a3-bd94-079886318ed5": {
     "rule_name": "Strace Process Activity",
     "sha256": "4143ebb3f6acf4091baf1b4af57cb236a938afaf130755b0a1f17a713366f3a0",
     "version": 5
+  },
+  "d68eb1b5-5f1c-4b6d-9e63-5b6b145cd4aa": {
+    "rule_name": "Microsoft 365 Exchange Anti-Phish Policy Deletion",
+    "sha256": "7cf04743243078b0532bdf97817765e8bd16bff043fca55642d24032d8631eb8",
+    "version": 1
+  },
+  "d72e33fc-6e91-42ff-ac8b-e573268c5a87": {
+    "rule_name": "Command Execution via SolarWinds Process",
+    "sha256": "68cc45ab08ebd607d346222e1c2cb0011eb632c11f1f7e1fedb59b75f254ba27",
+    "version": 1
+  },
+  "d743ff2a-203e-4a46-a3e3-40512cfe8fbb": {
+    "rule_name": "Microsoft 365 Exchange Malware Filter Policy Deletion",
+    "sha256": "19db83e95bba69d8c88ac383f18f6638a5910a33289493e23cc3e9a5407a6f6d",
+    "version": 1
   },
   "d76b02ef-fc95-4001-9297-01cb7412232f": {
     "rule_name": "Interactive Terminal Spawned via Python",
@@ -1336,8 +1966,8 @@
   },
   "d7e62693-aab9-4f66-a21a-3d79ecdd603d": {
     "rule_name": "SMTP on Port 26/TCP",
-    "sha256": "2d42506561edf6963bc17fd31f3680aa77e200d75f67f9d3a8aa8ae458ba7600",
-    "version": 4
+    "sha256": "911d3c97128b53ec8501cdf1de4b5d4f493c7c3e3bb8923c81d96546b7f3dbcd",
+    "version": 5
   },
   "d8fc1cca-93ed-43c1-bbb6-c0dd3eff2958": {
     "rule_name": "AWS IAM Deactivation of MFA Device",
@@ -1346,8 +1976,8 @@
   },
   "dafa3235-76dc-40e2-9f71-1773b96d24cf": {
     "rule_name": "Multi-Factor Authentication Disabled for an Azure User",
-    "sha256": "dace321a6a479114af3807d72924a01831c93705b800972c2482d93f0dddd4d6",
-    "version": 1
+    "sha256": "f7cd99d6039dc3dee20a0f9a20f97b7ec68e3ad17b313db4cf196cd5b53c6927",
+    "version": 2
   },
   "db8c33a8-03cd-4988-9e2c-d0a4863adb13": {
     "rule_name": "Credential Dumping - Prevented - Endpoint Security",
@@ -1356,8 +1986,8 @@
   },
   "dc9c1f74-dac3-48e3-b47f-eb79db358f57": {
     "rule_name": "Volume Shadow Copy Deletion via WMIC",
-    "sha256": "b975e339b0dfb9d77b35622952dc6da6588e472a33f529baa051ca526f1b73ec",
-    "version": 5
+    "sha256": "fd10faa79ed709288495b11ffb6ec2ec77a0f077b8050a4a900502dee42df83b",
+    "version": 6
   },
   "dca28dee-c999-400f-b640-50a081cc0fd1": {
     "rule_name": "Unusual Country For an AWS Command",
@@ -1371,8 +2001,8 @@
   },
   "debff20a-46bc-4a4d-bae5-5cdd14222795": {
     "rule_name": "Base16 or Base32 Encoding/Decoding Activity",
-    "sha256": "9a4a3364bcc6397bf35b650ba5341d1ccae86604f16813fc76b8792779f9e16d",
-    "version": 4
+    "sha256": "20c0bc69622f77e97f72e5c6142554a6df43cd16056890d9708b272e0cd3f7b4",
+    "version": 5
   },
   "df197323-72a8-46a9-a08e-3f5b04a4a97a": {
     "rule_name": "Unusual Windows User Calling the Metadata Service",
@@ -1381,8 +2011,8 @@
   },
   "df26fd74-1baa-4479-b42e-48da84642330": {
     "rule_name": "Azure Automation Account Created",
-    "sha256": "f02dcad1d04b48858033cb12ed31bb32ef5a7b48ed1467d82e03ab5f0efef2d9",
-    "version": 1
+    "sha256": "b24b045db089d2436f3d9147e572d8ac59ffb9566c057d50a056c45efee88df5",
+    "version": 2
   },
   "df959768-b0c9-4d45-988c-5606a2be8e5a": {
     "rule_name": "Unusual Process Execution - Temp",
@@ -1391,23 +2021,23 @@
   },
   "e02bd3ea-72c6-4181-ac2b-0f83d17ad969": {
     "rule_name": "Azure Firewall Policy Deletion",
-    "sha256": "406badade8dd1184dd48186e96b38c76aa21245fc91268f2cda174e8788709fe",
-    "version": 1
+    "sha256": "c39aeccef7f1f857bc68daacaa7e9fa216e130f6934409ebba7c61e1bf945a6d",
+    "version": 2
   },
   "e08ccd49-0380-4b2b-8d71-8000377d6e49": {
     "rule_name": "Attempts to Brute Force an Okta User Account",
-    "sha256": "17253919b65d1ef71316f0a812c5f7e24cbbc8489d75244e2429fe1918a9442b",
-    "version": 1
+    "sha256": "a3226b1f93c0daf89b90f2eab25d21a8391e9aecac05f35459ac17ed73cc48d2",
+    "version": 2
   },
   "e0f36de1-0342-453d-95a9-a068b257b053": {
     "rule_name": "Azure Event Hub Deletion",
-    "sha256": "1d631ac365a05f89623406f4a4dc74e11f26b8084bc01302085b900d043c1477",
-    "version": 1
+    "sha256": "db24a8b5bfdf52f87c824497bc9680d1b70a775a9cb08286704746ed74ca17e0",
+    "version": 2
   },
   "e14c5fd7-fdd7-49c2-9e5b-ec49d817bc8d": {
     "rule_name": "AWS RDS Cluster Creation",
-    "sha256": "3da5f35878e9e1f8d37bbe7fa365fbb0cdf39f615915d19ba5ba4b9c8c3fa46a",
-    "version": 2
+    "sha256": "ced102db5634a4ef32a1acd0cf1f2d7625ad5328c33910a5bcde4079f5df0613",
+    "version": 3
   },
   "e19e64ee-130e-4c07-961f-8a339f0b8362": {
     "rule_name": "Connection to External Network via Telnet",
@@ -1421,48 +2051,73 @@
   },
   "e2f9fdf5-8076-45ad-9427-41e0e03dc9c2": {
     "rule_name": "Suspicious Process Execution via Renamed PsExec Executable",
-    "sha256": "82c439d8b54fae7e4fea8b606896cb11f28fe99b8567f757aa85c776ee348d0a",
-    "version": 1
+    "sha256": "9768c49e8d50aca69403371300a9c79b56ef0870b893b92dc7defcb0ac8e0461",
+    "version": 2
   },
   "e2fb5b18-e33c-4270-851e-c3d675c9afcd": {
     "rule_name": "GCP IAM Role Deletion",
-    "sha256": "9e3d27e0979f5342e8fd16097e39577266b7e425b09a1640cb559a5d238aa444",
-    "version": 1
+    "sha256": "2ced7c5e7390d0b5fb5700edef55edf77ecc8c345cf564c7d472a0640fdaf0a7",
+    "version": 2
   },
   "e3343ab9-4245-4715-b344-e11c56b0a47f": {
     "rule_name": "Process Activity via Compiled HTML File",
-    "sha256": "e2b5456b05bd48c5e103306f8683918caa50739d7e140cb8ea02664e6df2bb7b",
-    "version": 4
+    "sha256": "7aa8cbe02aa84e873d2ab0828b5726f686fa87546a9d3bc7df92b3cbbead60bc",
+    "version": 5
   },
   "e3c5d5cb-41d5-4206-805c-f30561eae3ac": {
     "rule_name": "Ransomware - Prevented - Endpoint Security",
     "sha256": "911ba16663efb30078217f771edbd6e7356f869662483fac274b09c8097580cb",
     "version": 4
   },
+  "e3cf38fa-d5b8-46cc-87f9-4a7513e4281d": {
+    "rule_name": "Connection to Commonly Abused Free SSL Certificate Providers",
+    "sha256": "693991499cd3764ec572777eb8327a914699463fd3bf7291cb2cd7c37f9179b8",
+    "version": 1
+  },
   "e48236ca-b67a-4b4e-840c-fdc7782bc0c3": {
-    "rule_name": "Attempt to Modify Okta Network Zone",
-    "sha256": "a7aefb6f311e2522c037c7cf7c985d875cf4cf1548763da17472712c607884ce",
-    "version": 2
+    "rule_name": "Attempt to Modify an Okta Network Zone",
+    "sha256": "74dc0815c5ed0bdc9b10884ee3cebba932e8589cc689be20a2d9c1a726cf3458",
+    "version": 3
+  },
+  "e555105c-ba6d-481f-82bb-9b633e7b4827": {
+    "rule_name": "MFA Disabled for Google Workspace Organization",
+    "sha256": "ffdf7665f9094771764e0532606583dc0ab1491762b7bae83fa329c1f0507743",
+    "version": 1
   },
   "e56993d2-759c-4120-984c-9ec9bb940fd5": {
     "rule_name": "RDP (Remote Desktop Protocol) to the Internet",
-    "sha256": "a7285a40c6acdf3fd34f575e29f96bba2f2fe94ebd6f11ef3b8af5a3965af56a",
-    "version": 5
+    "sha256": "8c55d7e2ea7e99d99e983b3f0361e1f1ee2076e1ac3da8f28367a01e9e75100f",
+    "version": 6
   },
   "e6e3ecff-03dd-48ec-acbd-54a04de10c68": {
     "rule_name": "Possible Okta DoS Attack",
-    "sha256": "37f82e770ba51b533046e23fa84bb66667d31bb09c703f8869edd03e006369b0",
-    "version": 2
+    "sha256": "1d046cd29ab5f0036180c662210f193b534c30bc56f7fac5312bd35b633090fc",
+    "version": 3
+  },
+  "e7075e8d-a966-458e-a183-85cd331af255": {
+    "rule_name": "Default Cobalt Strike Team Server Certificate",
+    "sha256": "61ea16ce1556344e1014a0e765b1f1d5460956b8a18a73612e3f3f051d487b45",
+    "version": 1
+  },
+  "e7125cea-9fe1-42a5-9a05-b0792cf86f5a": {
+    "rule_name": "Execution of Persistent Suspicious Program",
+    "sha256": "e3dae289ce5ea3435e8c63dce8fab1b29a46b9acb14027a69f13714a35421945",
+    "version": 1
   },
   "e8571d5f-bea1-46c2-9f56-998de2d3ed95": {
     "rule_name": "Local Service Commands",
-    "sha256": "9c4d15ad510c947f7d97a9a2b22bd390529dba0e7714cc8cabb135d40e857137",
-    "version": 5
+    "sha256": "83b460c64379597208401df82f25602a3b614afb4349c45ec0889f8ac26a30bc",
+    "version": 6
+  },
+  "e86da94d-e54b-4fb5-b96c-cecff87e8787": {
+    "rule_name": "Installation of Security Support Provider",
+    "sha256": "0374c83718242ef5c40c3d532770ee321800e09ad3c355013ce1330544e80052",
+    "version": 1
   },
   "e90ee3af-45fc-432e-a850-4a58cf14a457": {
     "rule_name": "High Number of Okta User Password Reset or Unlock Attempts",
-    "sha256": "1541f7574778de40ca750a65d4e563fb9acbeaa55b8cacb1bd355a7aff51a729",
-    "version": 1
+    "sha256": "0c670e28f62f7e6a59b4e8d2bfb089bdb4b6dd439db64c1946212fc3a071cdfc",
+    "version": 2
   },
   "e94262f2-c1e9-4d3f-a907-aeab16712e1a": {
     "rule_name": "Unusual Executable File Creation by a System Critical Process",
@@ -1471,13 +2126,13 @@
   },
   "e9ff9c1c-fe36-4d0d-b3fd-9e0bf4853a62": {
     "rule_name": "Azure Automation Webhook Created",
-    "sha256": "2b52c2364068b5a8c6b19a9c5fc0f0d6bb6f157a8bae48c547b7e131bf868eab",
-    "version": 1
+    "sha256": "662e38c555e5aa51b141669319ecf8866ed54bc1d567194aa657fb3a085401df",
+    "version": 2
   },
   "ea0784f0-a4d7-4fea-ae86-4baaf27a6f17": {
     "rule_name": "SSH (Secure Shell) from the Internet",
-    "sha256": "45d7084cf74d2d321d14df44af4f40e44a2b18f17015d8724371441352cebeec",
-    "version": 5
+    "sha256": "135a80c1392d1a51e1a5d8467a53d0fab3542cea97428dc8174667a62ebdf35b",
+    "version": 6
   },
   "ea248a02-bc47-4043-8e94-2885b19b2636": {
     "rule_name": "AWS IAM Brute Force of Assume Role Policy",
@@ -1491,8 +2146,8 @@
   },
   "eb9eb8ba-a983-41d9-9c93-a1c05112ca5e": {
     "rule_name": "Potential Disabling of SELinux",
-    "sha256": "83f8a5d1e38bd23f0ca7fc5a0d2c4a6ee93195c78004f73daa6b0b22eafe3d46",
-    "version": 4
+    "sha256": "9562dcfa8d5503d91eaed71ad584f1d37066a1d0fe7765512e7311e5fcb98852",
+    "version": 5
   },
   "ebb200e8-adf0-43f8-a0bb-4ee5b5d852c6": {
     "rule_name": "Mimikatz Memssp Log File Detected",
@@ -1501,7 +2156,12 @@
   },
   "ebf1adea-ccf2-4943-8b96-7ab11ca173a5": {
     "rule_name": "IIS HTTP Logging Disabled",
-    "sha256": "1f190c70c5953421832c74b65afb7fac78f77f0205fd39d9b2323b6f635ee4ec",
+    "sha256": "0fc980061ea6bd44f87b40f38aede9eb1bc8c9c801cbedf06d5af4f1f2bcf9b5",
+    "version": 2
+  },
+  "ebfe1448-7fac-4d59-acea-181bd89b1f7f": {
+    "rule_name": "Process Execution from an Unusual Directory",
+    "sha256": "94a4fe172e3b405c1256674f5031ff2e632c4121e1f5e3070fc1c25eabb73415",
     "version": 1
   },
   "ecf2b32c-e221-4bd4-aa3b-c7d59b3bc01d": {
@@ -1511,7 +2171,22 @@
   },
   "ed9ecd27-e3e6-4fd9-8586-7754803f7fc8": {
     "rule_name": "Azure Global Administrator Role Addition to PIM User",
-    "sha256": "5d256600e1d7cae134431e91b56330dfc175bb638047f6994e9a2a296a0c592f",
+    "sha256": "708c0e6d2f8fefce078ac01ef50ee7e40b43e988e71ffec034da94669740f4e9",
+    "version": 2
+  },
+  "eda499b8-a073-4e35-9733-22ec71f57f3a": {
+    "rule_name": "AdFind Command Activity",
+    "sha256": "ad3b52a56ee56220f6c27593d177dce092c2936cb2bb67e85a9c542ba7a413eb",
+    "version": 1
+  },
+  "edb91186-1c7e-4db8-b53e-bfa33a1a0a8a": {
+    "rule_name": "Attempt to Deactivate an Okta Application",
+    "sha256": "8e8c8f851ab081ec056871b3416e954c2ead0208aad38893ff0e7c5a47a6db44",
+    "version": 1
+  },
+  "edf8ee23-5ea7-4123-ba19-56b41e424ae3": {
+    "rule_name": "ImageLoad via Windows Update Auto Update Client",
+    "sha256": "39ac9176f1b09f546ed9f8f61d58e3cb217481db47a0f819a1e2c18259f2e96c",
     "version": 1
   },
   "ef862985-3f13-4262-a686-5f357bbb9bc2": {
@@ -1521,23 +2196,58 @@
   },
   "f036953a-4615-4707-a1ca-dc53bf69dcd5": {
     "rule_name": "Unusual Child Processes of RunDLL32",
-    "sha256": "09614be604abb772733cf72e02be4c2926ce154181cf6bb3d25e32dedc17784f",
+    "sha256": "0fefec116fb90ec262136f0464b0762ea5fb9f6aa26bdfacf18f06bb9bb8ec71",
+    "version": 2
+  },
+  "f06414a6-f2a4-466d-8eba-10f85e8abf71": {
+    "rule_name": "Administrator Role Assigned to an Okta User",
+    "sha256": "ac07dabd050fb6a9dc896842e9c9e58c57d0ec948786230088e14afc98c4ef12",
+    "version": 1
+  },
+  "f0b48bbc-549e-4bcf-8ee0-a7a72586c6a7": {
+    "rule_name": "Attempt to Remove File Quarantine Attribute",
+    "sha256": "d661d2dd0138c5533c3e07fc3428395aada051f2fcf19158b4a8c9656850f5fc",
+    "version": 1
+  },
+  "f0eb70e9-71e9-40cd-813f-bf8e8c812cb1": {
+    "rule_name": "Execution with Explicit Credentials via Apple Scripting",
+    "sha256": "00f1eeeb4a4f3d2a6b1e225903d6ce431a403154f39b039a05f793128498a371",
+    "version": 1
+  },
+  "f2f46686-6f3c-4724-bd7d-24e31c70f98f": {
+    "rule_name": "LSASS Memory Dump Creation",
+    "sha256": "9fd6ebfa4edbaf4494f5a71e6605f55338fb5f01026505d342b31881528e35e8",
+    "version": 1
+  },
+  "f3475224-b179-4f78-8877-c2bd64c26b88": {
+    "rule_name": "WMI Incoming Lateral Movement",
+    "sha256": "1f81a9ebc9304e983f56c73f0d7f3778d17df0ca9281c93b861c5ba0f76489ca",
+    "version": 1
+  },
+  "f44fa4b6-524c-4e87-8d9e-a32599e4fb7c": {
+    "rule_name": "Persistence via Microsoft Office AddIns",
+    "sha256": "d8573e67b316f1f215afdddca56fa46418a0deb8e04742e63c981284014d519f",
     "version": 1
   },
   "f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc": {
     "rule_name": "Windows Script Executing PowerShell",
-    "sha256": "352b1601545802f131cdff065cc49e504bd34ca66903f88b0a3ecd4bcb5ccf09",
-    "version": 5
+    "sha256": "e979625931008693ecc40aa092667a5041a09e9400c840caba755d3036e63c3b",
+    "version": 6
   },
   "f675872f-6d85-40a3-b502-c0d2ef101e92": {
     "rule_name": "Delete Volume USN Journal with Fsutil",
-    "sha256": "4682267a5b43063a5a764c11c5002c05ac6283319af305dbde776d34bdaa9b3c",
-    "version": 5
+    "sha256": "b3b6ca09507035e91bec4a1b6c21d91c5e519af098a0b8358f33260f138a4479",
+    "version": 6
   },
   "f772ec8a-e182-483c-91d2-72058f76a44c": {
     "rule_name": "AWS CloudWatch Alarm Deletion",
-    "sha256": "76ebd3d15a1f7f0586b19997e4117dc0199bdbb9a23885c0ca99d9f44b4184ca",
-    "version": 2
+    "sha256": "657d446d966d40ddfb4ad8da6623cfc939916798c5ee5c4ec62ccc783fc343bf",
+    "version": 3
+  },
+  "f7c4dc5a-a58d-491d-9f14-9b66507121c0": {
+    "rule_name": "Persistent Scripts in the Startup Directory",
+    "sha256": "37ff69e83fd69cff15706ea852a9a695581e6e1446f907b770d02836b901aa5b",
+    "version": 1
   },
   "f9590f47-6bd5-4a49-bd49-a2f886476fb9": {
     "rule_name": "Unusual Linux System Network Configuration Discovery",
@@ -1546,23 +2256,33 @@
   },
   "f994964f-6fce-4d75-8e79-e16ccc412588": {
     "rule_name": "Suspicious Activity Reported by Okta User",
-    "sha256": "1a2eca78ad1369e31b9c8c61029566eece6fb2f13d3d75f8f45087ae7a4b8749",
-    "version": 2
+    "sha256": "d310e6cca8b0a816a00b7c14dc21049a16184477b48e94df9a0058b2048a3629",
+    "version": 3
+  },
+  "fa01341d-6662-426b-9d0c-6d81e33c8a9d": {
+    "rule_name": "Remote File Copy to a Hidden Share",
+    "sha256": "25e042c2aed46b25a6c7d5bf2b5cd097b5523193a1c2417579fdb11d424e3075",
+    "version": 1
   },
   "fb02b8d3-71ee-4af1-bacd-215d23f17efa": {
     "rule_name": "Network Connection via Registration Utility",
-    "sha256": "e993f004f3c37a3c8bd34af6ce6f927acbb4cfddcee952c82bc4fbcff4fcba19",
-    "version": 5
+    "sha256": "3a398bca99d1e42d9d86563ea7a23796f297b26203d69c23e75288d8f5de11dc",
+    "version": 6
   },
   "fbd44836-0d69-4004-a0b4-03c20370c435": {
     "rule_name": "AWS Configuration Recorder Stopped",
-    "sha256": "0fa99bdfc5a8d35e87e189818ea2c5e5c00eb86d1d38da97825b1f764b1a7ba4",
-    "version": 2
+    "sha256": "79b72425bfc74757ee2b4fbbe618a6b07add0705e38357cfa3d75dd543212c45",
+    "version": 3
+  },
+  "fc7c0fa4-8f03-4b3e-8336-c5feab0be022": {
+    "rule_name": "UAC Bypass Attempt via Elevated COM Internet Explorer Add-On Installer",
+    "sha256": "bd749ed53e7be12442870e4d64503aa7c763cec5b6d14193a9940ce89a12b1f7",
+    "version": 1
   },
   "fd4a992d-6130-4802-9ff8-829b89ae801f": {
     "rule_name": "Potential Application Shimming via Sdbinst",
-    "sha256": "1257e25246ddbca87151ebd7946fe48d40922d8e2b19335cea1c52051a501c00",
-    "version": 4
+    "sha256": "6c8a55d6df11450f2c943074768d2e6a9ee2d013eabb2e48241b6ed360bc5ce5",
+    "version": 5
   },
   "fd70c98a-c410-42dc-a2e3-761c71848acf": {
     "rule_name": "Encoding or Decoding Files via CertUtil",
@@ -1579,9 +2299,14 @@
     "sha256": "59caa4af066b68c6503c20b45f672828cff2cb84ef46d6c465d021eea1461c87",
     "version": 1
   },
+  "ff4dd44a-0ac6-44c4-8609-3f81bc820f02": {
+    "rule_name": "Microsoft 365 Exchange Transport Rule Creation",
+    "sha256": "b817d5b35a47dd2825836f6c49b8b549ca1ca5ee74e48360c92879db8a73279a",
+    "version": 1
+  },
   "ff9b571e-61d6-4f6c-9561-eb4cca3bafe1": {
     "rule_name": "GCP Firewall Rule Deletion",
-    "sha256": "4a1ccf74830785ac2e0b35a7a6a82f8e02b28dd99991a2c7fb0ed14ba21874b7",
-    "version": 1
+    "sha256": "18d7cce6dcc7aadbab7db85b09daf2bae493423e1db174f2e62088e34d54d10a",
+    "version": 2
   }
 }


### PR DESCRIPTION
## Issues
N/A

## Summary
Versions were locked on mergeback but not within the branch


Verified this matched Kibana as expected

```
 python -m detection_rules dev kibana-diff -b 7.11

Downloading rules from 7.11 branch in kibana repo using 50 threads ...
{
  "diff": [],
  "missing_from_kibana": [],
  "missing_from_repo": [],
  "stats": {
    "diff": 0,
    "missing_from_kibana": 0,
    "missing_from_repo": 0,
    "total_gh_prod_rules": 461,
    "total_repo_prod_rules": 461
  }
}
```