### PR TITLE
[Rule Tuning] 7.11.2: Add timestamp_override to all query and non-sequence EQL rules

### DIFF
--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -1,23 +1,23 @@
 {
   "000047bb-b27a-47ec-8b62-ef1a5d2c9e19": {
     "rule_name": "Attempt to Modify an Okta Policy Rule",
-    "sha256": "be6fbf2245a6365c6741b42f979b49c16c2d5f485f90365f4572ad17b1c6d266",
-    "version": 3
+    "sha256": "cac0db4aff1d1ded02c07501baa3bbe6f5e27d707c93ffd2eeca27d36820a20a",
+    "version": 4
   },
   "00140285-b827-4aee-aa09-8113f58a08f3": {
     "rule_name": "Potential Credential Access via Windows Utilities",
-    "sha256": "ed629ffafc2eda9866eea9b7538c947ed39f3caa91bc9318b7d8258962b8d58e",
-    "version": 1
+    "sha256": "aaa1e170fca28a38d31be457bde9aa519117096184eb0b7c03edd32b49031827",
+    "version": 2
   },
   "0022d47d-39c7-4f69-a232-4fe9dc7a3acd": {
     "rule_name": "System Shells via Services",
-    "sha256": "32aa5dae894539d46a474893aa8d053005b8b3875035989a8c43640d58d58644",
-    "version": 6
+    "sha256": "04fd329eb92cb9d357f7940cfa62cb8984f44cd5e65884330006e4d5415ed578",
+    "version": 7
   },
   "03024bd9-d23f-4ec1-8674-3cf1a21e130b": {
     "rule_name": "Microsoft 365 Exchange Safe Attachment Rule Disabled",
-    "sha256": "597de1037b8e935e00d29b0083b61f2f93e7ce6fab04637d0664a0c7b5a31b9a",
-    "version": 1
+    "sha256": "5bc652138aa627b6d8867f2f9023691c90cf89eae1e8b41f15c5a39a3e45c2f3",
+    "version": 2
   },
   "035889c4-2686-4583-a7df-67f89c292f2c": {
     "rule_name": "High Number of Process and/or Service Terminations",
@@ -26,38 +26,38 @@
   },
   "041d4d41-9589-43e2-ba13-5680af75ebc2": {
     "rule_name": "Potential DNS Tunneling via Iodine",
-    "sha256": "a22f964f608fc0699b9a917bfe4c5435b9eeec6de09ea8b09e1ab98030c9bde2",
-    "version": 5
+    "sha256": "7599799ca4a0a55c535334c454d59cb689f6378970a445147023453e12dc936f",
+    "version": 6
   },
   "0564fb9d-90b9-4234-a411-82a546dc1343": {
     "rule_name": "Microsoft IIS Service Account Password Dumped",
-    "sha256": "1526b1ab6e956f6f27eb41d78ac30b6377a5d859920edb7dfd9401d5d8382ba3",
-    "version": 2
+    "sha256": "75f947671148de3e29e3264168da66ac71eca6cbce3fa91d085393f5100a56b4",
+    "version": 3
   },
   "05b358de-aa6d-4f6c-89e6-78f74018b43b": {
     "rule_name": "Conhost Spawned By Suspicious Parent Process",
-    "sha256": "09938334fdaab62b2beac5369fbd1ab78ab4ed41a3764d6dae9274bf989fe101",
-    "version": 1
+    "sha256": "e1d0ef7d698458198b86b38759592dfc86d48b04a8f229b80ec4b0235193928e",
+    "version": 2
   },
   "05e5a668-7b51-4a67-93ab-e9af405c9ef3": {
     "rule_name": "Interactive Terminal Spawned via Perl",
-    "sha256": "efe7bd02504d62b8781e6ffc70abc015bd4025c4b7fd67565e568841919b53e7",
-    "version": 4
+    "sha256": "6dca378cf44291bfc85f995e2ef8dcdf0df44407d0b042cb72e33d49dee5a7c0",
+    "version": 5
   },
   "0635c542-1b96-4335-9b47-126582d2c19a": {
     "rule_name": "Remote System Discovery Commands",
-    "sha256": "8174bab1329c416caecc97faa33aa7fcd688064d44f11b6ae47de85198c8c610",
-    "version": 1
+    "sha256": "8ad286887e1e52dd9b5572836b215991274b766495448de4fe2f9b6042ac1a93",
+    "version": 2
   },
   "06dceabf-adca-48af-ac79-ffdf4c3b1e9a": {
     "rule_name": "Potential Evasion via Filter Manager",
-    "sha256": "03ac5cac28ca005e43bb065cac877fd834f2a5a1c4abe2d0e86b65dd9efbbcbd",
-    "version": 4
+    "sha256": "d2ce426a165fcaee593fab6a509528869efcd2f9e61a1c4c17719037b6fd0b82",
+    "version": 5
   },
   "074464f9-f30d-4029-8c03-0ed237fffec7": {
     "rule_name": "Remote Desktop Enabled in Windows Firewall",
-    "sha256": "710d393f51db68c5cee8407ee3db8d9f769d91288c10a6f5f3506e46888d3fbc",
-    "version": 1
+    "sha256": "a3035c5ca2734a10cc9657fa0c2c23fef1195b83d4c1316e932898537ebc27d6",
+    "version": 2
   },
   "082e3f8c-6f80-485c-91eb-5b112cb79b28": {
     "rule_name": "Launch Agent Creation or Modification and Immediate Loading",
@@ -66,8 +66,8 @@
   },
   "08d5d7e2-740f-44d8-aeda-e41f4263efaf": {
     "rule_name": "TCP Port 8000 Activity to the Internet",
-    "sha256": "620150666b5a85765d458c0ad166e11af070c6df20475d5f60c6a8b667b0126d",
-    "version": 6
+    "sha256": "fbafa9f4206bcfcd63c1a74767a930ee9e96f0a6f437e6252afd83cc73df2eb8",
+    "version": 7
   },
   "09443c92-46b3-45a4-8f25-383b028b258d": {
     "rule_name": "Process Termination followed by Deletion",
@@ -76,8 +76,8 @@
   },
   "0a97b20f-4144-49ea-be32-b540ecc445de": {
     "rule_name": "Malware - Detected - Endpoint Security",
-    "sha256": "adcd895329cc4d1c41bc4bf8b75404c838823731713fa11f3d3b671dd24cc31d",
-    "version": 4
+    "sha256": "d4b0108faa80fc35468cc5cfbbaf48b4db4dad7d1373cf48388752568eb83c98",
+    "version": 5
   },
   "0b29cab4-dbbd-4a3f-9e8e-1287c7c11ae5": {
     "rule_name": "Anomalous Windows Process Creation",
@@ -86,13 +86,13 @@
   },
   "0c7ca5c2-728d-4ad9-b1c5-bbba83ecb1f4": {
     "rule_name": "Peripheral Device Discovery",
-    "sha256": "cb51a32a4e8ce0e88271b31626be8e84c4f46d1e29e7b29a3afc611282c5470c",
-    "version": 1
+    "sha256": "b3d195f66eff7d2a1c2cc3733f699db9279b137852ec73c44268c9aaf61204e3",
+    "version": 2
   },
   "0d69150b-96f8-467c-a86d-a67a3378ce77": {
     "rule_name": "Nping Process Activity",
-    "sha256": "4bb206b502300c86a4e61297e3adff88d2986792f3ab900a0db31d29b589713b",
-    "version": 5
+    "sha256": "3df1266e8438c9787af97aff38a331b1f2a35d27d8a7541b45c39179cdd7b500",
+    "version": 6
   },
   "0d8ad79f-9025-45d8-80c1-4f0cd3c5e8e5": {
     "rule_name": "Execution of File Written or Modified by Microsoft Office",
@@ -101,8 +101,8 @@
   },
   "0e5acaae-6a64-4bbc-adb8-27649c03f7e1": {
     "rule_name": "GCP Service Account Key Creation",
-    "sha256": "651ee1ba3e8d38e3b0650fb146070bc177ddb32abc744c2291ada7f993239c9a",
-    "version": 2
+    "sha256": "265e657ed950612b93a122cdac4616aaf53c63454deaa484c2d4b8e0ffac2e55",
+    "version": 3
   },
   "0e79980b-4250-4a50-a509-69294c14e84b": {
     "rule_name": "MsBuild Making Network Connections",
@@ -111,73 +111,73 @@
   },
   "0f616aee-8161-4120-857e-742366f5eeb3": {
     "rule_name": "PowerShell spawning Cmd",
-    "sha256": "a8d9fcd5f266c1c5bf85063d3e23006ff92faa1c844be75e69a56a22ae4add26",
-    "version": 6
+    "sha256": "7e3863b9c9ebca7bc1bd8454cc06df45111aad839afa00701d01deb17557e769",
+    "version": 7
   },
   "11013227-0301-4a8c-b150-4db924484475": {
     "rule_name": "Abnormally Large DNS Response",
-    "sha256": "084010714173a6e65ff9ed8e36e12adfb535c46ef0d395a8fe9a997082773340",
-    "version": 1
+    "sha256": "fcd1f8db60952639ad3ee7ab8c7a16bd2b1c60369d4719c852994200e39bf9cb",
+    "version": 2
   },
   "1160dcdb-0a0a-4a79-91d8-9b84616edebd": {
     "rule_name": "Potential DLL SideLoading via Trusted Microsoft Programs",
-    "sha256": "42bd493577210bb3d458322e64dc3bfef8288024123681ff8a831d0d186582a4",
-    "version": 2
+    "sha256": "1887a28078d2b00c9d7c5c5fd8f13a55ada9cf7953c5e3f444d6839a32c97bc3",
+    "version": 3
   },
   "1178ae09-5aff-460a-9f2f-455cd0ac4d8e": {
     "rule_name": "UAC Bypass via Windows Firewall Snap-In Hijack",
-    "sha256": "8e6964722059775cf9281fe83d13ab053402a8bff97909f022214caea8d05a24",
-    "version": 1
+    "sha256": "87399b0ff196ae92920f9aa67e0535ec5a2ef85ce12cbb1fd7d0fe37d8508dc9",
+    "version": 2
   },
   "120559c6-5e24-49f4-9e30-8ffe697df6b9": {
     "rule_name": "User Discovery via Whoami",
-    "sha256": "a999fad6cc665af1661c4236b341868f37050cba2acee4f448e15c4b91dbd9f7",
-    "version": 5
+    "sha256": "a2594bb7b6f814bc779c6bc489a1ad7882ce299cf5fb2c000b040dfa748cf6ac",
+    "version": 6
   },
   "125417b8-d3df-479f-8418-12d7e034fee3": {
     "rule_name": "Attempt to Disable IPTables or Firewall",
-    "sha256": "87d42f9709d9399e1b79c6e7019210984844d88b6c851d8104d64ccdf606381d",
-    "version": 5
+    "sha256": "480b24cf11930aac2d017bb6d050f1ba82f830d9381cf0fecf7071d988562260",
+    "version": 6
   },
   "12f07955-1674-44f7-86b5-c35da0a6f41a": {
     "rule_name": "Suspicious Cmd Execution via WMI",
-    "sha256": "6b729a2dfa9c05431da196cc8d53b96e6cff8d20355ebda3c946832ac6570cd4",
-    "version": 1
+    "sha256": "8c53068d8e5b4053fea6daf84a565f31c405759b2852bf641fe25806ca78e742",
+    "version": 2
   },
   "139c7458-566a-410c-a5cd-f80238d6a5cd": {
     "rule_name": "SQL Traffic to the Internet",
-    "sha256": "cd68668f3a89f96fddb995cff2dd1c34c45188cfb6f8684ba6945f23a2b024e2",
-    "version": 6
+    "sha256": "863d0e7eb8b2e8c96e020329bb332e6d0cc0b06c3770ef6607a3e3739e1dcca3",
+    "version": 7
   },
   "141e9b3a-ff37-4756-989d-05d7cbf35b0e": {
     "rule_name": "Azure External Guest User Invitation",
-    "sha256": "19f48e8f623fb68f35bbe6746f8fd4935f1b2f5e29dcc9072bdec16cf0171eba",
-    "version": 2
+    "sha256": "43627cd1ed624daac407d02e6c9158da91824c99ab406d7538610d732c60e384",
+    "version": 3
   },
   "143cb236-0956-4f42-a706-814bcaa0cf5a": {
     "rule_name": "RPC (Remote Procedure Call) from the Internet",
-    "sha256": "eaed9eb3b9f22c95ce23b56b78f56eab96752442afbe674da92c6d196a4fe8de",
-    "version": 6
+    "sha256": "24559b065307470c045f9ade897b021cf83019c6d03a716450fdc57b67ecd52e",
+    "version": 7
   },
   "15c0b7a7-9c34-4869-b25b-fa6518414899": {
     "rule_name": "Remote File Download via Desktopimgdownldr Utility",
-    "sha256": "f82bd052efca4c7baef73d99dcb1b2a52fbe51229cdb460bbd9820c76ef4510f",
-    "version": 2
+    "sha256": "a484099235a7b474f53d5e801f77684ede6321d71c3403301d60f0b644597fe1",
+    "version": 3
   },
   "16280f1e-57e6-4242-aa21-bb4d16f13b2f": {
     "rule_name": "Azure Automation Runbook Created or Modified",
-    "sha256": "ad286a2be4535d1ffcf2283d3bf2ff4535f17ec5c9d863bcebd305e8ce8c98b4",
-    "version": 2
+    "sha256": "6f46ddb42d6b1ea82574dd1727b36cfb32d2662d5c3d787ba3321af0ed3f8a12",
+    "version": 3
   },
   "169f3a93-efc7-4df2-94d6-0d9438c310d1": {
     "rule_name": "AWS IAM Group Creation",
-    "sha256": "199bf9973118ddd2f9d8af6c7a0d5ce2fcaaabe21d753225c08d1f9a58869c84",
-    "version": 3
+    "sha256": "5dd2b107e0fc701668b8e697a5823207fc80d49607e6e8b5178f2f412443d8bc",
+    "version": 4
   },
   "16a52c14-7883-47af-8745-9357803f0d4c": {
     "rule_name": "Component Object Model Hijacking",
-    "sha256": "5e030748329745eeee71061e689ed93a163afb5e7facb86644773cff36b87b94",
-    "version": 1
+    "sha256": "2ce6fa72ac9194f3d8f1dd2883f9b17eb00ae9c438a97b92b314e10cefa513cb",
+    "version": 2
   },
   "1781d055-5c66-4adf-9c59-fc0fa58336a5": {
     "rule_name": "Unusual Windows Username",
@@ -206,8 +206,8 @@
   },
   "17c7f6a5-5bc9-4e1f-92bf-13632d24384d": {
     "rule_name": "Suspicious Execution - Short Program Name",
-    "sha256": "8ba6ec732352e58f2418f5189e0b79f202dc377af37c819839e66897147501b5",
-    "version": 1
+    "sha256": "6e89d71c59daded6ae826a8621232f987a054465337646e10ee7e1d284bc1ac2",
+    "version": 2
   },
   "17e68559-b274-4948-ad0b-f8415bb31126": {
     "rule_name": "Unusual Network Destination Domain Name",
@@ -216,8 +216,8 @@
   },
   "184dfe52-2999-42d9-b9d1-d1ca54495a61": {
     "rule_name": "GCP Logging Sink Modification",
-    "sha256": "76f5fb3584049eedd28cf7a96f175db16d5955ffacaa05e51a2fefe43084ef77",
-    "version": 2
+    "sha256": "58f943ff669854f623265eda509ef58e601bbd39af5f9ce82985e65d0817d796",
+    "version": 3
   },
   "19de8096-e2b0-4bd8-80c9-34a820813fff": {
     "rule_name": "Rare AWS Error Code",
@@ -226,18 +226,18 @@
   },
   "1a36cace-11a7-43a8-9a10-b497c5a02cd3": {
     "rule_name": "Azure Application Credential Modification",
-    "sha256": "566fd428efb2f6d4eb7eda9abdec74a6b407ea38023cf089c04e8da344ef549e",
-    "version": 1
+    "sha256": "f82e7c30280b4862032aa17c77a377dc129dcaf495468cc532d736845a9af8ee",
+    "version": 2
   },
   "1aa8fa52-44a7-4dae-b058-f3333b91c8d7": {
     "rule_name": "AWS CloudTrail Log Suspended",
-    "sha256": "1cbeedb8561afa64948fbe258e2718f4992802cc83809ce703e267504c5b727c",
-    "version": 3
+    "sha256": "8dad953d062015582e4e66a69bebdcb081d7e8504e3a8450486012cbef959148",
+    "version": 4
   },
   "1aa9181a-492b-4c01-8b16-fa0735786b2b": {
     "rule_name": "User Account Creation",
-    "sha256": "e3a50a2c723610d91e6d14813e2ffa6ccb9f6b14ebe1a293c4d08967a7d4b48c",
-    "version": 5
+    "sha256": "b104414747b46066388a40c0010698e2fadef3a589cd1863923ae97805f2d37c",
+    "version": 6
   },
   "1b21abcc-4d9f-4b08-a7f5-316f5f94b973": {
     "rule_name": "Connection to Internal Network via Telnet",
@@ -246,8 +246,8 @@
   },
   "1c6a8c7a-5cb6-4a82-ba27-d5a5b8a40a38": {
     "rule_name": "Possible Consent Grant Attack via Azure-Registered Application",
-    "sha256": "ccd0f37317c399e36df84c0a458ee06b859ab7869995d8f26e542b3679ac0cf6",
-    "version": 2
+    "sha256": "a6190376ebfd842ab3228b6713b5d75029b3516c8ec74b6e4ab43c83cba3eeb1",
+    "version": 3
   },
   "1cd01db9-be24-4bef-8e7c-e923f0ff78ab": {
     "rule_name": "Incoming Execution via WinRM Remote Shell",
@@ -261,13 +261,13 @@
   },
   "1d72d014-e2ab-4707-b056-9b96abe7b511": {
     "rule_name": "Public IP Reconnaissance Activity",
-    "sha256": "2af259b77e0e35a0e12611ece6eb7a237abbf9bad58646ea04c5803dbe0a6020",
-    "version": 1
+    "sha256": "35dc7d0a375f80421e98e210eed421e7f0bc2e1902eff8e2739bcf1cfdf3e062",
+    "version": 2
   },
   "1dcc51f6-ba26-49e7-9ef4-2655abb2361e": {
     "rule_name": "UAC Bypass via DiskCleanup Scheduled Task Hijack",
-    "sha256": "1832984e7f2bac120cdfa1bce9afb73503a975aa5bf582000608b056267b4dd4",
-    "version": 2
+    "sha256": "3f676ea1d24c02433d7e3b42c3288f59c319b51028ed2f6b5e3a4c84a1a95d9c",
+    "version": 3
   },
   "1defdd62-cd8d-426e-a246-81a37751bb2b": {
     "rule_name": "Execution of File Written or Modified by PDF Reader",
@@ -276,8 +276,8 @@
   },
   "1e0b832e-957e-43ae-b319-db82d228c908": {
     "rule_name": "Azure Storage Account Key Regenerated",
-    "sha256": "b670982bd2cea96cca6babe74af50324bbe3474f43e6561fde640c8e3284d6cb",
-    "version": 2
+    "sha256": "cfee55b352159e0848f887984ef2f0124a7209cb882637f14d4280525e744e49",
+    "version": 3
   },
   "1e9fc667-9ff1-4b33-9f40-fefca8537eb0": {
     "rule_name": "Unusual Sudo Activity",
@@ -296,48 +296,48 @@
   },
   "2003cdc8-8d83-4aa5-b132-1f9a8eb48514": {
     "rule_name": "Exploit - Detected - Endpoint Security",
-    "sha256": "83322d535ddc84dec40b7a90e9738726df2bd27ac3cdf96e7b9ebd967560bd25",
-    "version": 4
+    "sha256": "81850f386eb8a302e85e9d36c472f159c4db6f7df7068bd0657b7a4bed6687b4",
+    "version": 5
   },
   "201200f1-a99b-43fb-88ed-f65a45c4972c": {
     "rule_name": "Suspicious .NET Code Compilation",
-    "sha256": "64b587a8352b7bb14fdbb5176b6e3e5ad6d47335087d807cf59e0982141bf930",
-    "version": 2
+    "sha256": "0416d1b395d3e71f875fd844d5cfeefd2ca1de353c0595c765c7d7c60de4cfdb",
+    "version": 3
   },
   "22599847-5d13-48cb-8872-5796fee8692b": {
     "rule_name": "SUNBURST Command and Control Activity",
-    "sha256": "7a4f04aa1b58e764f3530e79089f90cf6a7636963425fa11485e40030542ea55",
-    "version": 1
+    "sha256": "a1f82797be5307027c2299d4e0bcd5e77d032fdef9bc6d5f5f31197a1af80c88",
+    "version": 2
   },
   "227dc608-e558-43d9-b521-150772250bae": {
     "rule_name": "AWS S3 Bucket Configuration Deletion",
-    "sha256": "7683d8361cece064211fb0bd88ac61722cf50eba1f58cf0dba3b9fea5b5a57e9",
-    "version": 2
+    "sha256": "905b4d51fc906750f57cd87dc8d7d9df6c09909d1f891757204047d2ba50c7f0",
+    "version": 3
   },
   "231876e7-4d1f-4d63-a47c-47dd1acdc1cb": {
     "rule_name": "Potential Shell via Web Server",
-    "sha256": "c2c31e7d78f6434fa9cd3db2dd06ab36a1a81340338a41557e7b16a7a1dc7c9d",
-    "version": 7
+    "sha256": "7207564a7508b0604510440b1fd1d3bebdeaf1e897e503fe298aa7f783c46410",
+    "version": 8
   },
   "2326d1b2-9acf-4dee-bd21-867ea7378b4d": {
     "rule_name": "GCP Storage Bucket Permissions Modification",
-    "sha256": "e8335174cc297b2c5f189a4013f316ea437efb1b4a045ffbf046cc666e55e2f7",
-    "version": 2
+    "sha256": "b34c9e0e5d452ba1f81e8fb67dcfd4b37fa2815b55f6167cef81ee2ae22f8435",
+    "version": 3
   },
   "25224a80-5a4a-4b8a-991e-6ab390465c4f": {
     "rule_name": "Lateral Movement via Startup Folder",
-    "sha256": "f707f3380372f319a10ff01815d201dd8ccf0f261956337c6ff838d41d76e478",
-    "version": 1
+    "sha256": "41299fef8c7f35e269c70d1e1e2924da08b1f5c726176c2d5fab5320cca82f61",
+    "version": 2
   },
   "2636aa6c-88b5-4337-9c31-8d0192a8ef45": {
     "rule_name": "Azure Blob Container Access Level Modification",
-    "sha256": "6880cec014be2430a132b6a2468d10a2ab2c7816dafafcbca87201ec1505bcef",
-    "version": 2
+    "sha256": "0f878d919fd4f04a318821523e81f19f7b201cfd00ea14dbbe6caefa12085a36",
+    "version": 3
   },
   "265db8f5-fc73-4d0d-b434-6483b56372e2": {
     "rule_name": "Persistence via Update Orchestrator Service Hijack",
-    "sha256": "b8982d412aef4e25fcff6aa043f6672b65ef99f8d291ac5ef962a745b50bf8d2",
-    "version": 2
+    "sha256": "f5d597657cdadf16e517169eb237df37db33d4afc77852c7fac5b42c1a6677da",
+    "version": 3
   },
   "26f68dba-ce29-497b-8e13-b4fde1db5a2d": {
     "rule_name": "Attempts to Brute Force a Microsoft 365 User Account",
@@ -346,8 +346,8 @@
   },
   "272a6484-2663-46db-a532-ef734bf9a796": {
     "rule_name": "Microsoft 365 Exchange Transport Rule Modification",
-    "sha256": "12d4eafa7f91342d743e0a51be51b3117990f359596bcc19965419bd74155ea7",
-    "version": 1
+    "sha256": "d0610ca7e553b3f159db6d65452c7f6a6834583c1b4e898204125c93730da1a5",
+    "version": 2
   },
   "2772264c-6fb9-4d9d-9014-b416eed21254": {
     "rule_name": "Incoming Execution via PowerShell Remoting",
@@ -356,58 +356,58 @@
   },
   "2783d84f-5091-4d7d-9319-9fceda8fa71b": {
     "rule_name": "GCP Firewall Rule Modification",
-    "sha256": "7cb9fa12872677397b5749bd9c678344728b3e13a30837e477262f653c8134a9",
-    "version": 2
+    "sha256": "0feabc81d71050379c9157c1cb287680a7c4fba732008ef9a3f17e86d6000acb",
+    "version": 3
   },
   "27f7c15a-91f8-4c3d-8b9e-1f99cc030a51": {
     "rule_name": "Microsoft 365 Teams External Access Enabled",
-    "sha256": "dad571cede63daa41944ed5b2a5c542fccb3af6b554ccc696aa214d87d8e477d",
-    "version": 1
+    "sha256": "4182ae86ebceb37ef4daf7e9d714531e546f3d75917079782cba4471e3683054",
+    "version": 2
   },
   "2856446a-34e6-435b-9fb5-f8f040bfa7ed": {
     "rule_name": "Net command via SYSTEM account",
-    "sha256": "d62c8c82699832f3ec4921bacd0ffaa294acf4faead1e04372fd3c8bc9fa7791",
-    "version": 4
+    "sha256": "7638c2f89b64cef3e108db8da0e69fde6886c3cf8ee55888962e46a36b8cbe40",
+    "version": 5
   },
   "2863ffeb-bf77-44dd-b7a5-93ef94b72036": {
     "rule_name": "Exploit - Prevented - Endpoint Security",
-    "sha256": "4a04fd5b4099a19a093d301762f68352221eca036db21c9b9b2e388dc5c56a9e",
-    "version": 4
+    "sha256": "8025e0d14b4ac2c3698276722c6310fd134681c4f71ee1f624681aae18e7940b",
+    "version": 5
   },
   "28896382-7d4f-4d50-9b72-67091901fd26": {
     "rule_name": "Suspicious Process from Conhost",
-    "sha256": "29ec058f9603c19950c03bba6b7ab0bc8c8609966dc782f1481059b97f6d2564",
-    "version": 1
+    "sha256": "9f775cc41219f22aeed5606b452afd1ef3492c54f2a31a159971683527bd7079",
+    "version": 2
   },
   "290aca65-e94d-403b-ba0f-62f320e63f51": {
     "rule_name": "UAC Bypass Attempt via Windows Directory Masquerading",
-    "sha256": "51616e4ec912d948fe113223c9c6bfdf36f5f3c164573c6e42adcf0bd6907186",
-    "version": 1
+    "sha256": "19dc06953af8af51a15fdaefb96489c18d189e4b624b72bc33877826d9cfad4d",
+    "version": 2
   },
   "2bf78aa2-9c56-48de-b139-f169bf99cf86": {
     "rule_name": "Adobe Hijack Persistence",
-    "sha256": "d0eeeda2b5eb588e6edf406c4f468adf31d0d4ef850e92722601a214890e19e0",
-    "version": 6
+    "sha256": "8898026965d74c21585cf6aec35a7e557e9ebf11998efa5d264e0e4dc9e8bb41",
+    "version": 7
   },
   "2d8043ed-5bda-4caf-801c-c1feb7410504": {
     "rule_name": "Enumeration of Kernel Modules",
-    "sha256": "f63deca5ee1ae8456d4c7e880f55784e73ba5ea2c372e828f5fbd65df3a32c92",
-    "version": 4
+    "sha256": "d190d8cec6950e03d8e267dca54b372158b1bb414490ac7f6db3d676d7c5d558",
+    "version": 5
   },
   "2e1e835d-01e5-48ca-b9fc-7a61f7f11902": {
     "rule_name": "Renamed AutoIt Scripts Interpreter",
-    "sha256": "e675b7f839446dad1cb5d44cbb903e5e137c1b97966ced2e1280a004cde07855",
-    "version": 2
+    "sha256": "53e55f065444d26397602d8833b406b630e6d6de7f8db36bdc80300cd00d20d2",
+    "version": 3
   },
   "2e580225-2a58-48ef-938b-572933be06fe": {
     "rule_name": "Halfbaked Command and Control Beacon",
-    "sha256": "e77f63807a89e722a20622ea33c5f733afc0f90378e2c9876a99543fd2c18ee2",
-    "version": 2
+    "sha256": "cdc14ec4b2b923b44462eeec6cca036053f8e2f2ba9da1cdab7ae27d4aaa1885",
+    "version": 3
   },
   "2f8a1226-5720-437d-9c20-e0029deb6194": {
     "rule_name": "Attempt to Disable Syslog Service",
-    "sha256": "529e18561a1d32da00b5c9c40099b2757b511cd5c18bb6a52c60bab0dd3c02cf",
-    "version": 5
+    "sha256": "741e753e168271d0ca5c5d7fbd2ae7660b81e53ce36255eec7cc428977c897a5",
+    "version": 6
   },
   "2fba96c0-ade5-4bce-b92f-a5df2509da3f": {
     "rule_name": "Startup Folder Persistence via Unsigned Process",
@@ -416,48 +416,48 @@
   },
   "30562697-9859-4ae0-a8c5-dab45d664170": {
     "rule_name": "GCP Firewall Rule Creation",
-    "sha256": "e994dbbf4d651d09a2adff62c38bb36abbc3e17f9537fd5a4bd50bd7aa586f3a",
-    "version": 2
+    "sha256": "045c646bf559d459cbad7abe6d452ac4f8fbf355523e81d5bd078230d3d1e2e0",
+    "version": 3
   },
   "31295df3-277b-4c56-a1fb-84e31b4222a9": {
     "rule_name": "Inbound Connection to an Unsecure Elasticsearch Node",
-    "sha256": "7214989872be520d178e1e95d0cd953d0bd0ac664fd60f355ef17fe3b164b173",
-    "version": 1
+    "sha256": "5d3c9667ede9ba23dfa05e1ec40a147903c3d22335d29f3006e74f2b130f67ca",
+    "version": 2
   },
   "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62": {
     "rule_name": "Bypass UAC via Event Viewer",
-    "sha256": "226e22578802c0db22d1805860c39c3472f692b81f32e5e0923cd7850726f394",
-    "version": 5
+    "sha256": "138656819a723b08184799b57c7b09266cf257c5e4842ef2e9e3e274c644a0ad",
+    "version": 6
   },
   "3202e172-01b1-4738-a932-d024c514ba72": {
     "rule_name": "GCP Pub/Sub Topic Deletion",
-    "sha256": "5180237a6d223a39920f0e25b96c62d1021db9754e4bd088b743c98802a75c82",
-    "version": 2
+    "sha256": "9f5f01e8c09d70086c93b58bed1b847b2536a16300f2183a79718538a3cf5a6b",
+    "version": 3
   },
   "323cb487-279d-4218-bcbd-a568efe930c6": {
     "rule_name": "Azure Network Watcher Deletion",
-    "sha256": "b61ac0124af599d2ed4d36f3e322e88c05316c3a8e4bd08fcc2dc66d78fe7dd9",
-    "version": 2
+    "sha256": "e5b565501ae4c616fa76d99dee894d9cdd5e3b0d803aaf00f2e4d9a9141ef3b0",
+    "version": 3
   },
   "32923416-763a-4531-bb35-f33b9232ecdb": {
     "rule_name": "RPC (Remote Procedure Call) to the Internet",
-    "sha256": "81e9194be578d1614c653e41b721efdffba8c2f991d0c00e8b3e99ba0fe50196",
-    "version": 6
+    "sha256": "2b5c0f40d332c98bc432ae688248f8f2ef44589a43052b3aecca94b61df3e360",
+    "version": 7
   },
   "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14": {
     "rule_name": "Program Files Directory Masquerading",
-    "sha256": "a6b409aa5c1a7cf56c20bd904dedd98c0637589d4f7fafd0e5abbc5b76b881ba",
-    "version": 1
+    "sha256": "ce3f8ded0fa72d256144440ac0bca99298283a465bf53d3d52b5a38f5fe0351f",
+    "version": 2
   },
   "32f4675e-6c49-4ace-80f9-97c9259dca2e": {
     "rule_name": "Suspicious MS Outlook Child Process",
-    "sha256": "ee650323541fc217097ebae5be9743116a3fc32b0781903b04357cd7e5ed6c4c",
-    "version": 6
+    "sha256": "5275750f21477fa6da25c475d8a62428b790254415ae9f915ae9855e34cf6024",
+    "version": 7
   },
   "333de828-8190-4cf5-8d7c-7575846f6fe0": {
     "rule_name": "AWS IAM User Addition to Group",
-    "sha256": "4531d115b94f4e437c84390cdc1aa7e8ccd515a3630fd15dd6d22ee52ced30ee",
-    "version": 3
+    "sha256": "c2a30a4e9da87291df7a1cb5c6f0488d1dc4363c8c6e8d5852cfe90b7aef9751",
+    "version": 4
   },
   "33f306e8-417c-411b-965c-c2812d6d3f4d": {
     "rule_name": "Remote File Download via PowerShell",
@@ -466,23 +466,23 @@
   },
   "34fde489-94b0-4500-a76f-b8a157cf9269": {
     "rule_name": "Telnet Port Activity",
-    "sha256": "f459488b88d14180081713099b0032605424654fa3e612f49563ac766fbc7fee",
-    "version": 5
+    "sha256": "a818c7383db3a78fc06748e8f69de6d5a29265b5cd157d418395f973930b4e63",
+    "version": 6
   },
   "3535c8bb-3bd5-40f4-ae32-b7cd589d5372": {
     "rule_name": "Port Forwarding Rule Addition",
-    "sha256": "f64dfa87334a889830ca53e2b225d199e02231d66b9066081f42c1ab3111e12f",
-    "version": 1
+    "sha256": "57c4a0ede1644dd809e968e63ffffe7c22507dc8712728997840850bcd637acf",
+    "version": 2
   },
   "35df0dd8-092d-4a83-88c1-5151a804f31b": {
     "rule_name": "Unusual Parent-Child Relationship",
-    "sha256": "d4e4d3d9ca777e5e01cb04ea212ddfc7c68e57a22b73b6e06b9eef7e75c63838",
-    "version": 6
+    "sha256": "96ed86ac690b1e778290ffe7c0d3a8e9917e20d6a8c8344bf5191801802ede93",
+    "version": 7
   },
   "36a8e048-d888-4f61-a8b9-0f9e2e40f317": {
     "rule_name": "Suspicious ImagePath Service Creation",
-    "sha256": "672a594cc4b4f0c61f7fe5198f2698210a2fc1db74a48dfc049a1a5a3ece6b0f",
-    "version": 1
+    "sha256": "b404ff24a631ad29d1fc24185a0254b0bbc22ac740efe4cd5a2efa5d4bc338e1",
+    "version": 2
   },
   "37b0816d-af40-40b4-885f-bb162b3c88a9": {
     "rule_name": "Anomalous Kernel Module Activity",
@@ -491,13 +491,13 @@
   },
   "37b211e8-4e2f-440f-86d8-06cc8f158cfa": {
     "rule_name": "AWS Execution via System Manager",
-    "sha256": "bbd154f013487bf4fe024a94d1324ebdaeafb6c888cc30157268e08df1994dea",
-    "version": 3
+    "sha256": "61dd1760bd8638bc67426d94284aa1224d97b34e9a68dc7542c9fd8f28098cc2",
+    "version": 4
   },
   "3805c3dc-f82c-4f8d-891e-63c24d3102b0": {
     "rule_name": "Attempted Bypass of Okta MFA",
-    "sha256": "e67a1aaa9d43641b3b423418015f78229dbf198b84e9c10f1dbee6548c878727",
-    "version": 3
+    "sha256": "0d3f3665184ac4b21104c3fcba336c4a8e5b58984c79be68719241115cb41a72",
+    "version": 4
   },
   "3838e0e3-1850-4850-a411-2e8c5ba40ba8": {
     "rule_name": "Network Connection via Certutil",
@@ -506,23 +506,23 @@
   },
   "38948d29-3d5d-42e3-8aec-be832aaaf8eb": {
     "rule_name": "Prompt for Credentials with OSASCRIPT",
-    "sha256": "bff999462d36e7706271a98328bb72001083af0b09cb9e3f8fb31b0021fc8946",
-    "version": 1
+    "sha256": "7a6dcc3eea9d2ecd5b9e942e20010eb93c4d3c7ae267c151bd5e8eb74360d2f5",
+    "version": 2
   },
   "38e5acdd-5f20-4d99-8fe4-f0a1a592077f": {
     "rule_name": "User Added as Owner for Azure Service Principal",
-    "sha256": "637089ce32c111f2bc450112dc43e77a0c191cc1ea49e6f0bf664309f913ecb9",
-    "version": 2
+    "sha256": "8464e66812e6b7521a8dc2abf7c67bc0f950a78949daaacc73fc293e4d663111",
+    "version": 3
   },
   "39144f38-5284-4f8e-a2ae-e3fd628d90b0": {
     "rule_name": "AWS EC2 Network Access Control List Creation",
-    "sha256": "79183338e96c2ffca1eeff36a0fda0b640854ad372fe3a599e26276401677c66",
-    "version": 3
+    "sha256": "b10f7e2de3f5d6138871b90f41126dfb05cf2bdcafbd36b57348268e22e38be4",
+    "version": 4
   },
   "397945f3-d39a-4e6f-8bcb-9656c2031438": {
     "rule_name": "Persistence via Microsoft Outlook VBA",
-    "sha256": "baa5488faf7b131d9587b945593517cf0d9641a088bebf675d75b20081f68bee",
-    "version": 1
+    "sha256": "3ef3999620b103e14c61eed74a63ee361926ae6a6f4b8d30353aa438c2e0665e",
+    "version": 2
   },
   "3a59fc81-99d3-47ea-8cd6-d48d561fca20": {
     "rule_name": "Potential DNS Tunneling via NsLookup",
@@ -531,28 +531,28 @@
   },
   "3a86e085-094c-412d-97ff-2439731e59cb": {
     "rule_name": "Setgid Bit Set via chmod",
-    "sha256": "88f9b435053af9149607e76525202c778a18d68d443b39fa55d5abe389038f30",
-    "version": 5
+    "sha256": "8a227c09d80f4787ecef3e02690f51fd836b29aafcd6b210d859c4cd51203941",
+    "version": 6
   },
   "3ad49c61-7adc-42c1-b788-732eda2f5abf": {
     "rule_name": "VNC (Virtual Network Computing) to the Internet",
-    "sha256": "2c04e5d522326cc744f1b49f8df15c4a76b74279207703af169a9fe62954370d",
-    "version": 6
+    "sha256": "77fbab55e9059eb6fb6492ba30971f3d3a4df6c2e2d7e325b04d0ecd7bc26b52",
+    "version": 7
   },
   "3b382770-efbb-44f4-beed-f5e0a051b895": {
     "rule_name": "Malware - Prevented - Endpoint Security",
-    "sha256": "49bf69bac026013bdfd88dbb0ebbf5f2cf01d0bcc8dbdc00d760cc4c1ecf6daf",
-    "version": 4
+    "sha256": "11be6e8247af54541336c5e12c8a3423afd6884940d4b7f50160abb215a2337b",
+    "version": 5
   },
   "3b47900d-e793-49e8-968f-c90dc3526aa1": {
     "rule_name": "Unusual Parent Process for cmd.exe",
-    "sha256": "3956449a0683db5b1401aa8c3a1230cd21ebc628f1b1e700d4913b13744b0aeb",
-    "version": 1
+    "sha256": "4ce1347f9fe15a5884acb582586ef9918d0709794bdb3581cbefc8cf9166e707",
+    "version": 2
   },
   "3bc6deaa-fbd4-433a-ae21-3e892f95624f": {
     "rule_name": "NTDS or SAM Database File Copied",
-    "sha256": "6129832a37aaa5e17a84c8d54a07e74155c9a7e7e58622fae606eb7e5a9fdaa9",
-    "version": 1
+    "sha256": "6c4b480706231207a2b53286531f84fb7497f1b136d293d0e1ad8af5b90353ce",
+    "version": 2
   },
   "3c7e32e6-6104-46d9-a06e-da0f8b5795a0": {
     "rule_name": "Unusual Linux Network Port Activity",
@@ -561,13 +561,13 @@
   },
   "3e002465-876f-4f04-b016-84ef48ce7e5d": {
     "rule_name": "AWS CloudTrail Log Updated",
-    "sha256": "d5508e7625989a082fffb99c02bc4ef880943ee818c2230c81a221d68c3b4092",
-    "version": 3
+    "sha256": "81893cb7efeaefbe69f4653b3dc5839948ec1fc43fc55f8370f3257e04f15d8c",
+    "version": 4
   },
   "3ecbdc9e-e4f2-43fa-8cca-63802125e582": {
     "rule_name": "Privilege Escalation via Named Pipe Impersonation",
-    "sha256": "b202446df1f2e4a0afeea4be08526355c5d5dbb62ea5551dc9808275199a1adb",
-    "version": 1
+    "sha256": "2472409ff9fa897575ec999b050152152e127c3c8f8fba6af7a746e812c3b41f",
+    "version": 2
   },
   "3efee4f0-182a-40a8-a835-102c68a4175d": {
     "rule_name": "Potential Password Spraying of Microsoft 365 User Accounts",
@@ -576,8 +576,8 @@
   },
   "403ef0d3-8259-40c9-a5b6-d48354712e49": {
     "rule_name": "Unusual Persistence via Services Registry",
-    "sha256": "3e33a9f1d52b9b07a34917a0697c94254c0b86881343a9c65d91c5e86ffe0b9d",
-    "version": 1
+    "sha256": "6522bc62d5d8d7ffc42fbb0aeac0f7da2ba74e3932da92569cfa2a871eafde1c",
+    "version": 2
   },
   "42bf698b-4738-445b-8231-c834ddefd8a0": {
     "rule_name": "Okta Brute Force or Password Spraying Attack",
@@ -591,13 +591,13 @@
   },
   "43303fd4-4839-4e48-b2b2-803ab060758d": {
     "rule_name": "Web Application Suspicious Activity: No User Agent",
-    "sha256": "75ab7209924df0f0f956fd6d1a9713461cbd51ae2b6e6ce2a1ff51eef35d7a82",
-    "version": 4
+    "sha256": "7b2f56166e460cbf13418552df56b54023525a2eaf0df76c055f62210bc8a027",
+    "version": 5
   },
   "440e2db4-bc7f-4c96-a068-65b78da59bde": {
     "rule_name": "Shortcut File Written or Modified for Persistence",
-    "sha256": "e5bc69f2b78b0c6331ce9314de1fe11b771510bdcd43512ff48699785d0e05d1",
-    "version": 1
+    "sha256": "cf28969a293d000e52873e97e24333b40307b6486244b54714e1b96f74aee319",
+    "version": 2
   },
   "445a342e-03fb-42d0-8656-0367eb2dead5": {
     "rule_name": "Unusual Windows Path Activity",
@@ -606,18 +606,18 @@
   },
   "453f659e-0429-40b1-bfdb-b6957286e04b": {
     "rule_name": "Permission Theft - Prevented - Endpoint Security",
-    "sha256": "de91fb70ece5386bf2fe4d065f50aa219516eff015f22534b5cd1b69064fe002",
-    "version": 4
+    "sha256": "abc8e7c3bcc3a15d3c3f0f751333d1273f45b2d2fec6908c64af0132f529c07d",
+    "version": 5
   },
   "45d273fb-1dca-457d-9855-bcb302180c21": {
     "rule_name": "Encrypting Files with WinRar or 7z",
-    "sha256": "422e05c31ffba0df8f3bae7faf300bfdadf97308441e829967edb08598f95598",
-    "version": 1
+    "sha256": "f359ec8bdfe01b859d3a325ba2cd0b00cff639a80f196ea48d201e3cbae74176",
+    "version": 2
   },
   "4630d948-40d4-4cef-ac69-4002e29bc3db": {
     "rule_name": "Adding Hidden File Attribute via Attrib",
-    "sha256": "571ed6e2dbf42785996098630255b55ef5f0dee3f6ca705988bc216fd33d3439",
-    "version": 6
+    "sha256": "b7ee618643d98c2169a1b8bc1e871d9adcc21fe9c7c438d548f54462a01b9a77",
+    "version": 7
   },
   "46f804f5-b289-43d6-a881-9387cf594f75": {
     "rule_name": "Unusual Process For a Linux Host",
@@ -626,8 +626,8 @@
   },
   "47f09343-8d1f-4bb5-8bb0-00c9d18f5010": {
     "rule_name": "Execution via Regsvcs/Regasm",
-    "sha256": "e75e919b3bae2df1eed41952fc6f41dbcc36756b8f830ac594ef37b6d8f8919a",
-    "version": 5
+    "sha256": "cd4a76da7357de9b301cac5aab25aff5b3cdc7993a4da71e670c8646c08dee94",
+    "version": 6
   },
   "47f76567-d58a-4fed-b32b-21f571e28910": {
     "rule_name": "Apple Script Execution followed by Network Connection",
@@ -636,18 +636,18 @@
   },
   "4a4e23cf-78a2-449c-bac3-701924c269d3": {
     "rule_name": "Possible FIN7 DGA Command and Control Behavior",
-    "sha256": "3fa7153a86cbc2ace7d71cfed53816495b74a6d6ee0094365420c17fa95c2957",
-    "version": 2
+    "sha256": "d7a4094671ab3413141af350b26471c1f84f5813e2c751ab1460ade4994ee1f4",
+    "version": 3
   },
   "4b438734-3793-4fda-bd42-ceeada0be8f9": {
     "rule_name": "Disable Windows Firewall Rules via Netsh",
-    "sha256": "318527838ec562ffa5c4c1ccf7576ea36b934c2a9d0d08ba12ead4defdda2143",
-    "version": 6
+    "sha256": "207cfd123ae87b0a770f175c9018d1e0d3ec80d82dff6d5e2c122b44c0fb09b6",
+    "version": 7
   },
   "4bd1c1af-79d4-4d37-9efa-6e0240640242": {
     "rule_name": "Unusual Process Execution Path - Alternate Data Stream",
-    "sha256": "d988671014362e73e19a8a61cf4d8271628b833daaa941b9e898366ccf0bcfc7",
-    "version": 1
+    "sha256": "f7941ff2450a8f5b2545ab32170eaf4b8ad7a2f5f86fe2f06a1b5495dd2b1f62",
+    "version": 2
   },
   "4d50a94f-2844-43fa-8395-6afbd5e1c5ef": {
     "rule_name": "AWS Management Console Brute Force of Root User Identity",
@@ -656,8 +656,8 @@
   },
   "4ed493fc-d637-4a36-80ff-ac84937e5461": {
     "rule_name": "Execution via MSSQL xp_cmdshell Stored Procedure",
-    "sha256": "b96be952934c2bcbbd1ed0d16452675fb017c9d2ea63823330ef96e99a3ce70d",
-    "version": 1
+    "sha256": "b116b6e30fcb1611da5546f1c52c12b88d5dfd9a2041e83fa34583e547860c2c",
+    "version": 2
   },
   "4ed678a9-3a4f-41fb-9fea-f85a6e0a0dff": {
     "rule_name": "Windows Suspicious Script Object Execution",
@@ -666,23 +666,23 @@
   },
   "4fe9d835-40e1-452d-8230-17c147cafad8": {
     "rule_name": "Execution via TSClient Mountpoint",
-    "sha256": "9290f46476c9f56f04b7b9aabeb75175375804c957088b0887618e8ce8b0e100",
-    "version": 1
+    "sha256": "1e2b65b762c850b45150a9e0e641e72054c9761de19ecd694cc1dfee10ea8ea7",
+    "version": 2
   },
   "513f0ffd-b317-4b9c-9494-92ce861f22c7": {
     "rule_name": "Registry Persistence via AppCert DLL",
-    "sha256": "317e55d046b33a23441d5ae5214e214792c050b26a514220a5a57177fcd328ba",
-    "version": 1
+    "sha256": "472d300c8c9ab634eca6e92d2c807265c348300e2c29f01a1dade2b5f74d73a9",
+    "version": 2
   },
   "514121ce-c7b6-474a-8237-68ff71672379": {
     "rule_name": "Microsoft 365 Exchange DKIM Signing Configuration Disabled",
-    "sha256": "62ec84bd95359f43ab55b4e4f464aa612eff03d4717105c1cad0bf2f4ca207bc",
-    "version": 1
+    "sha256": "c8d8d20fe7da189d29d5418c818dbcd69206b2517f805a9b0e908cc81bf55f93",
+    "version": 2
   },
   "51859fa0-d86b-4214-bf48-ebb30ed91305": {
     "rule_name": "GCP Logging Sink Deletion",
-    "sha256": "179abd386f4a83ae3ff067a6ef71e77b481cefeb368301c6367d96990478ce39",
-    "version": 2
+    "sha256": "91f9f78c852e08daa7562d9df8dbe86bb1a55e5e269c26fd014a9a7b70157f9f",
+    "version": 3
   },
   "51ce96fb-9e52-4dad-b0ba-99b54440fc9a": {
     "rule_name": "Incoming DCOM Lateral Movement with MMC",
@@ -691,8 +691,8 @@
   },
   "523116c0-d89d-4d7c-82c2-39e6845a78ef": {
     "rule_name": "AWS GuardDuty Detector Deletion",
-    "sha256": "03c8d3751e05c4bc6d2050a6e350b95e20b80a0fc370d29b7520aef0583c1702",
-    "version": 3
+    "sha256": "b7adc358703eb3dceb5073c695606ebc4b3f1e328477735bdb5aa1af4a1da7db",
+    "version": 4
   },
   "52aaab7b-b51c-441a-89ce-4387b3aea886": {
     "rule_name": "Unusual Network Connection via RunDLL32",
@@ -716,18 +716,18 @@
   },
   "5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de": {
     "rule_name": "Azure Diagnostic Settings Deletion",
-    "sha256": "a8b4e48c52cd06a7dfae8677a8c2055b4bbe2171a3f66ff858e6db0a94637684",
-    "version": 2
+    "sha256": "62305e86230ba4c5c3a1003451d02a3ba84428bc352f1502845e2242cacdf686",
+    "version": 3
   },
   "53a26770-9cbd-40c5-8b57-61d01a325e14": {
     "rule_name": "Suspicious PDF Reader Child Process",
-    "sha256": "53f61925ba39298ed65f48eef2a47cdfacd39d5bfbb319d1d88ce18745b2836b",
-    "version": 4
+    "sha256": "dfd73583e55e557d6b6b4cd595c2d9b899a833edee7f159aa9b899d6047cf5a6",
+    "version": 5
   },
   "54902e45-3467-49a4-8abc-529f2c8cfb80": {
     "rule_name": "Uncommon Registry Persistence Change",
-    "sha256": "09bf4205dee6d3b689bd2b6a6b8e43b2e4264ea34b10ea7094e4d783e98647db",
-    "version": 1
+    "sha256": "1c339b8b96957808c27abd4eb4b06d28917dd955b3121f4a794ec7db1d52e87d",
+    "version": 2
   },
   "55d551c6-333b-4665-ab7e-5d14a59715ce": {
     "rule_name": "PsExec Network Connection",
@@ -736,38 +736,38 @@
   },
   "56557cde-d923-4b88-adee-c61b3f3b5dc3": {
     "rule_name": "Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)",
-    "sha256": "88c22b8c1d0da1fde8aa5bb68147c976d156c5d0b41581c7b2e7804682875b13",
-    "version": 4
+    "sha256": "62b2c18b4283e72805e191b3fbff2f7ed1b2272eedc561fe049c38475b3ae34f",
+    "version": 5
   },
   "5663b693-0dea-4f2e-8275-f1ae5ff2de8e": {
     "rule_name": "GCP Logging Bucket Deletion",
-    "sha256": "2a09a46e4d41dfdb6032d04649fbd864a59aa9861bf2904a7f9a49c6fed0762b",
-    "version": 2
+    "sha256": "36c41e7616e6841d8e8ccc7b8cf07ac26c8bccff0fa0233db17221a20069fc99",
+    "version": 3
   },
   "5700cb81-df44-46aa-a5d7-337798f53eb8": {
     "rule_name": "VNC (Virtual Network Computing) from the Internet",
-    "sha256": "a2ea2cb2026677826f160a04916fafeb90ea540d33892a4df8253121c3dc1d4a",
-    "version": 6
+    "sha256": "7a98a305d038362c3fb3a83cf8bd99757e7cd97374f13a8c49583e9253abd937",
+    "version": 7
   },
   "571afc56-5ed9-465d-a2a9-045f099f6e7e": {
     "rule_name": "Credential Dumping - Detected - Endpoint Security",
-    "sha256": "bdc750ae44da6954d429af1c78db084f915fe63db463a2e084107bd4b7725a73",
-    "version": 4
+    "sha256": "26fa244a5b78452aa61775e3ee2894c6b1bd109cef9c2af649e4dc372ccb5820",
+    "version": 5
   },
   "581add16-df76-42bb-af8e-c979bfb39a59": {
     "rule_name": "Deleting Backup Catalogs with Wbadmin",
-    "sha256": "543592b4939c56351c5a38152ef4d04001547111f7beec7c24191bf85570366c",
-    "version": 6
+    "sha256": "8c36a1ee95f65fd57c309bdf9969add31b8f6d83c342445259834f46484dddad",
+    "version": 7
   },
   "58aa72ca-d968-4f34-b9f7-bea51d75eb50": {
     "rule_name": "RDP Enabled via Registry",
-    "sha256": "b0f105b512f1ebe64f70c5c3a5094cb3602906dd5b4dbaa0a9bd5c39998b435f",
-    "version": 1
+    "sha256": "18053d9896302f8e69ce8066403fe67c8995b0f7fd3c803e5c71a3ca9ef74279",
+    "version": 2
   },
   "58ac2aa5-6718-427c-a845-5f3ac5af00ba": {
     "rule_name": "Zoom Meeting with no Passcode",
-    "sha256": "cc04c68a382fb37bd26c5adb30a32d599bb5e1338a79d4c430ce5738b6a45d78",
-    "version": 1
+    "sha256": "00ebed2fca50a1579826be2ea418f5bee450e8a31e60680af072af3d99181292",
+    "version": 2
   },
   "58bc134c-e8d2-4291-a552-b4b3e537c60b": {
     "rule_name": "Lateral Tool Transfer",
@@ -776,8 +776,8 @@
   },
   "594e0cbf-86cc-45aa-9ff7-ff27db27d3ed": {
     "rule_name": "AWS CloudTrail Log Created",
-    "sha256": "72dd7588ffc9dfe3a34c7a7a7b6e433f5f2246e8334f6c5f29b40f8ba16037b0",
-    "version": 2
+    "sha256": "2af4c984cf43412d94bc2369b88c7ad65535fa95bddf98b15b81e62b3586de3b",
+    "version": 3
   },
   "59756272-1998-4b8c-be14-e287035c4d10": {
     "rule_name": "Unusual Linux System Owner or User Discovery Activity",
@@ -786,33 +786,33 @@
   },
   "5a14d01d-7ac8-4545-914c-b687c2cf66b3": {
     "rule_name": "UAC Bypass Attempt via Privileged IFileOperation COM Interface",
-    "sha256": "d4bd9acc538695bff422cdc9e4ac490996401fc395ff6b2d4d0823cfbdca5bc4",
-    "version": 1
+    "sha256": "396ab1ad60804f89853f9976fde22358716c8a6a735791f6342e110370086997",
+    "version": 2
   },
   "5ae4e6f8-d1bf-40fa-96ba-e29645e1e4dc": {
     "rule_name": "Remote SSH Login Enabled via systemsetup Command",
-    "sha256": "4231722b2c377f5fb4cb400e9418ad9b537ea08498dcfc356e3fa2dd8d79b86e",
-    "version": 1
+    "sha256": "223cb3241e8bdf4291664ddd39ab5534cc523b6daf9f6b2e6ed4223f3c4f2186",
+    "version": 2
   },
   "5aee924b-6ceb-4633-980e-1bde8cdb40c5": {
     "rule_name": "Potential Secure File Deletion via SDelete Utility",
-    "sha256": "7dd120455eb0e2906f3ad016539d3bd4dd5df34bbb1e90bbb827b64c9ad930e2",
-    "version": 2
+    "sha256": "8d78a38091e18b693817210f674b04535f1b66fcd042c355d8e27dc96c376d89",
+    "version": 3
   },
   "5b03c9fb-9945-4d2f-9568-fd690fee3fba": {
     "rule_name": "Virtual Machine Fingerprinting",
-    "sha256": "f8db95e26fe4f3919b26ddbfb6a048097a0a5a4de7e11b2a9486d3846da106c8",
-    "version": 4
+    "sha256": "280e064ffe4b31935712b8d34e3aa1c97c586ad103f4b61b86a209c6287254f6",
+    "version": 5
   },
   "5bb4a95d-5a08-48eb-80db-4c3a63ec78a8": {
     "rule_name": "Suspicious PrintSpooler Service Executable File Creation",
-    "sha256": "25049239f8bae0bd5cf322904313fa7cb6bf41a44a2d618db6e11ec0db3e491f",
-    "version": 1
+    "sha256": "8f56c94d9172737c682679aa448bed9762578c30b9e69c5981432e0372761b0e",
+    "version": 2
   },
   "5beaebc1-cc13-4bfc-9949-776f9e0dc318": {
     "rule_name": "AWS WAF Rule or Rule Group Deletion",
-    "sha256": "0d2374203b38e327452c3c572da95594340a8610ecc4231b3f445b8ecd6a4239",
-    "version": 3
+    "sha256": "23a72fb952c8871fdf25b30af1b83513cbede2411d85e86dc6b4ee58e3a1b30c",
+    "version": 4
   },
   "5c983105-4681-46c3-9890-0c66d05e776b": {
     "rule_name": "Unusual Linux Process Discovery Activity",
@@ -826,33 +826,33 @@
   },
   "5d0265bf-dea9-41a9-92ad-48a8dcd05080": {
     "rule_name": "Persistence via Login or Logout Hook",
-    "sha256": "4e88ca6458c7a271beefea95422cc2b97c7ba6731f400d6a97c932d3535ff4f0",
-    "version": 1
+    "sha256": "66c623494f33deec9f9578828274d64bc626b49e0c4089feb63ed368a2527440",
+    "version": 2
   },
   "5d1d6907-0747-4d5d-9b24-e4a18853dc0a": {
     "rule_name": "Suspicious Execution via Scheduled Task",
-    "sha256": "14bcfde36556d11e476d3c9b6a667134b4a9895ab1e60ab21fcabe502dd5ff3c",
-    "version": 1
+    "sha256": "91f0f28d9cab78550370bdb54ae1fe045b0386b78af41080ee15ace7422fbc8c",
+    "version": 2
   },
   "5e552599-ddec-4e14-bad1-28aa42404388": {
     "rule_name": "Microsoft 365 Teams Guest Access Enabled",
-    "sha256": "8a43bdd682722e1a831ca24d3b8aeb5138e73e8b464b7dc613174b62a1ead724",
-    "version": 1
+    "sha256": "22e55f416e232d19d6a6fdec998a0bf2c948111ce00daf4e92c92e954c442dbb",
+    "version": 2
   },
   "60884af6-f553-4a6c-af13-300047455491": {
     "rule_name": "Azure Command Execution on Virtual Machine",
-    "sha256": "322bebd844ffb21d830ab08eed67b26b3c45964f7dd93578520c641e668b7535",
-    "version": 2
+    "sha256": "a715d519189c188c0879a60afe5823e05137845c4c782a18fbe85d92c0a8e84c",
+    "version": 3
   },
   "60b6b72f-0fbc-47e7-9895-9ba7627a8b50": {
     "rule_name": "Azure Service Principal Addition",
-    "sha256": "c22c57b1e5bd8d490cfd1c79ad555b735f040598a0ef8bfa5789210cb476f5bf",
-    "version": 1
+    "sha256": "5f69299722e8c6c6469f902b7867c74056379d15e39f74d8f557d052236cfbb1",
+    "version": 2
   },
   "60f3adec-1df9-4104-9c75-b97d9f078b25": {
     "rule_name": "Microsoft 365 Exchange DLP Policy Removed",
-    "sha256": "574cfc55506404904910aa107eb70e4170d1db1cb4cc1b37f80a3c698e2d64e1",
-    "version": 1
+    "sha256": "a23fc63c1652d21efc02a07708eb3c7d173e4d734d5ea9949296486717b37c2f",
+    "version": 2
   },
   "610949a1-312f-4e04-bb55-3a79b8c95267": {
     "rule_name": "Unusual Process Network Connection",
@@ -861,8 +861,8 @@
   },
   "61c31c14-507f-4627-8c31-072556b89a9c": {
     "rule_name": "Mknod Process Activity",
-    "sha256": "47dcac670430caeec4f2a3af82d5367c6a27dfa80aacfcc662e6dbbf9f3f3cb8",
-    "version": 5
+    "sha256": "3532de678b47a8b6e4b89371d69e552d7b67fae0ec5501f0f97b448ff62b6c54",
+    "version": 6
   },
   "622ecb68-fa81-4601-90b5-f8cd661e4520": {
     "rule_name": "Incoming DCOM Lateral Movement via MSHTA",
@@ -881,53 +881,53 @@
   },
   "665e7a4f-c58e-4fc6-bc83-87a7572670ac": {
     "rule_name": "WebServer Access Logs Deleted",
-    "sha256": "03dd8d2c3e9f6d1d719ef31e1cd4d40a46fd25d023399a1dadfbce43640ba910",
-    "version": 1
+    "sha256": "539b8de4adfa60a09feba4677439be7a0f3a32b016a5d59224234a6cba4a882b",
+    "version": 2
   },
   "66883649-f908-4a5b-a1e0-54090a1d3a32": {
     "rule_name": "Connection to Commonly Abused Web Services",
-    "sha256": "d393849a40606e31a07adf06dd075984f3158fd858a797e4dca212bc61e98e2f",
-    "version": 1
+    "sha256": "9880ea66b7f0b33e6c8faa4ced81fd51dcdd75150bac98e336e103a232e9d42e",
+    "version": 2
   },
   "6731fbf2-8f28-49ed-9ab9-9a918ceb5a45": {
     "rule_name": "Attempt to Modify an Okta Policy",
-    "sha256": "3ec5aad58e1f18140fee7ae4ff11fd1faf068e7d0c351f1922efff21f1db296e",
-    "version": 3
+    "sha256": "141a2f379cab2fa52f9fb037db0bf219e44c455a5aafa0ae23c673fd38cf7832",
+    "version": 4
   },
   "676cff2b-450b-4cf1-8ed2-c0c58a4a2dd7": {
     "rule_name": "Attempt to Revoke Okta API Token",
-    "sha256": "0ec5b61bbd833bbdfb5c64dac527df602f43863310c016c7791c3928db184464",
-    "version": 3
+    "sha256": "e328e8296a29b8d680a32a4ff6e6456241ea6ae5142772d756908e9a64d9a638",
+    "version": 4
   },
   "67a9beba-830d-4035-bfe8-40b7e28f8ac4": {
     "rule_name": "SMTP to the Internet",
-    "sha256": "88b2bc63cda4078953dc59855583991e5fa306c3c717928e496e92c2d3deef27",
-    "version": 6
+    "sha256": "2132ba64c0691c394c31bb8b68cfe1779c3db0a8b224d068541dee3846f01db1",
+    "version": 7
   },
   "68113fdc-3105-4cdd-85bb-e643c416ef0b": {
     "rule_name": "Query Registry via reg.exe",
-    "sha256": "0a2f0ded00af21047d20cc20185957362679bc9d0590e1cfaab1a9cfc9cf33d5",
-    "version": 1
+    "sha256": "ac76956e9e5ca1a2b9303138d7962b83239d5233cc17c1951f575a1963e7aeae",
+    "version": 2
   },
   "6839c821-011d-43bd-bd5b-acff00257226": {
     "rule_name": "Image File Execution Options Injection",
-    "sha256": "d5b819c5e9a12fa9c10224e43f3822857f14a55eee98d3bb8e71af720d5d9965",
-    "version": 1
+    "sha256": "3b9679e6ded36023d52f4977ae939b556a66c54813c925f0a96b620bb1aaf8c8",
+    "version": 2
   },
   "6885d2ae-e008-4762-b98a-e8e1cd3a81e9": {
     "rule_name": "Threat Detected by Okta ThreatInsight",
-    "sha256": "14a996f72274ed0db272c844a9fd9c4744821f902db93e015708a7e80666d78a",
-    "version": 3
+    "sha256": "6d3c615dc61fba8e4789523d8b658467eebf55d12aaacbe78e092cf303e798d2",
+    "version": 4
   },
   "68921d85-d0dc-48b3-865f-43291ca2c4f2": {
     "rule_name": "Persistence via TelemetryController Scheduled Task Hijack",
-    "sha256": "90a6ba0e59d5d4104216c1e211f8db109530d5ceaa592082dbfe90ee70b1afd6",
-    "version": 2
+    "sha256": "652f005e7dd427a0d1caa47f44c0e35987934c392b51d869c63418c68aad0867",
+    "version": 3
   },
   "68994a6c-c7ba-4e82-b476-26a26877adf6": {
     "rule_name": "Google Workspace Admin Role Assigned to a User",
-    "sha256": "9987dd62c2d729ed9a5414cd2aaf20f0da5f80166fc35210f5187f4f421f0f77",
-    "version": 1
+    "sha256": "b2b287e32e46fb4a6af0815d394d8910c5de71a2f389112f7749d8083e2ddb9e",
+    "version": 2
   },
   "689b9d57-e4d5-4357-ad17-9c334609d79a": {
     "rule_name": "Scheduled Task Created by a Windows Script",
@@ -936,33 +936,33 @@
   },
   "68a7a5a5-a2fc-4a76-ba9f-26849de881b4": {
     "rule_name": "AWS CloudWatch Log Group Deletion",
-    "sha256": "2b3f9d809c39c7486e0089b1360dca3ffad10c850bb658b535dfdf54725669dc",
-    "version": 3
+    "sha256": "7123531c2f403e877a04a9bd9c0690242128efab72cfcb2ed4186433c305756f",
+    "version": 4
   },
   "68d56fdc-7ffa-4419-8e95-81641bd6f845": {
     "rule_name": "UAC Bypass via ICMLuaUtil Elevated COM Interface",
-    "sha256": "3b10d74eae99b1b9092bd8ee5135c7b05a6e5df78b231f9eeeefd61ac115a40f",
-    "version": 1
+    "sha256": "dda1ee5944e9a1be0b0bbf8ce73173115593dff29fae8d530efa30b4ea675991",
+    "version": 2
   },
   "69c251fb-a5d6-4035-b5ec-40438bd829ff": {
     "rule_name": "Modification of Boot Configuration",
-    "sha256": "b1d70ee5e38827d796c671f4f9348ae38783d2843d0358d587fbac034d91a07f",
-    "version": 5
+    "sha256": "1b0e39c02798b3aec53ad0414a3d548a4ae21df79eb215ce5c193991d7b143ec",
+    "version": 6
   },
   "69c420e8-6c9e-4d28-86c0-8a2be2d1e78c": {
     "rule_name": "AWS IAM Password Recovery Requested",
-    "sha256": "4e5b8c7586736f83e5cb879408c4821fb2c72e9276a1143e49349133b1a7c59a",
-    "version": 2
+    "sha256": "ed2d0e0a212e573ea92041b025fe7f636f904641c177cfefa890bedd36a4fe52",
+    "version": 3
   },
   "6a8ab9cc-4023-4d17-b5df-1a3e16882ce7": {
     "rule_name": "Unusual Service Host Child Process - Childless Service",
-    "sha256": "5f6da8e7b09f7db8e52412b2ee44b56d6dce3a2ea408a8bc58f9a44fdd33d782",
-    "version": 1
+    "sha256": "d7377f732f983bf9e4d23033681b4ba85752d775f3d284914e55434e0fc0b379",
+    "version": 2
   },
   "6aace640-e631-4870-ba8e-5fdda09325db": {
     "rule_name": "Exporting Exchange Mailbox via PowerShell",
-    "sha256": "790f16dd11d3bf2d01e453ef495d2e0a2ae796d83936bdd327385fc3f0453d36",
-    "version": 1
+    "sha256": "a4f4d48080543be6c84780e072b07173109723c55006b044051f67e50d5eed4a",
+    "version": 2
   },
   "6d448b96-c922-4adb-b51c-b767f1ea5b76": {
     "rule_name": "Unusual Process For a Windows Host",
@@ -981,48 +981,48 @@
   },
   "6ea55c81-e2ba-42f2-a134-bccf857ba922": {
     "rule_name": "Security Software Discovery using WMIC",
-    "sha256": "98db76428d1d6d8c1249a8220d772aeb20e89771aad6b5bc81ebd982e75beb8a",
-    "version": 1
+    "sha256": "7c13599b8e0d4f2c956bbe141227d03a87bb44d6e2ac0a410d4d714b98026725",
+    "version": 2
   },
   "6ea71ff0-9e95-475b-9506-2580d1ce6154": {
     "rule_name": "DNS Activity to the Internet",
-    "sha256": "993cdd705222f27c0d075f166b093394b5a4aa67d70bc0d93ea25c8b5e805de4",
-    "version": 6
+    "sha256": "13fedd6f05827fcd21807bf8b3ecd2923d883e0f27e3910702d7bd2254641681",
+    "version": 7
   },
   "6f1500bc-62d7-4eb9-8601-7485e87da2f4": {
     "rule_name": "SSH (Secure Shell) to the Internet",
-    "sha256": "43bc4ad3036356a6379efb90d28dfdded2c5f262a6ec734aa3f5f302eb4bb7fe",
-    "version": 6
+    "sha256": "9ffc5ec9fb514ad3fbe969537edd388d30ee0e374e73d3de589ad453aec2126a",
+    "version": 7
   },
   "6f435062-b7fc-4af9-acea-5b1ead65c5a5": {
     "rule_name": "Google Workspace Role Modified",
-    "sha256": "dcf3a00334259660c41d128e78f2c2640236abe078e179646057d9afed039105",
-    "version": 1
+    "sha256": "c5ef241dbb8750fb177ca2e1c3bf24efd7d0c4fa072d0fa0c22c031f5bf56de8",
+    "version": 2
   },
   "7024e2a0-315d-4334-bb1a-441c593e16ab": {
     "rule_name": "AWS CloudTrail Log Deleted",
-    "sha256": "f542997e53c9f5ae4e21b5ee7efbcf2db6301fb9ceda302267c540131d12766f",
-    "version": 3
+    "sha256": "cfa66db8a38fb8fc719bcfb5673e1e5835df3e77322a0e260b3bb2ccd34a7eec",
+    "version": 4
   },
   "7024e2a0-315d-4334-bb1a-552d604f27bc": {
     "rule_name": "AWS Config Service Tampering",
-    "sha256": "3f6c5f5dd272de11ed7c4b62acd3e45df5c85676a93c9760d259c06be98a4161",
-    "version": 3
+    "sha256": "027d56568c3cc971b88d2cb5166f2852d0534cf84545c99090eccd7759c6415e",
+    "version": 4
   },
   "71c5cb27-eca5-4151-bb47-64bc3f883270": {
     "rule_name": "Suspicious RDP ActiveX Client Loaded",
-    "sha256": "7019144b339ec91a1f2c549e51ffb8454226e7d1d954002bef3940f8f89cadc4",
-    "version": 1
+    "sha256": "356b304bedec2afa2d8ab15398ce6839d25df11453b5c1ca03310ef19dded015",
+    "version": 2
   },
   "729aa18d-06a6-41c7-b175-b65b739b1181": {
     "rule_name": "Attempt to Reset MFA Factors for an Okta User Account",
-    "sha256": "56a5d971043bcc6813ccef21f4786e1ae23536ab14d4603ce5f9931c1bed2083",
-    "version": 3
+    "sha256": "2a0fc5337827134733d1b71dac658f687b492525dacae23341aa040fa35a648f",
+    "version": 4
   },
   "7405ddf1-6c8e-41ce-818f-48bea6bcaed8": {
     "rule_name": "Potential Modification of Accessibility Binaries",
-    "sha256": "4be87ea9885598848d48eb5c18cc2ff5274309799d094acd8e52b22e13ee44f3",
-    "version": 5
+    "sha256": "71e0b5a65c5c1c009f67c4daa7102a967665283a5b3edeae258ffbf27c40fedb",
+    "version": 6
   },
   "746edc4c-c54c-49c6-97a1-651223819448": {
     "rule_name": "Unusual DNS Activity",
@@ -1031,33 +1031,33 @@
   },
   "75ee75d8-c180-481c-ba88-ee50129a6aef": {
     "rule_name": "Web Application Suspicious Activity: Unauthorized Method",
-    "sha256": "ddc7ab73355be41f897b01ef0179d7f2e122f9e5e080842130db2d08cc80a7f7",
-    "version": 4
+    "sha256": "87fdce46aaffc8303b29aa54c725e384cb978109cc9210f64c8b4fc1b477677d",
+    "version": 5
   },
   "76fd43b7-3480-4dd9-8ad7-8bd36bfad92f": {
     "rule_name": "Potential Remote Desktop Tunneling Detected",
-    "sha256": "32b94f1aff46559949f5d74874fbe90d2a2e2bdf3ef83068a4ba5840ddf47e76",
-    "version": 1
+    "sha256": "a8cbc9d75c6e4da24fa473047890575c9c70155a3b1501b0b986598ce655655c",
+    "version": 2
   },
   "774f5e28-7b75-4a58-b94e-41bf060fdd86": {
     "rule_name": "User Added as Owner for Azure Application",
-    "sha256": "5a52d664d3a54596aa8e4cffbe1900e29523f76f56d5ad2047c69f5051bd3a32",
-    "version": 2
+    "sha256": "15345a004d3553b592315f2b99bff617cf1e4fe51254318e687143ac5f203f8a",
+    "version": 3
   },
   "77a3c3df-8ec4-4da4-b758-878f551dee69": {
     "rule_name": "Adversary Behavior - Detected - Endpoint Security",
-    "sha256": "60af511ccd3ed511fec254c879279d5090ca084efa9c11bc4fb01690450b7180",
-    "version": 4
+    "sha256": "feb872802e7782ee07c3ce2339461810c274ee659c348fc97732f92049821215",
+    "version": 5
   },
   "785a404b-75aa-4ffd-8be5-3334a5a544dd": {
     "rule_name": "Application Added to Google Workspace Domain",
-    "sha256": "7da09b4d92040751ddf82e0a7a876775307af621becf1620a5554ec18c1649c0",
-    "version": 1
+    "sha256": "53775aedf8cb2c8a2549c947714c72e087d8f66202e04d7b71e2057676f531ee",
+    "version": 2
   },
   "7882cebf-6cf1-4de3-9662-213aa13e8b80": {
     "rule_name": "Azure Privilege Identity Management Role Modified",
-    "sha256": "fb52de2ab58d972616850de33eb9aa35be646289b0abad14cd7d1c1aa17c6953",
-    "version": 2
+    "sha256": "96119234498e675b911d5936a75ac414acbc6dfaf18bb0af8e748dbcaa570de9",
+    "version": 3
   },
   "78d3d8d9-b476-451d-a9e0-7a5addd70670": {
     "rule_name": "Spike in AWS Error Messages",
@@ -1066,38 +1066,38 @@
   },
   "792dd7a6-7e00-4a0a-8a9a-a7c24720b5ec": {
     "rule_name": "Azure Key Vault Modified",
-    "sha256": "6fa72b201f144df04b3655cbc0d7273dbfe868ade0cc7ebbc1a3086e4e6e9283",
-    "version": 2
+    "sha256": "395293327e180f887cbcc12dcd47cd37ad6960f6d342056c36d6503d26a0e3a6",
+    "version": 3
   },
   "7a137d76-ce3d-48e2-947d-2747796a78c0": {
     "rule_name": "Network Sniffing via Tcpdump",
-    "sha256": "a6d1f9bf40eb2be0f1afb3fe2823ad6b3ad5fd2e9e8d3633ba63c09a5a7553cb",
-    "version": 5
+    "sha256": "5046e9d5e694a8d1cea49021ff63b18bb21ac7ce9b1b398f409d51860f779728",
+    "version": 6
   },
   "7b08314d-47a0-4b71-ae4e-16544176924f": {
     "rule_name": "File and Directory Discovery",
-    "sha256": "d2ba3d143210b919fddb482a33df43a8d880a7246eba8e1a6eb637cd8d7233d9",
-    "version": 1
+    "sha256": "6f5328b72cc7ffc2206ff0b73647384d3bc410de54479be59278f1a3f51bd26e",
+    "version": 2
   },
   "7b8bfc26-81d2-435e-965c-d722ee397ef1": {
     "rule_name": "Windows Network Enumeration",
-    "sha256": "19e17f834104e04b4f86c1397f7e44d39a9c5aa6a6e7b8f7aa9dc64f393fb74c",
-    "version": 1
+    "sha256": "5ad19c982c17664ea924524285b788f821d183b40fc9b2d375b9c096b0943447",
+    "version": 2
   },
   "7bcbb3ac-e533-41ad-a612-d6c3bf666aba": {
     "rule_name": "Deletion of Bash Command Line History",
-    "sha256": "6c0e085bab042b2f97f4e9b7a8b753965e8df95cf9116216bd4c738b5cc7ab47",
-    "version": 4
+    "sha256": "481ad533c5634070546c3587f45e3f1d15e9ceefe76aef5819cdaf74951c0d47",
+    "version": 5
   },
   "7ceb2216-47dd-4e64-9433-cddc99727623": {
     "rule_name": "GCP Service Account Creation",
-    "sha256": "c3984837d03bd8964a042a3de20b2605f22b7ad68298d861e29d7f6d992623b0",
-    "version": 2
+    "sha256": "eed9e26ee27ab35033cdcb30265238b416201b0d8511b20fe428c7d9c083b403",
+    "version": 3
   },
   "7d2c38d7-ede7-4bdf-b140-445906e6c540": {
     "rule_name": "Tor Activity to the Internet",
-    "sha256": "685c420292df5f816146d2311d20930a92a9cd4c1bf83a001978b27fc10f5034",
-    "version": 6
+    "sha256": "4a69174a17e82fee11e0402348d00579b3bb466ae795a9ffbbee8c3b0fdf8384",
+    "version": 7
   },
   "7f370d54-c0eb-4270-ac5a-9a6020585dc6": {
     "rule_name": "Suspicious WMIC XSL Script Execution",
@@ -1111,48 +1111,48 @@
   },
   "80c52164-c82a-402c-9964-852533d58be1": {
     "rule_name": "Process Injection - Detected - Endpoint Security",
-    "sha256": "126b716fe963842ff8406842f8a101953a04e7e9f167e578094712fa6b006b00",
-    "version": 4
+    "sha256": "4f1de68d87322c3c6461f6185af8a92e1a0bf4c9cf15482acb0d5fc54aee9ad2",
+    "version": 5
   },
   "81cc58f5-8062-49a2-ba84-5cc4b4d31c40": {
     "rule_name": "Persistence via Kernel Module Modification",
-    "sha256": "000b7d6f15e6222587aa093137a9274ba9df2f7c8f9042677705c945ce52ea0c",
-    "version": 6
+    "sha256": "009b2d96598f654010970715c06ffaf13c67925d69b17952e0a4b02ff31552af",
+    "version": 7
   },
   "852c1f19-68e8-43a6-9dce-340771fe1be3": {
     "rule_name": "Suspicious PowerShell Engine ImageLoad",
-    "sha256": "6c77a9c90b0d38585e3ece485e95d00c1373e03bb21fdd132b166fdafb9d7390",
-    "version": 1
+    "sha256": "05067614056729ecd7eff01320f2dc8f93a02ea5e6817c2320554cf1e5781df8",
+    "version": 2
   },
   "8623535c-1e17-44e1-aa97-7a0699c3037d": {
     "rule_name": "AWS EC2 Network Access Control List Deletion",
-    "sha256": "6302175f659f66b65a513111fa8716d3c534c476d2a72186d08499b9b37ebd99",
-    "version": 3
+    "sha256": "891a050afc467a0d6c5df28ccfee056010e269e4b1aebeffe90e7f07437ff52a",
+    "version": 4
   },
   "867616ec-41e5-4edc-ada2-ab13ab45de8a": {
     "rule_name": "AWS IAM Group Deletion",
-    "sha256": "405b47638ac6da7ea5fac975810240eb8e1af8a1f5c631161352f451fe52ba0d",
-    "version": 2
+    "sha256": "9bc0125a9fbc1571fc776de116fdcf28d631cf42b498f7e6f1730a3f64d2c1d4",
+    "version": 3
   },
   "871ea072-1b71-4def-b016-6278b505138d": {
     "rule_name": "Enumeration of Administrator Accounts",
-    "sha256": "cb860fd7a221e6f146426f19bf688ec03504f828e012e5e7caf35a29c0eceb3b",
-    "version": 1
+    "sha256": "185f19110127ccbdf643549658b24af18b05f743db3ae0cde77892448ef74bf9",
+    "version": 2
   },
   "87ec6396-9ac4-4706-bcf0-2ebb22002f43": {
     "rule_name": "FTP (File Transfer Protocol) Activity to the Internet",
-    "sha256": "9fbd64aa4392d90265da1b892102ebb46bffd1aa36f7d306e585668347fced41",
-    "version": 6
+    "sha256": "b6aab90c7b2a4c83fd447e210bc554b40ac284a846025e0a3fd8e27dd14d7102",
+    "version": 7
   },
   "891cb88e-441a-4c3e-be2d-120d99fe7b0d": {
     "rule_name": "Suspicious WMI Image Load from MS Office",
-    "sha256": "5201eadecdb48d9d66a4a97a149c5bcfa0b1e92e1381acd95a924b796edfb1d4",
-    "version": 1
+    "sha256": "7066bc711a65e15d4b69f16a1b939ce476cac7ff8c4fcaa63f34e1907b68d1ba",
+    "version": 2
   },
   "897dc6b5-b39f-432a-8d75-d3730d50c782": {
     "rule_name": "Kerberos Traffic from Unusual Process",
-    "sha256": "8b7a072b62648e941e768d07169bbaea3f865b5b9323d9917247f21e1bca84b4",
-    "version": 1
+    "sha256": "a9c88449a4a2d7e3e8189db5592acfee7a0c276dbfb28e5760472c7ba302d259",
+    "version": 2
   },
   "89f9a4b0-9f8f-4ee0-8823-c4751a6d6696": {
     "rule_name": "Command Prompt Network Connection",
@@ -1161,23 +1161,23 @@
   },
   "8a1b0278-0f9a-487d-96bd-d4833298e87a": {
     "rule_name": "Setuid Bit Set via chmod",
-    "sha256": "1faca8319a2cbc4d45cb4c3f6a0f51cb973105038ead2094083b5a7c231ac741",
-    "version": 5
+    "sha256": "40d946883292446bd724e81d2f504f08012b10bbb1b6077fb6a58859ee3d398f",
+    "version": 6
   },
   "8a5c1e5f-ad63-481e-b53a-ef959230f7f1": {
     "rule_name": "Attempt to Deactivate an Okta Network Zone",
-    "sha256": "a2f5c5f1618797d200ef635b548bcf14d2e1574f3eb840f3ba58ffe941c7e9f0",
-    "version": 1
+    "sha256": "53367015febefe85c092f766055640626b50b1d81a0e4b0b9e88f63f188be398",
+    "version": 2
   },
   "8c1bdde8-4204-45c0-9e0c-c85ca3902488": {
     "rule_name": "RDP (Remote Desktop Protocol) from the Internet",
-    "sha256": "89d11db76a14823b4885cfcecf6aec506ed9c44dcc5187db8f14e8f158d98843",
-    "version": 6
+    "sha256": "ee34c803b7e56eeb6a9530b2e9d2d22de73c98befbf9a014c839bfca58de3c3f",
+    "version": 7
   },
   "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45": {
     "rule_name": "Unusual Child Process of dns.exe",
-    "sha256": "e77c3c77423aac5a2421d4bfcdb4e1a8d34bd0d6265cd11952584e67b3224c43",
-    "version": 2
+    "sha256": "7de8daa3edbdcff733f3ab86cd98ddcad27d568810adb13b99217dcf5ea3010f",
+    "version": 3
   },
   "8c81e506-6e82-4884-9b9a-75d3d252f967": {
     "rule_name": "Potential SharpRDP Behavior",
@@ -1186,13 +1186,13 @@
   },
   "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd": {
     "rule_name": "Ransomware - Detected - Endpoint Security",
-    "sha256": "afa86e4d621fd2e511406e86b4ae9c07348c4471320a9ef65b26e0643c34e133",
-    "version": 4
+    "sha256": "cc1ace9a3ad8ce73ec1f8770f4e28eeff0ef3cd0a16c05667446e6b3245ead12",
+    "version": 5
   },
   "8ddab73b-3d15-4e5d-9413-47f05553c1d7": {
     "rule_name": "Azure Automation Runbook Deleted",
-    "sha256": "398adb0364db4bfbb63d39f4d3764ae420c0bc4a22acaa6475211623314eda8e",
-    "version": 2
+    "sha256": "5469ed934f92d74acdb435451b375e88569f8a8ae6b817a7f80e7597efd81272",
+    "version": 3
   },
   "8f919d4b-a5af-47ca-a594-6be59cd924a4": {
     "rule_name": "Incoming DCOM Lateral Movement with ShellBrowserWindow or ShellWindows",
@@ -1201,28 +1201,28 @@
   },
   "8fb75dda-c47a-4e34-8ecd-34facf7aad13": {
     "rule_name": "GCP Service Account Deletion",
-    "sha256": "87663b229ffa8dd57f68884c9b517a4ad39ba98ade4a6f15806e7ed2f1befd12",
-    "version": 2
+    "sha256": "1cbd2dcf1b2d96cbb7212a41619a4d405cbf173fc7c46a327717a287d748733e",
+    "version": 3
   },
   "90169566-2260-4824-b8e4-8615c3b4ed52": {
     "rule_name": "Hping Process Activity",
-    "sha256": "5a2e01d58289f281749c117a835f976958732477825b70a6bcfc4752d0327947",
-    "version": 5
+    "sha256": "2898ab42516d08724766700fd52fb3cb8507f167be84ad21a09feb058835b4f3",
+    "version": 6
   },
   "9055ece6-2689-4224-a0e0-b04881e1f8ad": {
     "rule_name": "AWS RDS Cluster Deletion",
-    "sha256": "b865dc32c295ea3c9dccef5ef053e0ded05c053a48161df2289a70560744c888",
-    "version": 2
+    "sha256": "76bc8e8bf6c74f88736f29e1e9e785b7f1793903abbcf6c712d8ddad505bbb53",
+    "version": 3
   },
   "9180ffdf-f3d0-4db3-bf66-7a14bcff71b8": {
     "rule_name": "GCP Virtual Private Cloud Route Creation",
-    "sha256": "1fffd1f3ae6bb70acfbdc7b372633bde676e163371fb6f2b288596cb0292c42a",
-    "version": 2
+    "sha256": "5a6c8bdeeb597c962675d57f5d6406069f6a3610504f7094c135a80e5ab40e6c",
+    "version": 3
   },
   "91d04cd4-47a9-4334-ab14-084abe274d49": {
     "rule_name": "AWS WAF Access Control List Deletion",
-    "sha256": "aec7c8f0ec11d42cb4faaf633151ad4a5458c54708c066f552c00c6b21883607",
-    "version": 3
+    "sha256": "bc973ae5e108630170d8b951afdd2ccb368369aad786910e1af3319bc5c853ac",
+    "version": 4
   },
   "91f02f01-969f-4167-8d77-07827ac4cee0": {
     "rule_name": "Unusual Web User Agent",
@@ -1241,28 +1241,28 @@
   },
   "931e25a5-0f5e-4ae0-ba0d-9e94eff7e3a4": {
     "rule_name": "Sudoers File Modification",
-    "sha256": "edcba80637996ba019eefaf5903814c68b7a203bea58f07d0003775f87a4587d",
-    "version": 5
+    "sha256": "b7d9b32d4686296b39e9e61ef5a22be54164eee16a131558263798087949fba6",
+    "version": 6
   },
   "9395fd2c-9947-4472-86ef-4aceb2f7e872": {
     "rule_name": "AWS EC2 Flow Log Deletion",
-    "sha256": "6029cac80714e83f3024113dbe9951502643ac487f2a12d673f6e1c334c6d811",
-    "version": 3
+    "sha256": "664d4cfc75d2168cc75de2346474279ff7154d5c62b91c031551599cd05c9d37",
+    "version": 4
   },
   "93b22c0a-06a0-4131-b830-b10d5e166ff4": {
     "rule_name": "Suspicious SolarWinds Child Process",
-    "sha256": "8a388bbca239377760166ba4e4f7a3b5fb8d74d8b8e83423bd02b5eeb96cb9ef",
-    "version": 1
+    "sha256": "77107778375a7e1ba5489740bf3f6d6a3804c0deebed41ea92c45d7f3e8c38d7",
+    "version": 2
   },
   "93c1ce76-494c-4f01-8167-35edfb52f7b1": {
     "rule_name": "Encoded Executable Stored in the Registry",
-    "sha256": "a1b59cd14b175c430705b22a0f1c837dba4e9d326470ecf4a74c2268efcfa803",
-    "version": 1
+    "sha256": "5e12243b0ec527ff06ea2777feab9bba680f46bee79544f4ab9a00f345ee2416",
+    "version": 2
   },
   "93e63c3e-4154-4fc6-9f86-b411e0987bbf": {
     "rule_name": "Google Workspace Admin Role Deletion",
-    "sha256": "3bb70d74398ec3ca1b32067f347a4219cdfd427fe89621b7b8aa9ef2fe7043a4",
-    "version": 1
+    "sha256": "7c4aa48afbcff9d26841e06c45fc16e265cb936ec5bc43430547f28b4acdd13e",
+    "version": 2
   },
   "954ee7c8-5437-49ae-b2d6-2960883898e9": {
     "rule_name": "Remote Scheduled Task Creation",
@@ -1271,58 +1271,58 @@
   },
   "96b9f4ea-0e8c-435b-8d53-2096e75fcac5": {
     "rule_name": "Attempt to Create Okta API Token",
-    "sha256": "143160a8035bbd3e6df111157b3815c49de06189d89a22da01482c315d92f699",
-    "version": 3
+    "sha256": "28af4eeb1308afe6f25c74e224066f5513dce33e97bf4a09a5855bb374f6b676",
+    "version": 4
   },
   "96e90768-c3b7-4df6-b5d9-6237f8bc36a8": {
     "rule_name": "Compression of Keychain Credentials Directories",
-    "sha256": "1f4a1949a64039ea8d55e0d19a4f750fc3e52f96f389b4839426cc438271732d",
-    "version": 2
+    "sha256": "f6e3756ec4603100b249d30c832c61cafd051a7f88a01cdb3a868d0dc0359be8",
+    "version": 3
   },
   "97314185-2568-4561-ae81-f3e480e5e695": {
     "rule_name": "Microsoft 365 Exchange Anti-Phish Rule Modification",
-    "sha256": "b94acd2020fb45df725709165c4ca72568e6ba7bd13c50a8b42a246c6421139b",
-    "version": 1
+    "sha256": "3543269df878167d62af261483dfaab9182b57f22357842aae285209210eac43",
+    "version": 2
   },
   "97359fd8-757d-4b1d-9af1-ef29e4a8680e": {
     "rule_name": "GCP Storage Bucket Configuration Modification",
-    "sha256": "9060e6cc7731b8e0a8f18590c0b21345fc2732fbe238339a2b4dfad994438982",
-    "version": 2
+    "sha256": "4084b7e08cfeb780ed4c7cb54982cd624dc5e53508ed5bc106fb09a6ed3ac71a",
+    "version": 3
   },
   "97aba1ef-6034-4bd3-8c1a-1e0996b27afa": {
     "rule_name": "Suspicious Zoom Child Process",
-    "sha256": "b8561f3a0d827325832ed2346b479513df07895503221bac51983673383954de",
-    "version": 2
+    "sha256": "a728e2fa804205b19155f106b3c04a3742568741c1c495ddcfd49946639e7020",
+    "version": 3
   },
   "97f22dab-84e8-409d-955e-dacd1d31670b": {
     "rule_name": "Base64 Encoding/Decoding Activity",
-    "sha256": "14c8d3e3d6e63fce634dc9680d63cdc0a358e115c8e11d3335a88ddf7debb768",
-    "version": 5
+    "sha256": "607a50450204331d7ee50891c8d790ac24379743352267581e82a534f774373c",
+    "version": 6
   },
   "97fc44d3-8dae-4019-ae83-298c3015600f": {
     "rule_name": "Startup or Run Key Registry Modification",
-    "sha256": "8664d569f36790398ed216cc68da6b55af545e88bc152ce42e687882673f4bba",
-    "version": 1
+    "sha256": "8625de5d51b237ac097b4b8485235b1064b1c902df7d77c63ab8f138562b89eb",
+    "version": 2
   },
   "9890ee61-d061-403d-9bf6-64934c51f638": {
     "rule_name": "GCP IAM Service Account Key Deletion",
-    "sha256": "4b0cc6796a7a9e459d487f57f338c6d12dbd80aed917a4323cb5de8d180435a4",
-    "version": 2
+    "sha256": "65c712fdbadb4ec666674061d68226b9e3c102b03f2106cdebd0621ea19db63a",
+    "version": 3
   },
   "98995807-5b09-4e37-8a54-5cae5dc932d7": {
     "rule_name": "Microsoft 365 Exchange Management Group Role Assignment",
-    "sha256": "166a57ae856cc4f3548926bed7f35c5aab8d0a52d0aa3e8da38e05133d8ebb00",
-    "version": 1
+    "sha256": "115be7db3d64c5aaf7e87d245495ffd3fd38f1c3fe67533d108f2a7ac20286af",
+    "version": 2
   },
   "98fd7407-0bd5-5817-cda0-3fcc33113a56": {
     "rule_name": "AWS EC2 Snapshot Activity",
-    "sha256": "46d7ef0fca1d0206d9e1f7dcbe6902da46b4fef1296afa88ccff23682179ced2",
-    "version": 2
+    "sha256": "4ac0360beafc4c079799365d1d9d1accbd7074d369cc6740f5a5f960dd33bf01",
+    "version": 3
   },
   "990838aa-a953-4f3e-b3cb-6ddf7584de9e": {
     "rule_name": "Process Injection - Prevented - Endpoint Security",
-    "sha256": "92c674029d3c058f18ec3fafbf91a3c2443023a6a18db9c3118cbf6d4138388d",
-    "version": 4
+    "sha256": "022423bc49a60ec9e5e498ebbcb53aefd560e79e0b2f3a0d1ab3b523a69c413b",
+    "version": 5
   },
   "9a1a2dae-0b5f-4c3d-8305-a268d404c306": {
     "rule_name": "Endpoint Security",
@@ -1331,63 +1331,63 @@
   },
   "9a5b4e31-6cde-4295-9ff7-6be1b8567e1b": {
     "rule_name": "Suspicious Explorer Child Process",
-    "sha256": "df3197c7dbc849cfe2afe2cfbf8ed64ea00bc8cfce0bd713d6883dde8d2e5aaf",
-    "version": 1
+    "sha256": "682638b8ee8bbd25b306a15c47695f1420a82004fc51fd415f39c164c86812e5",
+    "version": 2
   },
   "9aa0e1f6-52ce-42e1-abb3-09657cee2698": {
     "rule_name": "Scheduled Tasks AT Command Enabled",
-    "sha256": "e6dd1917565689d121a222c996af2146eaa8dc7a096d5fafff9c2ce282828aed",
-    "version": 1
+    "sha256": "41829a9b79a22a1214bd1360bd10e601b851c6b18cbe9c1f09a4bdd7426fd35f",
+    "version": 2
   },
   "9b6813a1-daf1-457e-b0e6-0bb4e55b8a4c": {
     "rule_name": "Persistence via WMI Event Subscription",
-    "sha256": "97c4d5a146496b112ad9c7ba05d41d1bb72a153253d317abc78aaf058ec028e4",
-    "version": 1
+    "sha256": "a613b4ee192edb46c8557966cbe7f75ded7aa0eb4c3482fbc1d7ae500178b7d4",
+    "version": 2
   },
   "9c260313-c811-4ec8-ab89-8f6530e0246c": {
     "rule_name": "Hosts File Modified",
-    "sha256": "fbf1ed63ee10192094e425e3eb9d941fb5a6d0c6411400519ecec2175ebf61fd",
-    "version": 2
+    "sha256": "6a473138e933cb1899ac57f4062c02c8304a8c2a8d59dc926f3af31cc658300d",
+    "version": 3
   },
   "9ccf3ce0-0057-440a-91f5-870c6ad39093": {
     "rule_name": "Command Shell Activity Started via RunDLL32",
-    "sha256": "3352c204da15f5e6acfe7965c7f1d6b2e3b5248c7043bb2e7a209eda9615ab24",
-    "version": 1
+    "sha256": "ffaae603c0fa1d7436f8ea510f84ddfc50be4fd25ebbc6eeec733d39775bd65c",
+    "version": 2
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1": {
     "rule_name": "Trusted Developer Application Usage",
-    "sha256": "7a3412ac1f547c605d2973337db4396c84335c8597f26a29f0cd029519b54674",
-    "version": 5
+    "sha256": "78f7858dd10d07dfdee91e3d1a872c82a75e4a714673695e81cd2ce56cd5af76",
+    "version": 6
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2": {
     "rule_name": "Microsoft Build Engine Started by a Script Process",
-    "sha256": "076badcddc214367edbcab33b72564a70ccbc7a00327c9d43d0881abf021fa08",
-    "version": 5
+    "sha256": "443fe4115ac4876ac13361d9c51b3f8cd3d23c324e51d08ed9bc2d7ee85292c6",
+    "version": 6
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae3": {
     "rule_name": "Microsoft Build Engine Started by a System Process",
-    "sha256": "3b3f4739eb659e42f97a0c061f5ba89f37060f6b2b838b9363d813991d09b436",
-    "version": 5
+    "sha256": "d43be8b7a7e092ef11888e5b943c696e3fcba164567971e073e40bb01d80ff45",
+    "version": 6
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae4": {
     "rule_name": "Microsoft Build Engine Using an Alternate Name",
-    "sha256": "30df0fb4795c635659f6b787118792e8efa3f6c83fcd106240c44cc45cfa10cb",
-    "version": 5
+    "sha256": "544dde4552bf1768311ae7e0c33e73d7374c2573ee1be3a7b5080d943576b45d",
+    "version": 6
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5": {
     "rule_name": "Microsoft Build Engine Loading Windows Credential Libraries",
-    "sha256": "699faee1951f92fcc3d979de3cd88666af66530f6b69fd983a0c3de15355cdfb",
-    "version": 5
+    "sha256": "04d52622c9febc4986cf3530223968ef7ab841d3f82858585669b82675ca9fcf",
+    "version": 6
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae6": {
     "rule_name": "Microsoft Build Engine Started an Unusual Process",
-    "sha256": "29c43efb4d57ceeb47af9c9189d65dbb7da9a4e3af004e47ece0058b299c69dc",
-    "version": 5
+    "sha256": "1e5b8f6922097da81e22a0e6767a0bef2145647d53ab2de2421829f6bb60c688",
+    "version": 6
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae9": {
     "rule_name": "Process Injection by the Microsoft Build Engine",
-    "sha256": "a6dc309477c0ec0cf00a523e874e327fd4a21d5562cb15eba27a8d5f9c6eb0b3",
-    "version": 3
+    "sha256": "8145ecbefa775960be1ee4d237e886325b6bebae824f07e0540f2d67c9d6b0c5",
+    "version": 4
   },
   "9d19ece6-c20e-481a-90c5-ccca596537de": {
     "rule_name": "LaunchDaemon Creation or Modification and Immediate Loading",
@@ -1401,18 +1401,18 @@
   },
   "9f9a2a82-93a8-4b1a-8778-1780895626d4": {
     "rule_name": "File Permission Modification in Writable Directory",
-    "sha256": "bfc1a7d919075aade4e3501d0f773b7f2a87c57685ff8c0f274752a4889db677",
-    "version": 4
+    "sha256": "9797234b80c4f7d12daac255fd4dd049080c9730c82d73e37b7e2a4714e45399",
+    "version": 5
   },
   "a00681e3-9ed6-447c-ab2c-be648821c622": {
     "rule_name": "AWS Access Secret in Secrets Manager",
-    "sha256": "005bfadacd622ab3ec08b2c046255d82d5831a7ee4f00bbaccf4ddbfc3ac8686",
-    "version": 2
+    "sha256": "37be1522c5265733d1c521a2ee4c8a39b4ea867ef3d465e447547c269bc82a90",
+    "version": 3
   },
   "a10d3d9d-0f65-48f1-8b25-af175e2594f5": {
     "rule_name": "GCP Pub/Sub Topic Creation",
-    "sha256": "1ee3cc3dc635379279ab4ec164112e0138896d5e16f973d4ca0f53bc40834266",
-    "version": 2
+    "sha256": "6bfc349ca906a512e6a616a624af17727c6877327b17a555aae56fb1dcb77527",
+    "version": 3
   },
   "a13167f1-eec2-4015-9631-1fee60406dcf": {
     "rule_name": "InstallUtil Process Making Network Connections",
@@ -1421,18 +1421,18 @@
   },
   "a1329140-8de3-4445-9f87-908fb6d824f4": {
     "rule_name": "File Deletion via Shred",
-    "sha256": "6e5685ce4d4f76055e01992c5f3b2f834708653eaeee82f67965738ee592f0c2",
-    "version": 5
+    "sha256": "e134a599a0c31f531e1ef027d05105e91cf57dcea9bab63338081ab3379d553d",
+    "version": 6
   },
   "a17bcc91-297b-459b-b5ce-bc7460d8f82a": {
     "rule_name": "GCP Virtual Private Cloud Route Deletion",
-    "sha256": "53aeb11b780ae24e40d4884ebcc34ac56c98fd2c72951a38b72ea4491b157a10",
-    "version": 2
+    "sha256": "a2cf43f683742b3f0b3aaf43aadafc7dba6354013f2f48cbc7d446afad7229ca",
+    "version": 3
   },
   "a3ea12f3-0d4e-4667-8b44-4230c63f3c75": {
     "rule_name": "Execution via local SxS Shared Module",
-    "sha256": "b40e8b2a1fbe1356f46d89e8e2ffad2775ae12dabf61c6c56d4aeb5c1eefd655",
-    "version": 1
+    "sha256": "99645bfec35b37000af36efc7d7fb9d738ac7087f27b56d65478e7fb90ff6b4a",
+    "version": 2
   },
   "a4ec1382-4557-452b-89ba-e413b22ed4b8": {
     "rule_name": "Network Connection via Mshta",
@@ -1441,68 +1441,68 @@
   },
   "a60326d7-dca7-4fb7-93eb-1ca03a1febbd": {
     "rule_name": "AWS IAM Assume Role Policy Update",
-    "sha256": "74c51426db3c534d8d7db0d289ab13c3af4c88760dc8e8ff366a455e39657c4e",
-    "version": 2
+    "sha256": "655573dcfacc3a63d76ad5bfc8d631ccfe68850bd2fb66d0d20d185968fe9285",
+    "version": 3
   },
   "a605c51a-73ad-406d-bf3a-f24cc41d5c97": {
     "rule_name": "Azure Active Directory PowerShell Sign-in",
-    "sha256": "1b1038129eba695022215c9b87b49ef2b85573384b320b04232a18f60c3ea962",
-    "version": 1
+    "sha256": "1504dd19c4d00f6fec043813c49e5383a9d0a445ea693c06a7c01a3074efd36d",
+    "version": 2
   },
   "a624863f-a70d-417f-a7d2-7a404638d47f": {
     "rule_name": "Suspicious MS Office Child Process",
-    "sha256": "2a44865a315ce2796c4c626cb62df55873961063c023d4c0ee9ee416bc8cabbe",
-    "version": 6
+    "sha256": "2abff3a9f2e9bbf5479f1947bcb032d554167fc8da620100ac3a191f96dfbdd3",
+    "version": 7
   },
   "a7ccae7b-9d2c-44b2-a061-98e5946971fa": {
     "rule_name": "Suspicious PrintSpooler SPL File Created",
-    "sha256": "ce67fcf560f3bc44bc8afac138a1d05d7529ee9f898e1da8188ac53c7762eb5c",
-    "version": 1
+    "sha256": "980fb95e206349f1bcdae9b5721538026f766a9bdddb9a105251e9deca6e914f",
+    "version": 2
   },
   "a7e7bfa3-088e-4f13-b29e-3986e0e756b8": {
     "rule_name": "Credential Acquisition via Registry Hive Dumping",
-    "sha256": "3f0fa31ea94c0ebef7875c570d743ca7b49c1357c13a218f4804158a4252f22f",
-    "version": 1
+    "sha256": "04dba98361fb9bdbbf82ed28d24fb693e994954a297d9d048988f30663e5ea07",
+    "version": 2
   },
   "a87a4e42-1d82-44bd-b0bf-d9b7f91fb89e": {
     "rule_name": "Web Application Suspicious Activity: POST Request Declined",
-    "sha256": "d57715db20b15cedb42eaccb50d1eb05db2c5d2bbd52cea6aefd5d196d110e78",
-    "version": 4
+    "sha256": "b96e0e4e371be1ac1c315923d0d704df046678db261463030d33a0a925abb91d",
+    "version": 5
   },
   "a9198571-b135-4a76-b055-e3e5a476fd83": {
     "rule_name": "Hex Encoding/Decoding Activity",
-    "sha256": "d5f70e91eea294b0aba75d327617bbacb898f6163649faa28c5e92204a3756ce",
-    "version": 5
+    "sha256": "381b079f59d5ee4f7685a4b792f84ab7840cf0f97a418bc404cc26e5acd7e9a0",
+    "version": 6
   },
   "a989fa1b-9a11-4dd8-a3e9-f0de9c6eb5f2": {
     "rule_name": "Microsoft 365 Exchange Safe Link Policy Disabled",
-    "sha256": "5678366a0a895f1f838be70b450cc5b13299a4b8de3d882e178b8b0cf134de81",
-    "version": 1
+    "sha256": "d11f9e4122aff669f9a82f3e31c714c7e2a662467f55a71c2f23ecac63a6b8bd",
+    "version": 2
   },
   "a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73": {
     "rule_name": "Google Workspace Password Policy Modified",
-    "sha256": "6ab1ea750113b4528f973d71f7ba55d9f1322704fac965e99a95ea81e7c90572",
-    "version": 1
+    "sha256": "12f14c4749a7fceef70c089a2a38b19d7c33075ecb1f3e17608891313e4b80f9",
+    "version": 2
   },
   "a9b05c3b-b304-4bf9-970d-acdfaef2944c": {
     "rule_name": "Persistence via Hidden Run Key Detected",
-    "sha256": "61dd2fef1d6882b8bb49ee87f7966cee63609396ac718d490e4bebb9c0b51cba",
-    "version": 1
+    "sha256": "ad61204594077b7918ff7828d8f1a913b3fa87e52848462b6f15207af1bc50fb",
+    "version": 2
   },
   "a9cb3641-ff4b-4cdc-a063-b4b8d02a67c7": {
     "rule_name": "IPSEC NAT Traversal Port Activity",
-    "sha256": "463300c77ba30a5d1f6bab1cbd87ed99eb8604828b8fd5490c232f00d72e8a61",
-    "version": 5
+    "sha256": "aad1b5006e2ac2aac28fe8a07e3cad70cbb98e3823b81ba15a9f2c91d8817b5a",
+    "version": 6
   },
   "aa8007f0-d1df-49ef-8520-407857594827": {
     "rule_name": "GCP IAM Custom Role Creation",
-    "sha256": "2d8a912547e4c791bebd848bcee61454527b9d293caff47e494c72e0c071471a",
-    "version": 2
+    "sha256": "36f09d32f22926b656535eeab37abce2a55146b2efe665237596eeccfc907722",
+    "version": 3
   },
   "aa895aea-b69c-4411-b110-8d7599634b30": {
     "rule_name": "System Log File Deletion",
-    "sha256": "9b1ce89987303ce4f46efbe0b8c9ae58729c066ed20fa15a6c80cc690da89f09",
-    "version": 1
+    "sha256": "57dccd2cb0d159a8da2832c464b0e427c3f8ddda96824d66bb5ece7d71cf600c",
+    "version": 2
   },
   "aa9a274d-6b53-424d-ac5e-cb8ca4251650": {
     "rule_name": "Remotely Started Services via RPC",
@@ -1521,8 +1521,8 @@
   },
   "ac5012b8-8da8-440b-aaaf-aedafdea2dff": {
     "rule_name": "Suspicious WerFault Child Process",
-    "sha256": "b5058fc79430c9177df520158472c624379fa06004e37d670f63fa3659795281",
-    "version": 1
+    "sha256": "9006cec4ad27c31db36f6ed910183f2b0fd985304c19bc6e351cb734a18ab080",
+    "version": 2
   },
   "ac706eae-d5ec-4b14-b4fd-e8ba8086f0e1": {
     "rule_name": "Unusual AWS Command for a User",
@@ -1531,8 +1531,8 @@
   },
   "acbc8bb9-2486-49a8-8779-45fb5f9a93ee": {
     "rule_name": "Google Workspace API Access Granted via Domain-Wide Delegation of Authority",
-    "sha256": "f870007577845c26dc14d371fd5b361c9a62fd3e81b259545f722b215d8acea6",
-    "version": 1
+    "sha256": "e8a4bf103723eb12e3cd69a8149ff0ac55ea66ada671751e0842d58a1cd994f5",
+    "version": 2
   },
   "acd611f3-2b93-47b3-a0a3-7723bcc46f6d": {
     "rule_name": "Potential Command and Control via Internet Explorer",
@@ -1546,23 +1546,23 @@
   },
   "acf738b5-b5b2-4acc-bad9-1e18ee234f40": {
     "rule_name": "Suspicious Managed Code Hosting Process",
-    "sha256": "7d10ab696ba07deb10e38ef1fe5092ea27e5333c5929d80a86e5e04f1ccdc253",
-    "version": 1
+    "sha256": "e0437a436bd0809b9767d0771bd7f9ab554e5a269729c9888f4f0c42289c35a7",
+    "version": 2
   },
   "ad0e5e75-dd89-4875-8d0a-dfdc1828b5f3": {
     "rule_name": "Proxy Port Activity to the Internet",
-    "sha256": "6fb209a384be437b6dc787d0c427701f3cc1920aefe7258e79dbce4586d360f6",
-    "version": 6
+    "sha256": "6daf86b7ae1e77991a8746825cddde9048b4831cd7751c3fc9657b15deadd50e",
+    "version": 7
   },
   "ad3f2807-2b3e-47d7-b282-f84acbbe14be": {
     "rule_name": "Google Workspace Custom Admin Role Created",
-    "sha256": "e81156f6e1d2589b50aed1132c6fe51ad1240aa79f97748a0e229f26014083d9",
-    "version": 1
+    "sha256": "e8ce9ad3c57e19411395968326acf2a4c2089d7cfe7f6c6d39d5550ff26c278e",
+    "version": 2
   },
   "ad88231f-e2ab-491c-8fc6-64746da26cfe": {
     "rule_name": "Kerberos Cached Credentials Dumping",
-    "sha256": "150fe84b822037d5654a5468dc2e3057fb1df90a7822cb632b53737cdd709bac",
-    "version": 1
+    "sha256": "a32bc9518e2c0931cd2b9deff09caebba196cdf960d7534786c1002bd4e544f6",
+    "version": 2
   },
   "adb961e0-cb74-42a0-af9e-29fc41f88f5f": {
     "rule_name": "Netcat Network Activity",
@@ -1571,18 +1571,18 @@
   },
   "afcce5ad-65de-4ed2-8516-5e093d3ac99a": {
     "rule_name": "Local Scheduled Task Commands",
-    "sha256": "287b40cfe49eb44710e1ea328cd189b3aa07e74c0ec3112d14be0363a4885d34",
-    "version": 5
+    "sha256": "1f7db99c01f9a701380826045b7cb199fdb99450481d9b72bc60e152f5353b3f",
+    "version": 6
   },
   "b0046934-486e-462f-9487-0d4cf9e429c6": {
     "rule_name": "Timestomping using Touch Command",
-    "sha256": "f682c1280f269c6f20b67af7287419b0b993c116848367b74a44d8a961b83fd2",
-    "version": 1
+    "sha256": "85a166495a48e6eebe0ffc43e959711cb77b4fbd10fa986459e46b7f4db17c6c",
+    "version": 2
   },
   "b25a7df2-120a-4db2-bd3f-3e4b86b24bee": {
     "rule_name": "Remote File Copy via TeamViewer",
-    "sha256": "f7ae1ed53d8f7949ac4eb5ddf819effa6b55f9cb859a0c66d13816ade0e2c6c2",
-    "version": 1
+    "sha256": "00693df432fecce30109abc71f88dbe2b04ae1aa0f8a26475a91e6ab90b0b07b",
+    "version": 2
   },
   "b29ee2be-bf99-446c-ab1a-2dc0183394b8": {
     "rule_name": "Network Connection via Compiled HTML File",
@@ -1596,18 +1596,18 @@
   },
   "b41a13c6-ba45-4bab-a534-df53d0cfed6a": {
     "rule_name": "Suspicious Endpoint Security Parent Process",
-    "sha256": "1a599980beade6259299e17a6a299186116e9015d6334710a597f570b74e2d7f",
-    "version": 2
+    "sha256": "231d85fb51acbcddcdc5d41cde82d53e3069d08bce27592570c01aced7e6825f",
+    "version": 3
   },
   "b4bb1440-0fcb-4ed1-87e5-b06d58efc5e9": {
     "rule_name": "Attempt to Delete an Okta Policy",
-    "sha256": "ef0b2fe5b56a6ae22af6845f5513286d41709f78a68f06610a24aa9c884f3032",
-    "version": 3
+    "sha256": "bf819443073dbebcc3368bdfe074885ab4bd25693acd6cf03377c1fa41732a46",
+    "version": 4
   },
   "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921": {
     "rule_name": "Volume Shadow Copy Deletion via VssAdmin",
-    "sha256": "1ec687e814f560c6ebb3a8e6c8d6871126d6e3646b045428447733f14063f933",
-    "version": 6
+    "sha256": "279ef5024f334a402d809055b5c1685f1082f71c0a318531516dbd540ff3ca26",
+    "version": 7
   },
   "b64b183e-1a76-422d-9179-7b389513e74d": {
     "rule_name": "Windows Script Interpreter Executing Process via WMI",
@@ -1616,23 +1616,23 @@
   },
   "b6dce542-2b75-4ffb-b7d6-38787298ba9d": {
     "rule_name": "Azure Event Hub Authorization Rule Created or Updated",
-    "sha256": "404d89d51dc0e6afc9470e7861bea3a4556be38c85a92a637c6ee893f64c1e3a",
-    "version": 2
+    "sha256": "ff09c99de5283ae7e2cb78e43329cd9db62c6b79be25ee481de93cc1aa09110a",
+    "version": 3
   },
   "b719a170-3bdb-4141-b0e3-13e3cf627bfe": {
     "rule_name": "Attempt to Deactivate an Okta Policy",
-    "sha256": "08414dfb73180ab7116050258b01c01225bf3fcf6c0c722a4ea71b1485482992",
-    "version": 3
+    "sha256": "9f73c4e1d01477efa8e3e1984613b6eb3362f6fc89a93888927b7426fa01a9bf",
+    "version": 4
   },
   "b8075894-0b62-46e5-977c-31275da34419": {
     "rule_name": "Administrator Privileges Assigned to an Okta Group",
-    "sha256": "05c1f28999ada75cf2b12b483799455583321e12c3a500815eb8c56425725767",
-    "version": 3
+    "sha256": "3775382bd5260f71cb15c758f1eed47f78b5bb400bc1baa611b3d28704d79f24",
+    "version": 4
   },
   "b83a7e96-2eb3-4edf-8346-427b6858d3bd": {
     "rule_name": "Creation or Modification of Domain Backup DPAPI private key",
-    "sha256": "b21f9d6260efe5f5b4a126bfdc4c43c6bafd5d3d86a016a3bb3859fcd5908696",
-    "version": 2
+    "sha256": "3079830160ee1e9fa1439d0b3b2547e2594583051655b060e539bbe49c46953b",
+    "version": 3
   },
   "b86afe07-0d98-4738-b15d-8d7465f95ff5": {
     "rule_name": "Network Connection via MsXsl",
@@ -1641,18 +1641,18 @@
   },
   "b90cdde7-7e0d-4359-8bf0-2c112ce2008a": {
     "rule_name": "UAC Bypass Attempt with IEditionUpgradeManager Elevated COM Interface",
-    "sha256": "f4832ddf31a51c69210b2da2af5a78889cf7053b99eaabaf41a4bce7aaefa6d3",
-    "version": 1
+    "sha256": "a356c6b552f9b182763acfa38c451360bd70981b848afdc23c5566031f48d5ca",
+    "version": 2
   },
   "b9666521-4742-49ce-9ddc-b8e84c35acae": {
     "rule_name": "Creation of Hidden Files and Directories",
-    "sha256": "064d074d49298a64c36f7bd92450c570074ab633d34fe4b5470a2c956b96d839",
-    "version": 4
+    "sha256": "58109147ac539d0dba93b555813d127e0ae42d5ead5a32df50b9b94ebdb87bbc",
+    "version": 5
   },
   "b9960fef-82c6-4816-befa-44745030e917": {
     "rule_name": "SolarWinds Process Disabling Services via Registry",
-    "sha256": "81643150e39223d477c4123fbb81ffe5266c83f45f8ea8eb503db8674b344e06",
-    "version": 1
+    "sha256": "10851b590f0ff1f675738bd36db07201a6791e08499f094ef66b960ad88dee11",
+    "version": 2
   },
   "ba342eb2-583c-439f-b04d-1fdd7c1417cc": {
     "rule_name": "Unusual Windows Network Activity",
@@ -1661,43 +1661,43 @@
   },
   "baa5d22c-5e1c-4f33-bfc9-efa73bb53022": {
     "rule_name": "Suspicious Image Load (taskschd.dll) from MS Office",
-    "sha256": "319ecab19b574f534575e0f3c3dd52e5ea27d14f469ce2b782895aad2b90c51b",
-    "version": 1
+    "sha256": "d27cff3d6c5751e9cfd3404e7e0ed3b97a989e0df1e15fd4439bcf5fc7c6942d",
+    "version": 2
   },
   "bb4fe8d2-7ae2-475c-8b5d-55b449e4264f": {
     "rule_name": "Azure Resource Group Deletion",
-    "sha256": "b5f1102902e0aa82b044f0318fe48c46913cc697fb211c998ff0241d96ab71e3",
-    "version": 2
+    "sha256": "dc2d60e88c29a05e78f269f6facd482c456a9da301fdfd8c66f89cee0f8a4885",
+    "version": 3
   },
   "bb9b13b2-1700-48a8-a750-b43b0a72ab69": {
     "rule_name": "AWS EC2 Encryption Disabled",
-    "sha256": "5ac41e3ee65442e7438c687a5fbfda7bbc1de58f406d829d096217c041f0dc79",
-    "version": 3
+    "sha256": "00f1e4824b1ff5a97ebaa7c117a5492decb5225904fd9fefe0d16c6b12d3d6d0",
+    "version": 4
   },
   "bbd1a775-8267-41fa-9232-20e5582596ac": {
     "rule_name": "Microsoft 365 Teams Custom Application Interaction Allowed",
-    "sha256": "80b3d313db62358da59fc880599240dba855703161326e1418839c4d629dc5d8",
-    "version": 1
+    "sha256": "94b0fb4de4cac4e10566cb8ae4234e58cc66737f391a72915775586e0cbc57f4",
+    "version": 2
   },
   "bc0c6f0d-dab0-47a3-b135-0925f0a333bc": {
     "rule_name": "AWS Root Login Without MFA",
-    "sha256": "a7b243d3231e094d3ce39bdb56d32efce553195158969d781a8f1f899b8996c0",
-    "version": 2
+    "sha256": "585d427e1865ca47021b6701ca3214a0c4c22ee154aabdff05a378c9c9a66ef7",
+    "version": 3
   },
   "bc0f2d83-32b8-4ae2-b0e6-6a45772e9331": {
     "rule_name": "GCP Storage Bucket Deletion",
-    "sha256": "bdee66cc159be2da8e14be6693cae29df3085298aa4712587bc243cf58f95c6e",
-    "version": 2
+    "sha256": "7a809a16bb94956512c514a8fb8f7927700d307537cabcac128600dd9c8632e8",
+    "version": 3
   },
   "bc48bba7-4a23-4232-b551-eca3ca1e3f20": {
     "rule_name": "Azure Conditional Access Policy Modified",
-    "sha256": "ebe555d81187dfe879c5149586378c5400cd42e43e5f9c7f02b63bb71f8916f5",
-    "version": 2
+    "sha256": "46c90a2ba9b55dc072b15e9d564f941ad603cff49519bde6ee7c79e7ff66b079",
+    "version": 3
   },
   "bca7d28e-4a48-47b1-adb7-5074310e9a61": {
     "rule_name": "GCP Service Account Disabled",
-    "sha256": "3c4e6f366d741a7d224168ba9bfae6d2cc0657a11e64f6c509242be7e151ca23",
-    "version": 2
+    "sha256": "1abc4c8b1f73bd28b79d4b0ab488c95ce1a44f513ade1c5d831519ec2afe813f",
+    "version": 3
   },
   "bd7eefee-f671-494e-98df-f01daf9e5f17": {
     "rule_name": "Suspicious Print Spooler Point and Print DLL",
@@ -1706,18 +1706,18 @@
   },
   "c0429aa8-9974-42da-bfb6-53a0a515a145": {
     "rule_name": "Creation or Modification of a new GPO Scheduled Task or Service",
-    "sha256": "dceb645c6c3c15126cdb4a62a95c94a06c2b9cc9e4e7fe18b3a0ba799a20cd89",
-    "version": 2
+    "sha256": "a15dc8b9b0d2b27835ebdebc808f5e0849c535d2802be1ae44ab900b29a565ae",
+    "version": 3
   },
   "c0be5f31-e180-48ed-aa08-96b36899d48f": {
     "rule_name": "Credential Manipulation - Detected - Endpoint Security",
-    "sha256": "3e27a7e7fda1be83a083f51ec320e2c49e41a3048660137a7d551e30b8c997c3",
-    "version": 4
+    "sha256": "8cc4996c8b4f2215ed4f55e655ee2885255470bc1a1ad5b9ca9ddca5b67d360b",
+    "version": 5
   },
   "c25e9c87-95e1-4368-bfab-9fd34cf867ec": {
     "rule_name": "Microsoft IIS Connection Strings Decryption",
-    "sha256": "a491defc8e242a9adcf085b40368e489e28be78d130ecca8ea5925111862c4d7",
-    "version": 2
+    "sha256": "79a3b7715efb86fab78e72e5536f6c355077da76471e08e17e16956dbb06abdd",
+    "version": 3
   },
   "c28c4d8c-f014-40ef-88b6-79a1d67cd499": {
     "rule_name": "Unusual Linux Network Connection Discovery",
@@ -1736,18 +1736,18 @@
   },
   "c3167e1b-f73c-41be-b60b-87f4df707fe3": {
     "rule_name": "Permission Theft - Detected - Endpoint Security",
-    "sha256": "7b185258dbbaa2a9837362d5bb5f7551cfdf689ccbd0119140c1155c581dd80c",
-    "version": 4
+    "sha256": "01ef32f083b0567b88de07eb3e0d12f44d921b856a867438182a18a915ce6df9",
+    "version": 5
   },
   "c4210e1c-64f2-4f48-b67e-b5a8ffe3aa14": {
     "rule_name": "Mounting Hidden or WebDav Remote Shares",
-    "sha256": "d0e1e515a6f2b2e9163f44301afdb166de3872c7f64318fb9b8df0a7f6736909",
-    "version": 1
+    "sha256": "b84179def6e28b59ba5234ee8fbdfee37306718e1c7a33cda3451d2e037c90ac",
+    "version": 2
   },
   "c58c3081-2e1d-4497-8491-e73a45d1a6d6": {
     "rule_name": "GCP Virtual Private Cloud Network Deletion",
-    "sha256": "cba970c966fc145de9fd1c6954fb498487c855b455191cb1119c0947e359b375",
-    "version": 2
+    "sha256": "4f290d0d23f951fade6f3f059a997afaeb9df4c69dcc5c8c06be74186577863e",
+    "version": 3
   },
   "c5ce48a6-7f57-4ee8-9313-3d0024caee10": {
     "rule_name": "Installation of Custom Shim Databases",
@@ -1756,38 +1756,38 @@
   },
   "c5dc3223-13a2-44a2-946c-e9dc0aa0449c": {
     "rule_name": "Microsoft Build Engine Started by an Office Application",
-    "sha256": "a36e3ce490be6e3ecb40027634e19d4a9a020928db22ef0b1b7d67c53f967769",
-    "version": 5
+    "sha256": "22d5c4182a90dc3f985da71ab2a79feac45b616a49e9b40ac005ce1b58db1450",
+    "version": 6
   },
   "c6453e73-90eb-4fe7-a98c-cde7bbfc504a": {
     "rule_name": "Remote File Download via MpCmdRun",
-    "sha256": "2892da630216ea0fee0b335395737baba55faf9461d2239a19cc48d5d7417686",
-    "version": 2
+    "sha256": "ec891f05657fb312a46e46a6ece87ca1e888b953de1120db6c93e0bbc339b3b1",
+    "version": 3
   },
   "c6474c34-4953-447a-903e-9fcb7b6661aa": {
     "rule_name": "IRC (Internet Relay Chat) Protocol Activity to the Internet",
-    "sha256": "302dec5617303b5fc97a50c64f9d8af5f094d2725f69ec9b10edc556684ba2d9",
-    "version": 6
+    "sha256": "54df5574036f49aa1c3b1ae83294e6d0bd2906b138bf541e4eaa6332449dc988",
+    "version": 7
   },
   "c749e367-a069-4a73-b1f2-43a3798153ad": {
     "rule_name": "Attempt to Delete an Okta Network Zone",
-    "sha256": "dae25bf8b915abd1ebfa02549df9de1cff58093ffde028c10ff25d946fc27a1f",
-    "version": 1
+    "sha256": "d33b7ddc3848881bdc5fd89eb9c3fdf127e694cb448ab4ad1f226d1ac35cd584",
+    "version": 2
   },
   "c74fd275-ab2c-4d49-8890-e2943fa65c09": {
     "rule_name": "Attempt to Modify an Okta Application",
-    "sha256": "5a0b8f4ce3a86a9bcc1a56f719262ae58a2ac9be112d9ea744cfe3e2ffdbd307",
-    "version": 1
+    "sha256": "ef8f0d17bfa1893438e50436c155fb58b423d7c70d49d94b87e5143845f58890",
+    "version": 2
   },
   "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9": {
     "rule_name": "Unusual File Modification by dns.exe",
-    "sha256": "feed274042000e8477e08585cba127c5c3f0abf7492986467af6fb789d353dea",
-    "version": 2
+    "sha256": "89219be0f6a8a3e0939c890ebd17ad0b316bd3328dc94ed6aecd2f91baae5c6c",
+    "version": 3
   },
   "c82b2bd8-d701-420c-ba43-f11a155b681a": {
     "rule_name": "SMB (Windows File Sharing) Activity to the Internet",
-    "sha256": "dcabadc5473a10d79a9b66d8499da99622d1bf05bba1b13cfad0469c0de62ac5",
-    "version": 6
+    "sha256": "f2216d6fb197d8ebe56b438b60c6c17a2c6fee1272f95b362a62f66ae9d08a26",
+    "version": 7
   },
   "c82c7d8f-fb9e-4874-a4bd-fd9e3f9becf1": {
     "rule_name": "Direct Outbound SMB Connection",
@@ -1796,38 +1796,38 @@
   },
   "c87fca17-b3a9-4e83-b545-f30746c53920": {
     "rule_name": "Nmap Process Activity",
-    "sha256": "fb96a84ff04f02abc39a7b57704e5f2c4b027fb9b15d6561bd5d367e40abcfc1",
-    "version": 5
+    "sha256": "f7d2316ba6acd2bce179b629a2f2d807c6621fad1e6f4a05ed2e544060baa6f9",
+    "version": 6
   },
   "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa": {
     "rule_name": "Credential Manipulation - Prevented - Endpoint Security",
-    "sha256": "0734e9a063c5bbf35c5b4b73c95544f1399e648c12d6396698015de1d5d392ef",
-    "version": 4
+    "sha256": "5e44b1db0cda0ab4d0164d299c3ab1d19040ef76742cc689a565a1f1d05f419a",
+    "version": 5
   },
   "ca79768e-40e1-4e45-a097-0e5fbc876ac2": {
     "rule_name": "Microsoft 365 Exchange Malware Filter Rule Modification",
-    "sha256": "becf4796be38e87c8b61737c9a1786d4cf6f7af978d0c5a3d0a05e1b74a70eca",
-    "version": 1
+    "sha256": "51b65fec94a20040f5983aeaabdd81528b3dab3911e7e612795171ea64cde6ce",
+    "version": 2
   },
   "cad4500a-abd7-4ef3-b5d3-95524de7cfe1": {
     "rule_name": "Google Workspace MFA Enforcement Disabled",
-    "sha256": "548489977f9e7b6629606ed2704f733dec091533a4e45ad55c9ca83ccc4c6d28",
-    "version": 1
+    "sha256": "b63844150664f0411f2d2d5c878cce77fcdb882611a2588686e1f892d5a7e9e0",
+    "version": 2
   },
   "cc16f774-59f9-462d-8b98-d27ccd4519ec": {
     "rule_name": "Process Discovery via Tasklist",
-    "sha256": "9e2137223c6aa526dcc784ee7d6e74f1cb75d4aa50547430cbadaa6b617510a8",
-    "version": 4
+    "sha256": "c619b62ecb53d348c75792b948ab0b9b8b53374e1d19332bfb78f123bda8e094",
+    "version": 5
   },
   "cc89312d-6f47-48e4-a87c-4977bd4633c3": {
     "rule_name": "GCP Pub/Sub Subscription Deletion",
-    "sha256": "be0ac88b8ae314e2f2f188f4d5c9d2be45380231a09af38c357b4829d1939e05",
-    "version": 2
+    "sha256": "e69b031746dcf8715663be0e26e468235a4fdca6a7bd0ab85ebb68984e27e028",
+    "version": 3
   },
   "cc92c835-da92-45c9-9f29-b4992ad621a0": {
     "rule_name": "Attempt to Deactivate an Okta Policy Rule",
-    "sha256": "346fbc298bd3a67f9c307e39b8670c959030d2325dd0208e870ed37bcb8f4467",
-    "version": 3
+    "sha256": "c3d53bc1a5a55116dd350a87ae779d6b74d09897063bab5870c0e164b530fe6c",
+    "version": 4
   },
   "ccc55af4-9882-4c67-87b4-449a7ae8079c": {
     "rule_name": "Potential Process Herpaderping Attempt",
@@ -1836,13 +1836,13 @@
   },
   "cd16fb10-0261-46e8-9932-a0336278cdbe": {
     "rule_name": "Modification or Removal of an Okta Application Sign-On Policy",
-    "sha256": "6b5420121ddb4ff805a9953f6a58537d97b4f71b2162ead5b6ae11e3fc4557f0",
-    "version": 3
+    "sha256": "b423d8f1781945d1f743a5ec517fb17d039cbcecfff55dffa2199ed10fc235f7",
+    "version": 4
   },
   "cd4d5754-07e1-41d4-b9a5-ef4ea6a0a126": {
     "rule_name": "Socat Process Activity",
-    "sha256": "e557e70f6716c1dc338e0cd930933f8a52bdf4b04a40400f8f5b3f02e7cda8ff",
-    "version": 5
+    "sha256": "800f417ab3153b956bf14740aef7bba4409913c8a18c19e4151419aacfdecc61",
+    "version": 6
   },
   "cd66a419-9b3f-4f57-8ff8-ac4cd2d5f530": {
     "rule_name": "Anomalous Linux Compiler Activity",
@@ -1851,48 +1851,48 @@
   },
   "cd66a5af-e34b-4bb0-8931-57d0a043f2ef": {
     "rule_name": "Kernel Module Removal",
-    "sha256": "436cd24e09346d4810af409e99f550c88c21aaa6e82071a9b823748f37a5217a",
-    "version": 5
+    "sha256": "4ff38bae1f36562b3da44c1bfba3df1bfa7357a6fc71416407ab1981dc89d1bc",
+    "version": 6
   },
   "cd89602e-9db0-48e3-9391-ae3bf241acd8": {
     "rule_name": "Attempt to Deactivate MFA for an Okta User Account",
-    "sha256": "9c731ed4d8cd911769ebb630ac37079bbbc4d00f625ee1763fdacbaaec766f43",
-    "version": 3
+    "sha256": "bf3c8c2643d927650b978c33445092099c8f1e4ad946d638f8621d8ff2cf2e1e",
+    "version": 4
   },
   "ce64d965-6cb0-466d-b74f-8d2c76f47f05": {
     "rule_name": "New ActiveSyncAllowedDeviceID Added via PowerShell",
-    "sha256": "71aa16970e9b9d4d2a8d474e2293a12eed62a29a397e332582a5c429b32c63be",
-    "version": 1
+    "sha256": "cd6eedc231fe502a3bdaa324c47802176e603af08001c6f5b139a414b8baf992",
+    "version": 2
   },
   "cf53f532-9cc9-445a-9ae7-fced307ec53c": {
     "rule_name": "Cobalt Strike Command and Control Beacon",
-    "sha256": "547beccb9e948068f7f206f95c156d102b38063a4a26ef88d383ffc7af07e6d8",
-    "version": 2
+    "sha256": "22e04005795df325ce598f470c07578306c20b1e2ad4f10552dc734b53abedc9",
+    "version": 3
   },
   "cf549724-c577-4fd6-8f9b-d1b8ec519ec0": {
     "rule_name": "Domain Added to Google Workspace Trusted Domains",
-    "sha256": "94e51603e7092942ab70839b1dcde9c7c84b3e99b9c1af9afad933dcf749b668",
-    "version": 1
+    "sha256": "37bf638366896b35971a2e4ba3b5b763414bb15d9a8d21e55e7cf5785f2ca1da",
+    "version": 2
   },
   "cff92c41-2225-4763-b4ce-6f71e5bda5e6": {
     "rule_name": "Execution from Unusual Directory - Command Line",
-    "sha256": "d2196383de3fd71431cea3a7022b3c5467f569669d0c3d397912aa6033afa7d1",
-    "version": 1
+    "sha256": "abbc696eef76e67c082c799b1714b9f555ce201910e4123ed3f9573f8bbcc179",
+    "version": 2
   },
   "d0e159cf-73e9-40d1-a9ed-077e3158a855": {
     "rule_name": "Registry Persistence via AppInit DLL",
-    "sha256": "a547d65d3d5ecd73ca45fdcc069c8c2e9f70a3fafbe2bfc4e77c081b7a0bddd6",
-    "version": 1
+    "sha256": "a0785cbffecd78f1f38bfdd475f4b2cfc4393c973d799005702ef5196fa95fbc",
+    "version": 2
   },
   "d2053495-8fe7-4168-b3df-dad844046be3": {
     "rule_name": "PPTP (Point to Point Tunneling Protocol) Activity",
-    "sha256": "a5bde03953114a8b422e0ddb20f05d27f827e6eee266010be21ad274054f9392",
-    "version": 5
+    "sha256": "692bca729434e89ffa2c06e474554cdd89568f48c24892047a1a6db742bc5934",
+    "version": 6
   },
   "d331bbe2-6db4-4941-80a5-8270db72eb61": {
     "rule_name": "Clearing Windows Event Logs",
-    "sha256": "80c1831b191ed38004865c1dea80ea16e946845e34aad831d1aba8522df4b205",
-    "version": 6
+    "sha256": "5a3345b1375898e2d96937c57e97800e36e9b49f13a4180668c6f44b3e549e87",
+    "version": 7
   },
   "d461fac0-43e8-49e2-85ea-3a58fe120b4f": {
     "rule_name": "Shell Execution via Apple Scripting",
@@ -1901,13 +1901,13 @@
   },
   "d48e1c13-4aca-4d1f-a7b1-a9161c0ad86f": {
     "rule_name": "Attempt to Delete an Okta Application",
-    "sha256": "3fb886cd01f67f0c9c03be6492743853abd9eefb39e3a295273423149911205f",
-    "version": 1
+    "sha256": "afb64842c0a54eb3e5cfa2c2666a9af23903e8b4ebfa4dc19d0f616212d22b4f",
+    "version": 2
   },
   "d49cc73f-7a16-4def-89ce-9fc7127d7820": {
     "rule_name": "Web Application Suspicious Activity: sqlmap User Agent",
-    "sha256": "ee161dc933e878f4bc4cf1268c27f492ba323af6f082fe0b89d7385c31ef1b4e",
-    "version": 4
+    "sha256": "433ffde338fefd9d64542d5dc81eb073b458a2151131e6fde0768a85fc20843a",
+    "version": 5
   },
   "d4af3a06-1e0a-48ec-b96a-faf2309fae46": {
     "rule_name": "Unusual Linux System Information Discovery Activity",
@@ -1916,13 +1916,13 @@
   },
   "d563aaba-2e72-462b-8658-3e5ea22db3a6": {
     "rule_name": "Privilege Escalation via Windir Environment Variable",
-    "sha256": "6522b3fcd566576a6a1e2c65c59ff9e624cf083f2097a89d95ac1b32bd9a58ba",
-    "version": 1
+    "sha256": "99dfd643c2a36c1b6dc871d05f308a697320a34844ad3213783e8637c15808cb",
+    "version": 2
   },
   "d5d86bf5-cf0c-4c06-b688-53fdc072fdfd": {
     "rule_name": "Attempt to Delete an Okta Policy Rule",
-    "sha256": "a6291f43b9a5a2838276347274b3e05f46d3251899e576310db871da2fe66a92",
-    "version": 1
+    "sha256": "84c5d892ab21a437ebac47aa1a4a817b9e11a65eb520fb910e7d72f6dd2d9164",
+    "version": 2
   },
   "d61cbcf8-1bc1-4cff-85ba-e7b21c5beedc": {
     "rule_name": "Service Command Lateral Movement",
@@ -1931,63 +1931,63 @@
   },
   "d624f0ae-3dd1-4856-9aad-ccfe4d4bfa17": {
     "rule_name": "AWS CloudWatch Log Stream Deletion",
-    "sha256": "49611c41d6fe582c484c7a296b75e49bbea84a714e6dd7230e44d3179d0c1c66",
-    "version": 3
+    "sha256": "abb84201e8bfa65651ffb134c8681989181732438dcca96f5b39d2e742f4a797",
+    "version": 4
   },
   "d62b64a8-a7c9-43e5-aee3-15a725a794e7": {
     "rule_name": "GCP Pub/Sub Subscription Creation",
-    "sha256": "56291b3f724ed3a272022d9b290aea05d451d92df449c65cd5c8b454dbc8881d",
-    "version": 2
+    "sha256": "5815cf026c54469194103b8a1ddebc04eb5b1ce869a3a41a7f5ac3857285803a",
+    "version": 3
   },
   "d6450d4e-81c6-46a3-bd94-079886318ed5": {
     "rule_name": "Strace Process Activity",
-    "sha256": "4143ebb3f6acf4091baf1b4af57cb236a938afaf130755b0a1f17a713366f3a0",
-    "version": 5
+    "sha256": "3691ba5a6ea56663b45fc80286b7c51d2dd04d0444a399c0785dc16076644078",
+    "version": 6
   },
   "d68eb1b5-5f1c-4b6d-9e63-5b6b145cd4aa": {
     "rule_name": "Microsoft 365 Exchange Anti-Phish Policy Deletion",
-    "sha256": "7cf04743243078b0532bdf97817765e8bd16bff043fca55642d24032d8631eb8",
-    "version": 1
+    "sha256": "d11854f903a47b9aa94f16222e6c5cdfd516831fd12ac3f94168476b5838fa51",
+    "version": 2
   },
   "d72e33fc-6e91-42ff-ac8b-e573268c5a87": {
     "rule_name": "Command Execution via SolarWinds Process",
-    "sha256": "68cc45ab08ebd607d346222e1c2cb0011eb632c11f1f7e1fedb59b75f254ba27",
-    "version": 1
+    "sha256": "bdb98ed41e40d6f7dce270696e535b7fa8983d0b32650807489d7d1f06e9c66c",
+    "version": 2
   },
   "d743ff2a-203e-4a46-a3e3-40512cfe8fbb": {
     "rule_name": "Microsoft 365 Exchange Malware Filter Policy Deletion",
-    "sha256": "19db83e95bba69d8c88ac383f18f6638a5910a33289493e23cc3e9a5407a6f6d",
-    "version": 1
+    "sha256": "dcd757b2c70ffc37336013571378b078e20da74eacdd9597ebd8c86919c83b08",
+    "version": 2
   },
   "d76b02ef-fc95-4001-9297-01cb7412232f": {
     "rule_name": "Interactive Terminal Spawned via Python",
-    "sha256": "d389ff3e1f93109a4c4170ebd5c88df59d01b3304914f0be3795f5cba7270cf4",
-    "version": 4
+    "sha256": "56283dfe2653f43fe67949d88fd1c2e175a137c4538e7b6515f1c1c4cf023235",
+    "version": 5
   },
   "d7e62693-aab9-4f66-a21a-3d79ecdd603d": {
     "rule_name": "SMTP on Port 26/TCP",
-    "sha256": "911d3c97128b53ec8501cdf1de4b5d4f493c7c3e3bb8923c81d96546b7f3dbcd",
-    "version": 5
+    "sha256": "489757a06a439a07bd987a173a396ad69b90370a3e0acb82277d4ca3925b64ea",
+    "version": 6
   },
   "d8fc1cca-93ed-43c1-bbb6-c0dd3eff2958": {
     "rule_name": "AWS IAM Deactivation of MFA Device",
-    "sha256": "0268da56689bf5a65ab32d4a84f3706e78215a9837ef53daecba06451f0a80c2",
-    "version": 2
+    "sha256": "1b77a57e76ad6dfc79e7d95f7663ea4b9bfef18d0ed0069bb34182bfd2d22b11",
+    "version": 3
   },
   "dafa3235-76dc-40e2-9f71-1773b96d24cf": {
     "rule_name": "Multi-Factor Authentication Disabled for an Azure User",
-    "sha256": "f7cd99d6039dc3dee20a0f9a20f97b7ec68e3ad17b313db4cf196cd5b53c6927",
-    "version": 2
+    "sha256": "1a5b13bbbc9e151aac30ea7f4473debea355892cc7a289d052ed4d8b47d6776f",
+    "version": 3
   },
   "db8c33a8-03cd-4988-9e2c-d0a4863adb13": {
     "rule_name": "Credential Dumping - Prevented - Endpoint Security",
-    "sha256": "ce8fd451c2c3bc3c5f9b35f212dc0b75348bb07d1c1c4c1559e575150874345f",
-    "version": 4
+    "sha256": "d2cc502d59bfbd70f4141daac53c9d1b5f4bc02cfab59c4332124854a1d87ec2",
+    "version": 5
   },
   "dc9c1f74-dac3-48e3-b47f-eb79db358f57": {
     "rule_name": "Volume Shadow Copy Deletion via WMIC",
-    "sha256": "fd10faa79ed709288495b11ffb6ec2ec77a0f077b8050a4a900502dee42df83b",
-    "version": 6
+    "sha256": "a78e869e4a22fbcad724e729eb1f94c711a457d9f046a3856635c2857e38660c",
+    "version": 7
   },
   "dca28dee-c999-400f-b640-50a081cc0fd1": {
     "rule_name": "Unusual Country For an AWS Command",
@@ -1996,13 +1996,13 @@
   },
   "de9bd7e0-49e9-4e92-a64d-53ade2e66af1": {
     "rule_name": "Unusual Child Process from a System Virtual Process",
-    "sha256": "a2ab00848a53f5472cc4a8e84345f2f5aa31743276cd0d7946a84c8831e0f3fe",
-    "version": 1
+    "sha256": "c47e2e4e00f67549407ed0ae2d4d7db1532ff50d5293f52b8283d7d841e524bc",
+    "version": 2
   },
   "debff20a-46bc-4a4d-bae5-5cdd14222795": {
     "rule_name": "Base16 or Base32 Encoding/Decoding Activity",
-    "sha256": "20c0bc69622f77e97f72e5c6142554a6df43cd16056890d9708b272e0cd3f7b4",
-    "version": 5
+    "sha256": "a682f3e59e293b99eb3d435effa228cafa3938d325275e68a82b85869d0708f0",
+    "version": 6
   },
   "df197323-72a8-46a9-a08e-3f5b04a4a97a": {
     "rule_name": "Unusual Windows User Calling the Metadata Service",
@@ -2011,18 +2011,18 @@
   },
   "df26fd74-1baa-4479-b42e-48da84642330": {
     "rule_name": "Azure Automation Account Created",
-    "sha256": "b24b045db089d2436f3d9147e572d8ac59ffb9566c057d50a056c45efee88df5",
-    "version": 2
+    "sha256": "765cc2c11a3441564214b3fc4b49b1c1684de8da5137c2bfa74572a78ab9b96a",
+    "version": 3
   },
   "df959768-b0c9-4d45-988c-5606a2be8e5a": {
     "rule_name": "Unusual Process Execution - Temp",
-    "sha256": "341cfdb6003ebe2e04d21cabf87e4b10d70a4e08cb13c761d0a908c5a32b5b23",
-    "version": 5
+    "sha256": "3bc74d9fd01dd0927a435386302afe89bcb60c8bb286e4e1885e06651d25b2ba",
+    "version": 6
   },
   "e02bd3ea-72c6-4181-ac2b-0f83d17ad969": {
     "rule_name": "Azure Firewall Policy Deletion",
-    "sha256": "c39aeccef7f1f857bc68daacaa7e9fa216e130f6934409ebba7c61e1bf945a6d",
-    "version": 2
+    "sha256": "32b4d11ac6b6495661cab9e04fc95ef48fd51465591227b0069aae39827a9531",
+    "version": 3
   },
   "e08ccd49-0380-4b2b-8d71-8000377d6e49": {
     "rule_name": "Attempts to Brute Force an Okta User Account",
@@ -2031,13 +2031,13 @@
   },
   "e0f36de1-0342-453d-95a9-a068b257b053": {
     "rule_name": "Azure Event Hub Deletion",
-    "sha256": "db24a8b5bfdf52f87c824497bc9680d1b70a775a9cb08286704746ed74ca17e0",
-    "version": 2
+    "sha256": "b99daf7d5024207be1eec7c151ff2e8cad2b7ef7c47a3d2ecd9ba372f40017ce",
+    "version": 3
   },
   "e14c5fd7-fdd7-49c2-9e5b-ec49d817bc8d": {
     "rule_name": "AWS RDS Cluster Creation",
-    "sha256": "ced102db5634a4ef32a1acd0cf1f2d7625ad5328c33910a5bcde4079f5df0613",
-    "version": 3
+    "sha256": "053174e8aba7ee8eef851e60c2edcb41bc14bdcdf162f9683e44b4eedbef0832",
+    "version": 4
   },
   "e19e64ee-130e-4c07-961f-8a339f0b8362": {
     "rule_name": "Connection to External Network via Telnet",
@@ -2046,58 +2046,58 @@
   },
   "e2a67480-3b79-403d-96e3-fdd2992c50ef": {
     "rule_name": "AWS Management Console Root Login",
-    "sha256": "b29e2c5481bbf0bcbdca584b0f8cbfb2ef66865b4adeb807ab67ccaf1081c59d",
-    "version": 2
+    "sha256": "2d8fc8ff84ceed47bca16ef187f6e9b0feef63524eed45db0cfc4a70cb663b0e",
+    "version": 3
   },
   "e2f9fdf5-8076-45ad-9427-41e0e03dc9c2": {
     "rule_name": "Suspicious Process Execution via Renamed PsExec Executable",
-    "sha256": "9768c49e8d50aca69403371300a9c79b56ef0870b893b92dc7defcb0ac8e0461",
-    "version": 2
+    "sha256": "fcc8d66a6b444e403216ec25372ef32dc19755c1adaf5a10181680cbd51fc884",
+    "version": 3
   },
   "e2fb5b18-e33c-4270-851e-c3d675c9afcd": {
     "rule_name": "GCP IAM Role Deletion",
-    "sha256": "2ced7c5e7390d0b5fb5700edef55edf77ecc8c345cf564c7d472a0640fdaf0a7",
-    "version": 2
+    "sha256": "b7cb14b9f86fbd6700de65392846e21e554b97379cba6d77b21ceaa7e1366808",
+    "version": 3
   },
   "e3343ab9-4245-4715-b344-e11c56b0a47f": {
     "rule_name": "Process Activity via Compiled HTML File",
-    "sha256": "7aa8cbe02aa84e873d2ab0828b5726f686fa87546a9d3bc7df92b3cbbead60bc",
-    "version": 5
+    "sha256": "e6c3a918a6fed641a349f992888acfddf7eb7a7f03757d94d78ed227aa364cc2",
+    "version": 6
   },
   "e3c5d5cb-41d5-4206-805c-f30561eae3ac": {
     "rule_name": "Ransomware - Prevented - Endpoint Security",
-    "sha256": "911ba16663efb30078217f771edbd6e7356f869662483fac274b09c8097580cb",
-    "version": 4
+    "sha256": "3eaf582284975d232f4419f32b8f6e2b383e7c68328a779e7da46c7feebbccb1",
+    "version": 5
   },
   "e3cf38fa-d5b8-46cc-87f9-4a7513e4281d": {
     "rule_name": "Connection to Commonly Abused Free SSL Certificate Providers",
-    "sha256": "693991499cd3764ec572777eb8327a914699463fd3bf7291cb2cd7c37f9179b8",
-    "version": 1
+    "sha256": "d5c1778b8b06ec9a97a83ef1ff37b90c881133028c3e73e7d954470004db83a0",
+    "version": 2
   },
   "e48236ca-b67a-4b4e-840c-fdc7782bc0c3": {
     "rule_name": "Attempt to Modify an Okta Network Zone",
-    "sha256": "74dc0815c5ed0bdc9b10884ee3cebba932e8589cc689be20a2d9c1a726cf3458",
-    "version": 3
+    "sha256": "eb22dec56f8a7daf9f3803523f9cceb7972c1b899c633052403b1e992c5424ad",
+    "version": 4
   },
   "e555105c-ba6d-481f-82bb-9b633e7b4827": {
     "rule_name": "MFA Disabled for Google Workspace Organization",
-    "sha256": "ffdf7665f9094771764e0532606583dc0ab1491762b7bae83fa329c1f0507743",
-    "version": 1
+    "sha256": "9abfadd9fb00097a0bafbd914188789be09de30c2740922791789e3ab53c8a9d",
+    "version": 2
   },
   "e56993d2-759c-4120-984c-9ec9bb940fd5": {
     "rule_name": "RDP (Remote Desktop Protocol) to the Internet",
-    "sha256": "8c55d7e2ea7e99d99e983b3f0361e1f1ee2076e1ac3da8f28367a01e9e75100f",
-    "version": 6
+    "sha256": "27b24fb4f81b6583600cf3c68ecd4228c9b541f58ccc9180350dc493ec977b31",
+    "version": 7
   },
   "e6e3ecff-03dd-48ec-acbd-54a04de10c68": {
     "rule_name": "Possible Okta DoS Attack",
-    "sha256": "1d046cd29ab5f0036180c662210f193b534c30bc56f7fac5312bd35b633090fc",
-    "version": 3
+    "sha256": "106ffd7b336d3d2f62e0c565541ef07ebe8b377a7219e678b3f2a337eb35d938",
+    "version": 4
   },
   "e7075e8d-a966-458e-a183-85cd331af255": {
     "rule_name": "Default Cobalt Strike Team Server Certificate",
-    "sha256": "61ea16ce1556344e1014a0e765b1f1d5460956b8a18a73612e3f3f051d487b45",
-    "version": 1
+    "sha256": "64dfead1ef9066469366e2cadb08f751171478410ad2b034593c46c7cee27bf1",
+    "version": 2
   },
   "e7125cea-9fe1-42a5-9a05-b0792cf86f5a": {
     "rule_name": "Execution of Persistent Suspicious Program",
@@ -2106,13 +2106,13 @@
   },
   "e8571d5f-bea1-46c2-9f56-998de2d3ed95": {
     "rule_name": "Local Service Commands",
-    "sha256": "83b460c64379597208401df82f25602a3b614afb4349c45ec0889f8ac26a30bc",
-    "version": 6
+    "sha256": "cf6d83712cc60526fd908ff8340f3babc2ba382947921e61997418e895755a62",
+    "version": 7
   },
   "e86da94d-e54b-4fb5-b96c-cecff87e8787": {
     "rule_name": "Installation of Security Support Provider",
-    "sha256": "0374c83718242ef5c40c3d532770ee321800e09ad3c355013ce1330544e80052",
-    "version": 1
+    "sha256": "ab3bfc7f12dd37194cf775c83e92a5fb8e10a77d254e80d0cbce3abef3bf9c61",
+    "version": 2
   },
   "e90ee3af-45fc-432e-a850-4a58cf14a457": {
     "rule_name": "High Number of Okta User Password Reset or Unlock Attempts",
@@ -2121,18 +2121,18 @@
   },
   "e94262f2-c1e9-4d3f-a907-aeab16712e1a": {
     "rule_name": "Unusual Executable File Creation by a System Critical Process",
-    "sha256": "855808686438b26aeb52986cff8a6a02a30473977e41eda0c0b96d63e50f1817",
-    "version": 1
+    "sha256": "46d831233fa92a30570a7bac5c80cb5772b63e6167798ae2854f6d896f63e431",
+    "version": 2
   },
   "e9ff9c1c-fe36-4d0d-b3fd-9e0bf4853a62": {
     "rule_name": "Azure Automation Webhook Created",
-    "sha256": "662e38c555e5aa51b141669319ecf8866ed54bc1d567194aa657fb3a085401df",
-    "version": 2
+    "sha256": "f60eb699d29e466ef9e88ffc1c5462d2162e2b40a1e5c15a6c928040eda6c09b",
+    "version": 3
   },
   "ea0784f0-a4d7-4fea-ae86-4baaf27a6f17": {
     "rule_name": "SSH (Secure Shell) from the Internet",
-    "sha256": "135a80c1392d1a51e1a5d8467a53d0fab3542cea97428dc8174667a62ebdf35b",
-    "version": 6
+    "sha256": "5c9f1ae1341311001eb7c14c069f10a81ab5cfad7c8b6d9696819b6e4b996036",
+    "version": 7
   },
   "ea248a02-bc47-4043-8e94-2885b19b2636": {
     "rule_name": "AWS IAM Brute Force of Assume Role Policy",
@@ -2146,53 +2146,53 @@
   },
   "eb9eb8ba-a983-41d9-9c93-a1c05112ca5e": {
     "rule_name": "Potential Disabling of SELinux",
-    "sha256": "9562dcfa8d5503d91eaed71ad584f1d37066a1d0fe7765512e7311e5fcb98852",
-    "version": 5
+    "sha256": "3b343539b4dc70561e233016bbafa2e521920eec985a5b18a349b91031eb98ec",
+    "version": 6
   },
   "ebb200e8-adf0-43f8-a0bb-4ee5b5d852c6": {
     "rule_name": "Mimikatz Memssp Log File Detected",
-    "sha256": "967c2fa6de7e2a7c90d5a306d148d17e9f25f1b6b4b5b4fac0972ba4d42081c3",
-    "version": 1
+    "sha256": "b040ed5e6961427ffd09b24310f0fd7b5303573d6f770388a7f1eb181c799d1b",
+    "version": 2
   },
   "ebf1adea-ccf2-4943-8b96-7ab11ca173a5": {
     "rule_name": "IIS HTTP Logging Disabled",
-    "sha256": "0fc980061ea6bd44f87b40f38aede9eb1bc8c9c801cbedf06d5af4f1f2bcf9b5",
-    "version": 2
+    "sha256": "da21066645a55b63d8fecb808eecf1bd74748457263ef40dab8da1aaec3a51bd",
+    "version": 3
   },
   "ebfe1448-7fac-4d59-acea-181bd89b1f7f": {
     "rule_name": "Process Execution from an Unusual Directory",
-    "sha256": "94a4fe172e3b405c1256674f5031ff2e632c4121e1f5e3070fc1c25eabb73415",
-    "version": 1
+    "sha256": "64c50e1dbe97849d4f6b0b418d1206190121db260caca612646b457c804c8d3f",
+    "version": 2
   },
   "ecf2b32c-e221-4bd4-aa3b-c7d59b3bc01d": {
     "rule_name": "AWS RDS Instance/Cluster Stoppage",
-    "sha256": "f682272222a2a01580ad22f12647a2105b955a02c8fc18095e6ee5694bb565f2",
-    "version": 2
+    "sha256": "31ec9b4252253e348100d49100907f5db68352b72ec0e959b609a9eab4be5c0e",
+    "version": 3
   },
   "ed9ecd27-e3e6-4fd9-8586-7754803f7fc8": {
     "rule_name": "Azure Global Administrator Role Addition to PIM User",
-    "sha256": "708c0e6d2f8fefce078ac01ef50ee7e40b43e988e71ffec034da94669740f4e9",
-    "version": 2
+    "sha256": "181aab572cb5e16c41ef255ad97789d321122d3d0c4a865e257304d19f463298",
+    "version": 3
   },
   "eda499b8-a073-4e35-9733-22ec71f57f3a": {
     "rule_name": "AdFind Command Activity",
-    "sha256": "ad3b52a56ee56220f6c27593d177dce092c2936cb2bb67e85a9c542ba7a413eb",
-    "version": 1
+    "sha256": "773d4d374830376166856b84be6a91ca48b97e1098553fd4153bd5a5514ec128",
+    "version": 2
   },
   "edb91186-1c7e-4db8-b53e-bfa33a1a0a8a": {
     "rule_name": "Attempt to Deactivate an Okta Application",
-    "sha256": "8e8c8f851ab081ec056871b3416e954c2ead0208aad38893ff0e7c5a47a6db44",
-    "version": 1
+    "sha256": "16410686f1addb8ee1d8cc39ff4d33c8f00caf70339e98436662df5ef95e1e2b",
+    "version": 2
   },
   "edf8ee23-5ea7-4123-ba19-56b41e424ae3": {
     "rule_name": "ImageLoad via Windows Update Auto Update Client",
-    "sha256": "39ac9176f1b09f546ed9f8f61d58e3cb217481db47a0f819a1e2c18259f2e96c",
-    "version": 1
+    "sha256": "e6052dff19b5557c53e9db1244263626ff01c9988018efbf59923b07250d09d7",
+    "version": 2
   },
   "ef862985-3f13-4262-a686-5f357bbb9bc2": {
     "rule_name": "Whoami Process Activity",
-    "sha256": "5a7315dc64415bddab86cebfb4025059e77e5b0c8521d2c5acf629f979fd1722",
-    "version": 4
+    "sha256": "0977bd6e10761072797280e93ff365753d0d91c6107098df12bed4963b154122",
+    "version": 5
   },
   "f036953a-4615-4707-a1ca-dc53bf69dcd5": {
     "rule_name": "Unusual Child Processes of RunDLL32",
@@ -2201,13 +2201,13 @@
   },
   "f06414a6-f2a4-466d-8eba-10f85e8abf71": {
     "rule_name": "Administrator Role Assigned to an Okta User",
-    "sha256": "ac07dabd050fb6a9dc896842e9c9e58c57d0ec948786230088e14afc98c4ef12",
-    "version": 1
+    "sha256": "f23c21708a33952012b9296311171fdb9f8986310f55c48dba0c486fa7f92083",
+    "version": 2
   },
   "f0b48bbc-549e-4bcf-8ee0-a7a72586c6a7": {
     "rule_name": "Attempt to Remove File Quarantine Attribute",
-    "sha256": "d661d2dd0138c5533c3e07fc3428395aada051f2fcf19158b4a8c9656850f5fc",
-    "version": 1
+    "sha256": "180024780a0971d835e2a44fd9dbb0dd015fb488fbc89be89003e4685a07b538",
+    "version": 2
   },
   "f0eb70e9-71e9-40cd-813f-bf8e8c812cb1": {
     "rule_name": "Execution with Explicit Credentials via Apple Scripting",
@@ -2216,8 +2216,8 @@
   },
   "f2f46686-6f3c-4724-bd7d-24e31c70f98f": {
     "rule_name": "LSASS Memory Dump Creation",
-    "sha256": "9fd6ebfa4edbaf4494f5a71e6605f55338fb5f01026505d342b31881528e35e8",
-    "version": 1
+    "sha256": "18df26083a6c02fcaa4e7cee8ad92e03b464dc171dcea36b543b122a2c174982",
+    "version": 2
   },
   "f3475224-b179-4f78-8877-c2bd64c26b88": {
     "rule_name": "WMI Incoming Lateral Movement",
@@ -2226,28 +2226,28 @@
   },
   "f44fa4b6-524c-4e87-8d9e-a32599e4fb7c": {
     "rule_name": "Persistence via Microsoft Office AddIns",
-    "sha256": "d8573e67b316f1f215afdddca56fa46418a0deb8e04742e63c981284014d519f",
-    "version": 1
+    "sha256": "8e08c279331382bd518d79884d5d1ea71193b4eaebeee5349a1198c52fe5622b",
+    "version": 2
   },
   "f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc": {
     "rule_name": "Windows Script Executing PowerShell",
-    "sha256": "e979625931008693ecc40aa092667a5041a09e9400c840caba755d3036e63c3b",
-    "version": 6
+    "sha256": "59ce3a59bdb9ed1052472602725a34f56538b83c0a90bb8d2954fb07d417fe7a",
+    "version": 7
   },
   "f675872f-6d85-40a3-b502-c0d2ef101e92": {
     "rule_name": "Delete Volume USN Journal with Fsutil",
-    "sha256": "b3b6ca09507035e91bec4a1b6c21d91c5e519af098a0b8358f33260f138a4479",
-    "version": 6
+    "sha256": "d5f7787b38586f96eba4a09474b220c7eb0378acbe4ac430a7bf766239630d3d",
+    "version": 7
   },
   "f772ec8a-e182-483c-91d2-72058f76a44c": {
     "rule_name": "AWS CloudWatch Alarm Deletion",
-    "sha256": "657d446d966d40ddfb4ad8da6623cfc939916798c5ee5c4ec62ccc783fc343bf",
-    "version": 3
+    "sha256": "061877c4b789741e0bd2d4bfba5fb30e96a628308269dbbc3b39d49ce33d58e5",
+    "version": 4
   },
   "f7c4dc5a-a58d-491d-9f14-9b66507121c0": {
     "rule_name": "Persistent Scripts in the Startup Directory",
-    "sha256": "37ff69e83fd69cff15706ea852a9a695581e6e1446f907b770d02836b901aa5b",
-    "version": 1
+    "sha256": "cd8c249795eacd3b7a4c748a5794d3e2b48d63eb111e1a7013471e068cf49161",
+    "version": 2
   },
   "f9590f47-6bd5-4a49-bd49-a2f886476fb9": {
     "rule_name": "Unusual Linux System Network Configuration Discovery",
@@ -2256,13 +2256,13 @@
   },
   "f994964f-6fce-4d75-8e79-e16ccc412588": {
     "rule_name": "Suspicious Activity Reported by Okta User",
-    "sha256": "d310e6cca8b0a816a00b7c14dc21049a16184477b48e94df9a0058b2048a3629",
-    "version": 3
+    "sha256": "fe4f99d829a1426cf43e16b2efff819241cd72b5dfec5144bb4ac0415fe0afb4",
+    "version": 4
   },
   "fa01341d-6662-426b-9d0c-6d81e33c8a9d": {
     "rule_name": "Remote File Copy to a Hidden Share",
-    "sha256": "25e042c2aed46b25a6c7d5bf2b5cd097b5523193a1c2417579fdb11d424e3075",
-    "version": 1
+    "sha256": "50d2efa2cce15ad7d8084bc0af8847fd0e6bbf6250234a6fd759276cfc04be15",
+    "version": 2
   },
   "fb02b8d3-71ee-4af1-bacd-215d23f17efa": {
     "rule_name": "Network Connection via Registration Utility",
@@ -2271,42 +2271,42 @@
   },
   "fbd44836-0d69-4004-a0b4-03c20370c435": {
     "rule_name": "AWS Configuration Recorder Stopped",
-    "sha256": "79b72425bfc74757ee2b4fbbe618a6b07add0705e38357cfa3d75dd543212c45",
-    "version": 3
+    "sha256": "89856060e32329a084c73bbdce355d720cb79aca895202cea39db79ecc704830",
+    "version": 4
   },
   "fc7c0fa4-8f03-4b3e-8336-c5feab0be022": {
     "rule_name": "UAC Bypass Attempt via Elevated COM Internet Explorer Add-On Installer",
-    "sha256": "bd749ed53e7be12442870e4d64503aa7c763cec5b6d14193a9940ce89a12b1f7",
-    "version": 1
+    "sha256": "6067b40a4db1b3f6319eb436fd4aa338eda23b182565f1ae0c5d49da69ecd1d3",
+    "version": 2
   },
   "fd4a992d-6130-4802-9ff8-829b89ae801f": {
     "rule_name": "Potential Application Shimming via Sdbinst",
-    "sha256": "6c8a55d6df11450f2c943074768d2e6a9ee2d013eabb2e48241b6ed360bc5ce5",
-    "version": 5
+    "sha256": "c321c182cc1a8b7ee15673433fe16f6bd0b87e67010b5128bd7e0486fe493e11",
+    "version": 6
   },
   "fd70c98a-c410-42dc-a2e3-761c71848acf": {
     "rule_name": "Encoding or Decoding Files via CertUtil",
-    "sha256": "2742600aa65e49b28e702e92d0a235b62ca28b3e2aedd57cb91f4cceacab2f9a",
-    "version": 5
+    "sha256": "b4ccf60e28786ecb6902d7a38d49265627c0acc491f7db0ceaf332f4c05586bd",
+    "version": 6
   },
   "fd7a6052-58fa-4397-93c3-4795249ccfa2": {
     "rule_name": "Svchost spawning Cmd",
-    "sha256": "dca024c5e3835fc08837e0e2723ea60adcb7f3c2ff30d73a9d71e1eae670dd2a",
-    "version": 5
+    "sha256": "926a6b9f74f9730557ec6eed7aa0a5a4d4c29e9506a8d7b36104e93da5af6118",
+    "version": 6
   },
   "ff013cb4-274d-434a-96bb-fe15ddd3ae92": {
     "rule_name": "Roshal Archive (RAR) or PowerShell File Downloaded from the Internet",
-    "sha256": "59caa4af066b68c6503c20b45f672828cff2cb84ef46d6c465d021eea1461c87",
-    "version": 1
+    "sha256": "3239bfe296eb7c63506903d43dcf09dabe9b83387d6d6e9840abcfea2a7d6a1a",
+    "version": 2
   },
   "ff4dd44a-0ac6-44c4-8609-3f81bc820f02": {
     "rule_name": "Microsoft 365 Exchange Transport Rule Creation",
-    "sha256": "b817d5b35a47dd2825836f6c49b8b549ca1ca5ee74e48360c92879db8a73279a",
-    "version": 1
+    "sha256": "13c44d617fe906b97d8cc74566aa68faf1d450d2813b3975fc23c3bc9ab1e658",
+    "version": 2
   },
   "ff9b571e-61d6-4f6c-9561-eb4cca3bafe1": {
     "rule_name": "GCP Firewall Rule Deletion",
-    "sha256": "18d7cce6dcc7aadbab7db85b09daf2bae493423e1db174f2e62088e34d54d10a",
-    "version": 2
+    "sha256": "0d1109d0ef4e0bb769ea14addf28c8e4e60fa5f83f8cacfa7d678ec811fa5661",
+    "version": 3
   }
 }

--- a/rules/apm/apm_403_response_to_a_post.toml
+++ b/rules/apm/apm_403_response_to_a_post.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 47
 rule_id = "a87a4e42-1d82-44bd-b0bf-d9b7f91fb89e"
 severity = "medium"
 tags = ["Elastic", "APM"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/apm/apm_405_response_method_not_allowed.toml
+++ b/rules/apm/apm_405_response_method_not_allowed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 47
 rule_id = "75ee75d8-c180-481c-ba88-ee50129a6aef"
 severity = "medium"
 tags = ["Elastic", "APM"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/apm/apm_null_user_agent.toml
+++ b/rules/apm/apm_null_user_agent.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "43303fd4-4839-4e48-b2b2-803ab060758d"
 severity = "medium"
 tags = ["Elastic", "APM"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/apm/apm_sqlmap_user_agent.toml
+++ b/rules/apm/apm_sqlmap_user_agent.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 47
 rule_id = "d49cc73f-7a16-4def-89ce-9fc7127d7820"
 severity = "medium"
 tags = ["Elastic", "APM"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/aws/collection_cloudtrail_logging_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "594e0cbf-86cc-45aa-9ff7-ff27db27d3ed"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/aws/credential_access_iam_user_addition_to_group.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/04"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 21
 rule_id = "333de828-8190-4cf5-8d7c-7575846f6fe0"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
+++ b/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Nick Jones", "Elastic"]
@@ -30,6 +30,7 @@ risk_score = 73
 rule_id = "a00681e3-9ed6-447c-ab2c-be648821c622"
 severity = "high"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Data Protection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "7024e2a0-315d-4334-bb1a-441c593e16ab"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,6 +46,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -32,6 +32,7 @@ risk_score = 47
 rule_id = "1aa8fa52-44a7-4dae-b058-f3333b91c8d7"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -49,6 +50,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/15"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "f772ec8a-e182-483c-91d2-72058f76a44c"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,6 +46,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/aws/defense_evasion_config_service_rule_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/26"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -32,6 +32,7 @@ risk_score = 47
 rule_id = "7024e2a0-315d-4334-bb1a-552d604f27bc"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -49,6 +50,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/16"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 73
 rule_id = "fbd44836-0d69-4004-a0b4-03c20370c435"
 severity = "high"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,6 +46,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/15"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 73
 rule_id = "9395fd2c-9947-4472-86ef-4aceb2f7e872"
 severity = "high"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -48,6 +49,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -33,6 +33,7 @@ risk_score = 47
 rule_id = "8623535c-1e17-44e1-aa97-7a0699c3037d"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -50,6 +51,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/28"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 73
 rule_id = "523116c0-d89d-4d7c-82c2-39e6845a78ef"
 severity = "high"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -48,6 +49,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/27"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 21
 rule_id = "227dc608-e558-43d9-b521-150772250bae"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Asset Visibility"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/aws/defense_evasion_waf_acl_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "91d04cd4-47a9-4334-ab14-084abe274d49"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,6 +46,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/09"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "5beaebc1-cc13-4bfc-9949-776f9e0dc318"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,6 +46,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/24"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 47
 rule_id = "98fd7407-0bd5-5817-cda0-3fcc33113a56"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Asset Visibility"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/aws/impact_cloudtrail_logging_updated.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "3e002465-876f-4f04-b016-84ef48ce7e5d"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -46,12 +47,12 @@ id = "T1565.001"
 name = "Stored Data Manipulation"
 reference = "https://attack.mitre.org/techniques/T1565/001/"
 
+
+
 [rule.threat.tactic]
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]

--- a/rules/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 47
 rule_id = "68a7a5a5-a2fc-4a76-ba9f-26849de881b4"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,12 +46,11 @@ id = "T1485"
 name = "Data Destruction"
 reference = "https://attack.mitre.org/techniques/T1485/"
 
+
 [rule.threat.tactic]
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -61,6 +61,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 47
 rule_id = "d624f0ae-3dd1-4856-9aad-ccfe4d4bfa17"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -50,8 +51,6 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -62,6 +61,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/aws/impact_ec2_disable_ebs_encryption.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/05"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -32,6 +32,7 @@ risk_score = 47
 rule_id = "bb9b13b2-1700-48a8-a750-b43b0a72ab69"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Data Protection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -49,6 +50,7 @@ reference = "https://attack.mitre.org/techniques/T1565/"
 id = "T1565.001"
 name = "Stored Data Manipulation"
 reference = "https://attack.mitre.org/techniques/T1565/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/aws/impact_iam_deactivate_mfa_device.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -32,6 +32,7 @@ risk_score = 47
 rule_id = "d8fc1cca-93ed-43c1-bbb6-c0dd3eff2958"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/impact_iam_group_deletion.toml
+++ b/rules/aws/impact_iam_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 21
 rule_id = "867616ec-41e5-4edc-ada2-ab13ab45de8a"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/impact_rds_cluster_deletion.toml
+++ b/rules/aws/impact_rds_cluster_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -33,6 +33,7 @@ risk_score = 47
 rule_id = "9055ece6-2689-4224-a0e0-b04881e1f8ad"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Asset Visibility"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/aws/impact_rds_instance_cluster_stoppage.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "ecf2b32c-e221-4bd4-aa3b-c7d59b3bc01d"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Asset Visibility"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/initial_access_console_login_root.toml
+++ b/rules/aws/initial_access_console_login_root.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/11"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 73
 rule_id = "e2a67480-3b79-403d-96e3-fdd2992c50ef"
 severity = "high"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/initial_access_password_recovery.toml
+++ b/rules/aws/initial_access_password_recovery.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/02"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "69c420e8-6c9e-4d28-86c0-8a2be2d1e78c"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/initial_access_via_system_manager.toml
+++ b/rules/aws/initial_access_via_system_manager.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "37b211e8-4e2f-440f-86d8-06cc8f158cfa"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/aws/persistence_ec2_network_acl_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/04"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -33,6 +33,7 @@ risk_score = 21
 rule_id = "39144f38-5284-4f8e-a2ae-e3fd628d90b0"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/persistence_iam_group_creation.toml
+++ b/rules/aws/persistence_iam_group_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/05"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 21
 rule_id = "169f3a93-efc7-4df2-94d6-0d9438c310d1"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -44,11 +45,11 @@ framework = "MITRE ATT&CK"
 id = "T1136"
 name = "Create Account"
 reference = "https://attack.mitre.org/techniques/T1136/"
-
 [[rule.threat.technique.subtechnique]]
 id = "T1136.003"
 name = "Cloud Account"
 reference = "https://attack.mitre.org/techniques/T1136/003/"
+
 
 
 [rule.threat.tactic]

--- a/rules/aws/persistence_rds_cluster_creation.toml
+++ b/rules/aws/persistence_rds_cluster_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -33,6 +33,7 @@ risk_score = 21
 rule_id = "e14c5fd7-fdd7-49c2-9e5b-ec49d817bc8d"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Asset Visibility"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -52,9 +53,9 @@ reference = "https://attack.mitre.org/techniques/T1133/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 73
 rule_id = "bc0c6f0d-dab0-47a3-b135-0925f0a333bc"
 severity = "high"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "a60326d7-dca7-4fb7-93eb-1ca03a1febbd"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/collection_update_event_hub_auth_rule.toml
+++ b/rules/azure/collection_update_event_hub_auth_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "b6dce542-2b75-4ffb-b7d6-38787298ba9d"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/credential_access_key_vault_modified.toml
+++ b/rules/azure/credential_access_key_vault_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 47
 rule_id = "792dd7a6-7e00-4a0a-8a9a-a7c24720b5ec"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Data Protection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -48,6 +49,7 @@ reference = "https://attack.mitre.org/techniques/T1552/"
 id = "T1552.001"
 name = "Credentials In Files"
 reference = "https://attack.mitre.org/techniques/T1552/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/azure/credential_access_storage_account_key_regenerated.toml
+++ b/rules/azure/credential_access_storage_account_key_regenerated.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 21
 rule_id = "1e0b832e-957e-43ae-b319-db82d228c908"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/defense_evasion_azure_application_credential_modification.toml
+++ b/rules/azure/defense_evasion_azure_application_credential_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -32,6 +32,7 @@ risk_score = 47
 rule_id = "1a36cace-11a7-43a8-9a10-b497c5a02cd3"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -51,7 +52,9 @@ name = "Application Access Token"
 reference = "https://attack.mitre.org/techniques/T1550/001/"
 
 
+
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
+++ b/rules/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,6 +46,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -32,6 +32,7 @@ risk_score = 47
 rule_id = "60b6b72f-0fbc-47e7-9895-9ba7627a8b50"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -49,6 +50,7 @@ reference = "https://attack.mitre.org/techniques/T1550/"
 id = "T1550.001"
 name = "Application Access Token"
 reference = "https://attack.mitre.org/techniques/T1550/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/azure/defense_evasion_event_hub_deletion.toml
+++ b/rules/azure/defense_evasion_event_hub_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 47
 rule_id = "e0f36de1-0342-453d-95a9-a068b257b053"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -48,6 +49,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/azure/defense_evasion_firewall_policy_deletion.toml
+++ b/rules/azure/defense_evasion_firewall_policy_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "e02bd3ea-72c6-4181-ac2b-0f83d17ad969"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -44,6 +45,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/azure/defense_evasion_network_watcher_deletion.toml
+++ b/rules/azure/defense_evasion_network_watcher_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "323cb487-279d-4218-bcbd-a568efe930c6"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,6 +46,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/azure/discovery_blob_container_access_mod.toml
+++ b/rules/azure/discovery_blob_container_access_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "2636aa6c-88b5-4337-9c31-8d0192a8ef45"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Asset Visibility"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/execution_command_virtual_machine.toml
+++ b/rules/azure/execution_command_virtual_machine.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ risk_score = 47
 rule_id = "60884af6-f553-4a6c-af13-300047455491"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/impact_azure_automation_runbook_deleted.toml
+++ b/rules/azure/impact_azure_automation_runbook_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 21
 rule_id = "8ddab73b-3d15-4e5d-9413-47f05553c1d7"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/impact_resource_group_deletion.toml
+++ b/rules/azure/impact_resource_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 47
 rule_id = "bb4fe8d2-7ae2-475c-8b5d-55b449e4264f"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -45,12 +46,11 @@ id = "T1485"
 name = "Data Destruction"
 reference = "https://attack.mitre.org/techniques/T1485/"
 
+
 [rule.threat.tactic]
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -61,6 +61,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
+++ b/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 21
 rule_id = "a605c51a-73ad-406d-bf3a-f24cc41d5c97"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -51,7 +52,9 @@ name = "Cloud Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/004/"
 
 
+
 [rule.threat.tactic]
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 47
 rule_id = "1c6a8c7a-5cb6-4a82-ba27-d5a5b8a40a38"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/initial_access_external_guest_user_invite.toml
+++ b/rules/azure/initial_access_external_guest_user_invite.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "141e9b3a-ff37-4756-989d-05d7cbf35b0e"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/persistence_azure_automation_account_created.toml
+++ b/rules/azure/persistence_azure_automation_account_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 21
 rule_id = "df26fd74-1baa-4479-b42e-48da84642330"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/persistence_azure_automation_runbook_created_or_modified.toml
+++ b/rules/azure/persistence_azure_automation_runbook_created_or_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 21
 rule_id = "16280f1e-57e6-4242-aa21-bb4d16f13b2f"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/persistence_azure_automation_webhook_created.toml
+++ b/rules/azure/persistence_azure_automation_webhook_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 21
 rule_id = "e9ff9c1c-fe36-4d0d-b3fd-9e0bf4853a62"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 to = "now-25m"
 type = "query"
 

--- a/rules/azure/persistence_azure_conditional_access_policy_modified.toml
+++ b/rules/azure/persistence_azure_conditional_access_policy_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "bc48bba7-4a23-4232-b551-eca3ca1e3f20"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/persistence_azure_pim_user_added_global_admin.toml
+++ b/rules/azure/persistence_azure_pim_user_added_global_admin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/24"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 73
 rule_id = "ed9ecd27-e3e6-4fd9-8586-7754803f7fc8"
 severity = "high"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/persistence_azure_privileged_identity_management_role_modified.toml
+++ b/rules/azure/persistence_azure_privileged_identity_management_role_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 47
 rule_id = "7882cebf-6cf1-4de3-9662-213aa13e8b80"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/persistence_mfa_disabled_for_azure_user.toml
+++ b/rules/azure/persistence_mfa_disabled_for_azure_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "dafa3235-76dc-40e2-9f71-1773b96d24cf"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/persistence_user_added_as_owner_for_azure_application.toml
+++ b/rules/azure/persistence_user_added_as_owner_for_azure_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 21
 rule_id = "774f5e28-7b75-4a58-b94e-41bf060fdd86"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
+++ b/rules/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 21
 rule_id = "38e5acdd-5f20-4d99-8fe4-f0a1a592077f"
 severity = "low"
 tags = ["Elastic", "Cloud", "Azure", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/cross-platform/defense_evasion_deleting_websvr_access_logs.toml
+++ b/rules/cross-platform/defense_evasion_deleting_websvr_access_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "665e7a4f-c58e-4fc6-bc83-87a7572670ac"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Windows", "macOS", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -42,3 +43,4 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/07"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "9c260313-c811-4ec8-ab89-8f6530e0246c"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Windows", "macOS", "Threat Detection", "Impact"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -39,6 +40,7 @@ reference = "https://attack.mitre.org/techniques/T1565/"
 id = "T1565.001"
 name = "Stored Data Manipulation"
 reference = "https://attack.mitre.org/techniques/T1565/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
+++ b/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/14"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -33,6 +33,7 @@ tags = [
     "SecOps",
     "Configuration Audit",
 ]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/collection_gcp_pub_sub_subscription_creation.toml
+++ b/rules/gcp/collection_gcp_pub_sub_subscription_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "d62b64a8-a7c9-43e5-aee3-15a725a794e7"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/collection_gcp_pub_sub_topic_creation.toml
+++ b/rules/gcp/collection_gcp_pub_sub_topic_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "a10d3d9d-0f65-48f1-8b25-af175e2594f5"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_created.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "30562697-9859-4ae0-a8c5-dab45d664170"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 47
 rule_id = "ff9b571e-61d6-4f6c-9561-eb4cca3bafe1"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 47
 rule_id = "2783d84f-5091-4d7d-9319-9fceda8fa71b"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "5663b693-0dea-4f2e-8275-f1ae5ff2de8e"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_logging_sink_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_logging_sink_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/18"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 47
 rule_id = "51859fa0-d86b-4214-bf48-ebb30ed91305"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "cc89312d-6f47-48e4-a87c-4977bd4633c3"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/18"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "3202e172-01b1-4738-a932-d024c514ba72"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 47
 rule_id = "97359fd8-757d-4b1d-9af1-ef29e4a8680e"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 47
 rule_id = "2326d1b2-9acf-4dee-bd21-867ea7378b4d"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/exfiltration_gcp_logging_sink_modification.toml
+++ b/rules/gcp/exfiltration_gcp_logging_sink_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "184dfe52-2999-42d9-b9d1-d1ca54495a61"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Log Auditing"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/impact_gcp_iam_role_deletion.toml
+++ b/rules/gcp/impact_gcp_iam_role_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "e2fb5b18-e33c-4270-851e-c3d675c9afcd"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/impact_gcp_service_account_deleted.toml
+++ b/rules/gcp/impact_gcp_service_account_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "8fb75dda-c47a-4e34-8ecd-34facf7aad13"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/impact_gcp_service_account_disabled.toml
+++ b/rules/gcp/impact_gcp_service_account_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "bca7d28e-4a48-47b1-adb7-5074310e9a61"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/impact_gcp_storage_bucket_deleted.toml
+++ b/rules/gcp/impact_gcp_storage_bucket_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 47
 rule_id = "bc0f2d83-32b8-4ae2-b0e6-6a45772e9331"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 47
 rule_id = "c58c3081-2e1d-4497-8491-e73a45d1a6d6"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/impact_gcp_virtual_private_cloud_route_created.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_route_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "9180ffdf-f3d0-4db3-bf66-7a14bcff71b8"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 47
 rule_id = "a17bcc91-297b-459b-b5ce-bc7460d8f82a"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/initial_access_gcp_iam_custom_role_creation.toml
+++ b/rules/gcp/initial_access_gcp_iam_custom_role_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 47
 rule_id = "aa8007f0-d1df-49ef-8520-407857594827"
 severity = "medium"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/persistence_gcp_iam_service_account_key_deletion.toml
+++ b/rules/gcp/persistence_gcp_iam_service_account_key_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 21
 rule_id = "9890ee61-d061-403d-9bf6-64934c51f638"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/persistence_gcp_key_created_for_service_account.toml
+++ b/rules/gcp/persistence_gcp_key_created_for_service_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -32,6 +32,7 @@ risk_score = 21
 rule_id = "0e5acaae-6a64-4bbc-adb8-27649c03f7e1"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/gcp/persistence_gcp_service_account_created.toml
+++ b/rules/gcp/persistence_gcp_service_account_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "7ceb2216-47dd-4e64-9433-cddc99727623"
 severity = "low"
 tags = ["Elastic", "Cloud", "GCP", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/application_added_to_google_workspace_domain.toml
+++ b/rules/google-workspace/application_added_to_google_workspace_domain.toml
@@ -1,18 +1,19 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Detects when a Google marketplace application is added to the Google Workspace domain. An adversary may add a malicious application to
-an organization’s Google Workspace domain in order to maintain a presence in their target’s organization and steal data.
+Detects when a Google marketplace application is added to the Google Workspace domain. An adversary may add a malicious
+application to an organization’s Google Workspace domain in order to maintain a presence in their target’s organization
+and steal data.
 """
 false_positives = [
     """
-    Applications can be added to a Google Workspace domain by system administrators. Verify that the configuration change was
-    expected. Exceptions can be added to this rule to filter expected behavior.
+    Applications can be added to a Google Workspace domain by system administrators. Verify that the configuration
+    change was expected. Exceptions can be added to this rule to filter expected behavior.
     """,
 ]
 from = "now-130m"
@@ -34,8 +35,10 @@ risk_score = 47
 rule_id = "785a404b-75aa-4ffd-8be5-3334a5a544dd"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
 event.dataset:(gsuite.admin or google_workspace.admin) and event.provider:admin and event.category:iam and event.action:ADD_APPLICATION
 '''
+

--- a/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ risk_score = 73
 rule_id = "cf549724-c577-4fd6-8f9b-d1b8ec519ec0"
 severity = "high"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/google_workspace_admin_role_deletion.toml
+++ b/rules/google-workspace/google_workspace_admin_role_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ risk_score = 47
 rule_id = "93e63c3e-4154-4fc6-9f86-b411e0987bbf"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/google-workspace/google_workspace_mfa_enforcement_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ risk_score = 47
 rule_id = "cad4500a-abd7-4ef3-b5d3-95524de7cfe1"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/google_workspace_policy_modified.toml
+++ b/rules/google-workspace/google_workspace_policy_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -33,6 +33,7 @@ risk_score = 47
 rule_id = "a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/google-workspace/mfa_disabled_for_google_workspace_organization.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -33,6 +33,7 @@ risk_score = 47
 rule_id = "e555105c-ba6d-481f-82bb-9b633e7b4827"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ risk_score = 47
 rule_id = "68994a6c-c7ba-4e82-b476-26a26877adf6"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
+++ b/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/12"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -35,6 +35,7 @@ risk_score = 47
 rule_id = "acbc8bb9-2486-49a8-8779-45fb5f9a93ee"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/persistence_google_workspace_custom_admin_role_created.toml
+++ b/rules/google-workspace/persistence_google_workspace_custom_admin_role_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ risk_score = 47
 rule_id = "ad3f2807-2b3e-47d7-b282-f84acbbe14be"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/google-workspace/persistence_google_workspace_role_modified.toml
+++ b/rules/google-workspace/persistence_google_workspace_role_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ risk_score = 47
 rule_id = "6f435062-b7fc-4af9-acea-5b1ead65c5a5"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Google Workspace", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -53,3 +54,4 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/linux/credential_access_tcpdump_activity.toml
+++ b/rules/linux/credential_access_tcpdump_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 21
 rule_id = "7a137d76-ce3d-48e2-947d-2747796a78c0"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/24"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "125417b8-d3df-479f-8418-12d7e034fee3"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -41,6 +42,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/27"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "2f8a1226-5720-437d-9c20-e0029deb6194"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -39,6 +40,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/17"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 21
 rule_id = "debff20a-46bc-4a4d-bae5-5cdd14222795"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -40,6 +41,7 @@ reference = "https://attack.mitre.org/techniques/T1140/"
 id = "T1027"
 name = "Obfuscated Files or Information"
 reference = "https://attack.mitre.org/techniques/T1027/"
+
 
 [rule.threat.tactic]
 id = "TA0005"

--- a/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/17"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 21
 rule_id = "97f22dab-84e8-409d-955e-dacd1d31670b"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -40,6 +41,7 @@ reference = "https://attack.mitre.org/techniques/T1140/"
 id = "T1027"
 name = "Obfuscated Files or Information"
 reference = "https://attack.mitre.org/techniques/T1027/"
+
 
 [rule.threat.tactic]
 id = "TA0005"

--- a/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
+++ b/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/04"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "7bcbb3ac-e533-41ad-a612-d6c3bf666aba"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "T1070.003"
 name = "Clear Command History"
 reference = "https://attack.mitre.org/techniques/T1070/003/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/defense_evasion_disable_selinux_attempt.toml
+++ b/rules/linux/defense_evasion_disable_selinux_attempt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/22"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "eb9eb8ba-a983-41d9-9c93-a1c05112ca5e"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/defense_evasion_file_deletion_via_shred.toml
+++ b/rules/linux/defense_evasion_file_deletion_via_shred.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/27"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 21
 rule_id = "a1329140-8de3-4445-9f87-908fb6d824f4"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "T1070.004"
 name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/defense_evasion_file_mod_writable_dir.toml
+++ b/rules/linux/defense_evasion_file_mod_writable_dir.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/21"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -24,6 +24,7 @@ risk_score = 21
 rule_id = "9f9a2a82-93a8-4b1a-8778-1780895626d4"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/17"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 21
 rule_id = "a9198571-b135-4a76-b055-e3e5a476fd83"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -39,6 +40,7 @@ reference = "https://attack.mitre.org/techniques/T1140/"
 id = "T1027"
 name = "Obfuscated Files or Information"
 reference = "https://attack.mitre.org/techniques/T1027/"
+
 
 [rule.threat.tactic]
 id = "TA0005"

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/29"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 47
 rule_id = "b9666521-4742-49ce-9ddc-b8e84c35acae"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/defense_evasion_kernel_module_removal.toml
+++ b/rules/linux/defense_evasion_kernel_module_removal.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/24"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 73
 rule_id = "cd66a5af-e34b-4bb0-8931-57d0a043f2ef"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -61,6 +62,7 @@ reference = "https://attack.mitre.org/techniques/T1547/"
 id = "T1547.006"
 name = "Kernel Modules and Extensions"
 reference = "https://attack.mitre.org/techniques/T1547/006/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/defense_evasion_log_files_deleted.toml
+++ b/rules/linux/defense_evasion_log_files_deleted.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the deletion of sensitive Linux system logs. This may indicate an attempt to evade detection or destroy forensic
-evidence on a system.
+Identifies the deletion of sensitive Linux system logs. This may indicate an attempt to evade detection or destroy
+forensic evidence on a system.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "aa895aea-b69c-4411-b110-8d7599634b30"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -52,3 +53,4 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/linux/defense_evasion_timestomp_touch.toml
+++ b/rules/linux/defense_evasion_timestomp_touch.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "b0046934-486e-462f-9487-0d4cf9e429c6"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "macOS", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "T1070.006"
 name = "Timestomp"
 reference = "https://attack.mitre.org/techniques/T1070/006/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/discovery_kernel_module_enumeration.toml
+++ b/rules/linux/discovery_kernel_module_enumeration.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/23"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 47
 rule_id = "2d8043ed-5bda-4caf-801c-c1feb7410504"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/discovery_virtual_machine_fingerprinting.toml
+++ b/rules/linux/discovery_virtual_machine_fingerprinting.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/27"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 73
 rule_id = "5b03c9fb-9945-4d2f-9568-fd690fee3fba"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/discovery_whoami_commmand.toml
+++ b/rules/linux/discovery_whoami_commmand.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -24,6 +24,7 @@ risk_score = 21
 rule_id = "120559c6-5e24-49f4-9e30-8ffe697df6b9"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/execution_perl_tty_shell.toml
+++ b/rules/linux/execution_perl_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/16"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 73
 rule_id = "05e5a668-7b51-4a67-93ab-e9af405c9ef3"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/15"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 73
 rule_id = "d76b02ef-fc95-4001-9297-01cb7412232f"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_hping_activity.toml
+++ b/rules/linux/linux_hping_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 73
 rule_id = "90169566-2260-4824-b8e4-8615c3b4ed52"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_iodine_activity.toml
+++ b/rules/linux/linux_iodine_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 73
 rule_id = "041d4d41-9589-43e2-ba13-5680af75ebc2"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_mknod_activity.toml
+++ b/rules/linux/linux_mknod_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "61c31c14-507f-4627-8c31-072556b89a9c"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_nmap_activity.toml
+++ b/rules/linux/linux_nmap_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "c87fca17-b3a9-4e83-b545-f30746c53920"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_nping_activity.toml
+++ b/rules/linux/linux_nping_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 47
 rule_id = "0d69150b-96f8-467c-a86d-a67a3378ce77"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_process_started_in_temp_directory.toml
+++ b/rules/linux/linux_process_started_in_temp_directory.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "df959768-b0c9-4d45-988c-5606a2be8e5a"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_socat_activity.toml
+++ b/rules/linux/linux_socat_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 47
 rule_id = "cd4d5754-07e1-41d4-b9a5-ef4ea6a0a126"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/linux_strace_activity.toml
+++ b/rules/linux/linux_strace_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 21
 rule_id = "d6450d4e-81c6-46a3-bd94-079886318ed5"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/persistence_kernel_module_activity.toml
+++ b/rules/linux/persistence_kernel_module_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -24,6 +24,7 @@ risk_score = 21
 rule_id = "81cc58f5-8062-49a2-ba84-5cc4b4d31c40"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -41,6 +42,7 @@ reference = "https://attack.mitre.org/techniques/T1547/"
 id = "T1547.006"
 name = "Kernel Modules and Extensions"
 reference = "https://attack.mitre.org/techniques/T1547/006/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/persistence_shell_activity_by_web_server.toml
+++ b/rules/linux/persistence_shell_activity_by_web_server.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "231876e7-4d1f-4d63-a47c-47dd1acdc1cb"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -40,6 +41,7 @@ reference = "https://attack.mitre.org/techniques/T1505/"
 id = "T1505.003"
 name = "Web Shell"
 reference = "https://attack.mitre.org/techniques/T1505/003/"
+
 
 
 [rule.threat.tactic]

--- a/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/23"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 21
 rule_id = "3a86e085-094c-412d-97ff-2439731e59cb"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/23"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 21
 rule_id = "8a1b0278-0f9a-487d-96bd-d4833298e87a"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/linux/privilege_escalation_sudoers_file_mod.toml
+++ b/rules/linux/privilege_escalation_sudoers_file_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/13"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "931e25a5-0f5e-4ae0-ba0d-9e94eff7e3a4"
 severity = "low"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -35,6 +36,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.003"
 name = "Sudo and Sudo Caching"
 reference = "https://attack.mitre.org/techniques/T1548/003/"
+
 
 
 [rule.threat.tactic]

--- a/rules/macos/credential_access_compress_credentials_keychains.toml
+++ b/rules/macos/credential_access_compress_credentials_keychains.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 73
 rule_id = "96e90768-c3b7-4df6-b5d9-6237f8bc36a8"
 severity = "high"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -39,6 +40,7 @@ reference = "https://attack.mitre.org/techniques/T1555/"
 id = "T1555.001"
 name = "Keychain"
 reference = "https://attack.mitre.org/techniques/T1555/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/macos/credential_access_kerberosdump_kcc.toml
+++ b/rules/macos/credential_access_kerberosdump_kcc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "ad88231f-e2ab-491c-8fc6-64746da26cfe"
 severity = "high"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
+++ b/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/16"
 maturity = "production"
-updated_date = "2020/11/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 73
 rule_id = "38948d29-3d5d-42e3-8aec-be832aaaf8eb"
 severity = "high"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
+++ b/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 43
 rule_id = "f0b48bbc-549e-4bcf-8ee0-a7a72586c6a7"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -40,6 +41,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
+++ b/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "5ae4e6f8-d1bf-40fa-96ba-e29645e1e4dc"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/macos/persistence_login_logout_hooks_defaults.toml
+++ b/rules/macos/persistence_login_logout_hooks_defaults.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/07"
 maturity = "production"
-updated_date = "2020/12/07"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "5d0265bf-dea9-41a9-92ad-48a8dcd05080"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -42,3 +43,4 @@ reference = "https://attack.mitre.org/techniques/T1037/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "60f3adec-1df9-4104-9c75-b97d9f078b25"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "d743ff2a-203e-4a46-a3e3-40512cfe8fbb"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "ca79768e-40e1-4e45-a097-0e5fbc876ac2"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when a safe attachment rule is disabled in Microsoft 365. Safe attachment rules can extend malware protections
-to include routing all messages and attachments without a known malware signature to a special hypervisor environment.
-An adversary or insider threat may disable a safe attachment rule to exfiltrate data or evade defenses.
+Identifies when a safe attachment rule is disabled in Microsoft 365. Safe attachment rules can extend malware
+protections to include routing all messages and attachments without a known malware signature to a special hypervisor
+environment. An adversary or insider threat may disable a safe attachment rule to exfiltrate data or evade defenses.
 """
 false_positives = [
     """
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "03024bd9-d23f-4ec1-8674-3cf1a21e130b"
 severity = "low"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
+++ b/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "ff4dd44a-0ac6-44c4-8609-3f81bc820f02"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
+++ b/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -31,6 +31,7 @@ risk_score = 47
 rule_id = "272a6484-2663-46db-a532-ef734bf9a796"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the deletion of an anti-phishing policy in Microsoft 365. By default, Microsoft 365 includes built-in features that
-help protect users from phishing attacks. Anti-phishing polices increase this protection by refining settings to better
-detect and prevent attacks.
+Identifies the deletion of an anti-phishing policy in Microsoft 365. By default, Microsoft 365 includes built-in
+features that help protect users from phishing attacks. Anti-phishing polices increase this protection by refining
+settings to better detect and prevent attacks.
 """
 false_positives = [
     """
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "d68eb1b5-5f1c-4b6d-9e63-5b6b145cd4aa"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the modification of an anti-phishing rule in Microsoft 365. By default, Microsoft 365 includes built-in features
-that help protect users from phishing attacks. Anti-phishing rules increase this protection by refining settings to
-better detect and prevent attacks.
+Identifies the modification of an anti-phishing rule in Microsoft 365. By default, Microsoft 365 includes built-in
+features that help protect users from phishing attacks. Anti-phishing rules increase this protection by refining
+settings to better detect and prevent attacks.
 """
 false_positives = [
     """
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "97314185-2568-4561-ae81-f3e480e5e695"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/01/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when a Safe Link policy is disabled in Microsoft 365. Safe Link policies for Office applications extend phishing
-protection to documents that contain hyperlinks, even after they have been delivered to a user.
+Identifies when a Safe Link policy is disabled in Microsoft 365. Safe Link policies for Office applications extend
+phishing protection to documents that contain hyperlinks, even after they have been delivered to a user.
 """
 false_positives = [
     """
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "a989fa1b-9a11-4dd8-a3e9-f0de9c6eb5f2"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/microsoft_365_exchange_dkim_signing_config_disabled.toml
+++ b/rules/microsoft-365/microsoft_365_exchange_dkim_signing_config_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "514121ce-c7b6-474a-8237-68ff71672379"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Data Protection"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/microsoft_365_teams_custom_app_interaction_allowed.toml
+++ b/rules/microsoft-365/microsoft_365_teams_custom_app_interaction_allowed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/30"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 47
 rule_id = "bbd1a775-8267-41fa-9232-20e5582596ac"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/persistence_microsoft_365_exchange_management_role_assignment.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_exchange_management_role_assignment.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "98995807-5b09-4e37-8a54-5cae5dc932d7"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/persistence_microsoft_365_teams_external_access_enabled.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_teams_external_access_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/30"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 47
 rule_id = "27f7c15a-91f8-4c3d-8b9e-1f99cc030a51"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/microsoft-365/persistence_microsoft_365_teams_guest_access_enabled.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_teams_guest_access_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "5e552599-ddec-4e14-bad1-28aa42404388"
 severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_cobalt_strike_beacon.toml
+++ b/rules/network/command_and_control_cobalt_strike_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 73
 rule_id = "cf53f532-9cc9-445a-9ae7-fced307ec53c"
 severity = "high"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -51,6 +52,7 @@ reference = "https://attack.mitre.org/techniques/T1568/"
 id = "T1568.002"
 name = "Domain Generation Algorithms"
 reference = "https://attack.mitre.org/techniques/T1568/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
+++ b/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/05"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ tags = [
     "Elastic",
     "Network",
 ]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -60,3 +61,4 @@ reference = "https://attack.mitre.org/techniques/T1071/001/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/network/command_and_control_dns_directly_to_the_internet.toml
+++ b/rules/network/command_and_control_dns_directly_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -32,6 +32,7 @@ risk_score = 47
 rule_id = "6ea71ff0-9e95-475b-9506-2580d1ce6154"
 severity = "medium"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_download_rar_powershell_from_internet.toml
+++ b/rules/network/command_and_control_download_rar_powershell_from_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/02"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "ff013cb4-274d-434a-96bb-fe15ddd3ae92"
 severity = "medium"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 73
 rule_id = "4a4e23cf-78a2-449c-bac3-701924c269d3"
 severity = "high"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -50,6 +51,7 @@ reference = "https://attack.mitre.org/techniques/T1568/"
 id = "T1568.002"
 name = "Domain Generation Algorithms"
 reference = "https://attack.mitre.org/techniques/T1568/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/network/command_and_control_ftp_file_transfer_protocol_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_ftp_file_transfer_protocol_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "87ec6396-9ac4-4706-bcf0-2ebb22002f43"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_halfbaked_beacon.toml
+++ b/rules/network/command_and_control_halfbaked_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 73
 rule_id = "2e580225-2a58-48ef-938b-572933be06fe"
 severity = "high"
 tags = ["Elastic", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -52,6 +53,7 @@ reference = "https://attack.mitre.org/techniques/T1568/"
 id = "T1568.002"
 name = "Domain Generation Algorithms"
 reference = "https://attack.mitre.org/techniques/T1568/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/network/command_and_control_irc_internet_relay_chat_protocol_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_irc_internet_relay_chat_protocol_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "c6474c34-4953-447a-903e-9fcb7b6661aa"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_nat_traversal_port_activity.toml
+++ b/rules/network/command_and_control_nat_traversal_port_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "a9cb3641-ff4b-4cdc-a063-b4b8d02a67c7"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_port_26_activity.toml
+++ b/rules/network/command_and_control_port_26_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "d7e62693-aab9-4f66-a21a-3d79ecdd603d"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_port_8000_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_port_8000_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 21
 rule_id = "08d5d7e2-740f-44d8-aeda-e41f4263efaf"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_pptp_point_to_point_tunneling_protocol_activity.toml
+++ b/rules/network/command_and_control_pptp_point_to_point_tunneling_protocol_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 21
 rule_id = "d2053495-8fe7-4168-b3df-dad844046be3"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_proxy_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_proxy_port_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "ad0e5e75-dd89-4875-8d0a-dfdc1828b5f3"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_rdp_remote_desktop_protocol_from_the_internet.toml
+++ b/rules/network/command_and_control_rdp_remote_desktop_protocol_from_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "8c1bdde8-4204-45c0-9e0c-c85ca3902488"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_smtp_to_the_internet.toml
+++ b/rules/network/command_and_control_smtp_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 21
 rule_id = "67a9beba-830d-4035-bfe8-40b7e28f8ac4"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 47
 rule_id = "139c7458-566a-410c-a5cd-f80238d6a5cd"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_ssh_secure_shell_from_the_internet.toml
+++ b/rules/network/command_and_control_ssh_secure_shell_from_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "ea0784f0-a4d7-4fea-ae86-4baaf27a6f17"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_ssh_secure_shell_to_the_internet.toml
+++ b/rules/network/command_and_control_ssh_secure_shell_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "6f1500bc-62d7-4eb9-8601-7485e87da2f4"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_telnet_port_activity.toml
+++ b/rules/network/command_and_control_telnet_port_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "34fde489-94b0-4500-a76f-b8a157cf9269"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_tor_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_tor_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -26,6 +26,7 @@ risk_score = 47
 rule_id = "7d2c38d7-ede7-4bdf-b140-445906e6c540"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -48,16 +49,16 @@ event.category:(network or network_traffic) and network.transport:tcp and destin
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
-
 [[rule.threat.technique]]
 id = "T1090"
 name = "Proxy"
 reference = "https://attack.mitre.org/techniques/T1090/"
-
 [[rule.threat.technique.subtechnique]]
 id = "T1090.003"
 name = "Multi-hop Proxy"
 reference = "https://attack.mitre.org/techniques/T1090/003/"
+
+
 
 [rule.threat.tactic]
 id = "TA0011"

--- a/rules/network/command_and_control_vnc_virtual_network_computing_from_the_internet.toml
+++ b/rules/network/command_and_control_vnc_virtual_network_computing_from_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 73
 rule_id = "5700cb81-df44-46aa-a5d7-337798f53eb8"
 severity = "high"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/command_and_control_vnc_virtual_network_computing_to_the_internet.toml
+++ b/rules/network/command_and_control_vnc_virtual_network_computing_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -27,6 +27,7 @@ risk_score = 47
 rule_id = "3ad49c61-7adc-42c1-b788-732eda2f5abf"
 severity = "medium"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/discovery_post_exploitation_public_ip_reconnaissance.toml
+++ b/rules/network/discovery_post_exploitation_public_ip_reconnaissance.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/04"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "1d72d014-e2ab-4707-b056-9b96abe7b511"
 severity = "low"
 tags = ["Elastic", "Network", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_rdp_remote_desktop_protocol_to_the_internet.toml
+++ b/rules/network/initial_access_rdp_remote_desktop_protocol_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "e56993d2-759c-4120-984c-9ec9bb940fd5"
 severity = "low"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Initial Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_rpc_remote_procedure_call_from_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_from_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "143cb236-0956-4f42-a706-814bcaa0cf5a"
 severity = "high"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Initial Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "32923416-763a-4531-bb35-f33b9232ecdb"
 severity = "high"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Initial Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_smb_windows_file_sharing_activity_to_the_internet.toml
+++ b/rules/network/initial_access_smb_windows_file_sharing_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "c82b2bd8-d701-420c-ba43-f11a155b681a"
 severity = "high"
 tags = ["Elastic", "Host", "Network", "Threat Detection", "Initial Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/network/initial_access_unsecure_elasticsearch_node.toml
+++ b/rules/network/initial_access_unsecure_elasticsearch_node.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/11"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 47
 rule_id = "31295df3-277b-4c56-a1fb-84e31b4222a9"
 severity = "medium"
 tags = ["Elastic", "Network", "Threat Detection", "Initial Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/attempt_to_deactivate_okta_network_zone.toml
+++ b/rules/okta/attempt_to_deactivate_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/11/06"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,8 +30,10 @@ risk_score = 47
 rule_id = "8a5c1e5f-ad63-481e-b53a-ef959230f7f1"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
 event.dataset:okta.system and event.action:zone.deactivate
 '''
+

--- a/rules/okta/attempt_to_delete_okta_network_zone.toml
+++ b/rules/okta/attempt_to_delete_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/11/06"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "c749e367-a069-4a73-b1f2-43a3798153ad"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 73
 rule_id = "3805c3dc-f82c-4f8d-891e-63c24d3102b0"
 severity = "high"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -41,3 +42,4 @@ reference = "https://attack.mitre.org/techniques/T1111/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "676cff2b-450b-4cf1-8ed2-c0c58a4a2dd7"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/okta/impact_possible_okta_dos_attack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "e6e3ecff-03dd-48ec-acbd-54a04de10c68"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -46,3 +47,4 @@ reference = "https://attack.mitre.org/techniques/T1499/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+

--- a/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -23,6 +23,7 @@ risk_score = 47
 rule_id = "f994964f-6fce-4d75-8e79-e16ccc412588"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_deactivate_okta_application.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/11/06"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "edb91186-1c7e-4db8-b53e-bfa33a1a0a8a"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_deactivate_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 21
 rule_id = "b719a170-3bdb-4141-b0e3-13e3cf627bfe"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "cc92c835-da92-45c9-9f29-b4992ad621a0"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_delete_okta_application.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/11/06"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "d48e1c13-4aca-4d1f-a7b1-a9161c0ad86f"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_delete_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/28"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "b4bb1440-0fcb-4ed1-87e5-b06d58efc5e9"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_delete_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/11/06"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "d5d86bf5-cf0c-4c06-b688-53fdc072fdfd"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_modify_okta_application.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/11/06"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,10 @@ risk_score = 21
 rule_id = "c74fd275-ab2c-4d49-8890-e2943fa65c09"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
 event.dataset:okta.system and event.action:application.lifecycle.update
 '''
+

--- a/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "e48236ca-b67a-4b4e-840c-fdc7782bc0c3"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Network Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_modify_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,8 +29,10 @@ risk_score = 21
 rule_id = "6731fbf2-8f28-49ed-9ab9-9a918ceb5a45"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
 event.dataset:okta.system and event.action:policy.lifecycle.update
 '''
+

--- a/rules/okta/okta_attempt_to_modify_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "000047bb-b27a-47ec-8b62-ef1a5d2c9e19"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/01"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "cd16fb10-0261-46e8-9932-a0336278cdbe"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
+++ b/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -23,6 +23,7 @@ risk_score = 47
 rule_id = "6885d2ae-e008-4762-b98a-e8e1cd3a81e9"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "b8075894-0b62-46e5-977c-31275da34419"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/11/06"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -30,6 +30,7 @@ risk_score = 47
 rule_id = "f06414a6-f2a4-466d-8eba-10f85e8abf71"
 severity = "medium"
 tags = ["Elastic", "Okta", "SecOps", "Monitoring", "Continuous Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -49,3 +50,4 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -29,6 +29,7 @@ risk_score = 47
 rule_id = "96b9f4ea-0e8c-435b-8d53-2096e75fcac5"
 severity = "medium"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Monitoring"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "cd89602e-9db0-48e3-9391-ae3bf241acd8"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Detects attempts to reset an Okta user's enrolled multi-factor authentication (MFA) factors. An adversary may attempt
-to reset the MFA factors for an Okta user's account in order to register new MFA factors and abuse the account to blend
-in with normal activity in the victim's environment.
+Detects attempts to reset an Okta user's enrolled multi-factor authentication (MFA) factors. An adversary may attempt to
+reset the MFA factors for an Okta user's account in order to register new MFA factors and abuse the account to blend in
+with normal activity in the victim's environment.
 """
 false_positives = [
     """
@@ -29,6 +29,7 @@ risk_score = 21
 rule_id = "729aa18d-06a6-41c7-b175-b65b739b1181"
 severity = "low"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -48,3 +49,4 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/promotions/elastic_endpoint.toml
+++ b/rules/promotions/elastic_endpoint.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/08"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endpoint_adversary_behavior_detected.toml
+++ b/rules/promotions/endpoint_adversary_behavior_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "77a3c3df-8ec4-4da4-b758-878f551dee69"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_dumping_detected.toml
+++ b/rules/promotions/endpoint_cred_dumping_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "571afc56-5ed9-465d-a2a9-045f099f6e7e"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_dumping_prevented.toml
+++ b/rules/promotions/endpoint_cred_dumping_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "db8c33a8-03cd-4988-9e2c-d0a4863adb13"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_manipulation_detected.toml
+++ b/rules/promotions/endpoint_cred_manipulation_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "c0be5f31-e180-48ed-aa08-96b36899d48f"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_manipulation_prevented.toml
+++ b/rules/promotions/endpoint_cred_manipulation_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_exploit_detected.toml
+++ b/rules/promotions/endpoint_exploit_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "2003cdc8-8d83-4aa5-b132-1f9a8eb48514"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_exploit_prevented.toml
+++ b/rules/promotions/endpoint_exploit_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "2863ffeb-bf77-44dd-b7a5-93ef94b72036"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_malware_detected.toml
+++ b/rules/promotions/endpoint_malware_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 99
 rule_id = "0a97b20f-4144-49ea-be32-b540ecc445de"
 severity = "critical"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_malware_prevented.toml
+++ b/rules/promotions/endpoint_malware_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "3b382770-efbb-44f4-beed-f5e0a051b895"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_permission_theft_detected.toml
+++ b/rules/promotions/endpoint_permission_theft_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "c3167e1b-f73c-41be-b60b-87f4df707fe3"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_permission_theft_prevented.toml
+++ b/rules/promotions/endpoint_permission_theft_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "453f659e-0429-40b1-bfdb-b6957286e04b"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_process_injection_detected.toml
+++ b/rules/promotions/endpoint_process_injection_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "80c52164-c82a-402c-9964-852533d58be1"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_process_injection_prevented.toml
+++ b/rules/promotions/endpoint_process_injection_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "990838aa-a953-4f3e-b3cb-6ddf7584de9e"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_ransomware_detected.toml
+++ b/rules/promotions/endpoint_ransomware_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 99
 rule_id = "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd"
 severity = "critical"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_ransomware_prevented.toml
+++ b/rules/promotions/endpoint_ransomware_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "e3c5d5cb-41d5-4206-805c-f30561eae3ac"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/08"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/collection_email_powershell_exchange_mailbox.toml
+++ b/rules/windows/collection_email_powershell_exchange_mailbox.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/12/15"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the use of the Exchange PowerShell cmdlet, New-MailBoxExportRequest, to export the contents of a primary mailbox or
-archive to a .pst file. Adversaries may target user email to collect sensitive information.
+Identifies the use of the Exchange PowerShell cmdlet, New-MailBoxExportRequest, to export the contents of a primary
+mailbox or archive to a .pst file. Adversaries may target user email to collect sensitive information.
 """
 false_positives = ["Legitimate exchange system administration activity."]
 index = ["logs-endpoint.events.*", "winlogbeat-*"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "6aace640-e631-4870-ba8e-5fdda09325db"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Collection"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -42,3 +43,4 @@ reference = "https://attack.mitre.org/techniques/T1114/"
 id = "TA0009"
 name = "Collection"
 reference = "https://attack.mitre.org/tactics/TA0009/"
+

--- a/rules/windows/collection_persistence_powershell_exch_mailbox_activesync_add_device.toml
+++ b/rules/windows/collection_persistence_powershell_exch_mailbox_activesync_add_device.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/12/15"
 maturity = "production"
-updated_date = "2020/12/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the use of the Exchange PowerShell cmdlet, Set-CASMailbox, to add a new ActiveSync allowed device. Adversaries may
-target user email to collect sensitive information.
+Identifies the use of the Exchange PowerShell cmdlet, Set-CASMailbox, to add a new ActiveSync allowed device.
+Adversaries may target user email to collect sensitive information.
 """
 false_positives = ["Legitimate exchange system administration activity."]
 index = ["logs-endpoint.events.*", "winlogbeat-*"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "ce64d965-6cb0-466d-b74f-8d2c76f47f05"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Collection"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -42,3 +43,4 @@ reference = "https://attack.mitre.org/techniques/T1114/"
 id = "TA0009"
 name = "Collection"
 reference = "https://attack.mitre.org/tactics/TA0009/"
+

--- a/rules/windows/collection_winrar_encryption.toml
+++ b/rules/windows/collection_winrar_encryption.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "45d273fb-1dca-457d-9855-bcb302180c21"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Exfiltration"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/command_and_control_common_webservices.toml
+++ b/rules/windows/command_and_control_common_webservices.toml
@@ -1,15 +1,15 @@
 [metadata]
 creation_date = "2020/11/04"
 maturity = "production"
-updated_date = "2020/11/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
 Adversaries may implement command and control communications that use common web services in order to hide their
-activity. This attack technique is typically targeted to an organization and uses web services common to the victim network which allows the adversary to blend into legitimate traffic.
-activity. These popular services are typically targeted since they have most likely been used before a compromise and
-allow adversaries to blend in the network.
+activity. This attack technique is typically targeted to an organization and uses web services common to the victim
+network which allows the adversary to blend into legitimate traffic. activity. These popular services are typically
+targeted since they have most likely been used before a compromise and allow adversaries to blend in the network.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
@@ -20,6 +20,7 @@ risk_score = 21
 rule_id = "66883649-f908-4a5b-a1e0-54090a1d3a32"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -74,3 +75,4 @@ reference = "https://attack.mitre.org/techniques/T1102/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/windows/command_and_control_encrypted_channel_freesslcert.toml
+++ b/rules/windows/command_and_control_encrypted_channel_freesslcert.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/04"
 maturity = "production"
-updated_date = "2020/11/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "e3cf38fa-d5b8-46cc-87f9-4a7513e4281d"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -50,3 +51,4 @@ reference = "https://attack.mitre.org/techniques/T1573/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
+++ b/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "15c0b7a7-9c34-4869-b25b-fa6518414899"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "c6453e73-90eb-4fe7-a98c-cde7bbfc504a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
+++ b/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/12/14"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 73
 rule_id = "22599847-5d13-48cb-8872-5796fee8692b"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
+++ b/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ risk_score = 47
 rule_id = "b25a7df2-120a-4db2-bd3f-3e4b86b24bee"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/credential_access_cmdline_dump_tool.toml
+++ b/rules/windows/credential_access_cmdline_dump_tool.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2020/11/24"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the execution of known Windows utilities often abused to dump LSASS memory or the Active Directory
-database (NTDS.dit) in preparation for credential access.
+Identifies the execution of known Windows utilities often abused to dump LSASS memory or the Active Directory database
+(NTDS.dit) in preparation for credential access.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "00140285-b827-4aee-aa09-8113f58a08f3"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -48,3 +49,4 @@ reference = "https://attack.mitre.org/techniques/T1003/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
+++ b/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2020/11/24"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 73
 rule_id = "3bc6deaa-fbd4-433a-ae21-3e892f95624f"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -42,3 +43,4 @@ reference = "https://attack.mitre.org/techniques/T1003/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_credential_dumping_msbuild.toml
+++ b/rules/windows/credential_access_credential_dumping_msbuild.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -23,6 +23,7 @@ risk_score = 73
 rule_id = "b83a7e96-2eb3-4edf-8346-427b6858d3bd"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -41,6 +42,7 @@ reference = "https://attack.mitre.org/techniques/T1552/"
 id = "T1552.004"
 name = "Private Keys"
 reference = "https://attack.mitre.org/techniques/T1552/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/credential_access_dump_registry_hives.toml
+++ b/rules/windows/credential_access_dump_registry_hives.toml
@@ -1,23 +1,24 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/11/23"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
-description = """
-Identifies attempts to export a registry hive which may contain credentials using the Windows reg.exe tool.
-"""
+description = "Identifies attempts to export a registry hive which may contain credentials using the Windows reg.exe tool."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License"
 name = "Credential Acquisition via Registry Hive Dumping"
-references = ["https://medium.com/threatpunter/detecting-attempts-to-steal-passwords-from-the-registry-7512674487f8"]
+references = [
+    "https://medium.com/threatpunter/detecting-attempts-to-steal-passwords-from-the-registry-7512674487f8",
+]
 risk_score = 73
 rule_id = "a7e7bfa3-088e-4f13-b29e-3986e0e756b8"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -26,7 +27,6 @@ process where event.type in ("start", "process_started") and
  process.args : ("save", "export") and
  process.args : ("hklm\\sam", "hklm\\security") and
  not process.parent.executable : "C:\\Program Files*\\Rapid7\\Insight Agent\\components\\insight_agent\\*\\ir_agent.exe"
- 
 '''
 
 
@@ -42,3 +42,4 @@ reference = "https://attack.mitre.org/techniques/T1003/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
+++ b/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 73
 rule_id = "0564fb9d-90b9-4234-a411-82a546dc1343"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -41,3 +42,4 @@ reference = "https://attack.mitre.org/techniques/T1003/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_iis_connectionstrings_dumping.toml
+++ b/rules/windows/credential_access_iis_connectionstrings_dumping.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -24,6 +24,7 @@ risk_score = 73
 rule_id = "c25e9c87-95e1-4368-bfab-9fd34cf867ec"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -45,3 +46,4 @@ reference = "https://attack.mitre.org/techniques/T1003/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_kerberoasting_unusual_process.toml
+++ b/rules/windows/credential_access_kerberoasting_unusual_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -23,6 +23,7 @@ risk_score = 43
 rule_id = "897dc6b5-b39f-432a-8d75-d3730d50c782"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -46,3 +47,4 @@ reference = "https://attack.mitre.org/techniques/T1558/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_lsass_memdump_file_created.toml
+++ b/rules/windows/credential_access_lsass_memdump_file_created.toml
@@ -1,13 +1,14 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2020/11/24"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the creation of a Local Security Authority Subsystem Service (lsass.exe) default memory dump. This may indicate
-a credential access attempt via trusted system utilities such as Task Manager (taskmgr.exe) and SQL Dumper (sqldumper.exe) or known pentesting tools such as Dumpert and AndrewSpecial.
+Identifies the creation of a Local Security Authority Subsystem Service (lsass.exe) default memory dump. This may
+indicate a credential access attempt via trusted system utilities such as Task Manager (taskmgr.exe) and SQL Dumper
+(sqldumper.exe) or known pentesting tools such as Dumpert and AndrewSpecial.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
@@ -19,6 +20,7 @@ risk_score = 73
 rule_id = "f2f46686-6f3c-4724-bd7d-24e31c70f98f"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -38,3 +40,4 @@ reference = "https://attack.mitre.org/techniques/T1003/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 73
 rule_id = "ebb200e8-adf0-43f8-a0bb-4ee5b5d852c6"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/credential_access_mimikatz_powershell_module.toml
+++ b/rules/windows/credential_access_mimikatz_powershell_module.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/07"
 maturity = "development"
-updated_date = "2020/12/07"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 99
 rule_id = "ac96ceb8-4399-4191-af1d-4feeac1f1f46"
 severity = "critical"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 21
 rule_id = "4630d948-40d4-4cef-ac69-4002e29bc3db"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/30"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "d331bbe2-6db4-4941-80a5-8270db72eb61"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -39,3 +40,4 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_code_injection_conhost.toml
+++ b/rules/windows/defense_evasion_code_injection_conhost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "28896382-7d4f-4d50-9b72-67091901fd26"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_cve_2020_0601.toml
+++ b/rules/windows/defense_evasion_cve_2020_0601.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/19"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "56557cde-d923-4b88-adee-c61b3f3b5dc3"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -35,6 +36,7 @@ reference = "https://attack.mitre.org/techniques/T1553/"
 id = "T1553.002"
 name = "Code Signing"
 reference = "https://attack.mitre.org/techniques/T1553/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
+++ b/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "f675872f-6d85-40a3-b502-c0d2ef101e92"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "T1070.004"
 name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "581add16-df76-42bb-af8e-c979bfb39a59"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "T1070.004"
 name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "4b438734-3793-4fda-bd42-ceeada0be8f9"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
+++ b/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2020/11/30"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 47
 rule_id = "201200f1-a99b-43fb-88ed-f65a45c4972c"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
+++ b/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "074464f9-f30d-4029-8c03-0ed237fffec7"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -38,6 +39,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
+++ b/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "fd70c98a-c410-42dc-a2e3-761c71848acf"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
+++ b/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2020/10/13"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "edf8ee23-5ea7-4123-ba19-56b41e424ae3"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 73
 rule_id = "c5dc3223-13a2-44a2-946c-e9dc0aa0449c"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae3"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae4"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae6"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -43,6 +44,7 @@ reference = "https://attack.mitre.org/techniques/T1027/"
 id = "T1027.004"
 name = "Compile After Delivery"
 reference = "https://attack.mitre.org/techniques/T1027/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
+++ b/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "1160dcdb-0a0a-4a79-91d8-9b84616edebd"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
+++ b/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
+++ b/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2020/11/25"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "93c1ce76-494c-4f01-8167-35edfb52f7b1"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -39,3 +40,4 @@ reference = "https://attack.mitre.org/techniques/T1140/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_iis_httplogging_disabled.toml
+++ b/rules/windows/defense_evasion_iis_httplogging_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/14"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "ebf1adea-ccf2-4943-8b96-7ab11ca173a5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_injection_msbuild.toml
+++ b/rules/windows/defense_evasion_injection_msbuild.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae9"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
+++ b/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/24"
 maturity = "production"
-updated_date = "2020/11/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "b41a13c6-ba45-4bab-a534-df53d0cfed6a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -44,3 +45,4 @@ reference = "https://attack.mitre.org/techniques/T1036/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
+++ b/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies a suspicious AutoIt process execution. Malware written as an AutoIt script tends to rename the AutoIt executable
-to avoid detection.
+Identifies a suspicious AutoIt process execution. Malware written as an AutoIt script tends to rename the AutoIt
+executable to avoid detection.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "2e1e835d-01e5-48ca-b9fc-7a61f7f11902"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -38,3 +39,4 @@ reference = "https://attack.mitre.org/techniques/T1036/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
+++ b/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/24"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -23,6 +23,7 @@ risk_score = 47
 rule_id = "ac5012b8-8da8-440b-aaaf-aedafdea2dff"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_masquerading_trusted_directory.toml
+++ b/rules/windows/defense_evasion_masquerading_trusted_directory.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/11/18"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
 Identifies execution from a directory masquerading as the Windows Program Files directories. These paths are trusted and
-usually host trusted third party programs. An adversary may leverage masquerading, along with low privileges to bypass detections
-whitelisting those folders.
+usually host trusted third party programs. An adversary may leverage masquerading, along with low privileges to bypass
+detections whitelisting those folders.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
@@ -19,6 +19,7 @@ risk_score = 43
 rule_id = "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -41,3 +42,4 @@ reference = "https://attack.mitre.org/techniques/T1036/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/16"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "69c251fb-a5d6-4035-b5ec-40438bd829ff"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -38,6 +39,7 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "T1070.004"
 name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_port_forwarding_added_registry.toml
+++ b/rules/windows/defense_evasion_port_forwarding_added_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "3535c8bb-3bd5-40f4-ae32-b7cd589d5372"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -38,6 +39,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
+++ b/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 47
 rule_id = "9aa0e1f6-52ce-42e1-abb3-09657cee2698"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -38,6 +39,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
+++ b/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 21
 rule_id = "5aee924b-6ceb-4633-980e-1bde8cdb40c5"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "T1070.004"
 name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "b9960fef-82c6-4816-befa-44745030e917"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
+++ b/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2020/10/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "acf738b5-b5b2-4acc-bad9-1e18ee234f40"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
+++ b/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,8 +18,8 @@ risk_score = 47
 rule_id = "97aba1ef-6034-4bd3-8c1a-1e0996b27afa"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
-
 
 query = '''
 process where event.type in ("start", "process_started", "info") and
@@ -38,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1036/"
 id = "T1055"
 name = "Process Injection"
 reference = "https://attack.mitre.org/techniques/T1055/"
+
 
 [rule.threat.tactic]
 id = "TA0005"

--- a/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
+++ b/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 73
 rule_id = "e94262f2-c1e9-4d3f-a907-aeab16712e1a"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_unusual_dir_ads.toml
+++ b/rules/windows/defense_evasion_unusual_dir_ads.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/12/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 47
 rule_id = "4bd1c1af-79d4-4d37-9efa-6e0240640242"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -37,3 +38,4 @@ reference = "https://attack.mitre.org/techniques/T1564/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
+++ b/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 73
 rule_id = "de9bd7e0-49e9-4e92-a64d-53ade2e66af1"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 21
 rule_id = "06dceabf-adca-48af-ac79-ffdf4c3b1e9a"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 73
 rule_id = "dc9c1f74-dac3-48e3-b47f-eb79db358f57"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1070/"
 id = "T1070.004"
 name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/discovery_adfind_command_activity.toml
+++ b/rules/windows/discovery_adfind_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -28,6 +28,7 @@ risk_score = 21
 rule_id = "eda499b8-a073-4e35-9733-22ec71f57f3a"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -75,3 +76,4 @@ reference = "https://attack.mitre.org/techniques/T1482/"
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/windows/discovery_admin_recon.toml
+++ b/rules/windows/discovery_admin_recon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/12/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 21
 rule_id = "871ea072-1b71-4def-b016-6278b505138d"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/discovery_file_dir_discovery.toml
+++ b/rules/windows/discovery_file_dir_discovery.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/12/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Enumeration of files and directories using built-in tools. Adversaries may use the information discovered
-to plan follow-on activity.
+Enumeration of files and directories using built-in tools. Adversaries may use the information discovered to plan
+follow-on activity.
 """
 index = ["logs-endpoint.events.*", "winlogbeat-*"]
 language = "eql"
@@ -17,13 +17,13 @@ risk_score = 21
 rule_id = "7b08314d-47a0-4b71-ae4e-16544176924f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
   (process.name : "cmd.exe" or process.pe.original_file_name == "Cmd.Exe") and
   process.args : ("dir", "tree")
-
 '''
 
 

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "2856446a-34e6-435b-9fb5-f8f040bfa7ed"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/discovery_net_view.toml
+++ b/rules/windows/discovery_net_view.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/12/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,7 @@ risk_score = 47
 rule_id = "7b8bfc26-81d2-435e-965c-d722ee397ef1"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/discovery_peripheral_device.toml
+++ b/rules/windows/discovery_peripheral_device.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2020/11/02"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies use of the Windows file system utility (fsutil.exe ) to gather information about attached peripheral devices and components
-connected to a computer system.
+Identifies use of the Windows file system utility (fsutil.exe ) to gather information about attached peripheral devices
+and components connected to a computer system.
 """
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "eql"
@@ -17,6 +17,7 @@ risk_score = 21
 rule_id = "0c7ca5c2-728d-4ad9-b1c5-bbba83ecb1f4"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -38,3 +39,4 @@ reference = "https://attack.mitre.org/techniques/T1120/"
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/windows/discovery_process_discovery_via_tasklist_command.toml
+++ b/rules/windows/discovery_process_discovery_via_tasklist_command.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 21
 rule_id = "cc16f774-59f9-462d-8b98-d27ccd4519ec"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/discovery_query_registry_via_reg.toml
+++ b/rules/windows/discovery_query_registry_via_reg.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/12/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Enumeration or discovery of the Windows registry using reg.exe. This information can be used to perform
-follow-on activities.
+Enumeration or discovery of the Windows registry using reg.exe. This information can be used to perform follow-on
+activities.
 """
 index = ["logs-endpoint.events.*", "winlogbeat-*"]
 language = "eql"
@@ -17,6 +17,7 @@ risk_score = 21
 rule_id = "68113fdc-3105-4cdd-85bb-e643c416ef0b"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/discovery_remote_system_discovery_commands_windows.toml
+++ b/rules/windows/discovery_remote_system_discovery_commands_windows.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/12/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,7 @@ risk_score = 21
 rule_id = "0635c542-1b96-4335-9b47-126582d2c19a"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/discovery_security_software_wmic.toml
+++ b/rules/windows/discovery_security_software_wmic.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/10/19"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "6ea55c81-e2ba-42f2-a134-bccf857ba922"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -39,3 +40,4 @@ reference = "https://attack.mitre.org/techniques/T1518/"
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -23,6 +23,7 @@ risk_score = 21
 rule_id = "ef862985-3f13-4262-a686-5f357bbb9bc2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_apt_solarwinds_backdoor_child_cmd_powershell.toml
+++ b/rules/windows/execution_apt_solarwinds_backdoor_child_cmd_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/12/14"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "d72e33fc-6e91-42ff-ac8b-e573268c5a87"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_apt_solarwinds_backdoor_unusual_child_processes.toml
+++ b/rules/windows/execution_apt_solarwinds_backdoor_unusual_child_processes.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/12/14"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "93b22c0a-06a0-4131-b830-b10d5e166ff4"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_command_shell_started_by_powershell.toml
+++ b/rules/windows/execution_command_shell_started_by_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 21
 rule_id = "0f616aee-8161-4120-857e-742366f5eeb3"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -33,6 +34,7 @@ reference = "https://attack.mitre.org/techniques/T1059/"
 id = "T1059.001"
 name = "PowerShell"
 reference = "https://attack.mitre.org/techniques/T1059/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 21
 rule_id = "fd7a6052-58fa-4397-93c3-4795249ccfa2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 47
 rule_id = "3b47900d-e793-49e8-968f-c90dc3526aa1"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_command_shell_via_rundll32.toml
+++ b/rules/windows/execution_command_shell_via_rundll32.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 21
 rule_id = "9ccf3ce0-0057-440a-91f5-870c6ad39093"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1059/"
 id = "T1059.001"
 name = "PowerShell"
 reference = "https://attack.mitre.org/techniques/T1059/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/execution_from_unusual_directory.toml
+++ b/rules/windows/execution_from_unusual_directory.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/10/30"
 maturity = "production"
-updated_date = "2020/10/30"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies process execution from suspicious default Windows directories. This is sometimes done by
-adversaries to hide malware in trusted paths.
+Identifies process execution from suspicious default Windows directories. This is sometimes done by adversaries to hide
+malware in trusted paths.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "ebfe1448-7fac-4d59-acea-181bd89b1f7f"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -39,3 +40,4 @@ process.executable : ("C:\\PerfLogs\\*.exe","C:\\Users\\Public\\*.exe","C:\\User
  /* uncomment once in winlogbeat */
  /* and not (process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true) */
 '''
+

--- a/rules/windows/execution_from_unusual_path_cmdline.toml
+++ b/rules/windows/execution_from_unusual_path_cmdline.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/30"
 maturity = "production"
-updated_date = "2020/10/30"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "cff92c41-2225-4763-b4ce-6f71e5bda5e6"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -38,3 +39,4 @@ process.args : ("C:\\PerfLogs\\*","C:\\Users\\Public\\*","C:\\Users\\Default\\*"
  "C:\\Windows\\rescache\\*","C:\\Windows\\Provisioning\\*","C:\\Windows\\PrintDialog\\*","C:\\Windows\\PolicyDefinitions\\*","C:\\Windows\\media\\*",
  "C:\\Windows\\Globalization\\*","C:\\Windows\\L2Schemas\\*","C:\\Windows\\LiveKernelReports\\*","C:\\Windows\\ModemLogs\\*","C:\\Windows\\ImmersiveControlPanel\\*")
 '''
+

--- a/rules/windows/execution_shared_modules_local_sxs_dll.toml
+++ b/rules/windows/execution_shared_modules_local_sxs_dll.toml
@@ -1,13 +1,14 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2020/10/28"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the creation, change, or deletion of a DLL module within a Windows SxS local folder. Adversaries may abuse shared modules to
-execute malicious payloads by instructing the Windows module loader to load DLLs from arbitrary local paths.
+Identifies the creation, change, or deletion of a DLL module within a Windows SxS local folder. Adversaries may abuse
+shared modules to execute malicious payloads by instructing the Windows module loader to load DLLs from arbitrary local
+paths.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
@@ -20,6 +21,7 @@ risk_score = 43
 rule_id = "a3ea12f3-0d4e-4667-8b44-4230c63f3c75"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -39,3 +41,4 @@ reference = "https://attack.mitre.org/techniques/T1129/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/execution_suspicious_cmd_wmi.toml
+++ b/rules/windows/execution_suspicious_cmd_wmi.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "12f07955-1674-44f7-86b5-c35da0a6f41a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_suspicious_image_load_wmi_ms_office.toml
+++ b/rules/windows/execution_suspicious_image_load_wmi_ms_office.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/11/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 21
 rule_id = "891cb88e-441a-4c3e-be2d-120d99fe7b0d"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/30"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "53a26770-9cbd-40c5-8b57-61d01a325e14"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_suspicious_powershell_imgload.toml
+++ b/rules/windows/execution_suspicious_powershell_imgload.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "852c1f19-68e8-43a6-9dce-340771fe1be3"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/execution_suspicious_psexesvc.toml
+++ b/rules/windows/execution_suspicious_psexesvc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "e2f9fdf5-8076-45ad-9427-41e0e03dc9c2"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1569/"
 id = "T1569.002"
 name = "Service Execution"
 reference = "https://attack.mitre.org/techniques/T1569/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/execution_suspicious_short_program_name.toml
+++ b/rules/windows/execution_suspicious_short_program_name.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2020/11/15"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,9 +18,11 @@ risk_score = 47
 rule_id = "17c7f6a5-5bc9-4e1f-92bf-13632d24384d"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and length(process.name) > 0 and
  length(process.name) == 5 and host.os.name == "Windows" and length(process.pe.original_file_name) > 5
 '''
+

--- a/rules/windows/execution_via_compiled_html_file.toml
+++ b/rules/windows/execution_via_compiled_html_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 21
 rule_id = "e3343ab9-4245-4715-b344-e11c56b0a47f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_via_hidden_shell_conhost.toml
+++ b/rules/windows/execution_via_hidden_shell_conhost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 73
 rule_id = "05b358de-aa6d-4f6c-89e6-78f74018b43b"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_via_net_com_assemblies.toml
+++ b/rules/windows/execution_via_net_com_assemblies.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 21
 rule_id = "47f09343-8d1f-4bb5-8bb0-00c9d18f5010"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 73
 rule_id = "4ed493fc-d637-4a36-80ff-ac84937e5461"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_vssadmin.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_vssadmin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 73
 rule_id = "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/initial_access_script_executing_powershell.toml
+++ b/rules/windows/initial_access_script_executing_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -35,6 +36,7 @@ reference = "https://attack.mitre.org/techniques/T1566/"
 id = "T1566.001"
 name = "Spearphishing Attachment"
 reference = "https://attack.mitre.org/techniques/T1566/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/initial_access_suspicious_ms_office_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_office_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "a624863f-a70d-417f-a7d2-7a404638d47f"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "32f4675e-6c49-4ace-80f9-97c9259dca2e"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/initial_access_unusual_dns_service_children.toml
+++ b/rules/windows/initial_access_unusual_dns_service_children.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -35,6 +35,7 @@ risk_score = 73
 rule_id = "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/initial_access_unusual_dns_service_file_writes.toml
+++ b/rules/windows/initial_access_unusual_dns_service_file_writes.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,7 @@ risk_score = 73
 rule_id = "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
+++ b/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/29"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 43
 rule_id = "9a5b4e31-6cde-4295-9ff7-6be1b8567e1b"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/lateral_movement_dns_server_overflow.toml
+++ b/rules/windows/lateral_movement_dns_server_overflow.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -35,6 +35,7 @@ risk_score = 47
 rule_id = "11013227-0301-4a8c-b150-4db924484475"
 severity = "medium"
 tags = ["Elastic", "Network", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/lateral_movement_execution_from_tsclient_mup.toml
+++ b/rules/windows/lateral_movement_execution_from_tsclient_mup.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/11"
 maturity = "production"
-updated_date = "2020/11/11"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "4fe9d835-40e1-452d-8230-17c147cafad8"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/lateral_movement_local_service_commands.toml
+++ b/rules/windows/lateral_movement_local_service_commands.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "e8571d5f-bea1-46c2-9f56-998de2d3ed95"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/lateral_movement_mount_hidden_or_webdav_share_net.toml
+++ b/rules/windows/lateral_movement_mount_hidden_or_webdav_share_net.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "c4210e1c-64f2-4f48-b67e-b5a8ffe3aa14"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -42,6 +43,7 @@ reference = "https://attack.mitre.org/techniques/T1021/"
 id = "T1021.002"
 name = "SMB/Windows Admin Shares"
 reference = "https://attack.mitre.org/techniques/T1021/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2020/11/25"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies registry write modifications to enable Remote Desktop Protocol (RDP) access. This could be indicative of adversary lateral movement
-preparation.
+Identifies registry write modifications to enable Remote Desktop Protocol (RDP) access. This could be indicative of
+adversary lateral movement preparation.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*"]
@@ -18,6 +18,7 @@ risk_score = 43
 rule_id = "58aa72ca-d968-4f34-b9f7-bea51d75eb50"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -40,3 +41,4 @@ reference = "https://attack.mitre.org/techniques/T1021/"
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
+

--- a/rules/windows/lateral_movement_rdp_tunnel_plink.toml
+++ b/rules/windows/lateral_movement_rdp_tunnel_plink.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/10/14"
 maturity = "production"
-updated_date = "2020/10/14"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies potential use of an SSH utility to establish RDP over a reverse SSH Tunnel. This could be indicative of adversary lateral
-movement to interactively access restricted networks.
+Identifies potential use of an SSH utility to establish RDP over a reverse SSH Tunnel. This could be indicative of
+adversary lateral movement to interactively access restricted networks.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*"]
@@ -19,12 +19,13 @@ risk_score = 73
 rule_id = "76fd43b7-3480-4dd9-8ad7-8bd36bfad92f"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started", "info") and 
 /* RDP port and usual SSH tunneling related switches in commandline */
-wildcard(process.args, "*:3389") and wildcard(process.args,"-L", "-P", "-R", "-pw", "-ssh") 
+wildcard(process.args, "*:3389") and wildcard(process.args,"-L", "-P", "-R", "-pw", "-ssh")
 '''
 
 

--- a/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
+++ b/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/04"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "fa01341d-6662-426b-9d0c-6d81e33c8a9d"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1021/"
 id = "T1021.002"
 name = "SMB/Windows Admin Shares"
 reference = "https://attack.mitre.org/techniques/T1021/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/lateral_movement_suspicious_rdp_client_imageload.toml
+++ b/rules/windows/lateral_movement_suspicious_rdp_client_imageload.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/11/19"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies suspicious Image Loading of the Remote Desktop Services ActiveX Client (mstscax), this may indicate the presence
-of RDP lateral movement capability.
+Identifies suspicious Image Loading of the Remote Desktop Services ActiveX Client (mstscax), this may indicate the
+presence of RDP lateral movement capability.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "71c5cb27-eca5-4151-bb47-64bc3f883270"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -49,3 +50,4 @@ reference = "https://attack.mitre.org/techniques/T1021/"
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
+

--- a/rules/windows/lateral_movement_via_startup_folder_rdp_smb.toml
+++ b/rules/windows/lateral_movement_via_startup_folder_rdp_smb.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "25224a80-5a4a-4b8a-991e-6ab390465c4f"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -36,12 +37,11 @@ id = "T1021"
 name = "Remote Services"
 reference = "https://attack.mitre.org/techniques/T1021/"
 
+
 [rule.threat.tactic]
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -52,6 +52,7 @@ reference = "https://attack.mitre.org/techniques/T1547/"
 id = "T1547.001"
 name = "Registry Run Keys / Startup Folder"
 reference = "https://attack.mitre.org/techniques/T1547/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ risk_score = 21
 rule_id = "2bf78aa2-9c56-48de-b139-f169bf99cf86"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -35,6 +36,7 @@ reference = "https://attack.mitre.org/techniques/T1574/"
 id = "T1574.010"
 name = "Services File Permissions Weakness"
 reference = "https://attack.mitre.org/techniques/T1574/010/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_appcertdlls_registry.toml
+++ b/rules/windows/persistence_appcertdlls_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 47
 rule_id = "513f0ffd-b317-4b9c-9494-92ce861f22c7"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1546/"
 id = "T1546.009"
 name = "AppCert DLLs"
 reference = "https://attack.mitre.org/techniques/T1546/009/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_appinitdlls_registry.toml
+++ b/rules/windows/persistence_appinitdlls_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 47
 rule_id = "d0e159cf-73e9-40d1-a9ed-077e3158a855"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -40,6 +41,7 @@ reference = "https://attack.mitre.org/techniques/T1546/"
 id = "T1546.010"
 name = "AppInit DLLs"
 reference = "https://attack.mitre.org/techniques/T1546/010/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_evasion_registry_ifeo_injection.toml
+++ b/rules/windows/persistence_evasion_registry_ifeo_injection.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 41
 rule_id = "6839c821-011d-43bd-bd5b-acff00257226"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -43,6 +44,7 @@ reference = "https://attack.mitre.org/techniques/T1546/"
 id = "T1546.012"
 name = "Image File Execution Options Injection"
 reference = "https://attack.mitre.org/techniques/T1546/012/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_gpo_schtask_service_creation.toml
+++ b/rules/windows/persistence_gpo_schtask_service_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 21
 rule_id = "c0429aa8-9974-42da-bfb6-53a0a515a145"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_local_scheduled_task_commands.toml
+++ b/rules/windows/persistence_local_scheduled_task_commands.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ risk_score = 21
 rule_id = "afcce5ad-65de-4ed2-8516-5e093d3ac99a"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_ms_office_addins_file.toml
+++ b/rules/windows/persistence_ms_office_addins_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/16"
 maturity = "production"
-updated_date = "2020/10/16"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ risk_score = 71
 rule_id = "f44fa4b6-524c-4e87-8d9e-a32599e4fb7c"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -39,3 +40,4 @@ reference = "https://attack.mitre.org/techniques/T1137/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/windows/persistence_ms_outlook_vba_template.toml
+++ b/rules/windows/persistence_ms_outlook_vba_template.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/11/23"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 43
 rule_id = "397945f3-d39a-4e6f-8bcb-9656c2031438"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -40,3 +41,4 @@ reference = "https://attack.mitre.org/techniques/T1137/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "7405ddf1-6c8e-41ce-818f-48bea6bcaed8"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -66,6 +67,7 @@ name = "Accessibility Features"
 reference = "https://attack.mitre.org/techniques/T1546/008/"
 
 
+
 [rule.threat.tactic]
 id = "TA0003"
 name = "Persistence"
@@ -80,6 +82,7 @@ reference = "https://attack.mitre.org/techniques/T1546/"
 id = "T1546.008"
 name = "Accessibility Features"
 reference = "https://attack.mitre.org/techniques/T1546/008/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_registry_uncommon.toml
+++ b/rules/windows/persistence_registry_uncommon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "54902e45-3467-49a4-8abc-529f2c8cfb80"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/persistence_run_key_and_startup_broad.toml
+++ b/rules/windows/persistence_run_key_and_startup_broad.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 21
 rule_id = "97fc44d3-8dae-4019-ae83-298c3015600f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -59,6 +60,7 @@ reference = "https://attack.mitre.org/techniques/T1547/"
 id = "T1547.001"
 name = "Registry Run Keys / Startup Folder"
 reference = "https://attack.mitre.org/techniques/T1547/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_services_registry.toml
+++ b/rules/windows/persistence_services_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "403ef0d3-8259-40c9-a5b6-d48354712e49"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -46,6 +47,7 @@ reference = "https://attack.mitre.org/techniques/T1543/"
 id = "T1543.003"
 name = "Windows Service"
 reference = "https://attack.mitre.org/techniques/T1543/003/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
+++ b/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 47
 rule_id = "440e2db4-bc7f-4c96-a068-65b78da59bde"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -55,6 +56,7 @@ reference = "https://attack.mitre.org/techniques/T1547/"
 id = "T1547.001"
 name = "Registry Run Keys / Startup Folder"
 reference = "https://attack.mitre.org/techniques/T1547/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_startup_folder_scripts.toml
+++ b/rules/windows/persistence_startup_folder_scripts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,7 @@ risk_score = 47
 rule_id = "f7c4dc5a-a58d-491d-9f14-9b66507121c0"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -42,6 +43,7 @@ reference = "https://attack.mitre.org/techniques/T1547/"
 id = "T1547.001"
 name = "Registry Run Keys / Startup Folder"
 reference = "https://attack.mitre.org/techniques/T1547/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_suspicious_com_hijack_registry.toml
+++ b/rules/windows/persistence_suspicious_com_hijack_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 47
 rule_id = "16a52c14-7883-47af-8745-9357803f0d4c"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -49,6 +50,7 @@ reference = "https://attack.mitre.org/techniques/T1546/"
 id = "T1546.015"
 name = "Component Object Model Hijacking"
 reference = "https://attack.mitre.org/techniques/T1546/015/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_suspicious_image_load_scheduled_task_ms_office.toml
+++ b/rules/windows/persistence_suspicious_image_load_scheduled_task_ms_office.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/11/17"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -23,6 +23,7 @@ risk_score = 21
 rule_id = "baa5d22c-5e1c-4f33-bfc9-efa73bb53022"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
+++ b/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/11/19"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ risk_score = 43
 rule_id = "5d1d6907-0747-4d5d-9b24-e4a18853dc0a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/persistence_suspicious_service_created_registry.toml
+++ b/rules/windows/persistence_suspicious_service_created_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 73
 rule_id = "36a8e048-d888-4f61-a8b9-0f9e2e40f317"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -36,6 +37,7 @@ reference = "https://attack.mitre.org/techniques/T1543/"
 id = "T1543.003"
 name = "Windows Service"
 reference = "https://attack.mitre.org/techniques/T1543/003/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "0022d47d-39c7-4f69-a232-4fe9dc7a3acd"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1543/"
 id = "T1543.003"
 name = "Windows Service"
 reference = "https://attack.mitre.org/techniques/T1543/003/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "1aa9181a-492b-4c01-8b16-fa0735786b2b"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_via_application_shimming.toml
+++ b/rules/windows/persistence_via_application_shimming.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "fd4a992d-6130-4802-9ff8-829b89ae801f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -52,6 +53,7 @@ reference = "https://attack.mitre.org/techniques/T1546/"
 id = "T1546.011"
 name = "Application Shimming"
 reference = "https://attack.mitre.org/techniques/T1546/011/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_via_hidden_run_key_valuename.toml
+++ b/rules/windows/persistence_via_hidden_run_key_valuename.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 73
 rule_id = "a9b05c3b-b304-4bf9-970d-acdfaef2944c"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -45,6 +46,7 @@ reference = "https://attack.mitre.org/techniques/T1547/"
 id = "T1547.001"
 name = "Registry Run Keys / Startup Folder"
 reference = "https://attack.mitre.org/techniques/T1547/001/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
+++ b/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ risk_score = 47
 rule_id = "e86da94d-e54b-4fb5-b96c-cecff87e8787"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1547/"
 id = "T1547.005"
 name = "Security Support Provider"
 reference = "https://attack.mitre.org/techniques/T1547/005/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
+++ b/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,7 @@ risk_score = 73
 rule_id = "68921d85-d0dc-48b3-865f-43291ca2c4f2"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
+++ b/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "265db8f5-fc73-4d0d-b434-6483b56372e2"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -39,6 +40,7 @@ reference = "https://attack.mitre.org/techniques/T1543/"
 id = "T1543.003"
 name = "Windows Service"
 reference = "https://attack.mitre.org/techniques/T1543/003/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
+++ b/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/12/04"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "9b6813a1-daf1-457e-b0e6-0bb4e55b8a4c"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -25,7 +26,6 @@ process where event.type in ("start", "process_started") and
   (process.name : "wmic.exe" or process.pe.original_file_name == "wmic.exe") and
   process.args : "create" and
   process.args : ("ActiveScriptEventConsumer", "CommandLineEventConsumer")
-
 '''
 
 
@@ -41,3 +41,4 @@ reference = "https://attack.mitre.org/techniques/T1546/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/windows/privilege_escalation_named_pipe_impersonation.toml
+++ b/rules/windows/privilege_escalation_named_pipe_impersonation.toml
@@ -1,22 +1,26 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/11/23"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies a privilege escalation attempt via named pipe impersonation. An adversary may abuse this technique by utilizing a framework such Metasploit's meterpreter getsystem command.
+Identifies a privilege escalation attempt via named pipe impersonation. An adversary may abuse this technique by
+utilizing a framework such Metasploit's meterpreter getsystem command.
 """
 index = ["winlogbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License"
 name = "Privilege Escalation via Named Pipe Impersonation"
-references = ["https://www.ired.team/offensive-security/privilege-escalation/windows-namedpipes-privilege-escalation"]
+references = [
+    "https://www.ired.team/offensive-security/privilege-escalation/windows-namedpipes-privilege-escalation",
+]
 risk_score = 73
 rule_id = "3ecbdc9e-e4f2-43fa-8cca-63802125e582"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -38,3 +42,4 @@ reference = "https://attack.mitre.org/techniques/T1134/"
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -23,6 +23,7 @@ risk_score = 74
 rule_id = "5bb4a95d-5a08-48eb-80db-4c3a63ec78a8"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/11/03"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ risk_score = 74
 rule_id = "a7ccae7b-9d2c-44b2-a061-98e5946971fa"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
+++ b/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/26"
 maturity = "production"
-updated_date = "2020/11/26"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 71
 rule_id = "d563aaba-2e72-462b-8658-3e5ea22db3a6"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -32,14 +33,15 @@ framework = "MITRE ATT&CK"
 id = "T1574"
 name = "Hijack Execution Flow"
 reference = "https://attack.mitre.org/techniques/T1574/"
-
 [[rule.threat.technique.subtechnique]]
 id = "T1574.007"
 name = "Path Interception by PATH Environment Variable"
 reference = "https://attack.mitre.org/techniques/T1574/007/"
 
 
+
 [rule.threat.tactic]
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 71
 rule_id = "b90cdde7-7e0d-4359-8bf0-2c112ce2008a"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -39,6 +40,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.002"
 name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_uac_bypass_com_ieinstal.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_ieinstal.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "fc7c0fa4-8f03-4b3e-8336-c5feab0be022"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -41,6 +42,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.002"
 name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_uac_bypass_com_interface_icmluautil.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_interface_icmluautil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 73
 rule_id = "68d56fdc-7ffa-4419-8e95-81641bd6f845"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -38,6 +39,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.002"
 name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 47
 rule_id = "1dcc51f6-ba26-49e7-9ef4-2655abb2361e"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.002"
 name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_uac_bypass_dll_sideloading.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_dll_sideloading.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/27"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "5a14d01d-7ac8-4545-914c-b687c2cf66b3"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -40,6 +41,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.002"
 name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/17"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ risk_score = 21
 rule_id = "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.002"
 name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/26"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 71
 rule_id = "290aca65-e94d-403b-ba0f-62f320e63f51"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -37,6 +38,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.002"
 name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/14"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "1178ae09-5aff-460a-9f2f-455cd0ac4d8e"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -40,6 +41,7 @@ reference = "https://attack.mitre.org/techniques/T1548/"
 id = "T1548.002"
 name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "35df0dd8-092d-4a83-88c1-5151a804f31b"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -68,6 +69,7 @@ reference = "https://attack.mitre.org/techniques/T1055/"
 id = "T1055.012"
 name = "Process Hollowing"
 reference = "https://attack.mitre.org/techniques/T1055/012/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/privilege_escalation_unusual_svchost_childproc_childless.toml
+++ b/rules/windows/privilege_escalation_unusual_svchost_childproc_childless.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2020/12/09"
+updated_date = "2020/02/16"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies unusual child processes of Service Host (svchost.exe) that traditionally do not spawn any child processes. This may indicate
-a code injection or an equivalent form of exploitation.
+Identifies unusual child processes of Service Host (svchost.exe) that traditionally do not spawn any child processes.
+This may indicate a code injection or an equivalent form of exploitation.
 """
 false_positives = ["Changes to Windows services or a rarely executed child process."]
 from = "now-9m"
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "6a8ab9cc-4023-4d17-b5df-1a3e16882ce7"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
@@ -51,12 +52,12 @@ id = "T1055.012"
 name = "Process Hollowing"
 reference = "https://attack.mitre.org/techniques/T1055/012/"
 
+
+
 [rule.threat.tactic]
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -69,3 +70,4 @@ reference = "https://attack.mitre.org/techniques/T1055/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+


### PR DESCRIPTION
## Issues
related to https://github.com/elastic/security-team/issues/746
related to #945

## Summary
For rules in 7.11.2, set `timestamp_override = "event.ingested"` for all KQL, Lucene, and non-sequence EQL rules to account for misses that would result from ingest delays exceeding the lookback time defined in the rule.

#945 will update any new rules introduced since 7.12 release package