### PR TITLE
[New Rule] Installer Spawning cURL from macOS Package

### DIFF
--- a/rules/macos/execution_curl_spawned_from_installer_package.toml
+++ b/rules/macos/execution_curl_spawned_from_installer_package.toml
@@ -23,6 +23,7 @@ risk_score = 47
 rule_id = "99239e7d-b0d4-46e3-8609-acafcf99f68c"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
@@ -67,3 +68,4 @@ reference = "https://attack.mitre.org/techniques/T1071/001/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/macos/execution_curl_spawned_from_installer_package.toml
+++ b/rules/macos/execution_curl_spawned_from_installer_package.toml
@@ -17,7 +17,6 @@ index = ["logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License"
 name = "Installer Spawning cURL from macOS Package"
-note = "This activity has been observed in the Silver Sparrow campaign. Leverage the Exclusion framework is recommended to tune this to your environment."
 references = ["https://redcanary.com/blog/clipping-silver-sparrows-wings"]
 risk_score = 47
 rule_id = "99239e7d-b0d4-46e3-8609-acafcf99f68c"

--- a/rules/macos/execution_curl_spawned_from_installer_package.toml
+++ b/rules/macos/execution_curl_spawned_from_installer_package.toml
@@ -26,10 +26,9 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and event.type:start and
- process.parent.executable: "/System/Library/CoreServices/Installer.app/Contents/MacOS/Installer" and
- process.executable: (/bin/bash or /bin/zsh or /bin/sh) and
- process.command_line.text: "/usr/bin/curl"
+sequence by process.entity_id
+  [ process where host.os.family == "macos" and (process.parent.executable == "/usr/sbin/installer" or process.parent.executable == "/System/Library/CoreServices/Installer.app/Contents/MacOS/Installer") ]
+  [ network where not cidrMatch(destination.ip, "192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "224.0.0.0/8") ]
 '''
 
 

--- a/rules/macos/execution_curl_spawned_from_installer_package.toml
+++ b/rules/macos/execution_curl_spawned_from_installer_package.toml
@@ -6,8 +6,8 @@ updated_date = "2021/02/23"
 [rule]
 author = ["Elastic"]
 description = """
-This rule identifies when the built in macOS Installer program is used to install a package that spawns a shell and runs
-the cURL command.
+Identifies when the built in macOS Installer program is used to install a package that spawns a shell and runs
+the cURL command. This activity has been observed being leveraged by malware.
 """
 false_positives = [
     "Custom organization-specific macOS packages that use .pkg files to run cURL could trigger this rule.",
@@ -68,4 +68,3 @@ reference = "https://attack.mitre.org/techniques/T1071/001/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
-

--- a/rules/macos/execution_curl_spawned_from_installer_package.toml
+++ b/rules/macos/execution_curl_spawned_from_installer_package.toml
@@ -10,7 +10,7 @@ Identifies when the built in macOS Installer program is used to install a packag
 the cURL command. This activity has been observed being leveraged by malware.
 """
 false_positives = [
-    "Custom organization-specific macOS packages that use .pkg files to run cURL could trigger this rule.",
+    "Custom organization-specific macOS packages that use .pkg files to run cURL could trigger this rule. If known behavior is causing false positives, it can be excluded from the rule.",
 ]
 from = "now-9m"
 index = ["logs-endpoint.events.*"]

--- a/rules/macos/execution_curl_spawned_from_installer_package.toml
+++ b/rules/macos/execution_curl_spawned_from_installer_package.toml
@@ -1,0 +1,69 @@
+[metadata]
+creation_date = "2021/02/23"
+maturity = "production"
+updated_date = "2021/02/23"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule identifies when the built in macOS Installer program is used to install a package that spawns a shell and runs
+the cURL command.
+"""
+false_positives = [
+    "Custom organization-specific macOS packages that use .pkg files to run cURL could trigger this rule.",
+]
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "kuery"
+license = "Elastic License"
+name = "Installer Spawning cURL from macOS Package"
+note = "This activity has been observed in the Silver Sparrow campaign. Leverage the Exclusion framework is recommended to tune this to your environment."
+references = ["https://redcanary.com/blog/clipping-silver-sparrows-wings"]
+risk_score = 47
+rule_id = "99239e7d-b0d4-46e3-8609-acafcf99f68c"
+severity = "medium"
+tags = ["Elastic", "Host", "macOS", "Threat Detection", "Execution"]
+type = "query"
+
+query = '''
+event.category:process and event.type:start and
+ process.parent.executable: "/System/Library/CoreServices/Installer.app/Contents/MacOS/Installer" and
+ process.executable: (/bin/bash or /bin/zsh or /bin/sh) and
+ process.command_line.text: "/usr/bin/curl"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.007"
+name = "JavaScript/JScript"
+reference = "https://attack.mitre.org/techniques/T1059/007/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1071"
+name = "Application Layer Protocol"
+reference = "https://attack.mitre.org/techniques/T1071/"
+[[rule.threat.technique.subtechnique]]
+id = "T1071.001"
+name = "Web Protocols"
+reference = "https://attack.mitre.org/techniques/T1071/001/"
+
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"

--- a/rules/macos/execution_installer_spawned_network_event.toml
+++ b/rules/macos/execution_installer_spawned_network_event.toml
@@ -6,29 +6,43 @@ updated_date = "2021/02/23"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when the built in macOS Installer program is used to install a package that spawns a shell and runs
-the cURL command. This activity has been observed being leveraged by malware.
+Identifies when the built in macOS Installer program generates a network event after attempting to install a .pkg file.
+This activity has been observed being leveraged by malware.
 """
 false_positives = [
-    "Custom organization-specific macOS packages that use .pkg files to run cURL could trigger this rule. If known behavior is causing false positives, it can be excluded from the rule.",
+    """
+    Custom organization-specific macOS packages that use .pkg files to run cURL could trigger this rule. If known
+    behavior is causing false positives, it can be excluded from the rule.
+    """,
 ]
 from = "now-9m"
 index = ["logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License"
-name = "Installer Spawning cURL from macOS Package"
+name = "macOS Installer Spawns Network Event"
 references = ["https://redcanary.com/blog/clipping-silver-sparrows-wings"]
 risk_score = 47
 rule_id = "99239e7d-b0d4-46e3-8609-acafcf99f68c"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
 sequence by process.entity_id
-  [ process where host.os.family == "macos" and (process.parent.executable == "/usr/sbin/installer" or process.parent.executable == "/System/Library/CoreServices/Installer.app/Contents/MacOS/Installer") ]
-  [ network where not cidrMatch(destination.ip, "192.168.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "224.0.0.0/8") ]
+  [ process where host.os.family == "macos" and (
+    process.parent.executable == "/usr/sbin/installer" or
+    process.parent.executable == "/System/Library/CoreServices/Installer.app/Contents/MacOS/Installer") ]
+  [ network where not cidrmatch(destination.ip,
+    "192.168.0.0/16",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "224.0.0.0/8",
+    "127.0.0.0/8",
+    "169.254.0.0/16",
+    "::1",
+    "FE80::/10",
+    "FF00::/8") ]
 '''
 
 

--- a/rules/macos/execution_installer_spawned_network_event.toml
+++ b/rules/macos/execution_installer_spawned_network_event.toml
@@ -29,20 +29,19 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by process.entity_id
-  [ process where host.os.family == "macos" and (
-    process.parent.executable == "/usr/sbin/installer" or
-    process.parent.executable == "/System/Library/CoreServices/Installer.app/Contents/MacOS/Installer") ]
+sequence by process.entity_id with maxspan=1m
+  [ process where event.type == "start" and host.os.family == "macos" and 
+      process.parent.executable in ("/usr/sbin/installer", "/System/Library/CoreServices/Installer.app/Contents/MacOS/Installer") ]
   [ network where not cidrmatch(destination.ip,
-    "192.168.0.0/16",
-    "10.0.0.0/8",
-    "172.16.0.0/12",
-    "224.0.0.0/8",
-    "127.0.0.0/8",
-    "169.254.0.0/16",
-    "::1",
-    "FE80::/10",
-    "FF00::/8") ]
+      "192.168.0.0/16",
+      "10.0.0.0/8",
+      "172.16.0.0/12",
+      "224.0.0.0/8",
+      "127.0.0.0/8",
+      "169.254.0.0/16",
+      "::1",
+      "FE80::/10",
+      "FF00::/8") ]
 '''
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
Resolves #957 

## Summary
This rule identifies when the built-in macOS Installer program is used to install a package that spawns a shell and runs
the cURL command.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? Yes
