### PR TITLE
Change the asset .type field

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -498,8 +498,8 @@ class Package(object):
         # shutil.copyfile(CHANGELOG_FILE, str(rules_dir.joinpath('CHANGELOG.json')))
 
         for rule in self.rules:
-            with Path(rules_dir.joinpath(f'rule-{rule.id}.json')).open("w", encoding="utf-8") as f:
-                json.dump(rule.get_asset(), f, indent=2, sort_keys=True)
+            asset_path = rules_dir / f'rule-{rule.id}.json'
+            asset_path.write_text(json.dumps(rule.get_asset(), indent=4, sort_keys=True), encoding="utf-8")
 
         readme_text = ('# Detection rules\n\n'
                        'The detection rules package stores all the security rules '

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -434,7 +434,7 @@ class TOMLRule:
 
     def get_asset(self) -> dict:
         """Generate the relevant fleet compatible asset."""
-        return {"id": self.id, "attributes": self.contents.to_api_format(), "type": definitions.ASSET_TYPE}
+        return {"id": self.id, "attributes": self.contents.to_api_format(), "type": definitions.SAVED_OBJECT_TYPE}
 
     def save_toml(self):
         converted = self.contents.to_dict()

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -11,6 +11,7 @@ from marshmallow import validate
 from marshmallow_dataclass import NewType
 
 ASSET_TYPE = "security_rule"
+SAVED_OBJECT_TYPE = "security-rule"
 
 DATE_PATTERN = r'\d{4}/\d{2}/\d{2}'
 MATURITY_LEVELS = ['development', 'experimental', 'beta', 'production', 'deprecated']

--- a/etc/packages.yml
+++ b/etc/packages.yml
@@ -22,11 +22,11 @@ package:
   #  min_version: 1
   #  max_version: 5
 
-  # Integrations registry
+  # elastic/integrations
   registry_data:
     # integration package schema version
     format_version: "1.0.0"
     conditions:
       kibana_version: "^7.13.0"
     # this determines the version for the package-storage generated artifact
-    version: "0.0.1-dev.1"
+    version: "0.0.1-dev.3"


### PR DESCRIPTION
## Issues
Found in https://github.com/elastic/kibana/pull/95885 and fixed in https://github.com/elastic/integrations/pull/824

## Summary
Update the autogenerated integration so that type is the saved object type which is `security-rule`. Linked PRs have more context.