### PR TITLE
[New Rule] Microsoft Exchange Server’s Unified Messaging Spawning Vulnerability - CVE-2021-26857

### DIFF
--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -22,9 +22,9 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:cmd.exe and
-  process.parent.name:sqlservr.exe
+event.category:process and event.type:start and
+  process.parent.executable:((UMService.exe or UMWorkerProcess.exe) and
+    not (werfault.exe or wermgr.exe))
 '''
 
 

--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -22,9 +22,9 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and event.type:start and
-  process.parent.executable:((UMService.exe or UMWorkerProcess.exe) and
-    not (werfault.exe or wermgr.exe))
+event.category:process and event.type:(start or process_started) and
+  process.name:cmd.exe and
+  process.parent.name:sqlservr.exe
 '''
 
 

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -6,8 +6,8 @@ updated_date = "2021/03/04"
 [rule]
 author = ["Elastic", "Austin Songer"]
 description = """
-This rule identifies suspicious processes being spawned by the Microsoft Exchange Server Unified Messaging (UM) service. This
-activity has been observed from the CVE-2021-26857 exploit.
+Identifies suspicious processes being spawned by the Microsoft Exchange Server Unified Messaging (UM) service. This
+activity has been observed in CVE-2021-26857.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
@@ -42,3 +42,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -27,8 +27,8 @@ type = "query"
 
 query = '''
 event.category:process and event.type:start and
-  process.parent.executable:(UMWorkerProcess.exe and
-    not (werfault.exe or wermgr.exe))
+  process.parent.executable:(UMWorkerProcess.exe or UMService.exe) and
+    not process.parent.executable:(werfault.exe or wermgr.exe)
 '''
 
 

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -28,7 +28,7 @@ type = "query"
 query = '''
 event.category:process and event.type:start and
   process.parent.executable:(UMWorkerProcess.exe and
-  not (werfault.exe or wermgr.exe))
+    not (werfault.exe or wermgr.exe))
 '''
 
 

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -11,7 +11,7 @@ activity has been observed exploiting CVE-2021-26857.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Exchange Server UM Spawning Suspicious Processes"
 references = [
@@ -23,12 +23,12 @@ rule_id = "483c4daf-b0c6-49e0-adf3-0bfa93231d6b"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:start and
-  process.parent.executable:((UMService.exe or UMWorkerProcess.exe) and
-    not (WerFault.exe or wermgr.exe))
+process where event.type == "start" and
+  process.parent.name : ("UMService.exe", "UMWorkerProcess.exe") and
+    not process.parent.name : ("werfault.exe", "wermgr.exe")
 '''
 
 

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -7,7 +7,7 @@ updated_date = "2021/03/04"
 author = ["Elastic", "Austin Songer"]
 description = """
 Identifies suspicious processes being spawned by the Microsoft Exchange Server Unified Messaging (UM) service. This
-activity has been observed in CVE-2021-26857.
+activity has been observed exploiting CVE-2021-26857.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
@@ -26,7 +26,9 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and event.type:start and process.parent.executable:(UMWorkerProcess.exe and not (werfault.exe or wermgr.exe)) and winlog.event_id:(1 or 4688)
+event.category:process and event.type:start and
+  process.parent.executable:(UMWorkerProcess.exe and
+  not (werfault.exe or wermgr.exe))
 '''
 
 

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -1,0 +1,42 @@
+[metadata]
+creation_date = "2021/03/04"
+maturity = "development"
+updated_date = "2021/03/04"
+
+[rule]
+author = ["Austin Songer"]
+description = "desc"
+from = "now-9m"
+index = ["filebeat"]
+language = "kuery"
+license = "Elastic License v2"
+name = "name"
+note = "note"
+references = [
+    "https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers",
+    "https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities",
+]
+risk_score = 47
+rule_id = "483c4daf-b0c6-49e0-adf3-0bfa93231d6b"
+severity = "medium"
+tags = ["tags"]
+type = "query"
+
+query = '''
+event.category:process
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1190"
+name = "Exploit Public-Facing Application"
+reference = "https://attack.mitre.org/techniques/T1190/"
+
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -13,7 +13,7 @@ from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "Microsoft Exchange Server UM Spawning Suspcious Processes"
+name = "Microsoft Exchange Server UM Spawning Suspicious Processes"
 references = [
     "https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers",
     "https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities",
@@ -44,4 +44,3 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
-

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -4,13 +4,13 @@ maturity = "production"
 updated_date = "2021/03/04"
 
 [rule]
-author = ["Austin Songer"]
+author = ["Elastic", "Austin Songer"]
 description = """
 This rule identifies suspicious processes being spawned by the Microsoft Exchange Server Unified Messaging (UM) service. This
 activity has been observed from the CVE-2021-26857 exploit.
 """
 from = "now-9m"
-index = ["logs-*", "winlogbeat-*"]
+index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft Exchange Server UM Spawning Suspcious Processes"

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -9,6 +9,12 @@ description = """
 Identifies suspicious processes being spawned by the Microsoft Exchange Server Unified Messaging (UM) service. This
 activity has been observed exploiting CVE-2021-26857.
 """
+false_positives = [
+    """
+    Legitimate processes may be spawned from the Microsoft Exchange Server Unified Messaging (UM) service. If known
+    processes are causing false positives, they can be exempted from the rule.
+    """,
+]
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
@@ -28,7 +34,7 @@ type = "eql"
 query = '''
 process where event.type == "start" and
   process.parent.name : ("UMService.exe", "UMWorkerProcess.exe") and
-    not process.parent.name : ("werfault.exe", "wermgr.exe")
+    not process.name : ("werfault.exe", "wermgr.exe")
 '''
 
 
@@ -44,3 +50,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -1,17 +1,19 @@
 [metadata]
 creation_date = "2021/03/04"
-maturity = "development"
+maturity = "production"
 updated_date = "2021/03/04"
 
 [rule]
 author = ["Austin Songer"]
-description = "desc"
+description = """
+This rule identifies suspicious processes being spawned by the Microsoft Exchange Server Unified Messaging (UM). This
+activity has been observed from the CVE-2021-26857 exploit.
+"""
 from = "now-9m"
-index = ["filebeat"]
+index = ["winlogbeat-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "name"
-note = "note"
+name = "Microsoft Exchange Server UM Spawning Suspcious Processes"
 references = [
     "https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers",
     "https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities",
@@ -19,11 +21,12 @@ references = [
 risk_score = 47
 rule_id = "483c4daf-b0c6-49e0-adf3-0bfa93231d6b"
 severity = "medium"
-tags = ["tags"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process
+event.category:process and event.type:start and process.parent.executable:(UMWorkerProcess.exe and not (werfault.exe or wermgr.exe)) and winlog.event_id:(1 or 4688)
 '''
 
 
@@ -39,4 +42,3 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
-

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -28,7 +28,7 @@ type = "query"
 query = '''
 event.category:process and event.type:start and
   process.parent.executable:((UMService.exe or UMWorkerProcess.exe) and
-    not (werfault.exe or wermgr.exe))
+    not (WerFault.exe or wermgr.exe))
 '''
 
 

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -6,11 +6,11 @@ updated_date = "2021/03/04"
 [rule]
 author = ["Austin Songer"]
 description = """
-This rule identifies suspicious processes being spawned by the Microsoft Exchange Server Unified Messaging (UM). This
+This rule identifies suspicious processes being spawned by the Microsoft Exchange Server Unified Messaging (UM) service. This
 activity has been observed from the CVE-2021-26857 exploit.
 """
 from = "now-9m"
-index = ["winlogbeat-*"]
+index = ["logs-*", "winlogbeat-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft Exchange Server UM Spawning Suspcious Processes"

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -27,8 +27,8 @@ type = "query"
 
 query = '''
 event.category:process and event.type:start and
-  process.parent.executable:(UMWorkerProcess.exe or UMService.exe) and
-    not process.parent.executable:(werfault.exe or wermgr.exe)
+  process.parent.executable:((UMService.exe or UMWorkerProcess.exe) and
+    not (werfault.exe or wermgr.exe))
 '''
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
Resolves #972 

## Summary
This rule detects CVE-2021-2685 and detects new processes being spawned by the Exchange UM service where that process has not previously been observed before.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? Yes
