### PR TITLE
[Rule Tuning] Remove timestamp_override for endgame-* promotion rules

### DIFF
--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -76,8 +76,8 @@
   },
   "0a97b20f-4144-49ea-be32-b540ecc445de": {
     "rule_name": "Malware - Detected - Endpoint Security",
-    "sha256": "d4b0108faa80fc35468cc5cfbbaf48b4db4dad7d1373cf48388752568eb83c98",
-    "version": 5
+    "sha256": "adcd895329cc4d1c41bc4bf8b75404c838823731713fa11f3d3b671dd24cc31d",
+    "version": 4
   },
   "0b29cab4-dbbd-4a3f-9e8e-1287c7c11ae5": {
     "rule_name": "Anomalous Windows Process Creation",
@@ -296,8 +296,8 @@
   },
   "2003cdc8-8d83-4aa5-b132-1f9a8eb48514": {
     "rule_name": "Exploit - Detected - Endpoint Security",
-    "sha256": "81850f386eb8a302e85e9d36c472f159c4db6f7df7068bd0657b7a4bed6687b4",
-    "version": 5
+    "sha256": "83322d535ddc84dec40b7a90e9738726df2bd27ac3cdf96e7b9ebd967560bd25",
+    "version": 4
   },
   "201200f1-a99b-43fb-88ed-f65a45c4972c": {
     "rule_name": "Suspicious .NET Code Compilation",
@@ -371,8 +371,8 @@
   },
   "2863ffeb-bf77-44dd-b7a5-93ef94b72036": {
     "rule_name": "Exploit - Prevented - Endpoint Security",
-    "sha256": "8025e0d14b4ac2c3698276722c6310fd134681c4f71ee1f624681aae18e7940b",
-    "version": 5
+    "sha256": "4a04fd5b4099a19a093d301762f68352221eca036db21c9b9b2e388dc5c56a9e",
+    "version": 4
   },
   "28896382-7d4f-4d50-9b72-67091901fd26": {
     "rule_name": "Suspicious Process from Conhost",
@@ -541,8 +541,8 @@
   },
   "3b382770-efbb-44f4-beed-f5e0a051b895": {
     "rule_name": "Malware - Prevented - Endpoint Security",
-    "sha256": "11be6e8247af54541336c5e12c8a3423afd6884940d4b7f50160abb215a2337b",
-    "version": 5
+    "sha256": "49bf69bac026013bdfd88dbb0ebbf5f2cf01d0bcc8dbdc00d760cc4c1ecf6daf",
+    "version": 4
   },
   "3b47900d-e793-49e8-968f-c90dc3526aa1": {
     "rule_name": "Unusual Parent Process for cmd.exe",
@@ -606,8 +606,8 @@
   },
   "453f659e-0429-40b1-bfdb-b6957286e04b": {
     "rule_name": "Permission Theft - Prevented - Endpoint Security",
-    "sha256": "abc8e7c3bcc3a15d3c3f0f751333d1273f45b2d2fec6908c64af0132f529c07d",
-    "version": 5
+    "sha256": "de91fb70ece5386bf2fe4d065f50aa219516eff015f22534b5cd1b69064fe002",
+    "version": 4
   },
   "45d273fb-1dca-457d-9855-bcb302180c21": {
     "rule_name": "Encrypting Files with WinRar or 7z",
@@ -751,8 +751,8 @@
   },
   "571afc56-5ed9-465d-a2a9-045f099f6e7e": {
     "rule_name": "Credential Dumping - Detected - Endpoint Security",
-    "sha256": "26fa244a5b78452aa61775e3ee2894c6b1bd109cef9c2af649e4dc372ccb5820",
-    "version": 5
+    "sha256": "bdc750ae44da6954d429af1c78db084f915fe63db463a2e084107bd4b7725a73",
+    "version": 4
   },
   "581add16-df76-42bb-af8e-c979bfb39a59": {
     "rule_name": "Deleting Backup Catalogs with Wbadmin",
@@ -1046,8 +1046,8 @@
   },
   "77a3c3df-8ec4-4da4-b758-878f551dee69": {
     "rule_name": "Adversary Behavior - Detected - Endpoint Security",
-    "sha256": "feb872802e7782ee07c3ce2339461810c274ee659c348fc97732f92049821215",
-    "version": 5
+    "sha256": "60af511ccd3ed511fec254c879279d5090ca084efa9c11bc4fb01690450b7180",
+    "version": 4
   },
   "785a404b-75aa-4ffd-8be5-3334a5a544dd": {
     "rule_name": "Application Added to Google Workspace Domain",
@@ -1111,8 +1111,8 @@
   },
   "80c52164-c82a-402c-9964-852533d58be1": {
     "rule_name": "Process Injection - Detected - Endpoint Security",
-    "sha256": "4f1de68d87322c3c6461f6185af8a92e1a0bf4c9cf15482acb0d5fc54aee9ad2",
-    "version": 5
+    "sha256": "126b716fe963842ff8406842f8a101953a04e7e9f167e578094712fa6b006b00",
+    "version": 4
   },
   "81cc58f5-8062-49a2-ba84-5cc4b4d31c40": {
     "rule_name": "Persistence via Kernel Module Modification",
@@ -1186,8 +1186,8 @@
   },
   "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd": {
     "rule_name": "Ransomware - Detected - Endpoint Security",
-    "sha256": "cc1ace9a3ad8ce73ec1f8770f4e28eeff0ef3cd0a16c05667446e6b3245ead12",
-    "version": 5
+    "sha256": "afa86e4d621fd2e511406e86b4ae9c07348c4471320a9ef65b26e0643c34e133",
+    "version": 4
   },
   "8ddab73b-3d15-4e5d-9413-47f05553c1d7": {
     "rule_name": "Azure Automation Runbook Deleted",
@@ -1321,8 +1321,8 @@
   },
   "990838aa-a953-4f3e-b3cb-6ddf7584de9e": {
     "rule_name": "Process Injection - Prevented - Endpoint Security",
-    "sha256": "022423bc49a60ec9e5e498ebbcb53aefd560e79e0b2f3a0d1ab3b523a69c413b",
-    "version": 5
+    "sha256": "92c674029d3c058f18ec3fafbf91a3c2443023a6a18db9c3118cbf6d4138388d",
+    "version": 4
   },
   "9a1a2dae-0b5f-4c3d-8305-a268d404c306": {
     "rule_name": "Endpoint Security",
@@ -1711,8 +1711,8 @@
   },
   "c0be5f31-e180-48ed-aa08-96b36899d48f": {
     "rule_name": "Credential Manipulation - Detected - Endpoint Security",
-    "sha256": "8cc4996c8b4f2215ed4f55e655ee2885255470bc1a1ad5b9ca9ddca5b67d360b",
-    "version": 5
+    "sha256": "3e27a7e7fda1be83a083f51ec320e2c49e41a3048660137a7d551e30b8c997c3",
+    "version": 4
   },
   "c25e9c87-95e1-4368-bfab-9fd34cf867ec": {
     "rule_name": "Microsoft IIS Connection Strings Decryption",
@@ -1736,8 +1736,8 @@
   },
   "c3167e1b-f73c-41be-b60b-87f4df707fe3": {
     "rule_name": "Permission Theft - Detected - Endpoint Security",
-    "sha256": "01ef32f083b0567b88de07eb3e0d12f44d921b856a867438182a18a915ce6df9",
-    "version": 5
+    "sha256": "7b185258dbbaa2a9837362d5bb5f7551cfdf689ccbd0119140c1155c581dd80c",
+    "version": 4
   },
   "c4210e1c-64f2-4f48-b67e-b5a8ffe3aa14": {
     "rule_name": "Mounting Hidden or WebDav Remote Shares",
@@ -1801,8 +1801,8 @@
   },
   "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa": {
     "rule_name": "Credential Manipulation - Prevented - Endpoint Security",
-    "sha256": "5e44b1db0cda0ab4d0164d299c3ab1d19040ef76742cc689a565a1f1d05f419a",
-    "version": 5
+    "sha256": "0734e9a063c5bbf35c5b4b73c95544f1399e648c12d6396698015de1d5d392ef",
+    "version": 4
   },
   "ca79768e-40e1-4e45-a097-0e5fbc876ac2": {
     "rule_name": "Microsoft 365 Exchange Malware Filter Rule Modification",
@@ -1981,8 +1981,8 @@
   },
   "db8c33a8-03cd-4988-9e2c-d0a4863adb13": {
     "rule_name": "Credential Dumping - Prevented - Endpoint Security",
-    "sha256": "d2cc502d59bfbd70f4141daac53c9d1b5f4bc02cfab59c4332124854a1d87ec2",
-    "version": 5
+    "sha256": "ce8fd451c2c3bc3c5f9b35f212dc0b75348bb07d1c1c4c1559e575150874345f",
+    "version": 4
   },
   "dc9c1f74-dac3-48e3-b47f-eb79db358f57": {
     "rule_name": "Volume Shadow Copy Deletion via WMIC",
@@ -2066,8 +2066,8 @@
   },
   "e3c5d5cb-41d5-4206-805c-f30561eae3ac": {
     "rule_name": "Ransomware - Prevented - Endpoint Security",
-    "sha256": "3eaf582284975d232f4419f32b8f6e2b383e7c68328a779e7da46c7feebbccb1",
-    "version": 5
+    "sha256": "911ba16663efb30078217f771edbd6e7356f869662483fac274b09c8097580cb",
+    "version": 4
   },
   "e3cf38fa-d5b8-46cc-87f9-4a7513e4281d": {
     "rule_name": "Connection to Commonly Abused Free SSL Certificate Providers",

--- a/rules/apm/apm_403_response_to_a_post.toml
+++ b/rules/apm/apm_403_response_to_a_post.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/apm/apm_405_response_method_not_allowed.toml
+++ b/rules/apm/apm_405_response_method_not_allowed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/apm/apm_null_user_agent.toml
+++ b/rules/apm/apm_null_user_agent.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/apm/apm_sqlmap_user_agent.toml
+++ b/rules/apm/apm_sqlmap_user_agent.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/aws/collection_cloudtrail_logging_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/aws/credential_access_iam_user_addition_to_group.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
+++ b/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Nick Jones", "Elastic"]

--- a/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/15"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/aws/defense_evasion_config_service_rule_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/26"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/16"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/15"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/28"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/27"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/aws/defense_evasion_waf_acl_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/09"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/aws/impact_cloudtrail_logging_updated.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/aws/impact_ec2_disable_ebs_encryption.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/05"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/aws/impact_iam_deactivate_mfa_device.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_iam_group_deletion.toml
+++ b/rules/aws/impact_iam_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_rds_cluster_deletion.toml
+++ b/rules/aws/impact_rds_cluster_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/aws/impact_rds_instance_cluster_stoppage.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/initial_access_console_login_root.toml
+++ b/rules/aws/initial_access_console_login_root.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/11"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/initial_access_password_recovery.toml
+++ b/rules/aws/initial_access_password_recovery.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/02"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/initial_access_via_system_manager.toml
+++ b/rules/aws/initial_access_via_system_manager.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/aws/persistence_ec2_network_acl_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/persistence_iam_group_creation.toml
+++ b/rules/aws/persistence_iam_group_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/05"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/persistence_rds_cluster_creation.toml
+++ b/rules/aws/persistence_rds_cluster_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/collection_update_event_hub_auth_rule.toml
+++ b/rules/azure/collection_update_event_hub_auth_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/credential_access_key_vault_modified.toml
+++ b/rules/azure/credential_access_key_vault_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/credential_access_storage_account_key_regenerated.toml
+++ b/rules/azure/credential_access_storage_account_key_regenerated.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_azure_application_credential_modification.toml
+++ b/rules/azure/defense_evasion_azure_application_credential_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
+++ b/rules/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_event_hub_deletion.toml
+++ b/rules/azure/defense_evasion_event_hub_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_firewall_policy_deletion.toml
+++ b/rules/azure/defense_evasion_firewall_policy_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_network_watcher_deletion.toml
+++ b/rules/azure/defense_evasion_network_watcher_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/discovery_blob_container_access_mod.toml
+++ b/rules/azure/discovery_blob_container_access_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/execution_command_virtual_machine.toml
+++ b/rules/azure/execution_command_virtual_machine.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/impact_azure_automation_runbook_deleted.toml
+++ b/rules/azure/impact_azure_automation_runbook_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/impact_resource_group_deletion.toml
+++ b/rules/azure/impact_resource_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
+++ b/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/initial_access_external_guest_user_invite.toml
+++ b/rules/azure/initial_access_external_guest_user_invite.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_automation_account_created.toml
+++ b/rules/azure/persistence_azure_automation_account_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_automation_runbook_created_or_modified.toml
+++ b/rules/azure/persistence_azure_automation_runbook_created_or_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_automation_webhook_created.toml
+++ b/rules/azure/persistence_azure_automation_webhook_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_conditional_access_policy_modified.toml
+++ b/rules/azure/persistence_azure_conditional_access_policy_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_pim_user_added_global_admin.toml
+++ b/rules/azure/persistence_azure_pim_user_added_global_admin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_privileged_identity_management_role_modified.toml
+++ b/rules/azure/persistence_azure_privileged_identity_management_role_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_mfa_disabled_for_azure_user.toml
+++ b/rules/azure/persistence_mfa_disabled_for_azure_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_user_added_as_owner_for_azure_application.toml
+++ b/rules/azure/persistence_user_added_as_owner_for_azure_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
+++ b/rules/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/defense_evasion_deleting_websvr_access_logs.toml
+++ b/rules/cross-platform/defense_evasion_deleting_websvr_access_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/07"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
+++ b/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/collection_gcp_pub_sub_subscription_creation.toml
+++ b/rules/gcp/collection_gcp_pub_sub_subscription_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/collection_gcp_pub_sub_topic_creation.toml
+++ b/rules/gcp/collection_gcp_pub_sub_topic_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_created.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_logging_sink_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_logging_sink_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/exfiltration_gcp_logging_sink_modification.toml
+++ b/rules/gcp/exfiltration_gcp_logging_sink_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_iam_role_deletion.toml
+++ b/rules/gcp/impact_gcp_iam_role_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_service_account_deleted.toml
+++ b/rules/gcp/impact_gcp_service_account_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_service_account_disabled.toml
+++ b/rules/gcp/impact_gcp_service_account_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_storage_bucket_deleted.toml
+++ b/rules/gcp/impact_gcp_storage_bucket_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_virtual_private_cloud_route_created.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_route_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/initial_access_gcp_iam_custom_role_creation.toml
+++ b/rules/gcp/initial_access_gcp_iam_custom_role_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/persistence_gcp_iam_service_account_key_deletion.toml
+++ b/rules/gcp/persistence_gcp_iam_service_account_key_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/persistence_gcp_key_created_for_service_account.toml
+++ b/rules/gcp/persistence_gcp_key_created_for_service_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/persistence_gcp_service_account_created.toml
+++ b/rules/gcp/persistence_gcp_service_account_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/application_added_to_google_workspace_domain.toml
+++ b/rules/google-workspace/application_added_to_google_workspace_domain.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/google_workspace_admin_role_deletion.toml
+++ b/rules/google-workspace/google_workspace_admin_role_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/google-workspace/google_workspace_mfa_enforcement_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/google_workspace_policy_modified.toml
+++ b/rules/google-workspace/google_workspace_policy_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/google-workspace/mfa_disabled_for_google_workspace_organization.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
+++ b/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/12"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/persistence_google_workspace_custom_admin_role_created.toml
+++ b/rules/google-workspace/persistence_google_workspace_custom_admin_role_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/persistence_google_workspace_role_modified.toml
+++ b/rules/google-workspace/persistence_google_workspace_role_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/credential_access_tcpdump_activity.toml
+++ b/rules/linux/credential_access_tcpdump_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/27"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base16_or_base32_encoding_or_decoding_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base64_encoding_or_decoding_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
+++ b/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_disable_selinux_attempt.toml
+++ b/rules/linux/defense_evasion_disable_selinux_attempt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/22"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_file_deletion_via_shred.toml
+++ b/rules/linux/defense_evasion_file_deletion_via_shred.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/27"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_file_mod_writable_dir.toml
+++ b/rules/linux/defense_evasion_file_mod_writable_dir.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
+++ b/rules/linux/defense_evasion_hex_encoding_or_decoding_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/29"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_kernel_module_removal.toml
+++ b/rules/linux/defense_evasion_kernel_module_removal.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_log_files_deleted.toml
+++ b/rules/linux/defense_evasion_log_files_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_timestomp_touch.toml
+++ b/rules/linux/defense_evasion_timestomp_touch.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/discovery_kernel_module_enumeration.toml
+++ b/rules/linux/discovery_kernel_module_enumeration.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/discovery_virtual_machine_fingerprinting.toml
+++ b/rules/linux/discovery_virtual_machine_fingerprinting.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/27"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/discovery_whoami_commmand.toml
+++ b/rules/linux/discovery_whoami_commmand.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/execution_perl_tty_shell.toml
+++ b/rules/linux/execution_perl_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/16"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/15"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/linux_hping_activity.toml
+++ b/rules/linux/linux_hping_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/linux_iodine_activity.toml
+++ b/rules/linux/linux_iodine_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/linux_mknod_activity.toml
+++ b/rules/linux/linux_mknod_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/linux_nmap_activity.toml
+++ b/rules/linux/linux_nmap_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/linux_nping_activity.toml
+++ b/rules/linux/linux_nping_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/linux_process_started_in_temp_directory.toml
+++ b/rules/linux/linux_process_started_in_temp_directory.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/linux_socat_activity.toml
+++ b/rules/linux/linux_socat_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/linux_strace_activity.toml
+++ b/rules/linux/linux_strace_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/persistence_kernel_module_activity.toml
+++ b/rules/linux/persistence_kernel_module_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/persistence_shell_activity_by_web_server.toml
+++ b/rules/linux/persistence_shell_activity_by_web_server.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setgid_bit_set_via_chmod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
+++ b/rules/linux/privilege_escalation_setuid_bit_set_via_chmod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/privilege_escalation_sudoers_file_mod.toml
+++ b/rules/linux/privilege_escalation_sudoers_file_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/13"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_compress_credentials_keychains.toml
+++ b/rules/macos/credential_access_compress_credentials_keychains.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_kerberosdump_kcc.toml
+++ b/rules/macos/credential_access_kerberosdump_kcc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
+++ b/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/16"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
+++ b/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
+++ b/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_login_logout_hooks_defaults.toml
+++ b/rules/macos/persistence_login_logout_hooks_defaults.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/07"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
+++ b/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
+++ b/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/microsoft_365_exchange_dkim_signing_config_disabled.toml
+++ b/rules/microsoft-365/microsoft_365_exchange_dkim_signing_config_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/microsoft_365_teams_custom_app_interaction_allowed.toml
+++ b/rules/microsoft-365/microsoft_365_teams_custom_app_interaction_allowed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/30"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/persistence_microsoft_365_exchange_management_role_assignment.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_exchange_management_role_assignment.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/persistence_microsoft_365_teams_external_access_enabled.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_teams_external_access_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/30"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/persistence_microsoft_365_teams_guest_access_enabled.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_teams_guest_access_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_cobalt_strike_beacon.toml
+++ b/rules/network/command_and_control_cobalt_strike_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
+++ b/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/05"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_dns_directly_to_the_internet.toml
+++ b/rules/network/command_and_control_dns_directly_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_download_rar_powershell_from_internet.toml
+++ b/rules/network/command_and_control_download_rar_powershell_from_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/02"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_ftp_file_transfer_protocol_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_ftp_file_transfer_protocol_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_halfbaked_beacon.toml
+++ b/rules/network/command_and_control_halfbaked_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_irc_internet_relay_chat_protocol_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_irc_internet_relay_chat_protocol_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_nat_traversal_port_activity.toml
+++ b/rules/network/command_and_control_nat_traversal_port_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_port_26_activity.toml
+++ b/rules/network/command_and_control_port_26_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_port_8000_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_port_8000_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_pptp_point_to_point_tunneling_protocol_activity.toml
+++ b/rules/network/command_and_control_pptp_point_to_point_tunneling_protocol_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_proxy_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_proxy_port_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_rdp_remote_desktop_protocol_from_the_internet.toml
+++ b/rules/network/command_and_control_rdp_remote_desktop_protocol_from_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_smtp_to_the_internet.toml
+++ b/rules/network/command_and_control_smtp_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_sql_server_port_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_ssh_secure_shell_from_the_internet.toml
+++ b/rules/network/command_and_control_ssh_secure_shell_from_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_ssh_secure_shell_to_the_internet.toml
+++ b/rules/network/command_and_control_ssh_secure_shell_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_telnet_port_activity.toml
+++ b/rules/network/command_and_control_telnet_port_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_tor_activity_to_the_internet.toml
+++ b/rules/network/command_and_control_tor_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_vnc_virtual_network_computing_from_the_internet.toml
+++ b/rules/network/command_and_control_vnc_virtual_network_computing_from_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_vnc_virtual_network_computing_to_the_internet.toml
+++ b/rules/network/command_and_control_vnc_virtual_network_computing_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/discovery_post_exploitation_public_ip_reconnaissance.toml
+++ b/rules/network/discovery_post_exploitation_public_ip_reconnaissance.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/initial_access_rdp_remote_desktop_protocol_to_the_internet.toml
+++ b/rules/network/initial_access_rdp_remote_desktop_protocol_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/initial_access_rpc_remote_procedure_call_from_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_from_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/initial_access_smb_windows_file_sharing_activity_to_the_internet.toml
+++ b/rules/network/initial_access_smb_windows_file_sharing_activity_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/initial_access_unsecure_elasticsearch_node.toml
+++ b/rules/network/initial_access_unsecure_elasticsearch_node.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/11"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/attempt_to_deactivate_okta_network_zone.toml
+++ b/rules/okta/attempt_to_deactivate_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/attempt_to_delete_okta_network_zone.toml
+++ b/rules/okta/attempt_to_delete_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/okta/impact_possible_okta_dos_attack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_deactivate_okta_application.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_deactivate_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_delete_okta_application.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_delete_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/28"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_delete_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_okta_application.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/01"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
+++ b/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/elastic_endpoint.toml
+++ b/rules/promotions/elastic_endpoint.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/08"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endpoint_adversary_behavior_detected.toml
+++ b/rules/promotions/endpoint_adversary_behavior_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 47
 rule_id = "77a3c3df-8ec4-4da4-b758-878f551dee69"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_dumping_detected.toml
+++ b/rules/promotions/endpoint_cred_dumping_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "571afc56-5ed9-465d-a2a9-045f099f6e7e"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_dumping_prevented.toml
+++ b/rules/promotions/endpoint_cred_dumping_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 47
 rule_id = "db8c33a8-03cd-4988-9e2c-d0a4863adb13"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_manipulation_detected.toml
+++ b/rules/promotions/endpoint_cred_manipulation_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "c0be5f31-e180-48ed-aa08-96b36899d48f"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_cred_manipulation_prevented.toml
+++ b/rules/promotions/endpoint_cred_manipulation_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 47
 rule_id = "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_exploit_detected.toml
+++ b/rules/promotions/endpoint_exploit_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "2003cdc8-8d83-4aa5-b132-1f9a8eb48514"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_exploit_prevented.toml
+++ b/rules/promotions/endpoint_exploit_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 47
 rule_id = "2863ffeb-bf77-44dd-b7a5-93ef94b72036"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_malware_detected.toml
+++ b/rules/promotions/endpoint_malware_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 99
 rule_id = "0a97b20f-4144-49ea-be32-b540ecc445de"
 severity = "critical"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_malware_prevented.toml
+++ b/rules/promotions/endpoint_malware_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "3b382770-efbb-44f4-beed-f5e0a051b895"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_permission_theft_detected.toml
+++ b/rules/promotions/endpoint_permission_theft_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "c3167e1b-f73c-41be-b60b-87f4df707fe3"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_permission_theft_prevented.toml
+++ b/rules/promotions/endpoint_permission_theft_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 47
 rule_id = "453f659e-0429-40b1-bfdb-b6957286e04b"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_process_injection_detected.toml
+++ b/rules/promotions/endpoint_process_injection_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "80c52164-c82a-402c-9964-852533d58be1"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_process_injection_prevented.toml
+++ b/rules/promotions/endpoint_process_injection_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 47
 rule_id = "990838aa-a953-4f3e-b3cb-6ddf7584de9e"
 severity = "medium"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_ransomware_detected.toml
+++ b/rules/promotions/endpoint_ransomware_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 99
 rule_id = "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd"
 severity = "critical"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endpoint_ransomware_prevented.toml
+++ b/rules/promotions/endpoint_ransomware_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "e3c5d5cb-41d5-4206-805c-f30561eae3ac"
 severity = "high"
 tags = ["Elastic", "Endpoint Security"]
-timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/08"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/collection_email_powershell_exchange_mailbox.toml
+++ b/rules/windows/collection_email_powershell_exchange_mailbox.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/15"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/collection_persistence_powershell_exch_mailbox_activesync_add_device.toml
+++ b/rules/windows/collection_persistence_powershell_exch_mailbox_activesync_add_device.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/15"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/collection_winrar_encryption.toml
+++ b/rules/windows/collection_winrar_encryption.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_common_webservices.toml
+++ b/rules/windows/command_and_control_common_webservices.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_encrypted_channel_freesslcert.toml
+++ b/rules/windows/command_and_control_encrypted_channel_freesslcert.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
+++ b/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
+++ b/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
+++ b/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_cmdline_dump_tool.toml
+++ b/rules/windows/credential_access_cmdline_dump_tool.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
+++ b/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_credential_dumping_msbuild.toml
+++ b/rules/windows/credential_access_credential_dumping_msbuild.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_dump_registry_hives.toml
+++ b/rules/windows/credential_access_dump_registry_hives.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
+++ b/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_iis_connectionstrings_dumping.toml
+++ b/rules/windows/credential_access_iis_connectionstrings_dumping.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_kerberoasting_unusual_process.toml
+++ b/rules/windows/credential_access_kerberoasting_unusual_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_lsass_memdump_file_created.toml
+++ b/rules/windows/credential_access_lsass_memdump_file_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_mimikatz_powershell_module.toml
+++ b/rules/windows/credential_access_mimikatz_powershell_module.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/07"
 maturity = "development"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_code_injection_conhost.toml
+++ b/rules/windows/defense_evasion_code_injection_conhost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_cve_2020_0601.toml
+++ b/rules/windows/defense_evasion_cve_2020_0601.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
+++ b/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
+++ b/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
+++ b/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
+++ b/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
+++ b/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
+++ b/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
+++ b/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
+++ b/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_iis_httplogging_disabled.toml
+++ b/rules/windows/defense_evasion_iis_httplogging_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_injection_msbuild.toml
+++ b/rules/windows/defense_evasion_injection_msbuild.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
+++ b/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
+++ b/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
+++ b/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/24"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_masquerading_trusted_directory.toml
+++ b/rules/windows/defense_evasion_masquerading_trusted_directory.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/16"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_port_forwarding_added_registry.toml
+++ b/rules/windows/defense_evasion_port_forwarding_added_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
+++ b/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
+++ b/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
+++ b/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
+++ b/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
+++ b/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_unusual_dir_ads.toml
+++ b/rules/windows/defense_evasion_unusual_dir_ads.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
+++ b/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_adfind_command_activity.toml
+++ b/rules/windows/discovery_adfind_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_admin_recon.toml
+++ b/rules/windows/discovery_admin_recon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_file_dir_discovery.toml
+++ b/rules/windows/discovery_file_dir_discovery.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_net_view.toml
+++ b/rules/windows/discovery_net_view.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_peripheral_device.toml
+++ b/rules/windows/discovery_peripheral_device.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_process_discovery_via_tasklist_command.toml
+++ b/rules/windows/discovery_process_discovery_via_tasklist_command.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_query_registry_via_reg.toml
+++ b/rules/windows/discovery_query_registry_via_reg.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_remote_system_discovery_commands_windows.toml
+++ b/rules/windows/discovery_remote_system_discovery_commands_windows.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_security_software_wmic.toml
+++ b/rules/windows/discovery_security_software_wmic.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_apt_solarwinds_backdoor_child_cmd_powershell.toml
+++ b/rules/windows/execution_apt_solarwinds_backdoor_child_cmd_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_apt_solarwinds_backdoor_unusual_child_processes.toml
+++ b/rules/windows/execution_apt_solarwinds_backdoor_unusual_child_processes.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_command_shell_started_by_powershell.toml
+++ b/rules/windows/execution_command_shell_started_by_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_command_shell_via_rundll32.toml
+++ b/rules/windows/execution_command_shell_via_rundll32.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_from_unusual_directory.toml
+++ b/rules/windows/execution_from_unusual_directory.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/30"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_from_unusual_path_cmdline.toml
+++ b/rules/windows/execution_from_unusual_path_cmdline.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/30"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_shared_modules_local_sxs_dll.toml
+++ b/rules/windows/execution_shared_modules_local_sxs_dll.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_suspicious_cmd_wmi.toml
+++ b/rules/windows/execution_suspicious_cmd_wmi.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_suspicious_image_load_wmi_ms_office.toml
+++ b/rules/windows/execution_suspicious_image_load_wmi_ms_office.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/30"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_suspicious_powershell_imgload.toml
+++ b/rules/windows/execution_suspicious_powershell_imgload.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_suspicious_psexesvc.toml
+++ b/rules/windows/execution_suspicious_psexesvc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_suspicious_short_program_name.toml
+++ b/rules/windows/execution_suspicious_short_program_name.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_via_compiled_html_file.toml
+++ b/rules/windows/execution_via_compiled_html_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_via_hidden_shell_conhost.toml
+++ b/rules/windows/execution_via_hidden_shell_conhost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_via_net_com_assemblies.toml
+++ b/rules/windows/execution_via_net_com_assemblies.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_vssadmin.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_vssadmin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_script_executing_powershell.toml
+++ b/rules/windows/initial_access_script_executing_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_suspicious_ms_office_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_office_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_unusual_dns_service_children.toml
+++ b/rules/windows/initial_access_unusual_dns_service_children.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_unusual_dns_service_file_writes.toml
+++ b/rules/windows/initial_access_unusual_dns_service_file_writes.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
+++ b/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/29"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_dns_server_overflow.toml
+++ b/rules/windows/lateral_movement_dns_server_overflow.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_execution_from_tsclient_mup.toml
+++ b/rules/windows/lateral_movement_execution_from_tsclient_mup.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/11"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_local_service_commands.toml
+++ b/rules/windows/lateral_movement_local_service_commands.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_mount_hidden_or_webdav_share_net.toml
+++ b/rules/windows/lateral_movement_mount_hidden_or_webdav_share_net.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_rdp_tunnel_plink.toml
+++ b/rules/windows/lateral_movement_rdp_tunnel_plink.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
+++ b/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_suspicious_rdp_client_imageload.toml
+++ b/rules/windows/lateral_movement_suspicious_rdp_client_imageload.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_via_startup_folder_rdp_smb.toml
+++ b/rules/windows/lateral_movement_via_startup_folder_rdp_smb.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_appcertdlls_registry.toml
+++ b/rules/windows/persistence_appcertdlls_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_appinitdlls_registry.toml
+++ b/rules/windows/persistence_appinitdlls_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_evasion_registry_ifeo_injection.toml
+++ b/rules/windows/persistence_evasion_registry_ifeo_injection.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_gpo_schtask_service_creation.toml
+++ b/rules/windows/persistence_gpo_schtask_service_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_local_scheduled_task_commands.toml
+++ b/rules/windows/persistence_local_scheduled_task_commands.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_ms_office_addins_file.toml
+++ b/rules/windows/persistence_ms_office_addins_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/16"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_ms_outlook_vba_template.toml
+++ b/rules/windows/persistence_ms_outlook_vba_template.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_registry_uncommon.toml
+++ b/rules/windows/persistence_registry_uncommon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_run_key_and_startup_broad.toml
+++ b/rules/windows/persistence_run_key_and_startup_broad.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_services_registry.toml
+++ b/rules/windows/persistence_services_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
+++ b/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_startup_folder_scripts.toml
+++ b/rules/windows/persistence_startup_folder_scripts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_suspicious_com_hijack_registry.toml
+++ b/rules/windows/persistence_suspicious_com_hijack_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_suspicious_image_load_scheduled_task_ms_office.toml
+++ b/rules/windows/persistence_suspicious_image_load_scheduled_task_ms_office.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
+++ b/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_suspicious_service_created_registry.toml
+++ b/rules/windows/persistence_suspicious_service_created_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_via_application_shimming.toml
+++ b/rules/windows/persistence_via_application_shimming.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_via_hidden_run_key_valuename.toml
+++ b/rules/windows/persistence_via_hidden_run_key_valuename.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
+++ b/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
+++ b/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
+++ b/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
+++ b/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_named_pipe_impersonation.toml
+++ b/rules/windows/privilege_escalation_named_pipe_impersonation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
+++ b/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/26"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_uac_bypass_com_ieinstal.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_ieinstal.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_uac_bypass_com_interface_icmluautil.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_interface_icmluautil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_uac_bypass_dll_sideloading.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_dll_sideloading.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/27"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/17"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/26"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/14"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_unusual_svchost_childproc_childless.toml
+++ b/rules/windows/privilege_escalation_unusual_svchost_childproc_childless.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2020/02/16"
+updated_date = "2021/02/16"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues
related to https://github.com/elastic/kibana/pull/91597

## Summary
Removed the `timestamp_override` field from all `endgame-*` promotion rules, because the field is not mapped.

I also _very_ carefully reset the hashes and versions of these files to their previous state, so as not to double bump (since these have not yet been released). The more eyes on this the merrier (a good [reference](https://github.com/elastic/detection-rules/blob/66be82808c1db873870fc769e44e9614267bc3af/etc/version.lock.json) point - the last lock before the previous changes)

The `updated_date` was also fixed with the correct year (but this is inconsequential to the rules in Kibana as that field is used only locally at this point) 