### PR TITLE
Change asset type for integration to security-rule

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -481,7 +481,7 @@ class Package(object):
 
         package_dir = Path(save_dir).joinpath(manifest.version)
         docs_dir = package_dir / 'docs'
-        rules_dir = package_dir / 'kibana' / 'rules'
+        rules_dir = package_dir / 'kibana' / 'security-rule'
 
         docs_dir.mkdir(parents=True)
         rules_dir.mkdir(parents=True)


### PR DESCRIPTION
## Issues
None

## Summary
Related to https://github.com/elastic/package-spec/pull/142 and https://github.com/elastic/package-storage/pull/843.

Changed the asset type/folder to `security-rule`