### PR TITLE
Change the JSON schema for the security_rule Kibana asset

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -498,7 +498,8 @@ class Package(object):
         # shutil.copyfile(CHANGELOG_FILE, str(rules_dir.joinpath('CHANGELOG.json')))
 
         for rule in self.rules:
-            rule.save_json(Path(rules_dir.joinpath(f'rule-{rule.id}.json')))
+            with Path(rules_dir.joinpath(f'rule-{rule.id}.json')).open("w", encoding="utf-8") as f:
+                json.dump(rule.get_asset(), f, indent=2, sort_keys=True)
 
         readme_text = ('# Detection rules\n\n'
                        'The detection rules package stores all the security rules '

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -432,6 +432,10 @@ class TOMLRule:
     def name(self):
         return self.contents.data.name
 
+    def get_asset(self) -> dict:
+        """Generate the relevant fleet compatible asset."""
+        return {"id": self.id, "attributes": self.contents.to_api_format(), "type": definitions.ASSET_TYPE}
+
     def save_toml(self):
         converted = self.contents.to_dict()
         toml_write(converted, str(self.path.absolute()))

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -10,6 +10,8 @@ from typing import Literal
 from marshmallow import validate
 from marshmallow_dataclass import NewType
 
+ASSET_TYPE = "security_rule"
+
 DATE_PATTERN = r'\d{4}/\d{2}/\d{2}'
 MATURITY_LEVELS = ['development', 'experimental', 'beta', 'production', 'deprecated']
 OS_OPTIONS = ['windows', 'linux', 'macos']


### PR DESCRIPTION
## Issues
Realized in https://github.com/elastic/integrations/pull/797 and some EPM observations that this isn't structured like other Kibana assets. EPM expects Kibana assets to look like this:

```javascript
{
  "id": "Whatever the object ID string is, not necessarily enforced as UUID",

  // optional references whatever these are
  "references": null || [],

  // optional info that we don't need
  "migrationVersion": null || {}, 

  // this is where the data is ultimately stored
  "attributes": { ... },

  // type of asset that matches the folder
  "type": "security_rule";
}
```

We don't have to make `attributes` internally consistent with other saved objects, but we might want to.

We can still write our own installer in EPM anyway. See the reference on `AssetInstallers` to see how index patterns are installed separately from other assets.

## Summary


References:
* [ArchiveAsset](
https://github.com/elastic/kibana/blob/e01f317d9cd94461e1c11c17bde0cf3b70047012/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts#L24-L29) type defiinition
* [createSavedObjectKibanaAsset](https://github.com/elastic/kibana/blob/e01f317d9cd94461e1c11c17bde0cf3b70047012/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts#L65-L74) which fills in defaults for missing fields, shows us which ones can be omitted
* [AssetInstallers](https://github.com/elastic/kibana/blob/e01f317d9cd94461e1c11c17bde0cf3b70047012/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts#L42-L56) where each `KibanaAssetType` defines how it's installed 