### PR TITLE
Fix the version lock update code

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -112,7 +112,18 @@ def manage_versions(rules: List[TOMLRule], deprecated_rules: list = None, curren
 
         if save_changes:
             if changed_rules or (new_rules and add_new):
-                current_versions.update(new_rules if add_new else {})
+                if add_new:
+                    for rule in new_rules:
+                        current_versions[rule.id] = {"rule_name": rule.name,
+                                                     "sha256": rule.contents.sha256(),
+                                                     "version": rule.contents.autobumped_version,
+                                                     }
+                for rule in changed_rules:
+                    current_versions[rule.id] = {"rule_name": rule.name,
+                                                 "sha256": rule.contents.sha256(),
+                                                 "version": rule.contents.autobumped_version,
+                                                 }
+
                 current_versions = OrderedDict(sorted(current_versions.items(), key=lambda x: x[1]['rule_name']))
 
                 save_etc_dump(current_versions, 'version.lock.json')

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -114,15 +114,9 @@ def manage_versions(rules: List[TOMLRule], deprecated_rules: list = None, curren
             if changed_rules or (new_rules and add_new):
                 if add_new:
                     for rule in new_rules:
-                        current_versions[rule.id] = {"rule_name": rule.name,
-                                                     "sha256": rule.contents.sha256(),
-                                                     "version": rule.contents.autobumped_version,
-                                                     }
+                        current_versions[rule.id] = rule.contents.lock_info()
                 for rule in changed_rules:
-                    current_versions[rule.id] = {"rule_name": rule.name,
-                                                 "sha256": rule.contents.sha256(),
-                                                 "version": rule.contents.autobumped_version,
-                                                 }
+                    current_versions[rule.id] = rule.contents.lock_info()
 
                 current_versions = OrderedDict(sorted(current_versions.items(), key=lambda x: x[1]['rule_name']))
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -324,6 +324,9 @@ class TOMLRuleContents(MarshmallowDataclassMixin):
     def name(self) -> str:
         return self.data.name
 
+    def lock_info(self) -> dict:
+        return {"rule_name": self.name, "sha256": self.sha256(), "version": self.autobumped_version}
+
     @property
     def is_dirty(self) -> Optional[bool]:
         """Determine if the rule has changed since its version was locked."""


### PR DESCRIPTION
## Issues
Unable to save the version lock

## Summary
I noticed that the most recent changes in #1029 were made after I tested the lock.
I think I never tried re-saving the lock in the new branch. Some of the code was moved.

Now you can save the lock again.
Package hash still looks good.




## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
