### PR TITLE
Add tests to ensure rules are properly deprecated

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -298,6 +298,32 @@ def search_rule_prs(ctx, no_loop, query, columns, language, token, threads):
         ctx.invoke(search_rules, query=query, columns=columns, language=language, rules=all_rules, pager=True)
 
 
+@dev_group.command('deprecate-rule')
+@click.argument('rule-file', type=click.Path(dir_okay=False))
+@click.pass_context
+def deprecate_rule(ctx: click.Context, rule_file: str):
+    """Deprecate a rule."""
+    import pytoml
+    from .packaging import load_versions
+
+    version_info = load_versions()
+    rule_file = Path(rule_file)
+    contents = pytoml.loads(rule_file.read_text())
+    rule = Rule(path=rule_file, contents=contents)
+
+    if rule.id not in version_info:
+        click.echo('Rule has not been version locked and so does not need to be deprecated. '
+                   'Delete the file or update the maturity to `development` instead')
+        ctx.exit()
+
+    today = time.strftime('%Y/%m/%d')
+    rule.metadata.update(updated_date=today, deprecation_date=today, maturity='deprecated')
+    deprecated_path = get_path('rules', '_deprecated', rule_file.name)
+    rule.save(new_path=deprecated_path, as_rule=True)
+    rule_file.unlink()
+    click.echo(f'Rule moved to {deprecated_path} - remember to git add this file')
+
+
 @dev_group.group('test')
 def test_group():
     """Commands for testing against stack resources."""

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -106,13 +106,11 @@ def manage_versions(rules: List[Rule], deprecated_rules: list = None, current_ve
     if deprecated_rules:
         rule_deprecations = load_etc_dump('deprecated_rules.json')
 
-        deprecation_date = str(datetime.date.today())
-
         for rule in deprecated_rules:
             if rule.id not in rule_deprecations:
                 rule_deprecations[rule.id] = {
                     'rule_name': rule.name,
-                    'deprecation_date': deprecation_date,
+                    'deprecation_date': rule.metadata['deprecation_date'],
                     'stack_version': CurrentSchema.STACK_VERSION
                 }
                 newly_deprecated.append(rule.id)

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -20,6 +20,7 @@ import yaml
 from . import rule_loader
 from .misc import JS_LICENSE, cached
 from .rule import Rule, downgrade_contents_from_rule  # noqa: F401
+from .schemas import CurrentSchema
 from .utils import Ndjson, get_path, get_etc_path, load_etc_dump, save_etc_dump
 
 RELEASE_DIR = get_path("releases")
@@ -28,7 +29,7 @@ NOTICE_FILE = get_path('NOTICE.txt')
 # CHANGELOG_FILE = Path(get_etc_path('rules-changelog.json'))
 
 
-def filter_rule(rule: Rule, config_filter: dict, exclude_fields: dict) -> bool:
+def filter_rule(rule: Rule, config_filter: dict, exclude_fields: Optional[dict] = None) -> bool:
     """Filter a rule based off metadata and a package configuration."""
     flat_rule = rule.flattened_contents
     for key, values in config_filter.items():
@@ -46,6 +47,7 @@ def filter_rule(rule: Rule, config_filter: dict, exclude_fields: dict) -> bool:
         if len(rule_values & values) == 0:
             return False
 
+    exclude_fields = exclude_fields or {}
     for index, fields in exclude_fields.items():
         if rule.unique_fields and (rule.contents['index'] == index or index == 'any'):
             if set(rule.unique_fields) & set(fields):
@@ -66,7 +68,7 @@ def load_versions(current_versions: dict = None):
     return current_versions or load_etc_dump('version.lock.json')
 
 
-def manage_versions(rules: list, deprecated_rules: list = None, current_versions: dict = None,
+def manage_versions(rules: List[Rule], deprecated_rules: list = None, current_versions: dict = None,
                     exclude_version_update=False, add_new=True, save_changes=False, verbose=True) -> (list, list, list):
     """Update the contents of the version.lock file and optionally save changes."""
     new_rules = {}
@@ -109,7 +111,8 @@ def manage_versions(rules: list, deprecated_rules: list = None, current_versions
             if rule.id not in rule_deprecations:
                 rule_deprecations[rule.id] = {
                     'rule_name': rule.name,
-                    'deprecation_date': deprecation_date
+                    'deprecation_date': deprecation_date,
+                    'stack_version': CurrentSchema.STACK_VERSION
                 }
                 newly_deprecated.append(rule.id)
 
@@ -129,7 +132,8 @@ def manage_versions(rules: list, deprecated_rules: list = None, current_versions
                     click.echo('Updated version.lock.json file')
 
             if newly_deprecated:
-                save_etc_dump(sorted(OrderedDict(rule_deprecations)), 'deprecated_rules.json')
+                save_etc_dump(OrderedDict(sorted(rule_deprecations.items(), key=lambda e: e[1]['rule_name'])),
+                              'deprecated_rules.json')
 
                 if verbose:
                     click.echo('Updated deprecated_rules.json file')

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -69,7 +69,8 @@ def load_versions(current_versions: dict = None):
 
 
 def manage_versions(rules: List[Rule], deprecated_rules: list = None, current_versions: dict = None,
-                    exclude_version_update=False, add_new=True, save_changes=False, verbose=True) -> (list, list, list):
+                    exclude_version_update=False, add_new=True, save_changes=False,
+                    verbose=True) -> (List[str], List[str], List[str]):
     """Update the contents of the version.lock file and optionally save changes."""
     new_rules = {}
     changed_rules = []

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -234,9 +234,14 @@ def filter_rules(rules, metadata_field, value):
     return [rule for rule in rules if rule.metadata.get(metadata_field, '') == value]
 
 
-def get_production_rules(verbose=False):
+def get_production_rules(verbose: bool = False, include_deprecated: bool = False) -> List[Rule]:
     """Get rules with a maturity of production."""
-    return filter_rules(load_rules(verbose=verbose).values(), 'maturity', 'production')
+    from .packaging import filter_rule
+
+    maturity = ['production']
+    if include_deprecated:
+        maturity.append('deprecated')
+    return list(filter(lambda rule: filter_rule(rule, dict(maturity=maturity)), load_rules(verbose=verbose).values()))
 
 
 @cached

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -234,14 +234,14 @@ def filter_rules(rules, metadata_field, value):
     return [rule for rule in rules if rule.metadata.get(metadata_field, '') == value]
 
 
-def get_production_rules(verbose: bool = False, include_deprecated: bool = False) -> List[Rule]:
+def get_production_rules(verbose=False, include_deprecated=False) -> List[Rule]:
     """Get rules with a maturity of production."""
     from .packaging import filter_rule
 
     maturity = ['production']
     if include_deprecated:
         maturity.append('deprecated')
-    return list(filter(lambda rule: filter_rule(rule, dict(maturity=maturity)), load_rules(verbose=verbose).values()))
+    return [rule for rule in load_rules(verbose=verbose).values() if filter_rule(rule, {'maturity': maturity})]
 
 
 @cached

--- a/detection_rules/schemas/base.py
+++ b/detection_rules/schemas/base.py
@@ -72,6 +72,7 @@ class TomlMetadata(GenericSchema):
     # rule validated against each ecs schema contained
     beats_version = jsl.StringField(pattern=VERSION_PATTERN, required=False)
     comments = jsl.StringField(required=False)
+    deprecation_date = jsl.StringField(required=False, pattern=DATE_PATTERN, default=time.strftime('%Y/%m/%d'))
     ecs_versions = jsl.ArrayField(jsl.StringField(pattern=BRANCH_PATTERN, required=True), required=False)
     maturity = jsl.StringField(enum=MATURITY_LEVELS, default='development', required=True)
 

--- a/docs/deprecating.md
+++ b/docs/deprecating.md
@@ -12,6 +12,7 @@ release package to Kibana.
 
 1. Update the `maturity` to `deprecated`
 2. Move the rule file to [rules/_deprecated](../rules/_deprecated)
+3. Add `deprecation_date` and update `updated_date` to match
 
 Next time the versions are locked, the rule will be added to the [deprecated_rules.json](../etc/deprecated_rules.json)
 file.

--- a/docs/deprecating.md
+++ b/docs/deprecating.md
@@ -16,3 +16,8 @@ release package to Kibana.
 
 Next time the versions are locked, the rule will be added to the [deprecated_rules.json](../etc/deprecated_rules.json)
 file.
+
+
+### Using the deprecate-rule command
+
+Alternatively, you can run `python -m detection_rules dev deprecate-rule <rule-file>`, which will perform all the steps

--- a/docs/deprecating.md
+++ b/docs/deprecating.md
@@ -1,0 +1,17 @@
+# Deprecating rules
+
+Rules that have been version locked (added to [version.lock.json](../etc/version.lock.json)), which also means they
+have been added to the detection engine in Kibana, must be properly [deprecated](#steps-to-properly-deprecate-a-rule).
+
+If a rule was never version locked (not yet pushed to Kibana or still in non-`production` `maturity`), the rule can
+simply be removed with no additional changes, or updated the `maturity = "development"`, which will leave it out of the 
+release package to Kibana.
+
+
+## Steps to properly deprecate a rule
+
+1. Update the `maturity` to `deprecated`
+2. Move the rule file to [rules/_deprecated](../rules/_deprecated)
+
+Next time the versions are locked, the rule will be added to the [deprecated_rules.json](../etc/deprecated_rules.json)
+file.

--- a/etc/deprecated_rules.json
+++ b/etc/deprecated_rules.json
@@ -1,1 +1,7 @@
-{}
+{
+  "3a86e085-094c-412d-97ff-2439731e59cb": {
+    "deprecation_date": "2021-03-03",
+    "rule_name": "Setgid Bit Set via chmod",
+    "stack_version": "7.13"
+  }
+}

--- a/rules/_deprecated/privilege_escalation_setgid_bit_set_via_chmod.toml
+++ b/rules/_deprecated/privilege_escalation_setgid_bit_set_via_chmod.toml
@@ -1,0 +1,55 @@
+[metadata]
+creation_date = "2020/04/23"
+maturity = "deprecated"
+updated_date = "2021/03/16"
+
+[rule]
+author = ["Elastic"]
+description = """
+An adversary may add the setgid bit to a file or directory in order to run a file with the privileges of the owning
+group. An adversary can take advantage of this to either do a shell escape or exploit a vulnerability in an application
+with the setgid bit to get code running in a different user’s context. Additionally, adversaries can use this mechanism
+on their own malware to make sure they're able to execute in elevated contexts in the future.
+"""
+from = "now-9m"
+index = ["auditbeat-*", "logs-endpoint.events.*"]
+language = "lucene"
+license = "Elastic License"
+max_signals = 33
+name = "Setgid Bit Set via chmod"
+risk_score = 21
+rule_id = "3a86e085-094c-412d-97ff-2439731e59cb"
+severity = "low"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Privilege Escalation"]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+event.category:process AND event.type:(start or process_started) AND process.name:chmod AND process.args:(g+s OR /2[0-9]{3}/) AND NOT user.name:root
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1548"
+name = "Abuse Elevation Control Mechanism"
+reference = "https://attack.mitre.org/techniques/T1548/"
+[[rule.threat.technique.subtechnique]]
+id = "T1548.001"
+name = "Setuid and Setgid"
+reference = "https://attack.mitre.org/techniques/T1548/001/"
+
+
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"

--- a/rules/_deprecated/privilege_escalation_setgid_bit_set_via_chmod.toml
+++ b/rules/_deprecated/privilege_escalation_setgid_bit_set_via_chmod.toml
@@ -1,5 +1,6 @@
 [metadata]
 creation_date = "2020/04/23"
+deprecation_date = "2021/03/16"
 maturity = "deprecated"
 updated_date = "2021/03/16"
 


### PR DESCRIPTION
## Issues
resolves #959 

## Summary
Adds test to ensure rules are properly deprecated. Re-added deprecated rule that was previously removed and updated `deprecated_rules.json`. A readme was also added to provide proper steps to deprecating.

I tried to make this as minimal as possible in order to be the least impactful to #1029, but hope to get this in to prevent any more accidental deletions, such as in #1028