### PR TITLE
Lock 7.12 rule versions

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -69,7 +69,7 @@ def update_lock_versions(rule_ids):
         return
 
     rules = [r for r in rule_loader.load_rules(verbose=False).values() if r.id in rule_ids]
-    changed, new = manage_versions(rules, exclude_version_update=True, add_new=False, save_changes=True)
+    changed, new, _ = manage_versions(rules, exclude_version_update=True, add_new=False, save_changes=True)
 
     if not changed:
         click.echo('No hashes updated')

--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -106,7 +106,7 @@
   },
   "0a97b20f-4144-49ea-be32-b540ecc445de": {
     "rule_name": "Malware - Detected - Elastic Endgame",
-    "sha256": "9b7bd55891baec28d77bb897969b40cc982c15102259ffff69b3796919202dbd",
+    "sha256": "00f0fcc8e4641d92ddcd42b804404c551bdeca5e6d327e99b421533b456b060b",
     "version": 5
   },
   "0b29cab4-dbbd-4a3f-9e8e-1287c7c11ae5": {
@@ -356,7 +356,7 @@
   },
   "2003cdc8-8d83-4aa5-b132-1f9a8eb48514": {
     "rule_name": "Exploit - Detected - Elastic Endgame",
-    "sha256": "da7b6e128ad5867cbd3456cf71fb4583caf272f62e76d422a6e765b5a019b508",
+    "sha256": "6641c38a9f21bb4d011f23be360818e0a26261aee77dd52572cb4b1e74db9d54",
     "version": 5
   },
   "201200f1-a99b-43fb-88ed-f65a45c4972c": {
@@ -451,7 +451,7 @@
   },
   "2863ffeb-bf77-44dd-b7a5-93ef94b72036": {
     "rule_name": "Exploit - Prevented - Elastic Endgame",
-    "sha256": "027892bbc77dec382e1fff007e985d1ddaa09db9765397a995bca7504228a92d",
+    "sha256": "fd0d6607641a2a3fe279fa21859438372610f47c0073b8cff12a4b16d4482a5f",
     "version": 5
   },
   "28896382-7d4f-4d50-9b72-67091901fd26": {
@@ -646,7 +646,7 @@
   },
   "3b382770-efbb-44f4-beed-f5e0a051b895": {
     "rule_name": "Malware - Prevented - Elastic Endgame",
-    "sha256": "ee3b4a6b601f7f4929ff9f2d474a2deab9cef75f96c390b99208f95b12d8d619",
+    "sha256": "50b2c302ad283dc7ef63c2d065b0af314e0ece8c2c206130440099a3f7377e8e",
     "version": 5
   },
   "3b47900d-e793-49e8-968f-c90dc3526aa1": {
@@ -726,7 +726,7 @@
   },
   "453f659e-0429-40b1-bfdb-b6957286e04b": {
     "rule_name": "Permission Theft - Prevented - Elastic Endgame",
-    "sha256": "905e269e6ada516092e74e17fb1bb5d2bdc1ffdff1d87d42e253940d621e10bc",
+    "sha256": "6bc20dfde21b99bceb78555445eed77ed4cc1aeaacee0be75f5be13d6baff80f",
     "version": 5
   },
   "45ac4800-840f-414c-b221-53dd36a5aaf7": {
@@ -901,7 +901,7 @@
   },
   "571afc56-5ed9-465d-a2a9-045f099f6e7e": {
     "rule_name": "Credential Dumping - Detected - Elastic Endgame",
-    "sha256": "e75e954e18e9d0dc6cbbbdbcb5deb63eb2dd29996703bc5dc2af235c82af3b0c",
+    "sha256": "92dbac698697ff1baba20201340efa2fa6909bd0332febd19dc7b120157b8288",
     "version": 5
   },
   "581add16-df76-42bb-af8e-c979bfb39a59": {
@@ -1266,7 +1266,7 @@
   },
   "77a3c3df-8ec4-4da4-b758-878f551dee69": {
     "rule_name": "Adversary Behavior - Detected - Elastic Endgame",
-    "sha256": "8319fdbcc75a28932ed1ad89f7cae48a392d08b6bfd4a78ff5272c567bd03f6a",
+    "sha256": "3d4c7e624f49095b9d4e05a486080f30e75d992cbac6947a37cbba3922afb684",
     "version": 5
   },
   "785a404b-75aa-4ffd-8be5-3334a5a544dd": {
@@ -1331,7 +1331,7 @@
   },
   "80c52164-c82a-402c-9964-852533d58be1": {
     "rule_name": "Process Injection - Detected - Elastic Endgame",
-    "sha256": "e8ed57396574222f759925fd3d4da6c63688d077a18de5a0bcec00ecf6de88d5",
+    "sha256": "1230896bf33c82b435b0a085a3cc4d4211dc4910eee62d13d35e8cd672bb3f9d",
     "version": 5
   },
   "81cc58f5-8062-49a2-ba84-5cc4b4d31c40": {
@@ -1436,7 +1436,7 @@
   },
   "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd": {
     "rule_name": "Ransomware - Detected - Elastic Endgame",
-    "sha256": "d8491d74b0dd8ca7304f3b8147e98c0dbb00f6551f61cc67bcbeb2a9a8ed8336",
+    "sha256": "f887bad77276d23f9ce70a494ad975b51f2435f0f81308eb19c6b8f7760f5047",
     "version": 5
   },
   "8ddab73b-3d15-4e5d-9413-47f05553c1d7": {
@@ -1591,7 +1591,7 @@
   },
   "990838aa-a953-4f3e-b3cb-6ddf7584de9e": {
     "rule_name": "Process Injection - Prevented - Elastic Endgame",
-    "sha256": "c3f63131525208fb1a8d655818506192b58ed5ddca6f26501f96672999d58085",
+    "sha256": "c88ab010c4f6cce83349370811a1c01d6910cd907c7003a960779c7a87788b78",
     "version": 5
   },
   "99239e7d-b0d4-46e3-8609-acafcf99f68c": {
@@ -2036,7 +2036,7 @@
   },
   "c0be5f31-e180-48ed-aa08-96b36899d48f": {
     "rule_name": "Credential Manipulation - Detected - Elastic Endgame",
-    "sha256": "a536250a00d6139b67326b7a160bef3ce820b1202add2eb68e37aea8c81b572b",
+    "sha256": "beac6937eddc5c8bf327f253e55ae6002c455efcf0f7ad0115c03ee4b5ac28f0",
     "version": 5
   },
   "c25e9c87-95e1-4368-bfab-9fd34cf867ec": {
@@ -2061,7 +2061,7 @@
   },
   "c3167e1b-f73c-41be-b60b-87f4df707fe3": {
     "rule_name": "Permission Theft - Detected - Elastic Endgame",
-    "sha256": "b8e5fdd1a58640907a636b837eff2d2740c456b57954eac5fe0325d8f31c156c",
+    "sha256": "1daef429f179b7b2decc62fd0040a1a0869724f0c5ad862e930de744a7ea8d20",
     "version": 5
   },
   "c4210e1c-64f2-4f48-b67e-b5a8ffe3aa14": {
@@ -2131,7 +2131,7 @@
   },
   "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa": {
     "rule_name": "Credential Manipulation - Prevented - Elastic Endgame",
-    "sha256": "490cbfae68721fb35c3c8b8a0d41bc4b6efed8cc396d829e4afecc2e651c9ae1",
+    "sha256": "8701300b12edca7b1d753f35667a8ac660486880e262916978b2d93fc36f9b85",
     "version": 5
   },
   "ca79768e-40e1-4e45-a097-0e5fbc876ac2": {
@@ -2346,7 +2346,7 @@
   },
   "db8c33a8-03cd-4988-9e2c-d0a4863adb13": {
     "rule_name": "Credential Dumping - Prevented - Elastic Endgame",
-    "sha256": "27d6e4256f3c3e790e0339e015ee47e5c922269bdbb9091c04efe12ed0ec4592",
+    "sha256": "c96b35d3ac54f63415568d6a1f55de7c57c1b8e3e7bdff5e38c956812059b15e",
     "version": 5
   },
   "dc9c1f74-dac3-48e3-b47f-eb79db358f57": {
@@ -2431,7 +2431,7 @@
   },
   "e3c5d5cb-41d5-4206-805c-f30561eae3ac": {
     "rule_name": "Ransomware - Prevented - Elastic Endgame",
-    "sha256": "843eb805ba1977ac107e77885fa675b0633fea7cdf90a7437b83997cfe6ff5c8",
+    "sha256": "2fc23dc4ae8c8b6aa5864423da31e254624822a593ee182936070c3436dfa49b",
     "version": 5
   },
   "e3cf38fa-d5b8-46cc-87f9-4a7513e4281d": {

--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -1,533 +1,638 @@
 {
   "000047bb-b27a-47ec-8b62-ef1a5d2c9e19": {
     "rule_name": "Attempt to Modify an Okta Policy Rule",
-    "sha256": "cac0db4aff1d1ded02c07501baa3bbe6f5e27d707c93ffd2eeca27d36820a20a",
-    "version": 4
+    "sha256": "9fd22842d78b31392490aed929cb17cadea3ff1f5d1b92de22c7ba202918ff71",
+    "version": 5
   },
   "00140285-b827-4aee-aa09-8113f58a08f3": {
     "rule_name": "Potential Credential Access via Windows Utilities",
-    "sha256": "aaa1e170fca28a38d31be457bde9aa519117096184eb0b7c03edd32b49031827",
-    "version": 2
+    "sha256": "7f7b7468fdb5d4a7f71e670479c4d12175299d39c22e487219b50fe24a54c78a",
+    "version": 3
   },
   "0022d47d-39c7-4f69-a232-4fe9dc7a3acd": {
     "rule_name": "System Shells via Services",
-    "sha256": "04fd329eb92cb9d357f7940cfa62cb8984f44cd5e65884330006e4d5415ed578",
-    "version": 7
+    "sha256": "19a7de27f4afd70671c5b18f891926053d71637df671946030a7a4dcfd10f5a0",
+    "version": 8
+  },
+  "027ff9ea-85e7-42e3-99d2-bbb7069e02eb": {
+    "rule_name": "Potential Cookies Theft via Browser Debugging",
+    "sha256": "1c44db89d3410a06dc61f99dda258376dd4863095c7c858ad1da33d8c582fc2c",
+    "version": 1
+  },
+  "02ea4563-ec10-4974-b7de-12e65aa4f9b3": {
+    "rule_name": "Dumping Account Hashes via Built-In Commands",
+    "sha256": "b0a37cf64b4b4ba2e0a041004784943edd15cc3c32bde131e660754be51e0d31",
+    "version": 1
   },
   "03024bd9-d23f-4ec1-8674-3cf1a21e130b": {
     "rule_name": "Microsoft 365 Exchange Safe Attachment Rule Disabled",
-    "sha256": "5bc652138aa627b6d8867f2f9023691c90cf89eae1e8b41f15c5a39a3e45c2f3",
-    "version": 2
+    "sha256": "9caad75ec7574def8cbf8ee05c13118b5aecac89dcf42cfd646459815d560e08",
+    "version": 3
   },
   "035889c4-2686-4583-a7df-67f89c292f2c": {
     "rule_name": "High Number of Process and/or Service Terminations",
-    "sha256": "675294fdab8938639d7813f80e9ed17a038d03d3d20b16462738ed18c86c0811",
+    "sha256": "d3c85491c43408970d42c1b927c23cd6c0a690ed8b96fbcb84d81065be47fcec",
+    "version": 2
+  },
+  "0415f22a-2336-45fa-ba07-618a5942e22c": {
+    "rule_name": "Modification of OpenSSH Binaries",
+    "sha256": "103e3e20a1129164d2bd6dac9138dceb577ecd75951f69691758d4d68181921e",
     "version": 1
   },
   "041d4d41-9589-43e2-ba13-5680af75ebc2": {
     "rule_name": "Potential DNS Tunneling via Iodine",
-    "sha256": "7599799ca4a0a55c535334c454d59cb689f6378970a445147023453e12dc936f",
-    "version": 6
+    "sha256": "9296a1f58fff4f043c856fe8310f458066aa080d0ae36619fc290fef47206ff0",
+    "version": 7
   },
   "0564fb9d-90b9-4234-a411-82a546dc1343": {
     "rule_name": "Microsoft IIS Service Account Password Dumped",
-    "sha256": "75f947671148de3e29e3264168da66ac71eca6cbce3fa91d085393f5100a56b4",
-    "version": 3
+    "sha256": "bcda2313ca40b6fb5e29b30a8a4a34392c0e5ec339b88f2b93e391657b5e3dc6",
+    "version": 4
   },
   "05b358de-aa6d-4f6c-89e6-78f74018b43b": {
     "rule_name": "Conhost Spawned By Suspicious Parent Process",
-    "sha256": "e1d0ef7d698458198b86b38759592dfc86d48b04a8f229b80ec4b0235193928e",
-    "version": 2
+    "sha256": "a4bd75a7a91e1886e8798836d4833b9206c29c8c3d09e6a9bae27337804eee7c",
+    "version": 3
   },
   "05e5a668-7b51-4a67-93ab-e9af405c9ef3": {
     "rule_name": "Interactive Terminal Spawned via Perl",
-    "sha256": "6dca378cf44291bfc85f995e2ef8dcdf0df44407d0b042cb72e33d49dee5a7c0",
-    "version": 5
+    "sha256": "7b1fe8dbaad6ea318a3f95ac4547646a0fa8b5338043822f714e5a1a111dc1c0",
+    "version": 6
   },
   "0635c542-1b96-4335-9b47-126582d2c19a": {
     "rule_name": "Remote System Discovery Commands",
-    "sha256": "8ad286887e1e52dd9b5572836b215991274b766495448de4fe2f9b6042ac1a93",
-    "version": 2
+    "sha256": "16d8a132a4c14359e8917a15b94a476cff425e291fc3733d15bae53552e8c4b0",
+    "version": 3
   },
   "06dceabf-adca-48af-ac79-ffdf4c3b1e9a": {
     "rule_name": "Potential Evasion via Filter Manager",
-    "sha256": "d2ce426a165fcaee593fab6a509528869efcd2f9e61a1c4c17719037b6fd0b82",
-    "version": 5
+    "sha256": "47d4e1e65e3a1c015019ad8161e49447930897e74ab76ad6df30445f8f10e46b",
+    "version": 6
   },
   "074464f9-f30d-4029-8c03-0ed237fffec7": {
     "rule_name": "Remote Desktop Enabled in Windows Firewall",
-    "sha256": "a3035c5ca2734a10cc9657fa0c2c23fef1195b83d4c1316e932898537ebc27d6",
-    "version": 2
+    "sha256": "45c1c0dee9af84917c91545f9845f57dc37d7695a21a743d5c1f73b8ea9fb0d2",
+    "version": 3
+  },
+  "080bc66a-5d56-4d1f-8071-817671716db9": {
+    "rule_name": "Suspicious Browser Child Process",
+    "sha256": "3a499c8697025a438c86ba5961db32de9237c228e0337aa79b43ac98a7624d64",
+    "version": 1
   },
   "082e3f8c-6f80-485c-91eb-5b112cb79b28": {
     "rule_name": "Launch Agent Creation or Modification and Immediate Loading",
-    "sha256": "e528a87ea96507db3839017216ed364081e638391209af086b126d1de534f30c",
+    "sha256": "7147dbd3f68475c0087ebb6aabbc2b86ebbe5be53eed996c4499c4b12a6efc21",
+    "version": 2
+  },
+  "083fa162-e790-4d85-9aeb-4fea04188adb": {
+    "rule_name": "Suspicious Hidden Child Process of Launchd",
+    "sha256": "019a93733bdf8a597fa9216fd6bc89578add18dc6058735cf9974be5db89ecfb",
     "version": 1
   },
   "08d5d7e2-740f-44d8-aeda-e41f4263efaf": {
     "rule_name": "TCP Port 8000 Activity to the Internet",
-    "sha256": "fbafa9f4206bcfcd63c1a74767a930ee9e96f0a6f437e6252afd83cc73df2eb8",
-    "version": 7
+    "sha256": "d0c6cdede82a9cafacef49dcd6afc1b13383214401be7fbaa3b09ae1fbe9a3fb",
+    "version": 8
+  },
+  "092b068f-84ac-485d-8a55-7dd9e006715f": {
+    "rule_name": "Creation of Hidden Launch Agent or Daemon",
+    "sha256": "5863e9461fec288af7418b55eb3a1352d66726c36f3b908c8ae0dd5c4f4a86c5",
+    "version": 1
   },
   "09443c92-46b3-45a4-8f25-383b028b258d": {
     "rule_name": "Process Termination followed by Deletion",
-    "sha256": "c5f205ff54c1d0e79f4b4750bf6a7a410a4c6541e53a51be0d8cb5e8cc8e67c6",
-    "version": 1
+    "sha256": "1889f7fd920e6989fcbcf7a13004b0cd0b3952f2e9e769f90f808e6385256793",
+    "version": 2
   },
   "0a97b20f-4144-49ea-be32-b540ecc445de": {
-    "rule_name": "Malware - Detected - Endpoint Security",
-    "sha256": "adcd895329cc4d1c41bc4bf8b75404c838823731713fa11f3d3b671dd24cc31d",
-    "version": 4
+    "rule_name": "Malware - Detected - Elastic Endgame",
+    "sha256": "9b7bd55891baec28d77bb897969b40cc982c15102259ffff69b3796919202dbd",
+    "version": 5
   },
   "0b29cab4-dbbd-4a3f-9e8e-1287c7c11ae5": {
     "rule_name": "Anomalous Windows Process Creation",
-    "sha256": "2c0ef448095688b59b12cdf6eaa8b1cf916845b1b9ca33e47412f87f855d493d",
-    "version": 3
+    "sha256": "b23bb13b7dd326ec1974177f034b66193fe903b19d5da1431f558abfce3cdb97",
+    "version": 4
   },
   "0c7ca5c2-728d-4ad9-b1c5-bbba83ecb1f4": {
     "rule_name": "Peripheral Device Discovery",
-    "sha256": "b3d195f66eff7d2a1c2cc3733f699db9279b137852ec73c44268c9aaf61204e3",
-    "version": 2
+    "sha256": "499dcd1aa2d62a15f68fa52d95b87511f7f4e14f24ffe83babb3e72e990ff81d",
+    "version": 3
   },
   "0d69150b-96f8-467c-a86d-a67a3378ce77": {
     "rule_name": "Nping Process Activity",
-    "sha256": "3df1266e8438c9787af97aff38a331b1f2a35d27d8a7541b45c39179cdd7b500",
-    "version": 6
+    "sha256": "3858f3acbb3617200c0effe46d9f284940970045efbdf53b927613f428c6895c",
+    "version": 7
   },
   "0d8ad79f-9025-45d8-80c1-4f0cd3c5e8e5": {
     "rule_name": "Execution of File Written or Modified by Microsoft Office",
-    "sha256": "1c2093218988bd5075f751f889f33bf5951acd5b6eed596e7b16356c713992b4",
-    "version": 2
+    "sha256": "008f38d1a423c52ee58b69430efc29490f468a1f60691783a2bdeebe8ba3a376",
+    "version": 3
   },
   "0e5acaae-6a64-4bbc-adb8-27649c03f7e1": {
     "rule_name": "GCP Service Account Key Creation",
-    "sha256": "265e657ed950612b93a122cdac4616aaf53c63454deaa484c2d4b8e0ffac2e55",
-    "version": 3
+    "sha256": "5fdc2bd59f8e3122de5f063b1c7b5b85e4625add85003fb7d794c254bf77e99d",
+    "version": 4
   },
   "0e79980b-4250-4a50-a509-69294c14e84b": {
     "rule_name": "MsBuild Making Network Connections",
-    "sha256": "49f28f634ed84feabea9a0466856d470b32de0629543625a47b810c023bf3f7d",
-    "version": 6
+    "sha256": "833b8ac407769d2ff54b29c503522466b5ea212d0aff6d04f30865dce0e4b597",
+    "version": 7
   },
   "0f616aee-8161-4120-857e-742366f5eeb3": {
     "rule_name": "PowerShell spawning Cmd",
-    "sha256": "7e3863b9c9ebca7bc1bd8454cc06df45111aad839afa00701d01deb17557e769",
-    "version": 7
+    "sha256": "02b0c2f928a762f61da9b493780d5fe36255c5565093c0d59db3776340a7b2be",
+    "version": 8
+  },
+  "0ff84c42-873d-41a2-a4ed-08d74d352d01": {
+    "rule_name": "Privilege Escalation via Root Crontab File Modification",
+    "sha256": "83d4b9750134c982b98575d88af2b900eae9cdc6af0018600b670fe3ba054773",
+    "version": 1
+  },
+  "10a500bb-a28f-418e-ba29-ca4c8d1a9f2f": {
+    "rule_name": "WebProxy Settings Modification",
+    "sha256": "b5af8f94b5401606c27cd0ce6128e4f9dc64a173581df4bf126adf3ca7f98aaa",
+    "version": 1
   },
   "11013227-0301-4a8c-b150-4db924484475": {
     "rule_name": "Abnormally Large DNS Response",
-    "sha256": "fcd1f8db60952639ad3ee7ab8c7a16bd2b1c60369d4719c852994200e39bf9cb",
-    "version": 2
+    "sha256": "fe7e1d6692e9f4763fef4efaa0a58df4c99b2fbe822d6110726dc9499f895cc2",
+    "version": 3
   },
   "1160dcdb-0a0a-4a79-91d8-9b84616edebd": {
     "rule_name": "Potential DLL SideLoading via Trusted Microsoft Programs",
-    "sha256": "1887a28078d2b00c9d7c5c5fd8f13a55ada9cf7953c5e3f444d6839a32c97bc3",
-    "version": 3
+    "sha256": "ca51b94b3c29316c10c03e610304f5677957a12dccc54d778b80f8a888d139ee",
+    "version": 4
   },
   "1178ae09-5aff-460a-9f2f-455cd0ac4d8e": {
     "rule_name": "UAC Bypass via Windows Firewall Snap-In Hijack",
-    "sha256": "87399b0ff196ae92920f9aa67e0535ec5a2ef85ce12cbb1fd7d0fe37d8508dc9",
-    "version": 2
+    "sha256": "cf1509c89e66ee7021944e2946913d7844fc2b785ebd32eaeda9be63b774118a",
+    "version": 3
   },
   "120559c6-5e24-49f4-9e30-8ffe697df6b9": {
     "rule_name": "User Discovery via Whoami",
-    "sha256": "a2594bb7b6f814bc779c6bc489a1ad7882ce299cf5fb2c000b040dfa748cf6ac",
-    "version": 6
+    "sha256": "226bffc8f05628ba3e39c84344b42aff68d3c0a8ad10612929d4cb704d902d3e",
+    "version": 7
   },
   "125417b8-d3df-479f-8418-12d7e034fee3": {
     "rule_name": "Attempt to Disable IPTables or Firewall",
-    "sha256": "480b24cf11930aac2d017bb6d050f1ba82f830d9381cf0fecf7071d988562260",
-    "version": 6
+    "sha256": "fd5543ef34df35a3f89f31a7aa8b144f0fcf5c7ee4d4f7e0ba01944aa07148a5",
+    "version": 7
   },
   "12f07955-1674-44f7-86b5-c35da0a6f41a": {
     "rule_name": "Suspicious Cmd Execution via WMI",
-    "sha256": "8c53068d8e5b4053fea6daf84a565f31c405759b2852bf641fe25806ca78e742",
-    "version": 2
+    "sha256": "120221c53163f94f7921394a5239a48a64c87bc263ebcb4fabe661f2813d19a9",
+    "version": 3
   },
   "139c7458-566a-410c-a5cd-f80238d6a5cd": {
     "rule_name": "SQL Traffic to the Internet",
-    "sha256": "863d0e7eb8b2e8c96e020329bb332e6d0cc0b06c3770ef6607a3e3739e1dcca3",
-    "version": 7
+    "sha256": "26fce2242bdb3d7341ec772772151eae5dfe28e3f14a60bbe586e0d5d5842ad7",
+    "version": 8
   },
   "141e9b3a-ff37-4756-989d-05d7cbf35b0e": {
     "rule_name": "Azure External Guest User Invitation",
-    "sha256": "43627cd1ed624daac407d02e6c9158da91824c99ab406d7538610d732c60e384",
-    "version": 3
+    "sha256": "4e4ee6c8ffdc78dd61b144430434fbcf0b863fe87569b70f447ef27944132a32",
+    "version": 4
   },
   "143cb236-0956-4f42-a706-814bcaa0cf5a": {
     "rule_name": "RPC (Remote Procedure Call) from the Internet",
-    "sha256": "24559b065307470c045f9ade897b021cf83019c6d03a716450fdc57b67ecd52e",
-    "version": 7
+    "sha256": "fa80e2746a7cbe81b481e9e99deccdbbe6103281705265b702795d173428a0ba",
+    "version": 8
+  },
+  "14ed1aa9-ebfd-4cf9-a463-0ac59ec55204": {
+    "rule_name": "Potential Persistence via Time Provider Modification",
+    "sha256": "8817ddfdb38379b4031a751743514e46c8a4e608c68ea79adf13a6aa11a09b2d",
+    "version": 1
   },
   "15c0b7a7-9c34-4869-b25b-fa6518414899": {
     "rule_name": "Remote File Download via Desktopimgdownldr Utility",
-    "sha256": "a484099235a7b474f53d5e801f77684ede6321d71c3403301d60f0b644597fe1",
-    "version": 3
+    "sha256": "6f80c029b353e70d9a1f7c36606e212b33eba9316d32af35617e27351e92c098",
+    "version": 4
+  },
+  "15dacaa0-5b90-466b-acab-63435a59701a": {
+    "rule_name": "Virtual Private Network Connection Attempt",
+    "sha256": "dce41c54cfb048f038e53c478c4df69a51ccb8580b2d1017f26d9c59bab389d3",
+    "version": 1
   },
   "16280f1e-57e6-4242-aa21-bb4d16f13b2f": {
     "rule_name": "Azure Automation Runbook Created or Modified",
-    "sha256": "6f46ddb42d6b1ea82574dd1727b36cfb32d2662d5c3d787ba3321af0ed3f8a12",
-    "version": 3
+    "sha256": "2bb1add88acb6c2c1709874e8fb81a697790ecd83275ec9a2c955c7fea26fb95",
+    "version": 4
+  },
+  "16904215-2c95-4ac8-bf5c-12354e047192": {
+    "rule_name": "Potential Kerberos Attack via Bifrost",
+    "sha256": "b3449825b9dc0d1404a9151db31d0ea7439870cc1960816cc1089a768004bc39",
+    "version": 1
   },
   "169f3a93-efc7-4df2-94d6-0d9438c310d1": {
     "rule_name": "AWS IAM Group Creation",
-    "sha256": "5dd2b107e0fc701668b8e697a5823207fc80d49607e6e8b5178f2f412443d8bc",
-    "version": 4
+    "sha256": "631682b56b2b379e24924f00acd807aace8cb78f8c347751d601d084968f5e4b",
+    "version": 5
   },
   "16a52c14-7883-47af-8745-9357803f0d4c": {
     "rule_name": "Component Object Model Hijacking",
-    "sha256": "2ce6fa72ac9194f3d8f1dd2883f9b17eb00ae9c438a97b92b314e10cefa513cb",
-    "version": 2
+    "sha256": "58327576782adbc39e99e774604472036ec95eed3c5e324fc19288e7d635c8b3",
+    "version": 3
   },
   "1781d055-5c66-4adf-9c59-fc0fa58336a5": {
     "rule_name": "Unusual Windows Username",
-    "sha256": "e3bc57714f47a0836cc1c6b7290a3872c953fc3320da7c95d0a8cb6a9ed7f3d7",
-    "version": 3
+    "sha256": "9be6e9d33905da257f09d6239e9d870486b9c717bb33964f542ca7ba782f5628",
+    "version": 4
   },
   "1781d055-5c66-4adf-9c71-fc0fa58338c7": {
     "rule_name": "Unusual Windows Service",
-    "sha256": "522b54696d2442ac05611c60b30f7d3ff6979437525632c8ca29ba3244c7dc1e",
-    "version": 3
+    "sha256": "2056eb4358a68b426256be231c045180bdc5ed38f6ea5b6f8140d1656c102a7d",
+    "version": 4
   },
   "1781d055-5c66-4adf-9d60-fc0fa58337b6": {
     "rule_name": "Suspicious Powershell Script",
-    "sha256": "93b050224f92e0f3e5a043d6d2598a105fea78aebd8815f32e6932920731c7be",
-    "version": 3
+    "sha256": "460a16a595ce6ae95c9edea03ef73004bc7c7308105aa6c9ea445cbde9af7acd",
+    "version": 4
   },
   "1781d055-5c66-4adf-9d82-fc0fa58449c8": {
     "rule_name": "Unusual Windows User Privilege Elevation Activity",
-    "sha256": "b8604ca4da00ed753c2528b252b3a70dc27e923442b8d3cb9b6efe70b0733069",
-    "version": 3
+    "sha256": "f379e94cb9af607a023c169713f9d08359187394314686ae5e0c9e90c0cfc475",
+    "version": 4
   },
   "1781d055-5c66-4adf-9e93-fc0fa69550c9": {
     "rule_name": "Unusual Windows Remote User",
-    "sha256": "9b5521dffd2429f28febd39b2e0c6854439e3020f4ea36dae83899321f987f80",
-    "version": 3
+    "sha256": "6301bb6c40b90afcc655e7203e2e3f15fcf4238f100a9f746635c2617b2cddb2",
+    "version": 4
   },
   "17c7f6a5-5bc9-4e1f-92bf-13632d24384d": {
     "rule_name": "Suspicious Execution - Short Program Name",
-    "sha256": "6e89d71c59daded6ae826a8621232f987a054465337646e10ee7e1d284bc1ac2",
-    "version": 2
+    "sha256": "3763b227c0acc1f158a5aafbc971558f823486f26d38ebc8633193bd1110f8d8",
+    "version": 3
   },
   "17e68559-b274-4948-ad0b-f8415bb31126": {
     "rule_name": "Unusual Network Destination Domain Name",
-    "sha256": "6e872b23e100ee779531cb816953fbf9c13e475e07b3ab4e52ecdef1e474e124",
-    "version": 3
+    "sha256": "4f247c995b369cacb22a5734b72185bd8dc067b58972e3e959245d9bf0d391ab",
+    "version": 4
   },
   "184dfe52-2999-42d9-b9d1-d1ca54495a61": {
     "rule_name": "GCP Logging Sink Modification",
-    "sha256": "58f943ff669854f623265eda509ef58e601bbd39af5f9ce82985e65d0817d796",
-    "version": 3
+    "sha256": "35a8d45c5765943a2b0854dfbfd7f9a7c05c534a58de18e214418ce3008ae96d",
+    "version": 4
   },
   "19de8096-e2b0-4bd8-80c9-34a820813fff": {
     "rule_name": "Rare AWS Error Code",
-    "sha256": "ba1f3d9db01dd4ecac10bceae27c1686745f53fc59c9164cdda820d1ff955667",
-    "version": 2
+    "sha256": "f930c016a444fe99f60d4358a2ddcc45ec3119fbb8cf3de8738eefc5251968bc",
+    "version": 3
   },
   "1a36cace-11a7-43a8-9a10-b497c5a02cd3": {
     "rule_name": "Azure Application Credential Modification",
-    "sha256": "f82e7c30280b4862032aa17c77a377dc129dcaf495468cc532d736845a9af8ee",
-    "version": 2
+    "sha256": "0e553ebd2b48ffd3009e16ce1205812ac1be5735a01d970f370b341b6c4e72eb",
+    "version": 3
+  },
+  "1a6075b0-7479-450e-8fe7-b8b8438ac570": {
+    "rule_name": "Execution of COM object via Xwizard",
+    "sha256": "4776192663bb176f851e07e413ee7d932ecc34e7ad179253f59c2be526afec0e",
+    "version": 1
   },
   "1aa8fa52-44a7-4dae-b058-f3333b91c8d7": {
     "rule_name": "AWS CloudTrail Log Suspended",
-    "sha256": "8dad953d062015582e4e66a69bebdcb081d7e8504e3a8450486012cbef959148",
-    "version": 4
+    "sha256": "558d273d31db3b26cb8f5901941fbed9b12e0a325763c1575e72ef05365c6d3d",
+    "version": 5
   },
   "1aa9181a-492b-4c01-8b16-fa0735786b2b": {
     "rule_name": "User Account Creation",
-    "sha256": "b104414747b46066388a40c0010698e2fadef3a589cd1863923ae97805f2d37c",
-    "version": 6
+    "sha256": "48eeaa5b92d1414286256cc18a96522927ab951e02ad33695747981f23a084fb",
+    "version": 7
   },
   "1b21abcc-4d9f-4b08-a7f5-316f5f94b973": {
     "rule_name": "Connection to Internal Network via Telnet",
-    "sha256": "a0c3903438a1efe0c78f19773f9405b91c94f92239c59e63d1ec89073afb78cd",
-    "version": 4
+    "sha256": "82e4e45d80664b9115f0a2e0f4b1e2a43ccb0ec7283e64bc2bdbd70311c54256",
+    "version": 5
   },
   "1c6a8c7a-5cb6-4a82-ba27-d5a5b8a40a38": {
     "rule_name": "Possible Consent Grant Attack via Azure-Registered Application",
-    "sha256": "a6190376ebfd842ab3228b6713b5d75029b3516c8ec74b6e4ab43c83cba3eeb1",
-    "version": 3
+    "sha256": "9fda634b944d5b1b8496b6d82c3a59571af1b0dd7ff7e10ef6b98ef93590f247",
+    "version": 4
   },
   "1cd01db9-be24-4bef-8e7c-e923f0ff78ab": {
     "rule_name": "Incoming Execution via WinRM Remote Shell",
-    "sha256": "b6932e27a95974385f586931c228695347bfd04535e89f328976ff0db921235a",
-    "version": 1
+    "sha256": "06b2b27914185928fcafb1a80db136dde43ea01d646bc66e4f3cdf6beea7a469",
+    "version": 2
   },
   "1d276579-3380-4095-ad38-e596a01bc64f": {
     "rule_name": "Remote File Download via Script Interpreter",
-    "sha256": "4abb8480e4397d41ccad67d9f2aea6c629a9a089247d426bc92135e3073f83a7",
-    "version": 1
+    "sha256": "a0716e9b819c5dc12e825c123a907de9b2a6b20f3dcf5191faa43f33a5acdc6f",
+    "version": 2
   },
   "1d72d014-e2ab-4707-b056-9b96abe7b511": {
     "rule_name": "Public IP Reconnaissance Activity",
-    "sha256": "35dc7d0a375f80421e98e210eed421e7f0bc2e1902eff8e2739bcf1cfdf3e062",
-    "version": 2
+    "sha256": "6951b8fd1149be5a4ee15ce56da0be9905189e5e20a1f829b42f5af393eb8157",
+    "version": 3
   },
   "1dcc51f6-ba26-49e7-9ef4-2655abb2361e": {
     "rule_name": "UAC Bypass via DiskCleanup Scheduled Task Hijack",
-    "sha256": "3f676ea1d24c02433d7e3b42c3288f59c319b51028ed2f6b5e3a4c84a1a95d9c",
-    "version": 3
+    "sha256": "fa843684a8d65c3fe110c03105a4c698740ce245f7a8aa354c44087e1d9a3b65",
+    "version": 4
   },
   "1defdd62-cd8d-426e-a246-81a37751bb2b": {
     "rule_name": "Execution of File Written or Modified by PDF Reader",
-    "sha256": "aa68e54b0b1dab44af2dafcbdb5c36d1b2b9e6d5363b407789b653864158e52f",
-    "version": 2
+    "sha256": "3969c9f3230d84375fb447b14e9979360ab9e90b5dcce2e9382eb1d8e0cad454",
+    "version": 3
   },
   "1e0b832e-957e-43ae-b319-db82d228c908": {
     "rule_name": "Azure Storage Account Key Regenerated",
-    "sha256": "cfee55b352159e0848f887984ef2f0124a7209cb882637f14d4280525e744e49",
-    "version": 3
+    "sha256": "62b1903d5035ffa9244e81b945b7f4c801d101d615281ce9914fa093541ec7ad",
+    "version": 4
   },
   "1e9fc667-9ff1-4b33-9f40-fefca8537eb0": {
     "rule_name": "Unusual Sudo Activity",
-    "sha256": "6e49f87f11fba067e6fea0b97078cf1e2d77aa0f6c259309ec67f9fecb867a7f",
-    "version": 1
+    "sha256": "ea35fdcda2944c1f32b9212d1a678d78dbb16552282224aaba7c0cf16fd29716",
+    "version": 2
   },
   "1faec04b-d902-4f89-8aff-92cd9043c16f": {
     "rule_name": "Unusual Linux User Calling the Metadata Service",
-    "sha256": "78a5c11812e5b1a80a2060f55840a2c19bb4f16eaf7c12ebd427d977e1579e65",
-    "version": 1
+    "sha256": "3c8fba418050d2079a9f223c58298de759b56c0949e7ec330a256ffa6fed65d1",
+    "version": 2
   },
   "1fe3b299-fbb5-4657-a937-1d746f2c711a": {
     "rule_name": "Unusual Network Activity from a Windows System Binary",
-    "sha256": "1c6a98ed8c939c838cc1d87528f00eee1d6a188c9fd7c6adea39ffb08d1b737b",
-    "version": 1
+    "sha256": "db699aa748d2368754bd1425dd417d14af479b9812bd1bd1b30fcfdaa28a8a59",
+    "version": 2
   },
   "2003cdc8-8d83-4aa5-b132-1f9a8eb48514": {
-    "rule_name": "Exploit - Detected - Endpoint Security",
-    "sha256": "83322d535ddc84dec40b7a90e9738726df2bd27ac3cdf96e7b9ebd967560bd25",
-    "version": 4
+    "rule_name": "Exploit - Detected - Elastic Endgame",
+    "sha256": "da7b6e128ad5867cbd3456cf71fb4583caf272f62e76d422a6e765b5a019b508",
+    "version": 5
   },
   "201200f1-a99b-43fb-88ed-f65a45c4972c": {
     "rule_name": "Suspicious .NET Code Compilation",
-    "sha256": "0416d1b395d3e71f875fd844d5cfeefd2ca1de353c0595c765c7d7c60de4cfdb",
-    "version": 3
+    "sha256": "6369d78ac26e4f7b3174ef0923cf4ee45dea20c14723637aecfcc0b8f7c0dac3",
+    "version": 4
+  },
+  "203ab79b-239b-4aa5-8e54-fc50623ee8e4": {
+    "rule_name": "Creation or Modification of Root Certificate",
+    "sha256": "530e80dcf00f3d075008dc84df00d8ae307d4cafe4bb16d2f9afe00d7a66e8d6",
+    "version": 1
+  },
+  "20457e4f-d1de-4b92-ae69-142e27a4342a": {
+    "rule_name": "Access of Stored Browser Credentials",
+    "sha256": "70475c97c91896aca0fdd68519bec234ff444f48d2bbbdafb7da5a1da5944868",
+    "version": 1
+  },
+  "20dc4620-3b68-4269-8124-ca5091e00ea8": {
+    "rule_name": "Auditd Max Login Sessions",
+    "sha256": "ec73780468dff45dc2dcc20f8f517ae11fc0c908d85287c5f64e1054dfd43467",
+    "version": 1
+  },
+  "2215b8bd-1759-4ffa-8ab8-55c8e6b32e7f": {
+    "rule_name": "SSH Authorized Keys File Modification",
+    "sha256": "b636cdf117c8dbe569e93a97d6c59c53758757fd9b3f7743978cfb10a5d33b5d",
+    "version": 1
   },
   "22599847-5d13-48cb-8872-5796fee8692b": {
     "rule_name": "SUNBURST Command and Control Activity",
-    "sha256": "a1f82797be5307027c2299d4e0bcd5e77d032fdef9bc6d5f5f31197a1af80c88",
-    "version": 2
+    "sha256": "61f57fd48f1fb63565f2b0bc95e9b394345522799cd75fa10b55e1b7fda552d5",
+    "version": 3
   },
   "227dc608-e558-43d9-b521-150772250bae": {
     "rule_name": "AWS S3 Bucket Configuration Deletion",
-    "sha256": "905b4d51fc906750f57cd87dc8d7d9df6c09909d1f891757204047d2ba50c7f0",
-    "version": 3
+    "sha256": "7c6c2fff0b01f346a5a4c24b8df93d4939cb25949d7fc9f4578b9594ccac78f2",
+    "version": 4
   },
   "231876e7-4d1f-4d63-a47c-47dd1acdc1cb": {
     "rule_name": "Potential Shell via Web Server",
-    "sha256": "7207564a7508b0604510440b1fd1d3bebdeaf1e897e503fe298aa7f783c46410",
-    "version": 8
+    "sha256": "961b1deac49c71fddc94965ab111a3c85bd9f42d0f8aa826f31843e763f53882",
+    "version": 9
   },
   "2326d1b2-9acf-4dee-bd21-867ea7378b4d": {
     "rule_name": "GCP Storage Bucket Permissions Modification",
-    "sha256": "b34c9e0e5d452ba1f81e8fb67dcfd4b37fa2815b55f6167cef81ee2ae22f8435",
-    "version": 3
+    "sha256": "edc4cb4820017d89a64e1e5f5190912787091e860fefdc09e47a1ccf3d2e28a4",
+    "version": 4
   },
   "25224a80-5a4a-4b8a-991e-6ab390465c4f": {
     "rule_name": "Lateral Movement via Startup Folder",
-    "sha256": "41299fef8c7f35e269c70d1e1e2924da08b1f5c726176c2d5fab5320cca82f61",
-    "version": 2
+    "sha256": "541c555ba3d9c4e25fdeed71f0c1033b4c3f0ffcfabf9a5ea94828114d63cefc",
+    "version": 3
   },
   "2636aa6c-88b5-4337-9c31-8d0192a8ef45": {
     "rule_name": "Azure Blob Container Access Level Modification",
-    "sha256": "0f878d919fd4f04a318821523e81f19f7b201cfd00ea14dbbe6caefa12085a36",
-    "version": 3
+    "sha256": "dd2d9553b890f746fbcf9ab966b7e2252b590a2a0a2a27eb1b2ab7e9e7943318",
+    "version": 4
   },
   "265db8f5-fc73-4d0d-b434-6483b56372e2": {
     "rule_name": "Persistence via Update Orchestrator Service Hijack",
-    "sha256": "f5d597657cdadf16e517169eb237df37db33d4afc77852c7fac5b42c1a6677da",
-    "version": 3
+    "sha256": "2fde8b5429bcf1a32d15d54f96a2386179c681a0bc3e5eca71ac09eaa51272ad",
+    "version": 4
   },
   "26f68dba-ce29-497b-8e13-b4fde1db5a2d": {
     "rule_name": "Attempts to Brute Force a Microsoft 365 User Account",
-    "sha256": "1678ed5e26e08ff3c4b51dea2cee32f9fb1275bc8042634dae096429511f64c1",
-    "version": 1
+    "sha256": "99d42e8419647d93781f48cd1dfae7aa518fdb7d64bbf14a5d92d3488610b2ce",
+    "version": 2
   },
   "272a6484-2663-46db-a532-ef734bf9a796": {
     "rule_name": "Microsoft 365 Exchange Transport Rule Modification",
-    "sha256": "d0610ca7e553b3f159db6d65452c7f6a6834583c1b4e898204125c93730da1a5",
-    "version": 2
+    "sha256": "38f1daaff7be80a26561301c00fa778dd3493fd89499628a87133aedfd459363",
+    "version": 3
   },
   "2772264c-6fb9-4d9d-9014-b416eed21254": {
     "rule_name": "Incoming Execution via PowerShell Remoting",
-    "sha256": "57b09eec9a69ad0e38e8e43010bf9c0937e1508d050755d0a480820c02f3434f",
-    "version": 1
+    "sha256": "ec3c481e92364c4fad7260840ea8ce1c35fe40bdaf781b7bcff726ac436e1bf9",
+    "version": 2
   },
   "2783d84f-5091-4d7d-9319-9fceda8fa71b": {
     "rule_name": "GCP Firewall Rule Modification",
-    "sha256": "0feabc81d71050379c9157c1cb287680a7c4fba732008ef9a3f17e86d6000acb",
-    "version": 3
+    "sha256": "f72b655abdc07f8715c792d19d9c505d927a226d96119a4ce13980d1b61c510c",
+    "version": 4
   },
   "27f7c15a-91f8-4c3d-8b9e-1f99cc030a51": {
     "rule_name": "Microsoft 365 Teams External Access Enabled",
-    "sha256": "4182ae86ebceb37ef4daf7e9d714531e546f3d75917079782cba4471e3683054",
-    "version": 2
+    "sha256": "314b665e4aaee834713a0e81e740a6f90aa8531f20f57fff50776abee3561b1a",
+    "version": 3
   },
   "2856446a-34e6-435b-9fb5-f8f040bfa7ed": {
     "rule_name": "Net command via SYSTEM account",
-    "sha256": "7638c2f89b64cef3e108db8da0e69fde6886c3cf8ee55888962e46a36b8cbe40",
-    "version": 5
+    "sha256": "bcf411fda8a3e622613b7eddce8f38129bde7a1520c7e2b436d8628974441dbf",
+    "version": 6
   },
   "2863ffeb-bf77-44dd-b7a5-93ef94b72036": {
-    "rule_name": "Exploit - Prevented - Endpoint Security",
-    "sha256": "4a04fd5b4099a19a093d301762f68352221eca036db21c9b9b2e388dc5c56a9e",
-    "version": 4
+    "rule_name": "Exploit - Prevented - Elastic Endgame",
+    "sha256": "027892bbc77dec382e1fff007e985d1ddaa09db9765397a995bca7504228a92d",
+    "version": 5
   },
   "28896382-7d4f-4d50-9b72-67091901fd26": {
     "rule_name": "Suspicious Process from Conhost",
-    "sha256": "9f775cc41219f22aeed5606b452afd1ef3492c54f2a31a159971683527bd7079",
-    "version": 2
+    "sha256": "2165f6cb7509d5e3c4d1e85f8f395edd0c5cac0eab932c77d292932af0ce26fa",
+    "version": 3
   },
   "290aca65-e94d-403b-ba0f-62f320e63f51": {
     "rule_name": "UAC Bypass Attempt via Windows Directory Masquerading",
-    "sha256": "19dc06953af8af51a15fdaefb96489c18d189e4b624b72bc33877826d9cfad4d",
-    "version": 2
+    "sha256": "a17a946ce684041c687dafaa532e579e76f45ad9ccca23fc95e534224c4d0520",
+    "version": 3
   },
   "2bf78aa2-9c56-48de-b139-f169bf99cf86": {
     "rule_name": "Adobe Hijack Persistence",
-    "sha256": "8898026965d74c21585cf6aec35a7e557e9ebf11998efa5d264e0e4dc9e8bb41",
-    "version": 7
+    "sha256": "098b1c3015f7f3d2e4c182836e1cb291997e6bcae75991dc66dcbb4fd02c046d",
+    "version": 8
   },
   "2d8043ed-5bda-4caf-801c-c1feb7410504": {
     "rule_name": "Enumeration of Kernel Modules",
-    "sha256": "d190d8cec6950e03d8e267dca54b372158b1bb414490ac7f6db3d676d7c5d558",
-    "version": 5
+    "sha256": "04390626a994d38d1067e1f6102faf343e3946318596f73b4619c51aa0d7489f",
+    "version": 6
   },
   "2e1e835d-01e5-48ca-b9fc-7a61f7f11902": {
     "rule_name": "Renamed AutoIt Scripts Interpreter",
-    "sha256": "53e55f065444d26397602d8833b406b630e6d6de7f8db36bdc80300cd00d20d2",
-    "version": 3
+    "sha256": "5250ee0f4d13cd87faecfbf97ba1cae636c2c99325f8cb287f4d322c5142f6c8",
+    "version": 4
   },
   "2e580225-2a58-48ef-938b-572933be06fe": {
     "rule_name": "Halfbaked Command and Control Beacon",
-    "sha256": "cdc14ec4b2b923b44462eeec6cca036053f8e2f2ba9da1cdab7ae27d4aaa1885",
-    "version": 3
+    "sha256": "1abd8a52908e88463907419e423538f77187732d05c2942900b1fa28958e7de8",
+    "version": 4
+  },
+  "2edc8076-291e-41e9-81e4-e3fcbc97ae5e": {
+    "rule_name": "Creation of a Hidden Local User Account",
+    "sha256": "9f4084ad28a9a4e1378334c8832a4c05e04155476ead195ca7fee9397702109b",
+    "version": 1
   },
   "2f8a1226-5720-437d-9c20-e0029deb6194": {
     "rule_name": "Attempt to Disable Syslog Service",
-    "sha256": "741e753e168271d0ca5c5d7fbd2ae7660b81e53ce36255eec7cc428977c897a5",
-    "version": 6
+    "sha256": "0cc8ce121a7f9ffea5aadb7586ba3f74a1b24c7f510506354622e0cb326a0fd8",
+    "version": 7
   },
   "2fba96c0-ade5-4bce-b92f-a5df2509da3f": {
     "rule_name": "Startup Folder Persistence via Unsigned Process",
-    "sha256": "eddb73a664e938bfa193825a0de166c1ae4577d8e2f1ce732819db7f92bfc126",
+    "sha256": "88d50c899d049787cadcf825cd76a12de950a6f91cbd75e64461970a259ac97d",
+    "version": 2
+  },
+  "2ffa1f1e-b6db-47fa-994b-1512743847eb": {
+    "rule_name": "Windows Defender Disabled via Registry Modification",
+    "sha256": "0c066a6c77276dde032a4c39d5f1e9d34b4de0e2c393e60531125f5f1770d887",
     "version": 1
   },
   "30562697-9859-4ae0-a8c5-dab45d664170": {
     "rule_name": "GCP Firewall Rule Creation",
-    "sha256": "045c646bf559d459cbad7abe6d452ac4f8fbf355523e81d5bd078230d3d1e2e0",
-    "version": 3
+    "sha256": "3b68d16c6adae9c7ef0dc411d509e9fe76aaee87a78d1aba35a49ce1b34af640",
+    "version": 4
   },
   "31295df3-277b-4c56-a1fb-84e31b4222a9": {
     "rule_name": "Inbound Connection to an Unsecure Elasticsearch Node",
-    "sha256": "5d3c9667ede9ba23dfa05e1ec40a147903c3d22335d29f3006e74f2b130f67ca",
-    "version": 2
+    "sha256": "ef7c4255f4cb9f05d51a45a2402b145fd585cece3349c3f9fd5844d5801daee6",
+    "version": 3
   },
   "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62": {
     "rule_name": "Bypass UAC via Event Viewer",
-    "sha256": "138656819a723b08184799b57c7b09266cf257c5e4842ef2e9e3e274c644a0ad",
-    "version": 6
+    "sha256": "fe37432e9e4d6ed45e85043fb7af715f22d688ee6d80f2c863726d68d49a4aaf",
+    "version": 7
   },
   "3202e172-01b1-4738-a932-d024c514ba72": {
     "rule_name": "GCP Pub/Sub Topic Deletion",
-    "sha256": "9f5f01e8c09d70086c93b58bed1b847b2536a16300f2183a79718538a3cf5a6b",
-    "version": 3
+    "sha256": "262ac7bb0e14b8218fef8c90979e078c1650e9b5139891dade0f2d9831e03c95",
+    "version": 4
   },
   "323cb487-279d-4218-bcbd-a568efe930c6": {
     "rule_name": "Azure Network Watcher Deletion",
-    "sha256": "e5b565501ae4c616fa76d99dee894d9cdd5e3b0d803aaf00f2e4d9a9141ef3b0",
-    "version": 3
+    "sha256": "2c2a51b2f29298b70096505180c009bf1dfa23d27ae0fc5d42a4e8246e2f27ce",
+    "version": 4
   },
   "32923416-763a-4531-bb35-f33b9232ecdb": {
     "rule_name": "RPC (Remote Procedure Call) to the Internet",
-    "sha256": "2b5c0f40d332c98bc432ae688248f8f2ef44589a43052b3aecca94b61df3e360",
-    "version": 7
+    "sha256": "07747df10d0c1f1f86f2cf45dd6109fe948618bf5fdc5fecc2eb06602e0e3114",
+    "version": 8
   },
   "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14": {
     "rule_name": "Program Files Directory Masquerading",
-    "sha256": "ce3f8ded0fa72d256144440ac0bca99298283a465bf53d3d52b5a38f5fe0351f",
-    "version": 2
+    "sha256": "5776969c744d8770af275525d4484eea657c06f85bb158a17ec46840bc0d8a79",
+    "version": 3
   },
   "32f4675e-6c49-4ace-80f9-97c9259dca2e": {
     "rule_name": "Suspicious MS Outlook Child Process",
-    "sha256": "5275750f21477fa6da25c475d8a62428b790254415ae9f915ae9855e34cf6024",
-    "version": 7
+    "sha256": "6e0051f68fbc7f951da463a0f13255d5db381abfa816f2af03ad3b5f9a2c310d",
+    "version": 8
   },
   "333de828-8190-4cf5-8d7c-7575846f6fe0": {
     "rule_name": "AWS IAM User Addition to Group",
-    "sha256": "c2a30a4e9da87291df7a1cb5c6f0488d1dc4363c8c6e8d5852cfe90b7aef9751",
-    "version": 4
+    "sha256": "393ce421873be12fab73cb0b0205c86660df523acdb5c217545723c86075a769",
+    "version": 5
   },
   "33f306e8-417c-411b-965c-c2812d6d3f4d": {
     "rule_name": "Remote File Download via PowerShell",
-    "sha256": "3f7622021f11c5c2649c14842643ecee2ece082c6e00228f579757cbdf1a5261",
-    "version": 1
+    "sha256": "0b1eb863c256967c4d2aa9423f1df47ac3ac3cf7a5c3db98660a488f516e07cb",
+    "version": 2
   },
   "34fde489-94b0-4500-a76f-b8a157cf9269": {
     "rule_name": "Telnet Port Activity",
-    "sha256": "a818c7383db3a78fc06748e8f69de6d5a29265b5cd157d418395f973930b4e63",
-    "version": 6
+    "sha256": "7da2279d0fe682877117672d7e68f973bb30b8c956507ebe82a96b7a3ac41d70",
+    "version": 7
+  },
+  "35330ba2-c859-4c98-8b7f-c19159ea0e58": {
+    "rule_name": "Execution via Electron Child Process Node.js Module",
+    "sha256": "b7b1464cba3b3f44340fccf082c8a42407d3bdcbfcf90b85f2557ac58e97c3f2",
+    "version": 1
   },
   "3535c8bb-3bd5-40f4-ae32-b7cd589d5372": {
     "rule_name": "Port Forwarding Rule Addition",
-    "sha256": "57c4a0ede1644dd809e968e63ffffe7c22507dc8712728997840850bcd637acf",
-    "version": 2
+    "sha256": "c9f0359efcb3e1b185aabeca1992928a55fd97098d2033d53a522e495da506c4",
+    "version": 3
   },
   "35df0dd8-092d-4a83-88c1-5151a804f31b": {
     "rule_name": "Unusual Parent-Child Relationship",
-    "sha256": "96ed86ac690b1e778290ffe7c0d3a8e9917e20d6a8c8344bf5191801802ede93",
-    "version": 7
+    "sha256": "6a46141b11cc0cb3310a27469db9094a6d2ae61b07373b4404f82802fd8b168c",
+    "version": 8
   },
   "36a8e048-d888-4f61-a8b9-0f9e2e40f317": {
     "rule_name": "Suspicious ImagePath Service Creation",
-    "sha256": "b404ff24a631ad29d1fc24185a0254b0bbc22ac740efe4cd5a2efa5d4bc338e1",
-    "version": 2
+    "sha256": "922ec3de8ec673c8094683d428592de1ad4d44af9afd45caa9a4cf8b0e7289eb",
+    "version": 3
+  },
+  "37994bca-0611-4500-ab67-5588afe73b77": {
+    "rule_name": "Azure Active Directory High Risk Sign-in",
+    "sha256": "02af1fc63fe53ac3d6bfdfd484692845851796c093f3ab4fe863c6b98d11dfef",
+    "version": 1
   },
   "37b0816d-af40-40b4-885f-bb162b3c88a9": {
     "rule_name": "Anomalous Kernel Module Activity",
-    "sha256": "cd02c225183b6d5187a07bf67653afe3372de17dde89842143f115477aca31d7",
-    "version": 2
+    "sha256": "becbe9b821ecab6d6a0caf046be29df9ad0e7bfaa4cf11f7b044c96e3716f6b3",
+    "version": 3
   },
   "37b211e8-4e2f-440f-86d8-06cc8f158cfa": {
     "rule_name": "AWS Execution via System Manager",
-    "sha256": "61dd1760bd8638bc67426d94284aa1224d97b34e9a68dc7542c9fd8f28098cc2",
-    "version": 4
+    "sha256": "f136a167c78ee46606a2f1c0087fa7367a67690ea10d482ff32f34271ea1ecba",
+    "version": 5
+  },
+  "37f638ea-909d-4f94-9248-edd21e4a9906": {
+    "rule_name": "Finder Sync Plugin Registered and Enabled",
+    "sha256": "f78513d0ba56c0826ac966d349e4af84ef881c44b0c67c912905d18ae544d862",
+    "version": 1
   },
   "3805c3dc-f82c-4f8d-891e-63c24d3102b0": {
     "rule_name": "Attempted Bypass of Okta MFA",
-    "sha256": "0d3f3665184ac4b21104c3fcba336c4a8e5b58984c79be68719241115cb41a72",
-    "version": 4
+    "sha256": "21efa012a7a5b3da682402555b0dd29a6f9e59df51925e3c7592eb3651da1b76",
+    "version": 5
   },
   "3838e0e3-1850-4850-a411-2e8c5ba40ba8": {
     "rule_name": "Network Connection via Certutil",
-    "sha256": "def0708eb6e6a00bb2f17fb1fafee41d4e11f5e4385ca2ca08447724ff623f68",
-    "version": 4
+    "sha256": "8036da9336f11b5e4c6381a89a1aca0fbe65d0159b529ca83bc2c985004f4994",
+    "version": 5
   },
   "38948d29-3d5d-42e3-8aec-be832aaaf8eb": {
     "rule_name": "Prompt for Credentials with OSASCRIPT",
-    "sha256": "7a6dcc3eea9d2ecd5b9e942e20010eb93c4d3c7ae267c151bd5e8eb74360d2f5",
-    "version": 2
+    "sha256": "862fe5f0c824fc337577015ea7456a3d5bba2d45e714bb08d08b245b9ce72d84",
+    "version": 3
   },
   "38e5acdd-5f20-4d99-8fe4-f0a1a592077f": {
     "rule_name": "User Added as Owner for Azure Service Principal",
-    "sha256": "8464e66812e6b7521a8dc2abf7c67bc0f950a78949daaacc73fc293e4d663111",
-    "version": 3
+    "sha256": "46f760538182b2c1561e580c5254d30d295ae874156b2df1f7d7945d7f5ffc36",
+    "version": 4
   },
   "39144f38-5284-4f8e-a2ae-e3fd628d90b0": {
     "rule_name": "AWS EC2 Network Access Control List Creation",
-    "sha256": "b10f7e2de3f5d6138871b90f41126dfb05cf2bdcafbd36b57348268e22e38be4",
-    "version": 4
+    "sha256": "6a7f54980b56695b6e0e694eadb754eb92d921046139205187bec632cf8dcae2",
+    "version": 5
   },
   "397945f3-d39a-4e6f-8bcb-9656c2031438": {
     "rule_name": "Persistence via Microsoft Outlook VBA",
-    "sha256": "3ef3999620b103e14c61eed74a63ee361926ae6a6f4b8d30353aa438c2e0665e",
-    "version": 2
+    "sha256": "6de0440b5c9995f4fd4e00b5d7dd242561ace6cc188ef3aff436f59020df155c",
+    "version": 3
   },
   "3a59fc81-99d3-47ea-8cd6-d48d561fca20": {
     "rule_name": "Potential DNS Tunneling via NsLookup",
-    "sha256": "732ac08d2d07ec76126d378233aaa6ceaad8088afaa81e456854b8a71a3db361",
-    "version": 1
+    "sha256": "fcf9efe1ab14be63857894d4a575c9d3c22a630d6e526295ef3c8f9df346e51a",
+    "version": 2
   },
   "3a86e085-094c-412d-97ff-2439731e59cb": {
     "rule_name": "Setgid Bit Set via chmod",
@@ -536,903 +641,1078 @@
   },
   "3ad49c61-7adc-42c1-b788-732eda2f5abf": {
     "rule_name": "VNC (Virtual Network Computing) to the Internet",
-    "sha256": "77fbab55e9059eb6fb6492ba30971f3d3a4df6c2e2d7e325b04d0ecd7bc26b52",
-    "version": 7
+    "sha256": "918bcd3ff0c8d95983985346361a963c0422f1905c3da03bb0db1d3e0bec8de8",
+    "version": 8
   },
   "3b382770-efbb-44f4-beed-f5e0a051b895": {
-    "rule_name": "Malware - Prevented - Endpoint Security",
-    "sha256": "49bf69bac026013bdfd88dbb0ebbf5f2cf01d0bcc8dbdc00d760cc4c1ecf6daf",
-    "version": 4
+    "rule_name": "Malware - Prevented - Elastic Endgame",
+    "sha256": "ee3b4a6b601f7f4929ff9f2d474a2deab9cef75f96c390b99208f95b12d8d619",
+    "version": 5
   },
   "3b47900d-e793-49e8-968f-c90dc3526aa1": {
     "rule_name": "Unusual Parent Process for cmd.exe",
-    "sha256": "4ce1347f9fe15a5884acb582586ef9918d0709794bdb3581cbefc8cf9166e707",
-    "version": 2
+    "sha256": "d27efd2b8dafe3a2e0be361ab3c639e22431debe9d6d26b030e73f4ead90b40d",
+    "version": 3
   },
   "3bc6deaa-fbd4-433a-ae21-3e892f95624f": {
     "rule_name": "NTDS or SAM Database File Copied",
-    "sha256": "6c4b480706231207a2b53286531f84fb7497f1b136d293d0e1ad8af5b90353ce",
-    "version": 2
+    "sha256": "72d86d240941f0db11c146a6540daab15515e7407a3bc2c007720ea7e291bef9",
+    "version": 3
   },
   "3c7e32e6-6104-46d9-a06e-da0f8b5795a0": {
     "rule_name": "Unusual Linux Network Port Activity",
-    "sha256": "b1d42eb05bc2bb9c5ca66aab76709e4f3aa79e9293af35f760905331f4fe3d43",
-    "version": 3
+    "sha256": "5cc8ad5cd8645964e6128824ebac5c3adbaf8248845a61e423a8d8700e461d3d",
+    "version": 4
   },
   "3e002465-876f-4f04-b016-84ef48ce7e5d": {
     "rule_name": "AWS CloudTrail Log Updated",
-    "sha256": "81893cb7efeaefbe69f4653b3dc5839948ec1fc43fc55f8370f3257e04f15d8c",
-    "version": 4
+    "sha256": "9216d90a18952b805aacae52dbaa570bea4bd7fab61c0ed8256c3f755b144ef6",
+    "version": 5
+  },
+  "3e3d15c6-1509-479a-b125-21718372157e": {
+    "rule_name": "Suspicious Emond Child Process",
+    "sha256": "60ad0bc321eee4f3d4d9a5346985b65aa95105034d55525170670faa700a9663",
+    "version": 1
   },
   "3ecbdc9e-e4f2-43fa-8cca-63802125e582": {
     "rule_name": "Privilege Escalation via Named Pipe Impersonation",
-    "sha256": "2472409ff9fa897575ec999b050152152e127c3c8f8fba6af7a746e812c3b41f",
-    "version": 2
+    "sha256": "3f2d95fdb79cb6ca4c56f1becabbe1d57288b6104b0b40f17398e3fde07651bf",
+    "version": 3
   },
   "3efee4f0-182a-40a8-a835-102c68a4175d": {
     "rule_name": "Potential Password Spraying of Microsoft 365 User Accounts",
-    "sha256": "86bd2b4c6d0bc71a1b6510262a029195221c555fc4f67f094e93dc1879d04e93",
-    "version": 1
+    "sha256": "8a40719ca1948bcfe7b12bb8eb054d89f0d93fda2bde8627d07c72269461296e",
+    "version": 2
   },
   "403ef0d3-8259-40c9-a5b6-d48354712e49": {
     "rule_name": "Unusual Persistence via Services Registry",
-    "sha256": "6522bc62d5d8d7ffc42fbb0aeac0f7da2ba74e3932da92569cfa2a871eafde1c",
-    "version": 2
+    "sha256": "86dcf4ab94aac1674ce265cd27a0c7a873ee1b4cddffb646754f22e06fb8bd6a",
+    "version": 3
+  },
+  "41824afb-d68c-4d0e-bfee-474dac1fa56e": {
+    "rule_name": "EggShell Backdoor Execution",
+    "sha256": "7137fff9945d2a9bacfe270cb70b11338e51815d181fa391c4d3b3e6b8690f14",
+    "version": 1
+  },
+  "41b638a1-8ab6-4f8e-86d9-466317ef2db5": {
+    "rule_name": "Potential Hidden Local User Account Creation",
+    "sha256": "ea80efbc02b8aad167e451638ae7a69edc767de89dd986f6b9f4f76fb43a145c",
+    "version": 1
   },
   "42bf698b-4738-445b-8231-c834ddefd8a0": {
     "rule_name": "Okta Brute Force or Password Spraying Attack",
-    "sha256": "fab4b7b457970b0ff1295a2fe4e230ca8221c8a4f5b6491512a62ae3d870d00f",
-    "version": 3
+    "sha256": "f010eb32774ea99fee8e147ac454d08ab147e38306cb6ef8a6678b603f6c7da2",
+    "version": 4
   },
   "4330272b-9724-4bc6-a3ca-f1532b81e5c2": {
     "rule_name": "Unusual Login Activity",
-    "sha256": "bff9c2058c32e5568671a4de897f191a1a5fad599b2982f5f5c543d6a2dcb5df",
-    "version": 3
+    "sha256": "3f35fdeeb2a9009f7f98d3094d9923caff8ad61e07dbaeb0f483e5de46092849",
+    "version": 4
   },
   "43303fd4-4839-4e48-b2b2-803ab060758d": {
     "rule_name": "Web Application Suspicious Activity: No User Agent",
-    "sha256": "7b2f56166e460cbf13418552df56b54023525a2eaf0df76c055f62210bc8a027",
-    "version": 5
+    "sha256": "f09ede4b1f68fffa1f520173d6012ec98bee09abdbfa6cbea491169459a1a96e",
+    "version": 6
   },
   "440e2db4-bc7f-4c96-a068-65b78da59bde": {
     "rule_name": "Shortcut File Written or Modified for Persistence",
-    "sha256": "cf28969a293d000e52873e97e24333b40307b6486244b54714e1b96f74aee319",
-    "version": 2
+    "sha256": "944caee6eb6c128e932e1a8b587dbf2a3da7cf3a70751349132eee695e1ad82f",
+    "version": 3
   },
   "445a342e-03fb-42d0-8656-0367eb2dead5": {
     "rule_name": "Unusual Windows Path Activity",
-    "sha256": "051a230879f4261f63624018cf932d319e6c4484457aa525a006d0d05facf1d3",
-    "version": 3
+    "sha256": "20166dce2b7f66d82826f7ee93173a1166fbd36a5e32c73dbc6ca24bddba566f",
+    "version": 4
   },
   "453f659e-0429-40b1-bfdb-b6957286e04b": {
-    "rule_name": "Permission Theft - Prevented - Endpoint Security",
-    "sha256": "de91fb70ece5386bf2fe4d065f50aa219516eff015f22534b5cd1b69064fe002",
-    "version": 4
+    "rule_name": "Permission Theft - Prevented - Elastic Endgame",
+    "sha256": "905e269e6ada516092e74e17fb1bb5d2bdc1ffdff1d87d42e253940d621e10bc",
+    "version": 5
+  },
+  "45ac4800-840f-414c-b221-53dd36a5aaf7": {
+    "rule_name": "Windows Event Logs Cleared",
+    "sha256": "edd24d6cd33cf4d97a8db4de08b016939e394923fc60273d7ab52e5324629e24",
+    "version": 1
   },
   "45d273fb-1dca-457d-9855-bcb302180c21": {
     "rule_name": "Encrypting Files with WinRar or 7z",
-    "sha256": "f359ec8bdfe01b859d3a325ba2cd0b00cff639a80f196ea48d201e3cbae74176",
-    "version": 2
+    "sha256": "23f9191786f04df01ac4076310352f81c20bec7f33495f5d7cbfd41c560e5330",
+    "version": 3
   },
   "4630d948-40d4-4cef-ac69-4002e29bc3db": {
     "rule_name": "Adding Hidden File Attribute via Attrib",
-    "sha256": "b7ee618643d98c2169a1b8bc1e871d9adcc21fe9c7c438d548f54462a01b9a77",
-    "version": 7
+    "sha256": "e0a43819f24cae47b5c43190b24e1621f8eed29e1ad91b44408ebb411ea176c3",
+    "version": 8
   },
   "46f804f5-b289-43d6-a881-9387cf594f75": {
     "rule_name": "Unusual Process For a Linux Host",
-    "sha256": "a0ced469a145609a24f3d0b37087aaa6923e859472645ef59120c0cb4e1ff168",
-    "version": 3
+    "sha256": "3d44fb859092c933ff07c33783f154c4f558523cdecfda53baaae7916154278c",
+    "version": 4
   },
   "47f09343-8d1f-4bb5-8bb0-00c9d18f5010": {
     "rule_name": "Execution via Regsvcs/Regasm",
-    "sha256": "cd4a76da7357de9b301cac5aab25aff5b3cdc7993a4da71e670c8646c08dee94",
-    "version": 6
+    "sha256": "fa283dded0764ed89000be343cbbb926c659d742d2cf19d15ad5c5680a096578",
+    "version": 7
   },
   "47f76567-d58a-4fed-b32b-21f571e28910": {
     "rule_name": "Apple Script Execution followed by Network Connection",
-    "sha256": "c9c44540966b2d9592ad5f670eba6bd6ee29beba41798f2788fc66fd3c0f6c1d",
+    "sha256": "72865db7bc50525258024cbd485983b15e70529f488290fdc041b3b7f3dc6701",
+    "version": 2
+  },
+  "483c4daf-b0c6-49e0-adf3-0bfa93231d6b": {
+    "rule_name": "Microsoft Exchange Server UM Spawning Suspicious Processes",
+    "sha256": "8c07df1d0c0f730e3e3126804f0934ba930fe3aaf3514718b5d17e3873665f4b",
+    "version": 1
+  },
+  "48ec9452-e1fd-4513-a376-10a1a26d2c83": {
+    "rule_name": "Potential Persistence via Periodic Tasks",
+    "sha256": "86d2748f31e20258f69fe7ba9854837085bc03cef366264cc8c829b8c6daad07",
     "version": 1
   },
   "4a4e23cf-78a2-449c-bac3-701924c269d3": {
     "rule_name": "Possible FIN7 DGA Command and Control Behavior",
-    "sha256": "d7a4094671ab3413141af350b26471c1f84f5813e2c751ab1460ade4994ee1f4",
-    "version": 3
+    "sha256": "756cb216cd97d55f3734636ebb9f37e77bdf0fa739d61392234863ef4578ee3e",
+    "version": 4
   },
   "4b438734-3793-4fda-bd42-ceeada0be8f9": {
     "rule_name": "Disable Windows Firewall Rules via Netsh",
-    "sha256": "207cfd123ae87b0a770f175c9018d1e0d3ec80d82dff6d5e2c122b44c0fb09b6",
-    "version": 7
+    "sha256": "c56f00f0dcd010dd2ae8232b248fe30e1b555070bf5763883d16d308344e46b2",
+    "version": 8
   },
   "4bd1c1af-79d4-4d37-9efa-6e0240640242": {
     "rule_name": "Unusual Process Execution Path - Alternate Data Stream",
-    "sha256": "f7941ff2450a8f5b2545ab32170eaf4b8ad7a2f5f86fe2f06a1b5495dd2b1f62",
-    "version": 2
+    "sha256": "494b14a0febe47fbf05ff1d46818cb54d8be78d60bd3ce1292780f02e2bae6a9",
+    "version": 3
   },
   "4d50a94f-2844-43fa-8395-6afbd5e1c5ef": {
     "rule_name": "AWS Management Console Brute Force of Root User Identity",
-    "sha256": "03e5525912390c97777265582854a101c5ec36a22ce7ac831b671bba2de39f4f",
+    "sha256": "64af2d4d1a6c0103a258da4f91072f1a0d5830d16444c435302c37abb1b9cef3",
+    "version": 2
+  },
+  "4da13d6e-904f-4636-81d8-6ab14b4e6ae9": {
+    "rule_name": "Attempt to Disable Gatekeeper",
+    "sha256": "a1c698224ee74f11eeba8d602264b9a9d46c89d48aad8869719dbcf780655d7b",
     "version": 1
   },
   "4ed493fc-d637-4a36-80ff-ac84937e5461": {
     "rule_name": "Execution via MSSQL xp_cmdshell Stored Procedure",
-    "sha256": "b116b6e30fcb1611da5546f1c52c12b88d5dfd9a2041e83fa34583e547860c2c",
-    "version": 2
+    "sha256": "8f13ebc41ff581ab9ee2142432046802d67c0df696829571a82d8bda22e1dc27",
+    "version": 3
   },
   "4ed678a9-3a4f-41fb-9fea-f85a6e0a0dff": {
     "rule_name": "Windows Suspicious Script Object Execution",
-    "sha256": "575bb0ccbaf54a34b2a4967355a6aeabd8e1e1da541113896f9de5e4d02dbc8c",
-    "version": 2
+    "sha256": "6ca4e463c26cbc55ca658eac2c38ca905c276b64174e634c570821d22c5960f0",
+    "version": 3
   },
   "4fe9d835-40e1-452d-8230-17c147cafad8": {
     "rule_name": "Execution via TSClient Mountpoint",
-    "sha256": "1e2b65b762c850b45150a9e0e641e72054c9761de19ecd694cc1dfee10ea8ea7",
-    "version": 2
+    "sha256": "fd6aa0fb6621012cb8e02b57f75725de1c2d778441edb0a01096a2b76f972d53",
+    "version": 3
   },
   "513f0ffd-b317-4b9c-9494-92ce861f22c7": {
     "rule_name": "Registry Persistence via AppCert DLL",
-    "sha256": "472d300c8c9ab634eca6e92d2c807265c348300e2c29f01a1dade2b5f74d73a9",
-    "version": 2
+    "sha256": "a18109b668acb88d44b78365be64838b14a3144532e52ed72211806b193cc789",
+    "version": 3
   },
   "514121ce-c7b6-474a-8237-68ff71672379": {
     "rule_name": "Microsoft 365 Exchange DKIM Signing Configuration Disabled",
-    "sha256": "c8d8d20fe7da189d29d5418c818dbcd69206b2517f805a9b0e908cc81bf55f93",
-    "version": 2
+    "sha256": "c0046a687a92a5db62c89a332014e61090cb179a01cf7ba29a9cfb6fc6d11045",
+    "version": 3
   },
   "51859fa0-d86b-4214-bf48-ebb30ed91305": {
     "rule_name": "GCP Logging Sink Deletion",
-    "sha256": "91f9f78c852e08daa7562d9df8dbe86bb1a55e5e269c26fd014a9a7b70157f9f",
-    "version": 3
+    "sha256": "0af9c826220d7a09fd8d6762145489a933d134988a6cca9ebfe3fa7ea3ac0b6d",
+    "version": 4
   },
   "51ce96fb-9e52-4dad-b0ba-99b54440fc9a": {
     "rule_name": "Incoming DCOM Lateral Movement with MMC",
-    "sha256": "5e1b6224a46c6f4bac302f5a4b217ea1aa3c52fd980bf278b667f36cd3261083",
-    "version": 1
+    "sha256": "56798ab9bdf8cb5392c135b08741c952206a72d42388d404c2e89aa693d02938",
+    "version": 2
   },
   "523116c0-d89d-4d7c-82c2-39e6845a78ef": {
     "rule_name": "AWS GuardDuty Detector Deletion",
-    "sha256": "b7adc358703eb3dceb5073c695606ebc4b3f1e328477735bdb5aa1af4a1da7db",
-    "version": 4
+    "sha256": "67550129e26db722ab8421e82407ecf4289c7647b86dfaff159ced0e69960bb3",
+    "version": 5
   },
   "52aaab7b-b51c-441a-89ce-4387b3aea886": {
     "rule_name": "Unusual Network Connection via RunDLL32",
-    "sha256": "62f9a83f87a1646d277900c459415fe58eeb8c9dd0b803948689441ab0672d25",
-    "version": 7
+    "sha256": "dbaeba388f235b616bad9d6ca3a613a15eca038d6bfbc5a1b1fd0ab5a57ecc44",
+    "version": 8
   },
   "52afbdc5-db15-485e-bc24-f5707f820c4b": {
     "rule_name": "Unusual Linux Network Activity",
-    "sha256": "ef8e961af1c2c6c36321af0253da8a005674aa2c3a6ef52c8498d3d3af6f619d",
-    "version": 3
+    "sha256": "5f257bdb27a56eb43a27513f8fa691ecaabec3c3323b9dd95772ed912ece5022",
+    "version": 4
   },
   "52afbdc5-db15-485e-bc35-f5707f820c4c": {
     "rule_name": "Unusual Linux Web Activity",
-    "sha256": "f1509a26320aeb35879f3ed33199d5608bc2f040ea884523217a08c5e5d74eea",
-    "version": 3
+    "sha256": "a25a0fe20cc7cdd9b940f1455c54b3cbd54a07d575ec8d8b6219b61af322aaad",
+    "version": 4
   },
   "52afbdc5-db15-596e-bc35-f5707f820c4b": {
     "rule_name": "Unusual Linux Network Service",
-    "sha256": "1262f7693276b5913f124eba96f84d2c81408e67dfd2bad1b96a2176f0506d62",
-    "version": 3
+    "sha256": "af448b51ebd531a54c02ae19fc4cc63deef15eb691efcc957764e26879b9a87c",
+    "version": 4
   },
   "5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de": {
     "rule_name": "Azure Diagnostic Settings Deletion",
-    "sha256": "62305e86230ba4c5c3a1003451d02a3ba84428bc352f1502845e2242cacdf686",
-    "version": 3
+    "sha256": "6c8e96ba4b07ed6cce18921a829831829bc4b6bba5d7ff87e9ed5a3f10fb99c8",
+    "version": 4
   },
   "53a26770-9cbd-40c5-8b57-61d01a325e14": {
     "rule_name": "Suspicious PDF Reader Child Process",
-    "sha256": "dfd73583e55e557d6b6b4cd595c2d9b899a833edee7f159aa9b899d6047cf5a6",
-    "version": 5
+    "sha256": "5830f8b50da5b26e2a04464f2c05f012785a123a00594b577b53823ad1e45ab9",
+    "version": 6
   },
   "54902e45-3467-49a4-8abc-529f2c8cfb80": {
     "rule_name": "Uncommon Registry Persistence Change",
-    "sha256": "1c339b8b96957808c27abd4eb4b06d28917dd955b3121f4a794ec7db1d52e87d",
-    "version": 2
+    "sha256": "32c64b8fa0f6c50c2253632facb556b54d2013478619f79cc60cb6f6519ce918",
+    "version": 3
   },
   "55d551c6-333b-4665-ab7e-5d14a59715ce": {
     "rule_name": "PsExec Network Connection",
-    "sha256": "135ac096e16bb4d0f7fda7f52b5fbae7cb80c49e8628cdd928800d9e3940d0e2",
-    "version": 6
+    "sha256": "4e4fbdc65c3b54bf30a91147ac126d5e470995cd70f02c1dd673719b0738a0a6",
+    "version": 7
   },
   "56557cde-d923-4b88-adee-c61b3f3b5dc3": {
     "rule_name": "Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)",
-    "sha256": "62b2c18b4283e72805e191b3fbff2f7ed1b2272eedc561fe049c38475b3ae34f",
-    "version": 5
+    "sha256": "99b97b04ec67066da705129885b9ba38cc1e85079cbb82511602ffe6f32d9a21",
+    "version": 6
+  },
+  "565c2b44-7a21-4818-955f-8d4737967d2e": {
+    "rule_name": "Potential Admin Group Account Addition",
+    "sha256": "ed5d0e8263555d6f10542d6785a859b3afd968cafccd087a25ca3db999148b86",
+    "version": 1
+  },
+  "565d6ca5-75ba-4c82-9b13-add25353471c": {
+    "rule_name": "Dumping of Keychain Content via Security Command",
+    "sha256": "902f4fc3cc9b2951b82e74f03c337b150f2584f77ae83e6d2a23ad8b5abb3c45",
+    "version": 1
   },
   "5663b693-0dea-4f2e-8275-f1ae5ff2de8e": {
     "rule_name": "GCP Logging Bucket Deletion",
-    "sha256": "36c41e7616e6841d8e8ccc7b8cf07ac26c8bccff0fa0233db17221a20069fc99",
-    "version": 3
+    "sha256": "e0c3667841d87d0690d68568ce1aba2ad6056277a7c9ab4b82c5c2cc0893543a",
+    "version": 4
   },
   "5700cb81-df44-46aa-a5d7-337798f53eb8": {
     "rule_name": "VNC (Virtual Network Computing) from the Internet",
-    "sha256": "7a98a305d038362c3fb3a83cf8bd99757e7cd97374f13a8c49583e9253abd937",
-    "version": 7
+    "sha256": "36b65bd4c5ed5603facd249fcdcde0d882a566a2035474487501b01caf373106",
+    "version": 8
   },
   "571afc56-5ed9-465d-a2a9-045f099f6e7e": {
-    "rule_name": "Credential Dumping - Detected - Endpoint Security",
-    "sha256": "bdc750ae44da6954d429af1c78db084f915fe63db463a2e084107bd4b7725a73",
-    "version": 4
+    "rule_name": "Credential Dumping - Detected - Elastic Endgame",
+    "sha256": "e75e954e18e9d0dc6cbbbdbcb5deb63eb2dd29996703bc5dc2af235c82af3b0c",
+    "version": 5
   },
   "581add16-df76-42bb-af8e-c979bfb39a59": {
     "rule_name": "Deleting Backup Catalogs with Wbadmin",
-    "sha256": "8c36a1ee95f65fd57c309bdf9969add31b8f6d83c342445259834f46484dddad",
-    "version": 7
+    "sha256": "e8343cc13f0ad5efb019926e8bb951cc8e1c715b6654d1949c57f02c5c697eb4",
+    "version": 8
   },
   "58aa72ca-d968-4f34-b9f7-bea51d75eb50": {
     "rule_name": "RDP Enabled via Registry",
-    "sha256": "18053d9896302f8e69ce8066403fe67c8995b0f7fd3c803e5c71a3ca9ef74279",
-    "version": 2
+    "sha256": "319db6b0ff0a8cf89ddad11cb2f65328fc71e7483f5ef7e0064285dd8aee58a5",
+    "version": 3
   },
   "58ac2aa5-6718-427c-a845-5f3ac5af00ba": {
     "rule_name": "Zoom Meeting with no Passcode",
-    "sha256": "00ebed2fca50a1579826be2ea418f5bee450e8a31e60680af072af3d99181292",
-    "version": 2
+    "sha256": "d7c58b73bcc4feaab5f1d82dd5edf9cc3155848139ec12c8e8d3655314e554d8",
+    "version": 3
   },
   "58bc134c-e8d2-4291-a552-b4b3e537c60b": {
     "rule_name": "Lateral Tool Transfer",
-    "sha256": "94039776569f68c81b2596b9811ba52331323a57b2069a1060c42d8fcf601d03",
-    "version": 1
+    "sha256": "7f2b4f3a2547ecc9c00623f5a23e27e68065769490004d0852a4cadfd8c1821d",
+    "version": 2
   },
   "594e0cbf-86cc-45aa-9ff7-ff27db27d3ed": {
     "rule_name": "AWS CloudTrail Log Created",
-    "sha256": "2af4c984cf43412d94bc2369b88c7ad65535fa95bddf98b15b81e62b3586de3b",
-    "version": 3
+    "sha256": "4e4284e7019514dcefe6f8ba018488e50b39e72be8166a28ed4f53988c84c0f2",
+    "version": 4
   },
   "59756272-1998-4b8c-be14-e287035c4d10": {
     "rule_name": "Unusual Linux System Owner or User Discovery Activity",
-    "sha256": "bcf941f7244ac82c4700aaa98b51326165d8c561e6be7ea725a0372ac568c9e6",
-    "version": 1
+    "sha256": "4dfce8f9b71d1c1154bcf7d7e227f86a80e23ecf68649d7067d1b9daa21960b3",
+    "version": 2
   },
   "5a14d01d-7ac8-4545-914c-b687c2cf66b3": {
     "rule_name": "UAC Bypass Attempt via Privileged IFileOperation COM Interface",
-    "sha256": "396ab1ad60804f89853f9976fde22358716c8a6a735791f6342e110370086997",
-    "version": 2
+    "sha256": "45f4900869e06a7119f2fe063138136b610fa5466eacda0d15671b77d8681c4c",
+    "version": 3
   },
   "5ae4e6f8-d1bf-40fa-96ba-e29645e1e4dc": {
     "rule_name": "Remote SSH Login Enabled via systemsetup Command",
-    "sha256": "223cb3241e8bdf4291664ddd39ab5534cc523b6daf9f6b2e6ed4223f3c4f2186",
-    "version": 2
+    "sha256": "3904144c2a84becbda46c175a1262beaa354b80fafc98a08af34b82ddb427b71",
+    "version": 3
   },
   "5aee924b-6ceb-4633-980e-1bde8cdb40c5": {
     "rule_name": "Potential Secure File Deletion via SDelete Utility",
-    "sha256": "8d78a38091e18b693817210f674b04535f1b66fcd042c355d8e27dc96c376d89",
-    "version": 3
+    "sha256": "db6a48363181317379d1b10bafba451a8180220cabc58a4c99d0cadb003e6168",
+    "version": 4
   },
   "5b03c9fb-9945-4d2f-9568-fd690fee3fba": {
     "rule_name": "Virtual Machine Fingerprinting",
-    "sha256": "280e064ffe4b31935712b8d34e3aa1c97c586ad103f4b61b86a209c6287254f6",
-    "version": 5
+    "sha256": "4d58659666dd2e75ce087788358695c725f6f898de4266ed07e5bb5513906022",
+    "version": 6
   },
   "5bb4a95d-5a08-48eb-80db-4c3a63ec78a8": {
     "rule_name": "Suspicious PrintSpooler Service Executable File Creation",
-    "sha256": "8f56c94d9172737c682679aa448bed9762578c30b9e69c5981432e0372761b0e",
-    "version": 2
+    "sha256": "0e034939927514cb22b5337ca02e42f305c56eea2df55b5cf9bf016f06767e5c",
+    "version": 3
   },
   "5beaebc1-cc13-4bfc-9949-776f9e0dc318": {
     "rule_name": "AWS WAF Rule or Rule Group Deletion",
-    "sha256": "23a72fb952c8871fdf25b30af1b83513cbede2411d85e86dc6b4ee58e3a1b30c",
-    "version": 4
+    "sha256": "a4148086fb244ba1469dbab67e88e1f0bbe16902b3e163c9a321b2727518f61a",
+    "version": 5
   },
   "5c983105-4681-46c3-9890-0c66d05e776b": {
     "rule_name": "Unusual Linux Process Discovery Activity",
-    "sha256": "701bb83db4ee9988f602d8483da8fd2616afd8d5182f6caba81a678824382d69",
-    "version": 1
+    "sha256": "d00b5c874958e60ebea75b76e2ed82104b526c831d61e946c915fd0cc7efa80d",
+    "version": 2
   },
   "5cd55388-a19c-47c7-8ec4-f41656c2fded": {
     "rule_name": "Outbound Scheduled Task Activity via PowerShell",
-    "sha256": "9e8ee2abd46dc1f135f981e2df161ad295f37034b2caef627a87509b42868976",
+    "sha256": "24d5ea3ff2d410f537c9b96af25167ce0c2c11fa2c647d18ff6bd0b90437962f",
+    "version": 2
+  },
+  "5cd8e1f7-0050-4afc-b2df-904e40b2f5ae": {
+    "rule_name": "User Added to Privileged Group in Active Directory",
+    "sha256": "9909c3f640cbe91ab61036338e97be1d9d918b70a48bab400087cd58234c6563",
     "version": 1
   },
   "5d0265bf-dea9-41a9-92ad-48a8dcd05080": {
     "rule_name": "Persistence via Login or Logout Hook",
-    "sha256": "66c623494f33deec9f9578828274d64bc626b49e0c4089feb63ed368a2527440",
-    "version": 2
+    "sha256": "5b0652a7ac92c8c5327b4f724acb114886eb6d5e682b61ef61e151624b15b3df",
+    "version": 3
   },
   "5d1d6907-0747-4d5d-9b24-e4a18853dc0a": {
     "rule_name": "Suspicious Execution via Scheduled Task",
-    "sha256": "91f0f28d9cab78550370bdb54ae1fe045b0386b78af41080ee15ace7422fbc8c",
-    "version": 2
+    "sha256": "4369b44ff1e27e0a5323f7f1ea2e08d8855bc451d944ffa053cf0309b2b56d4a",
+    "version": 3
+  },
+  "5d9f8cfc-0d03-443e-a167-2b0597ce0965": {
+    "rule_name": "Suspicious Automator Workflows Execution",
+    "sha256": "1423cb901db24ee2389356865a804a69d1c5ccd02aca4cf100ca7486f830aee2",
+    "version": 1
   },
   "5e552599-ddec-4e14-bad1-28aa42404388": {
     "rule_name": "Microsoft 365 Teams Guest Access Enabled",
-    "sha256": "22e55f416e232d19d6a6fdec998a0bf2c948111ce00daf4e92c92e954c442dbb",
-    "version": 2
+    "sha256": "5f2c21e6c59b979f2837809cbf9b28a4a55ea2766479b0d25c07069830eb0339",
+    "version": 3
   },
   "60884af6-f553-4a6c-af13-300047455491": {
     "rule_name": "Azure Command Execution on Virtual Machine",
-    "sha256": "a715d519189c188c0879a60afe5823e05137845c4c782a18fbe85d92c0a8e84c",
-    "version": 3
+    "sha256": "de8c2546ec2c5678f109b45497f5f3fb0ebb6e24f94cab472f27eccf78df1c70",
+    "version": 4
   },
   "60b6b72f-0fbc-47e7-9895-9ba7627a8b50": {
     "rule_name": "Azure Service Principal Addition",
-    "sha256": "5f69299722e8c6c6469f902b7867c74056379d15e39f74d8f557d052236cfbb1",
-    "version": 2
+    "sha256": "dceafec5303d3fc9c0bedf1e61aae7d2df1ed99555c2bcfa553472e09e7cdb15",
+    "version": 3
   },
   "60f3adec-1df9-4104-9c75-b97d9f078b25": {
     "rule_name": "Microsoft 365 Exchange DLP Policy Removed",
-    "sha256": "a23fc63c1652d21efc02a07708eb3c7d173e4d734d5ea9949296486717b37c2f",
-    "version": 2
+    "sha256": "cb0a48398fe183e52d291d0d07befd88b3b6fcc1a445cc6cec11a77f07bb6457",
+    "version": 3
   },
   "610949a1-312f-4e04-bb55-3a79b8c95267": {
     "rule_name": "Unusual Process Network Connection",
-    "sha256": "4b4462020136392da9adc5255f937664f218535edd5602e49fe21831a795bfd4",
-    "version": 6
+    "sha256": "9284b390c8c7e73e77a69f2d0e2900f6b6ef1e04caca2806f594f3695bc65b86",
+    "version": 7
   },
   "61c31c14-507f-4627-8c31-072556b89a9c": {
     "rule_name": "Mknod Process Activity",
-    "sha256": "3532de678b47a8b6e4b89371d69e552d7b67fae0ec5501f0f97b448ff62b6c54",
-    "version": 6
+    "sha256": "9070708b87661e05dc8b0275151d9c928fbf29feacc6b771a10e56eea2ff82ea",
+    "version": 7
   },
   "622ecb68-fa81-4601-90b5-f8cd661e4520": {
     "rule_name": "Incoming DCOM Lateral Movement via MSHTA",
-    "sha256": "bc0f34f950e9e0160d34ca918e98ecae1b5ff9c07d1a04dd1c4e37cbb87b0e97",
-    "version": 1
+    "sha256": "622971b557f9455358e7a8aabf246eb45113c34526df86049404d2cecf957872",
+    "version": 2
   },
   "63e65ec3-43b1-45b0-8f2d-45b34291dc44": {
     "rule_name": "Network Connection via Signed Binary",
-    "sha256": "5d84c2fa70575d8f1b2136ec8618d3aaba781d6844314dcf1e8e9e6f333928d0",
-    "version": 6
+    "sha256": "fe36d773c522704ff2482572c21539cd38821bc22794dbdc12f9bc016145f498",
+    "version": 7
   },
   "647fc812-7996-4795-8869-9c4ea595fe88": {
     "rule_name": "Anomalous Process For a Linux Population",
-    "sha256": "906c854f64f56a381c73270b7974d2ea0285d8fc16e9f6c6121e54cef5d0e402",
-    "version": 3
+    "sha256": "18a15c55696cf0d0cddd5cfaf86e3d2e40f8ff9343d96827bd04caddfaa765f5",
+    "version": 4
+  },
+  "6482255d-f468-45ea-a5b3-d3a7de1331ae": {
+    "rule_name": "Modification of Safari Settings via Defaults Command",
+    "sha256": "cc2e51435bfbcaee2bc001ddb08e9a13882b6fa7966902529b885591cb09d5cc",
+    "version": 1
+  },
+  "661545b4-1a90-4f45-85ce-2ebd7c6a15d0": {
+    "rule_name": "Attempt to Mount SMB Share via Command Line",
+    "sha256": "22df29a521ec99fa01bf16c417ab71290f62629f00e77a9d9daa68703717e996",
+    "version": 1
   },
   "665e7a4f-c58e-4fc6-bc83-87a7572670ac": {
     "rule_name": "WebServer Access Logs Deleted",
-    "sha256": "539b8de4adfa60a09feba4677439be7a0f3a32b016a5d59224234a6cba4a882b",
-    "version": 2
+    "sha256": "9e822f662024fca699b240383c9eebbb725dd9219991cbb412fbc73130137e78",
+    "version": 3
   },
   "66883649-f908-4a5b-a1e0-54090a1d3a32": {
     "rule_name": "Connection to Commonly Abused Web Services",
-    "sha256": "9880ea66b7f0b33e6c8faa4ced81fd51dcdd75150bac98e336e103a232e9d42e",
-    "version": 2
+    "sha256": "a1fff4f3dbe5caaae711d5159e0accb5456b52a76123156b29cc95e157ce1a6a",
+    "version": 3
+  },
+  "66da12b1-ac83-40eb-814c-07ed1d82b7b9": {
+    "rule_name": "Suspicious macOS MS Office Child Process",
+    "sha256": "1c968672e7ce48c011da51c976e9b3e08bb0163bf5c4d9ccaa5b6c734af30cbd",
+    "version": 1
   },
   "6731fbf2-8f28-49ed-9ab9-9a918ceb5a45": {
     "rule_name": "Attempt to Modify an Okta Policy",
-    "sha256": "141a2f379cab2fa52f9fb037db0bf219e44c455a5aafa0ae23c673fd38cf7832",
-    "version": 4
+    "sha256": "9f352402471508f9beb0380934fbab2c369b2cedb2883d4787c563e438ef2c26",
+    "version": 5
   },
   "676cff2b-450b-4cf1-8ed2-c0c58a4a2dd7": {
     "rule_name": "Attempt to Revoke Okta API Token",
-    "sha256": "e328e8296a29b8d680a32a4ff6e6456241ea6ae5142772d756908e9a64d9a638",
-    "version": 4
+    "sha256": "0e37375debfa41285fb8bd8d59a3cc01d286c68b3c4b946d266950a0186358f4",
+    "version": 5
   },
   "67a9beba-830d-4035-bfe8-40b7e28f8ac4": {
     "rule_name": "SMTP to the Internet",
-    "sha256": "2132ba64c0691c394c31bb8b68cfe1779c3db0a8b224d068541dee3846f01db1",
-    "version": 7
+    "sha256": "38ddd772b9bc49726619cf527ed48d8871a0611ca88d76d03054c6702456d14d",
+    "version": 8
   },
   "68113fdc-3105-4cdd-85bb-e643c416ef0b": {
     "rule_name": "Query Registry via reg.exe",
-    "sha256": "ac76956e9e5ca1a2b9303138d7962b83239d5233cc17c1951f575a1963e7aeae",
-    "version": 2
+    "sha256": "5752b998b95537fedce81850330b693ee3cb9f030b36bf07dba1da9107bd68d9",
+    "version": 3
   },
   "6839c821-011d-43bd-bd5b-acff00257226": {
     "rule_name": "Image File Execution Options Injection",
-    "sha256": "3b9679e6ded36023d52f4977ae939b556a66c54813c925f0a96b620bb1aaf8c8",
-    "version": 2
+    "sha256": "4a98f9ffc77d8325feab58efcc9434c8126e081df4f08581d71f4252481b85ef",
+    "version": 3
   },
   "6885d2ae-e008-4762-b98a-e8e1cd3a81e9": {
     "rule_name": "Threat Detected by Okta ThreatInsight",
-    "sha256": "6d3c615dc61fba8e4789523d8b658467eebf55d12aaacbe78e092cf303e798d2",
-    "version": 4
+    "sha256": "3dbd7c25330bec436d304357b5de1f5455d68b458e48cb7520cac32369bb8e8e",
+    "version": 5
   },
   "68921d85-d0dc-48b3-865f-43291ca2c4f2": {
     "rule_name": "Persistence via TelemetryController Scheduled Task Hijack",
-    "sha256": "652f005e7dd427a0d1caa47f44c0e35987934c392b51d869c63418c68aad0867",
-    "version": 3
+    "sha256": "ba8e3ade3df05a1fb64eb35dfeeaec65a32cde2c12fef701bc7886922086929f",
+    "version": 4
   },
   "68994a6c-c7ba-4e82-b476-26a26877adf6": {
     "rule_name": "Google Workspace Admin Role Assigned to a User",
-    "sha256": "b2b287e32e46fb4a6af0815d394d8910c5de71a2f389112f7749d8083e2ddb9e",
-    "version": 2
+    "sha256": "f373fc616d2547e567eed968ea489d666d4aee4782aa5a5f4dbe0560bf9ae903",
+    "version": 3
   },
   "689b9d57-e4d5-4357-ad17-9c334609d79a": {
     "rule_name": "Scheduled Task Created by a Windows Script",
-    "sha256": "b219c3f1ae863fc87d2555183a467eccaed16b9f09796f272c52db9db4925437",
-    "version": 1
+    "sha256": "96a498857ecfa3670559082998836262a34e0cbe938a3da03eb0d656e255135b",
+    "version": 2
   },
   "68a7a5a5-a2fc-4a76-ba9f-26849de881b4": {
     "rule_name": "AWS CloudWatch Log Group Deletion",
-    "sha256": "7123531c2f403e877a04a9bd9c0690242128efab72cfcb2ed4186433c305756f",
-    "version": 4
+    "sha256": "3ee90e8c70ab9c127c4252c8b8b0ed6e8744b2e00427d290632a93f5c6870e1a",
+    "version": 5
   },
   "68d56fdc-7ffa-4419-8e95-81641bd6f845": {
     "rule_name": "UAC Bypass via ICMLuaUtil Elevated COM Interface",
-    "sha256": "dda1ee5944e9a1be0b0bbf8ce73173115593dff29fae8d530efa30b4ea675991",
-    "version": 2
+    "sha256": "07e69dae4636c541406550cce46b8fa3d3fa1def248727c430a001de85cf0413",
+    "version": 3
   },
   "69c251fb-a5d6-4035-b5ec-40438bd829ff": {
     "rule_name": "Modification of Boot Configuration",
-    "sha256": "1b0e39c02798b3aec53ad0414a3d548a4ae21df79eb215ce5c193991d7b143ec",
-    "version": 6
+    "sha256": "485320db38810d542bde35625e3d722b6a8d910527a2aa85e42678f9da452f68",
+    "version": 7
   },
   "69c420e8-6c9e-4d28-86c0-8a2be2d1e78c": {
     "rule_name": "AWS IAM Password Recovery Requested",
-    "sha256": "ed2d0e0a212e573ea92041b025fe7f636f904641c177cfefa890bedd36a4fe52",
-    "version": 3
+    "sha256": "e17154513b449918f01d301ed584a5f8c3e858fe1759fafa5326bf4d5687c41a",
+    "version": 4
   },
   "6a8ab9cc-4023-4d17-b5df-1a3e16882ce7": {
     "rule_name": "Unusual Service Host Child Process - Childless Service",
-    "sha256": "d7377f732f983bf9e4d23033681b4ba85752d775f3d284914e55434e0fc0b379",
-    "version": 2
+    "sha256": "79553b3a40acce22ecd91c9946948f0e588df04e533323c192d8e41ded8b499f",
+    "version": 3
   },
   "6aace640-e631-4870-ba8e-5fdda09325db": {
     "rule_name": "Exporting Exchange Mailbox via PowerShell",
-    "sha256": "a4f4d48080543be6c84780e072b07173109723c55006b044051f67e50d5eed4a",
-    "version": 2
+    "sha256": "1bc245d47e85c5adb07ad46c5d5fa23a23365c3fd1a51bf2dd0c100de7aa8b5f",
+    "version": 3
+  },
+  "6b84d470-9036-4cc0-a27c-6d90bbfe81ab": {
+    "rule_name": "Sensitive Files Compression",
+    "sha256": "874476d64dc93e62fb147e271200d17de5f5b06c10e60f38204fbe5a561617a7",
+    "version": 1
+  },
+  "6cd1779c-560f-4b68-a8f1-11009b27fe63": {
+    "rule_name": "Microsoft Exchange Server UM Writing Suspicious Files",
+    "sha256": "ea100f0813f073c65e61677854ff4126e96fc1979da663bfdd2df094200eaf2f",
+    "version": 1
   },
   "6d448b96-c922-4adb-b51c-b767f1ea5b76": {
     "rule_name": "Unusual Process For a Windows Host",
-    "sha256": "74d68f9a6e585ad26b9200232e892b1d843aa6b141c91f2abf3def1aa7344bf1",
-    "version": 3
+    "sha256": "c508e9d610c130e50e29fd19a1599886bd7354601146b78f00704320cf44c3ad",
+    "version": 4
   },
   "6e40d56f-5c0e-4ac6-aece-bee96645b172": {
     "rule_name": "Anomalous Process For a Windows Population",
-    "sha256": "e65df18aefdd9bf967dcd78f887216a5c8a4a12fb34d344f64a2a8ddc17edb6f",
-    "version": 3
+    "sha256": "8d9233246b62fa21f68fe8e03c480dd1112e790f3621b755bd9970ee24a660f6",
+    "version": 4
+  },
+  "6e9b351e-a531-4bdc-b73e-7034d6eed7ff": {
+    "rule_name": "Enumeration of Users or Groups via Built-in Commands",
+    "sha256": "340bbc2617692d06162a232de13795a36bf540d34641506481d8e7eec565c66c",
+    "version": 1
   },
   "6ea41894-66c3-4df7-ad6b-2c5074eb3df8": {
     "rule_name": "Potential Windows Error Manager Masquerading",
-    "sha256": "7c9d7f37ae3388f4ce88cbabac925c158192140c5815d9bda106e88e7f9c01a5",
-    "version": 2
+    "sha256": "0062c2a192b58a69c17b50f78563e312da63225ef34decdd44a2246a7afba5fb",
+    "version": 3
   },
   "6ea55c81-e2ba-42f2-a134-bccf857ba922": {
     "rule_name": "Security Software Discovery using WMIC",
-    "sha256": "7c13599b8e0d4f2c956bbe141227d03a87bb44d6e2ac0a410d4d714b98026725",
-    "version": 2
+    "sha256": "b94cdf578c5aa4cdaf45b7a08a41047bce69f28c54303d86d72cc822e66aec8e",
+    "version": 3
   },
   "6ea71ff0-9e95-475b-9506-2580d1ce6154": {
     "rule_name": "DNS Activity to the Internet",
-    "sha256": "13fedd6f05827fcd21807bf8b3ecd2923d883e0f27e3910702d7bd2254641681",
-    "version": 7
+    "sha256": "34354545bef5a283a7a05a7f0cea301b97b6925915dd8b795b579fb1a42c0fc1",
+    "version": 8
   },
   "6f1500bc-62d7-4eb9-8601-7485e87da2f4": {
     "rule_name": "SSH (Secure Shell) to the Internet",
-    "sha256": "9ffc5ec9fb514ad3fbe969537edd388d30ee0e374e73d3de589ad453aec2126a",
-    "version": 7
+    "sha256": "ccd5c6ae27b2cc637f6bbb39e5d6b025d56dc2c81975d697ada670a54ce65ef5",
+    "version": 8
   },
   "6f435062-b7fc-4af9-acea-5b1ead65c5a5": {
     "rule_name": "Google Workspace Role Modified",
-    "sha256": "c5ef241dbb8750fb177ca2e1c3bf24efd7d0c4fa072d0fa0c22c031f5bf56de8",
-    "version": 2
+    "sha256": "ac3b1dffa8bbfb7fef221d538429a07ab7335c6b57a250b4b18164d80e599a2e",
+    "version": 3
   },
   "7024e2a0-315d-4334-bb1a-441c593e16ab": {
     "rule_name": "AWS CloudTrail Log Deleted",
-    "sha256": "cfa66db8a38fb8fc719bcfb5673e1e5835df3e77322a0e260b3bb2ccd34a7eec",
-    "version": 4
+    "sha256": "f42e45a2a267bebad57ec1829fc225206d73496a6046e59740d10febbb7f6a1c",
+    "version": 5
   },
   "7024e2a0-315d-4334-bb1a-552d604f27bc": {
     "rule_name": "AWS Config Service Tampering",
-    "sha256": "027d56568c3cc971b88d2cb5166f2852d0534cf84545c99090eccd7759c6415e",
-    "version": 4
+    "sha256": "ec8ed91ddf4c947aabb68bcbac976bbfb567e91a8354496e0beab7b597c1237d",
+    "version": 5
+  },
+  "70fa1af4-27fd-4f26-bd03-50b6af6b9e24": {
+    "rule_name": "Attempt to Unload Elastic Endpoint Security Kernel Extension",
+    "sha256": "033fe29096800453c53a4a100cbe2e826148a4c053b440ae8962c008ef04a476",
+    "version": 1
+  },
+  "717f82c2-7741-4f9b-85b8-d06aeb853f4f": {
+    "rule_name": "Modification of Dynamic Linker Preload Shared Object",
+    "sha256": "7bd86063fc605889d7271c9a07188685af2cffccb1fedcba8b0155e4fd81d1cb",
+    "version": 1
+  },
+  "71bccb61-e19b-452f-b104-79a60e546a95": {
+    "rule_name": "Unusual File Creation - Alternate Data Stream",
+    "sha256": "eb2d6bdc651c4d7654fc996bcd8b7238f06ac89c28e7cb8a2e198397e9b3dcc8",
+    "version": 1
   },
   "71c5cb27-eca5-4151-bb47-64bc3f883270": {
     "rule_name": "Suspicious RDP ActiveX Client Loaded",
-    "sha256": "356b304bedec2afa2d8ab15398ce6839d25df11453b5c1ca03310ef19dded015",
-    "version": 2
+    "sha256": "d6f547243894063d94c8152b6485b57855368f0f9288e9d97e4f9e622f1b7e44",
+    "version": 3
   },
   "729aa18d-06a6-41c7-b175-b65b739b1181": {
     "rule_name": "Attempt to Reset MFA Factors for an Okta User Account",
-    "sha256": "2a0fc5337827134733d1b71dac658f687b492525dacae23341aa040fa35a648f",
-    "version": 4
+    "sha256": "733c0472aa406d5f99fd60c84903d3dc4f9b0e87daa44e1437c857a70903948e",
+    "version": 5
   },
   "7405ddf1-6c8e-41ce-818f-48bea6bcaed8": {
     "rule_name": "Potential Modification of Accessibility Binaries",
-    "sha256": "71e0b5a65c5c1c009f67c4daa7102a967665283a5b3edeae258ffbf27c40fedb",
-    "version": 6
+    "sha256": "ba040e94b982f1b9f417b04f1575ccc06418083b121e165cc9fcfc1013cb291e",
+    "version": 7
+  },
+  "7453e19e-3dbf-4e4e-9ae0-33d6c6ed15e1": {
+    "rule_name": "Modification of Environment Variable via Launchctl",
+    "sha256": "22a035e178cd410860585cc37d70b21e123895d0c40a6eff9f32d0daab2e63a2",
+    "version": 1
   },
   "746edc4c-c54c-49c6-97a1-651223819448": {
     "rule_name": "Unusual DNS Activity",
-    "sha256": "fe1405fde4d6da1912b657718cc824ba375605b47642e27393d580cbde8b87e1",
-    "version": 3
+    "sha256": "af51bdc27c86e87d19b50f0daa04da3c6df9a80227f61e73e44e86db37f30006",
+    "version": 4
   },
   "75ee75d8-c180-481c-ba88-ee50129a6aef": {
     "rule_name": "Web Application Suspicious Activity: Unauthorized Method",
-    "sha256": "87fdce46aaffc8303b29aa54c725e384cb978109cc9210f64c8b4fc1b477677d",
-    "version": 5
+    "sha256": "24efd8911deea109938424203bf258676d9e86d311862341b034ecc6e2c4ee85",
+    "version": 6
+  },
+  "76152ca1-71d0-4003-9e37-0983e12832da": {
+    "rule_name": "Potential Privilege Escalation via Sudoers File Modification",
+    "sha256": "1409f78ac3dbe51d37efaa4eedd30eff8c4744cece822d9ef22284af1d12ec32",
+    "version": 1
   },
   "76fd43b7-3480-4dd9-8ad7-8bd36bfad92f": {
     "rule_name": "Potential Remote Desktop Tunneling Detected",
-    "sha256": "a8cbc9d75c6e4da24fa473047890575c9c70155a3b1501b0b986598ce655655c",
-    "version": 2
+    "sha256": "51e2b3082e7350103b6ccafe28053932e602837e855ca1284269bc7974f1241c",
+    "version": 3
+  },
+  "770e0c4d-b998-41e5-a62e-c7901fd7f470": {
+    "rule_name": "Enumeration Command Spawned via WMIPrvSE",
+    "sha256": "1b2d4be4a6bec79d6bbc28d6fa1e664f19d7da816c2439cf357bacf48f034928",
+    "version": 1
   },
   "774f5e28-7b75-4a58-b94e-41bf060fdd86": {
     "rule_name": "User Added as Owner for Azure Application",
-    "sha256": "15345a004d3553b592315f2b99bff617cf1e4fe51254318e687143ac5f203f8a",
-    "version": 3
+    "sha256": "cbbdb9adc5c96a67cffb7a9edf791f5ea5c029f373be5d9704b7124f9055bc38",
+    "version": 4
   },
   "77a3c3df-8ec4-4da4-b758-878f551dee69": {
-    "rule_name": "Adversary Behavior - Detected - Endpoint Security",
-    "sha256": "60af511ccd3ed511fec254c879279d5090ca084efa9c11bc4fb01690450b7180",
-    "version": 4
+    "rule_name": "Adversary Behavior - Detected - Elastic Endgame",
+    "sha256": "8319fdbcc75a28932ed1ad89f7cae48a392d08b6bfd4a78ff5272c567bd03f6a",
+    "version": 5
   },
   "785a404b-75aa-4ffd-8be5-3334a5a544dd": {
     "rule_name": "Application Added to Google Workspace Domain",
-    "sha256": "53775aedf8cb2c8a2549c947714c72e087d8f66202e04d7b71e2057676f531ee",
-    "version": 2
+    "sha256": "643ea6cdd8f71ac2f159cfb7769bc1b22d62669de4d0a4cff6abc4427a88523c",
+    "version": 3
   },
   "7882cebf-6cf1-4de3-9662-213aa13e8b80": {
     "rule_name": "Azure Privilege Identity Management Role Modified",
-    "sha256": "96119234498e675b911d5936a75ac414acbc6dfaf18bb0af8e748dbcaa570de9",
-    "version": 3
+    "sha256": "dfa1d78e8e7e6f1d2e0b6db120101a10b676fef27656179ecf5fd03426cca4f4",
+    "version": 4
   },
   "78d3d8d9-b476-451d-a9e0-7a5addd70670": {
     "rule_name": "Spike in AWS Error Messages",
-    "sha256": "f4ac999620ed766ccfeb2fca9f79490e65d8c5de4a2372a69872c5474ca4d6b3",
-    "version": 2
+    "sha256": "84249aad3a778dcf0d66f4527ec8f01e4bad658abbe51e3ddf19c9dd3b1b35e9",
+    "version": 3
   },
   "792dd7a6-7e00-4a0a-8a9a-a7c24720b5ec": {
     "rule_name": "Azure Key Vault Modified",
-    "sha256": "395293327e180f887cbcc12dcd47cd37ad6960f6d342056c36d6503d26a0e3a6",
-    "version": 3
+    "sha256": "2c9cd618d0709db211347fb0f927d39032c5804fb01e22615384d9c443a989f8",
+    "version": 4
   },
   "7a137d76-ce3d-48e2-947d-2747796a78c0": {
     "rule_name": "Network Sniffing via Tcpdump",
-    "sha256": "5046e9d5e694a8d1cea49021ff63b18bb21ac7ce9b1b398f409d51860f779728",
-    "version": 6
+    "sha256": "a1d61d8865b525e77420ddd2744a088b6776dae60edb6673253cd1aeba1fd426",
+    "version": 7
   },
   "7b08314d-47a0-4b71-ae4e-16544176924f": {
     "rule_name": "File and Directory Discovery",
-    "sha256": "6f5328b72cc7ffc2206ff0b73647384d3bc410de54479be59278f1a3f51bd26e",
-    "version": 2
+    "sha256": "565d9e046bb625807c9d552344c5097df14d3f17d12b8c23cc8ef382da27c557",
+    "version": 3
   },
   "7b8bfc26-81d2-435e-965c-d722ee397ef1": {
     "rule_name": "Windows Network Enumeration",
-    "sha256": "5ad19c982c17664ea924524285b788f821d183b40fc9b2d375b9c096b0943447",
-    "version": 2
+    "sha256": "d1dddf7a8a9eadcb67c6a2b66936c7f6ff6681947045d7db7cd83ce91e71a903",
+    "version": 3
   },
   "7bcbb3ac-e533-41ad-a612-d6c3bf666aba": {
-    "rule_name": "Deletion of Bash Command Line History",
-    "sha256": "481ad533c5634070546c3587f45e3f1d15e9ceefe76aef5819cdaf74951c0d47",
-    "version": 5
+    "rule_name": "Tampering of Bash Command-Line History",
+    "sha256": "f5d97fc723896745fc89eaf2b77608aafa7dab27702ded21ebde4a2756bafe36",
+    "version": 6
   },
   "7ceb2216-47dd-4e64-9433-cddc99727623": {
     "rule_name": "GCP Service Account Creation",
-    "sha256": "eed9e26ee27ab35033cdcb30265238b416201b0d8511b20fe428c7d9c083b403",
-    "version": 3
+    "sha256": "1973dff13c3ef1ce1395c7f5cd1a2f803af70309eaa9281d0d485b79e804c57b",
+    "version": 4
   },
   "7d2c38d7-ede7-4bdf-b140-445906e6c540": {
     "rule_name": "Tor Activity to the Internet",
-    "sha256": "4a69174a17e82fee11e0402348d00579b3bb466ae795a9ffbbee8c3b0fdf8384",
-    "version": 7
+    "sha256": "a795f581489be91fab79b53ab0afee754fd43c0655cde52c08dd70983c606cb1",
+    "version": 8
   },
   "7f370d54-c0eb-4270-ac5a-9a6020585dc6": {
     "rule_name": "Suspicious WMIC XSL Script Execution",
-    "sha256": "dd9d99cd6900e72df71b70782901c1bd17d3ea2e315b5ca80d3f1b7830746ee1",
-    "version": 1
+    "sha256": "bf602350bac0c1b0bb608932184a4c059aff662530b1e19cd095b753e1bb84c1",
+    "version": 2
   },
   "809b70d3-e2c3-455e-af1b-2626a5a1a276": {
     "rule_name": "Unusual City For an AWS Command",
-    "sha256": "a72ac53d78c6de2093b247a25fc6d8a7bee0cd5cc96490e8046640ae77081b30",
-    "version": 2
+    "sha256": "a0672af3749608279dff9f81ac44c3781a6f8d71d9c97251281c6871c84198c9",
+    "version": 3
   },
   "80c52164-c82a-402c-9964-852533d58be1": {
-    "rule_name": "Process Injection - Detected - Endpoint Security",
-    "sha256": "126b716fe963842ff8406842f8a101953a04e7e9f167e578094712fa6b006b00",
-    "version": 4
+    "rule_name": "Process Injection - Detected - Elastic Endgame",
+    "sha256": "e8ed57396574222f759925fd3d4da6c63688d077a18de5a0bcec00ecf6de88d5",
+    "version": 5
   },
   "81cc58f5-8062-49a2-ba84-5cc4b4d31c40": {
     "rule_name": "Persistence via Kernel Module Modification",
-    "sha256": "009b2d96598f654010970715c06ffaf13c67925d69b17952e0a4b02ff31552af",
-    "version": 7
+    "sha256": "6d2938fb1e03fb76895197f4565a860e7c346b8cba3ac5bc612938f6af910d86",
+    "version": 8
+  },
+  "827f8d8f-4117-4ae4-b551-f56d54b9da6b": {
+    "rule_name": "Apple Scripting Execution with Administrator Privileges",
+    "sha256": "f77cf6a6f9ef86b2152b36bf3811485d39bf9c62dcaa02fb0df6c2233cdc8019",
+    "version": 1
   },
   "852c1f19-68e8-43a6-9dce-340771fe1be3": {
     "rule_name": "Suspicious PowerShell Engine ImageLoad",
-    "sha256": "05067614056729ecd7eff01320f2dc8f93a02ea5e6817c2320554cf1e5781df8",
-    "version": 2
+    "sha256": "b2f8c881e1a8035f71937f423f8575b0bcbf1aa09c17cfd35e2bdb86f03040ae",
+    "version": 3
   },
   "8623535c-1e17-44e1-aa97-7a0699c3037d": {
     "rule_name": "AWS EC2 Network Access Control List Deletion",
-    "sha256": "891a050afc467a0d6c5df28ccfee056010e269e4b1aebeffe90e7f07437ff52a",
-    "version": 4
+    "sha256": "1185bc3fe349c578b958b90129b3cdf96bb44627762533355acd1826e7977b8e",
+    "version": 5
   },
   "867616ec-41e5-4edc-ada2-ab13ab45de8a": {
     "rule_name": "AWS IAM Group Deletion",
-    "sha256": "9bc0125a9fbc1571fc776de116fdcf28d631cf42b498f7e6f1730a3f64d2c1d4",
-    "version": 3
+    "sha256": "b892135f26f63bdd82000f1b10fd897f193b478b9b68a599eadd52b5bc8d8f2d",
+    "version": 4
+  },
+  "870aecc0-cea4-4110-af3f-e02e9b373655": {
+    "rule_name": "Security Software Discovery via Grep",
+    "sha256": "2788679679566bcd320e35c2a0470f4bfe32816d19f57c7e9aa8d3cb491e2d5f",
+    "version": 1
   },
   "871ea072-1b71-4def-b016-6278b505138d": {
     "rule_name": "Enumeration of Administrator Accounts",
-    "sha256": "185f19110127ccbdf643549658b24af18b05f743db3ae0cde77892448ef74bf9",
-    "version": 2
+    "sha256": "53248ec0debf86a1acb0802d5e09db4eee88174caa617c0056bd33de9132b75f",
+    "version": 3
   },
   "87ec6396-9ac4-4706-bcf0-2ebb22002f43": {
     "rule_name": "FTP (File Transfer Protocol) Activity to the Internet",
-    "sha256": "b6aab90c7b2a4c83fd447e210bc554b40ac284a846025e0a3fd8e27dd14d7102",
-    "version": 7
+    "sha256": "b6ea4d4c77b8c1ed584826fd5828493dc1a33eee3546be3a15f540a56a9dc9f7",
+    "version": 8
+  },
+  "88817a33-60d3-411f-ba79-7c905d865b2a": {
+    "rule_name": "Sublime Plugin or Application Script Modification",
+    "sha256": "d89a2f8c0e73fe51b3f8dcb1b1fdd398f5b9eb9d4277bf19ec14fd8ebd4f2237",
+    "version": 1
   },
   "891cb88e-441a-4c3e-be2d-120d99fe7b0d": {
     "rule_name": "Suspicious WMI Image Load from MS Office",
-    "sha256": "7066bc711a65e15d4b69f16a1b939ce476cac7ff8c4fcaa63f34e1907b68d1ba",
-    "version": 2
+    "sha256": "c121d271be5aee39579f55f23df74c162c85b34e216e5f873d343e52bf9ce58c",
+    "version": 3
   },
   "897dc6b5-b39f-432a-8d75-d3730d50c782": {
     "rule_name": "Kerberos Traffic from Unusual Process",
-    "sha256": "a9c88449a4a2d7e3e8189db5592acfee7a0c276dbfb28e5760472c7ba302d259",
-    "version": 2
+    "sha256": "8dfd5e2b37ef8b8c3e3be8bd7022b8a3d2af58a7ae8bc173a1fee6ee39108392",
+    "version": 3
   },
   "89f9a4b0-9f8f-4ee0-8823-c4751a6d6696": {
     "rule_name": "Command Prompt Network Connection",
-    "sha256": "071525e0da043ae11036fb3009483b2ca19b758831b9b1d35125135bdf020e13",
-    "version": 5
+    "sha256": "8b6406885b7bb2e8a1b923ce1cad697d9b124fbbde62d1f6e8a9d52a87632a1e",
+    "version": 6
+  },
+  "89fa6cb7-6b53-4de2-b604-648488841ab8": {
+    "rule_name": "Persistence via DirectoryService Plugin Modification",
+    "sha256": "995613c20767772f136c8fd1e9042ebadc315863d6725a297e307e12c2585414",
+    "version": 1
   },
   "8a1b0278-0f9a-487d-96bd-d4833298e87a": {
-    "rule_name": "Setuid Bit Set via chmod",
-    "sha256": "40d946883292446bd724e81d2f504f08012b10bbb1b6077fb6a58859ee3d398f",
-    "version": 6
+    "rule_name": "Setuid / Setgid Bit Set via chmod",
+    "sha256": "976ea459e84095bc4281a27b77f4485562dc5c9fe282e2cdaa5c1c252db1f86f",
+    "version": 7
   },
   "8a5c1e5f-ad63-481e-b53a-ef959230f7f1": {
     "rule_name": "Attempt to Deactivate an Okta Network Zone",
-    "sha256": "53367015febefe85c092f766055640626b50b1d81a0e4b0b9e88f63f188be398",
-    "version": 2
+    "sha256": "61571932334075bb61ef4e7014b640324aee7ce36641be1072a1857d9a822e22",
+    "version": 3
+  },
+  "8acb7614-1d92-4359-bfcf-478b6d9de150": {
+    "rule_name": "Suspicious JAR Child Process",
+    "sha256": "a834bd01b5ce337def5b5819bad0a5405af2ba7f274ebefe2a0259c763098186",
+    "version": 1
+  },
+  "8b2b3a62-a598-4293-bc14-3d5fa22bb98f": {
+    "rule_name": "Executable File Creation with Multiple Extensions",
+    "sha256": "c71bb3f63edeb09cc751265c0bb466c34b9f916dcc6e9bebdeddd1c7c684c19f",
+    "version": 1
   },
   "8c1bdde8-4204-45c0-9e0c-c85ca3902488": {
     "rule_name": "RDP (Remote Desktop Protocol) from the Internet",
-    "sha256": "ee34c803b7e56eeb6a9530b2e9d2d22de73c98befbf9a014c839bfca58de3c3f",
-    "version": 7
+    "sha256": "f30a96cc61cdf5e211d92b76487063c9e51353c4dc7ac405f49c36e2fc891fac",
+    "version": 8
   },
   "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45": {
     "rule_name": "Unusual Child Process of dns.exe",
-    "sha256": "7de8daa3edbdcff733f3ab86cd98ddcad27d568810adb13b99217dcf5ea3010f",
-    "version": 3
+    "sha256": "91ed3efd44382abbc811c230cab6b7a9ac77631e30b47bb2cc12ea0019b1d085",
+    "version": 4
   },
   "8c81e506-6e82-4884-9b9a-75d3d252f967": {
     "rule_name": "Potential SharpRDP Behavior",
-    "sha256": "bf5fcfd9cd7226a093ca39837bc17517c032364a947c002339b22e141ee8da1a",
-    "version": 1
+    "sha256": "e03a2207ef0ce5d054391b1d1e16eb746b9f84752e7208fb3af36b66ec18a314",
+    "version": 2
   },
   "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd": {
-    "rule_name": "Ransomware - Detected - Endpoint Security",
-    "sha256": "afa86e4d621fd2e511406e86b4ae9c07348c4471320a9ef65b26e0643c34e133",
-    "version": 4
+    "rule_name": "Ransomware - Detected - Elastic Endgame",
+    "sha256": "d8491d74b0dd8ca7304f3b8147e98c0dbb00f6551f61cc67bcbeb2a9a8ed8336",
+    "version": 5
   },
   "8ddab73b-3d15-4e5d-9413-47f05553c1d7": {
     "rule_name": "Azure Automation Runbook Deleted",
-    "sha256": "5469ed934f92d74acdb435451b375e88569f8a8ae6b817a7f80e7597efd81272",
-    "version": 3
+    "sha256": "42b989e1865255c87d054240c23883f066a2754a30c73a484cf56416fb0eb29c",
+    "version": 4
+  },
+  "8f3e91c7-d791-4704-80a1-42c160d7aa27": {
+    "rule_name": "Potential Port Monitor or Print Processor Registration Abuse",
+    "sha256": "40ca32414f8638d2f2938e5351e614e11eecc6d500735380d50c5fbbe18c762f",
+    "version": 1
   },
   "8f919d4b-a5af-47ca-a594-6be59cd924a4": {
     "rule_name": "Incoming DCOM Lateral Movement with ShellBrowserWindow or ShellWindows",
-    "sha256": "39a399aa526d2d2a43153510b8e38765f3c4daafc199cddd96183cef46562b50",
-    "version": 1
+    "sha256": "3c7a0eec5e46e14bab90be6ed4bd2f446e1d6db10b78a0fafbf2e14ba50b160c",
+    "version": 2
   },
   "8fb75dda-c47a-4e34-8ecd-34facf7aad13": {
     "rule_name": "GCP Service Account Deletion",
-    "sha256": "1cbd2dcf1b2d96cbb7212a41619a4d405cbf173fc7c46a327717a287d748733e",
-    "version": 3
+    "sha256": "83e917da62c777836f77e9163d3ac2a851f077c92b6fc6cd0c12af141a6ed5f9",
+    "version": 4
   },
   "90169566-2260-4824-b8e4-8615c3b4ed52": {
     "rule_name": "Hping Process Activity",
-    "sha256": "2898ab42516d08724766700fd52fb3cb8507f167be84ad21a09feb058835b4f3",
-    "version": 6
+    "sha256": "76a775773c732032200cd4ea84b9406164a1ba22e8fe524d080c917615b3d316",
+    "version": 7
   },
   "9055ece6-2689-4224-a0e0-b04881e1f8ad": {
     "rule_name": "AWS RDS Cluster Deletion",
-    "sha256": "76bc8e8bf6c74f88736f29e1e9e785b7f1793903abbcf6c712d8ddad505bbb53",
-    "version": 3
+    "sha256": "dbd7891e19893dac401464b86d2890841e47bbf61bce56a9285676ebb7ca3f41",
+    "version": 4
+  },
+  "9092cd6c-650f-4fa3-8a8a-28256c7489c9": {
+    "rule_name": "Keychain Password Retrieval via Command Line",
+    "sha256": "9ddb866c4bcee8043e23af4c23c937710155ac26079a30b278687928aaed2b11",
+    "version": 1
+  },
+  "90e28af7-1d96-4582-bf11-9a1eff21d0e5": {
+    "rule_name": "Auditd Login Attempt at Forbidden Time",
+    "sha256": "eb4167409e9e670184fc8432258137ce52177203e8e9f51b5293b9ac3acbf7f5",
+    "version": 1
   },
   "9180ffdf-f3d0-4db3-bf66-7a14bcff71b8": {
     "rule_name": "GCP Virtual Private Cloud Route Creation",
-    "sha256": "5a6c8bdeeb597c962675d57f5d6406069f6a3610504f7094c135a80e5ab40e6c",
-    "version": 3
+    "sha256": "0fa7a4734a239108ed3fd8f802e219ca6b58cdba349f463bf2d65484bc3b31e9",
+    "version": 4
   },
   "91d04cd4-47a9-4334-ab14-084abe274d49": {
     "rule_name": "AWS WAF Access Control List Deletion",
-    "sha256": "bc973ae5e108630170d8b951afdd2ccb368369aad786910e1af3319bc5c853ac",
-    "version": 4
+    "sha256": "69f44b552dcc33049009a47ddd1ccb1ad1dc684763b72919d71f36240b9b85f9",
+    "version": 5
   },
   "91f02f01-969f-4167-8d77-07827ac4cee0": {
     "rule_name": "Unusual Web User Agent",
-    "sha256": "b288acb521629bc9ebf5f0510ac30a1d10543df3c2ccb568fa213bc2a4b34599",
-    "version": 3
+    "sha256": "3235c8a98dd7280928ad77b9fdd7d87a8189c8025c82c4fd4934cf5c4be7f067",
+    "version": 4
   },
   "91f02f01-969f-4167-8f55-07827ac3acc9": {
     "rule_name": "Unusual Web Request",
-    "sha256": "679984488067c3386d68012ce558514f534f412c64560d6f5251ddb5c199e28d",
-    "version": 3
+    "sha256": "05cded9c521f7c1c3d294ea3bc28690cd66db94e95e1fa3e54e2e1feb518ee94",
+    "version": 4
   },
   "91f02f01-969f-4167-8f66-07827ac3bdd9": {
     "rule_name": "DNS Tunneling",
-    "sha256": "a79e4b9ab06f30eea5e33bfd2d9882e77234155f80f10aaeb6339bb4723fcd4e",
-    "version": 3
+    "sha256": "b15eabc6db99f314e02c8cd2d1afdd5f9b52301be4089503c91cd48a51740b98",
+    "version": 4
   },
   "931e25a5-0f5e-4ae0-ba0d-9e94eff7e3a4": {
     "rule_name": "Sudoers File Modification",
-    "sha256": "b7d9b32d4686296b39e9e61ef5a22be54164eee16a131558263798087949fba6",
-    "version": 6
+    "sha256": "ad003aaf442893dd3a1e0f83940bfc37799f5b3a99398ec4c486f35e0a7f1fe7",
+    "version": 7
   },
   "9395fd2c-9947-4472-86ef-4aceb2f7e872": {
     "rule_name": "AWS EC2 Flow Log Deletion",
-    "sha256": "664d4cfc75d2168cc75de2346474279ff7154d5c62b91c031551599cd05c9d37",
-    "version": 4
+    "sha256": "03212509b93a119cd88d9ada6c1d0e3cb72650ab432932f71c8e46c032b31110",
+    "version": 5
   },
   "93b22c0a-06a0-4131-b830-b10d5e166ff4": {
     "rule_name": "Suspicious SolarWinds Child Process",
-    "sha256": "77107778375a7e1ba5489740bf3f6d6a3804c0deebed41ea92c45d7f3e8c38d7",
-    "version": 2
+    "sha256": "23220ce15e2b4d3768918e69f4ac38f910352b9eed00044f55257c99f50c1e29",
+    "version": 3
   },
   "93c1ce76-494c-4f01-8167-35edfb52f7b1": {
     "rule_name": "Encoded Executable Stored in the Registry",
-    "sha256": "5e12243b0ec527ff06ea2777feab9bba680f46bee79544f4ab9a00f345ee2416",
-    "version": 2
+    "sha256": "b58febfdf9c4805096ba315f8cc7a67171708522bd086ceb5175b3e75884d062",
+    "version": 3
   },
   "93e63c3e-4154-4fc6-9f86-b411e0987bbf": {
     "rule_name": "Google Workspace Admin Role Deletion",
-    "sha256": "7c4aa48afbcff9d26841e06c45fc16e265cb936ec5bc43430547f28b4acdd13e",
-    "version": 2
+    "sha256": "e87ff7f7ca5e46e9d1e1cafece41081e23d1732fe7fd739d28016f593402c02e",
+    "version": 3
+  },
+  "93f47b6f-5728-4004-ba00-625083b3dcb0": {
+    "rule_name": "Modification of Standard Authentication Module or Configuration",
+    "sha256": "33a3ec49d81d46e1b8a2f182b6768d52a01db4b71a670302ddf179a79e016955",
+    "version": 1
   },
   "954ee7c8-5437-49ae-b2d6-2960883898e9": {
     "rule_name": "Remote Scheduled Task Creation",
-    "sha256": "dd83a9d7e1d24d5351b3c80bf0a9824ca7d1e07a85a3ff6a403f00351d22aff8",
-    "version": 1
+    "sha256": "db1e447093400fb88cad39601df5fd94ef453efb368f573b2eb2ca93ab8038b8",
+    "version": 2
   },
   "96b9f4ea-0e8c-435b-8d53-2096e75fcac5": {
     "rule_name": "Attempt to Create Okta API Token",
-    "sha256": "28af4eeb1308afe6f25c74e224066f5513dce33e97bf4a09a5855bb374f6b676",
-    "version": 4
+    "sha256": "bfc9cd72f6976408cf3032a8654ab41cf7e9f176e5de8659649595ec91349072",
+    "version": 5
   },
   "96e90768-c3b7-4df6-b5d9-6237f8bc36a8": {
-    "rule_name": "Compression of Keychain Credentials Directories",
-    "sha256": "f6e3756ec4603100b249d30c832c61cafd051a7f88a01cdb3a868d0dc0359be8",
-    "version": 3
+    "rule_name": "Access to Keychain Credentials Directories",
+    "sha256": "4ccc15d7accc12765f6c0132a6ecb106df50fe6d72c7a7cc40760d5f4428226f",
+    "version": 4
   },
   "97314185-2568-4561-ae81-f3e480e5e695": {
     "rule_name": "Microsoft 365 Exchange Anti-Phish Rule Modification",
-    "sha256": "3543269df878167d62af261483dfaab9182b57f22357842aae285209210eac43",
-    "version": 2
+    "sha256": "5997f239182f18e7896e44985ede70d33356f240029502b5f827760328d602ba",
+    "version": 3
   },
   "97359fd8-757d-4b1d-9af1-ef29e4a8680e": {
     "rule_name": "GCP Storage Bucket Configuration Modification",
-    "sha256": "4084b7e08cfeb780ed4c7cb54982cd624dc5e53508ed5bc106fb09a6ed3ac71a",
-    "version": 3
+    "sha256": "fd2124864d86491d8102f28e4c9a925393dea3f947f4c86ee5078aa3f075b80f",
+    "version": 4
   },
   "97aba1ef-6034-4bd3-8c1a-1e0996b27afa": {
     "rule_name": "Suspicious Zoom Child Process",
-    "sha256": "a728e2fa804205b19155f106b3c04a3742568741c1c495ddcfd49946639e7020",
-    "version": 3
+    "sha256": "2c8a2e1781948610289bc5637ff2bbbee23e344a460ef0b4835f4e2e057a61cf",
+    "version": 4
   },
   "97f22dab-84e8-409d-955e-dacd1d31670b": {
     "rule_name": "Base64 Encoding/Decoding Activity",
-    "sha256": "607a50450204331d7ee50891c8d790ac24379743352267581e82a534f774373c",
-    "version": 6
+    "sha256": "86fb84d8b0d3b72763c1f25b159b87869dedc4bbea83405c178c095c7f2e66f3",
+    "version": 7
   },
   "97fc44d3-8dae-4019-ae83-298c3015600f": {
     "rule_name": "Startup or Run Key Registry Modification",
-    "sha256": "8625de5d51b237ac097b4b8485235b1064b1c902df7d77c63ab8f138562b89eb",
-    "version": 2
+    "sha256": "b7924ce398182288ac6e386c7eca198ec8e4822ab0d0a81b6f3a4198c0e094d2",
+    "version": 3
   },
   "9890ee61-d061-403d-9bf6-64934c51f638": {
     "rule_name": "GCP IAM Service Account Key Deletion",
-    "sha256": "65c712fdbadb4ec666674061d68226b9e3c102b03f2106cdebd0621ea19db63a",
-    "version": 3
+    "sha256": "f7f1704cb9744936c508fd2d2688f1ddd25483f7b721441613330cb0738e871e",
+    "version": 4
   },
   "98995807-5b09-4e37-8a54-5cae5dc932d7": {
     "rule_name": "Microsoft 365 Exchange Management Group Role Assignment",
-    "sha256": "115be7db3d64c5aaf7e87d245495ffd3fd38f1c3fe67533d108f2a7ac20286af",
-    "version": 2
+    "sha256": "ab124a4979eed853bf76b2c70e962fbb25b052fb780abc53bb57e108e439a58c",
+    "version": 3
   },
   "98fd7407-0bd5-5817-cda0-3fcc33113a56": {
     "rule_name": "AWS EC2 Snapshot Activity",
-    "sha256": "4ac0360beafc4c079799365d1d9d1accbd7074d369cc6740f5a5f960dd33bf01",
-    "version": 3
+    "sha256": "2bc8162a177286d484c667e5e2e9f116f91ce690daccbad88f506609c47af6c2",
+    "version": 4
   },
   "990838aa-a953-4f3e-b3cb-6ddf7584de9e": {
-    "rule_name": "Process Injection - Prevented - Endpoint Security",
-    "sha256": "92c674029d3c058f18ec3fafbf91a3c2443023a6a18db9c3118cbf6d4138388d",
-    "version": 4
+    "rule_name": "Process Injection - Prevented - Elastic Endgame",
+    "sha256": "c3f63131525208fb1a8d655818506192b58ed5ddca6f26501f96672999d58085",
+    "version": 5
+  },
+  "99239e7d-b0d4-46e3-8609-acafcf99f68c": {
+    "rule_name": "macOS Installer Spawns Network Event",
+    "sha256": "984cad1381dd9afa09106634c1dbe9b53fe5827b48812999a26b779a5ebab44b",
+    "version": 1
   },
   "9a1a2dae-0b5f-4c3d-8305-a268d404c306": {
     "rule_name": "Endpoint Security",
-    "sha256": "8ec7416fc13c3cdde052cb4ffa8d26b6b2ac42862a6aa8422c5b703e87918188",
-    "version": 2
+    "sha256": "31e256034eddcc3cd52c8bf4d19fb6f15bcf6f5baaff2667bc83c43340d66b46",
+    "version": 3
   },
   "9a5b4e31-6cde-4295-9ff7-6be1b8567e1b": {
     "rule_name": "Suspicious Explorer Child Process",
-    "sha256": "682638b8ee8bbd25b306a15c47695f1420a82004fc51fd415f39c164c86812e5",
-    "version": 2
+    "sha256": "67e04b668886cb15a8f78a419ebcd47a8872132bdd605220f5cee14fe7639f2a",
+    "version": 3
   },
   "9aa0e1f6-52ce-42e1-abb3-09657cee2698": {
     "rule_name": "Scheduled Tasks AT Command Enabled",
-    "sha256": "41829a9b79a22a1214bd1360bd10e601b851c6b18cbe9c1f09a4bdd7426fd35f",
-    "version": 2
+    "sha256": "56621bdde7460e7002b91b6599ca2b6ea6fe1ceb56d0131d5881bf527e9c8812",
+    "version": 3
   },
   "9b6813a1-daf1-457e-b0e6-0bb4e55b8a4c": {
     "rule_name": "Persistence via WMI Event Subscription",
-    "sha256": "a613b4ee192edb46c8557966cbe7f75ded7aa0eb4c3482fbc1d7ae500178b7d4",
-    "version": 2
+    "sha256": "f01e503ef6b63f2a8c35c344ee2b8e403170d55b57da27f20fa7e204eebdf462",
+    "version": 3
   },
   "9c260313-c811-4ec8-ab89-8f6530e0246c": {
     "rule_name": "Hosts File Modified",
-    "sha256": "6a473138e933cb1899ac57f4062c02c8304a8c2a8d59dc926f3af31cc658300d",
-    "version": 3
+    "sha256": "8554125184d18d61f09dd97afd8277b7c6d5ed67325839f8d7360240705593bf",
+    "version": 4
   },
   "9ccf3ce0-0057-440a-91f5-870c6ad39093": {
     "rule_name": "Command Shell Activity Started via RunDLL32",
-    "sha256": "ffaae603c0fa1d7436f8ea510f84ddfc50be4fd25ebbc6eeec733d39775bd65c",
-    "version": 2
+    "sha256": "8d17dd01441dcd298f4dde480618fba6f19c02c1cf38d30202bac38d155ef833",
+    "version": 3
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1": {
     "rule_name": "Trusted Developer Application Usage",
-    "sha256": "78f7858dd10d07dfdee91e3d1a872c82a75e4a714673695e81cd2ce56cd5af76",
-    "version": 6
+    "sha256": "01562e377ae2b4b0c607fb9d5776d0d78e0c2452bfd0ec90c08ff9f99499e349",
+    "version": 7
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2": {
     "rule_name": "Microsoft Build Engine Started by a Script Process",
-    "sha256": "443fe4115ac4876ac13361d9c51b3f8cd3d23c324e51d08ed9bc2d7ee85292c6",
-    "version": 6
+    "sha256": "dae0c00990f6f60d49186a33af3b1a6d1f6f92959bec44fb7241a4d55aac5131",
+    "version": 7
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae3": {
     "rule_name": "Microsoft Build Engine Started by a System Process",
-    "sha256": "d43be8b7a7e092ef11888e5b943c696e3fcba164567971e073e40bb01d80ff45",
-    "version": 6
+    "sha256": "590bb03aba7ebfa4693696414b268ae0f9614257e62403c35563a8c083beff67",
+    "version": 7
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae4": {
     "rule_name": "Microsoft Build Engine Using an Alternate Name",
-    "sha256": "544dde4552bf1768311ae7e0c33e73d7374c2573ee1be3a7b5080d943576b45d",
-    "version": 6
+    "sha256": "9f5ac6bea29ac60ffa4286fe619ae5fddaf595f4ee2841af7eb6cfab8dae87ff",
+    "version": 7
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5": {
     "rule_name": "Microsoft Build Engine Loading Windows Credential Libraries",
-    "sha256": "04d52622c9febc4986cf3530223968ef7ab841d3f82858585669b82675ca9fcf",
-    "version": 6
+    "sha256": "7dc0c63ed67be02b08bf0be148d7a335fb17160e97e483c927228f7a27b5ce0b",
+    "version": 7
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae6": {
     "rule_name": "Microsoft Build Engine Started an Unusual Process",
-    "sha256": "1e5b8f6922097da81e22a0e6767a0bef2145647d53ab2de2421829f6bb60c688",
-    "version": 6
+    "sha256": "0a94d4c720be38237d84929f0d932fc8558b8da9d39ca3b4d365c2bbf61a550c",
+    "version": 7
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae9": {
     "rule_name": "Process Injection by the Microsoft Build Engine",
-    "sha256": "8145ecbefa775960be1ee4d237e886325b6bebae824f07e0540f2d67c9d6b0c5",
-    "version": 4
+    "sha256": "d8821ed0858f6a691346f464fb1d272dcefda6e8f15fd9e38cf65737ebc86369",
+    "version": 5
   },
   "9d19ece6-c20e-481a-90c5-ccca596537de": {
     "rule_name": "LaunchDaemon Creation or Modification and Immediate Loading",
-    "sha256": "97eb1480debfc4d14c82db4a2d76bcaf1e5b3c7e7fd04ffcfb458eb5dc804373",
-    "version": 1
+    "sha256": "57a21909bc81e2d66277f26faab338f1b36d8a88c1b74f785409bc935b3533ca",
+    "version": 2
   },
   "9d302377-d226-4e12-b54c-1906b5aec4f6": {
     "rule_name": "Unusual Linux Process Calling the Metadata Service",
-    "sha256": "004f6cedd68f8a3e36c0e678f27bcd2047fadc049f48bc4fb8a4a7367e7b9211",
-    "version": 1
+    "sha256": "99083f476f27c715e48e8664229115c61b61b1652bd1be73a0e95b65b31a879a",
+    "version": 2
   },
   "9f9a2a82-93a8-4b1a-8778-1780895626d4": {
     "rule_name": "File Permission Modification in Writable Directory",
-    "sha256": "9797234b80c4f7d12daac255fd4dd049080c9730c82d73e37b7e2a4714e45399",
-    "version": 5
+    "sha256": "1a9d8438f890d811aca47a6cf5535b3354b2a638cfa19ce66fbcc4b5baa3f51c",
+    "version": 6
   },
   "a00681e3-9ed6-447c-ab2c-be648821c622": {
     "rule_name": "AWS Access Secret in Secrets Manager",
-    "sha256": "37be1522c5265733d1c521a2ee4c8a39b4ea867ef3d465e447547c269bc82a90",
-    "version": 3
+    "sha256": "910830753f6ca39288c0e8312d4bba1e472cb090cf2b13c2f6dec8d60cd6ce44",
+    "version": 4
   },
   "a10d3d9d-0f65-48f1-8b25-af175e2594f5": {
     "rule_name": "GCP Pub/Sub Topic Creation",
-    "sha256": "6bfc349ca906a512e6a616a624af17727c6877327b17a555aae56fb1dcb77527",
-    "version": 3
+    "sha256": "fba36ab5e9facd0e6703c3f5a52f444f5f980b7eaf5ede0088575be015e4c127",
+    "version": 4
   },
   "a13167f1-eec2-4015-9631-1fee60406dcf": {
     "rule_name": "InstallUtil Process Making Network Connections",
-    "sha256": "770756236699c90255ee512de436252e9aee5f134879f8125dbfbbdf0568d461",
-    "version": 2
+    "sha256": "22617dc74d926a2a732c42e67b1196e6cf972b743bf69db18de1e3c7686299a2",
+    "version": 3
   },
   "a1329140-8de3-4445-9f87-908fb6d824f4": {
     "rule_name": "File Deletion via Shred",
-    "sha256": "e134a599a0c31f531e1ef027d05105e91cf57dcea9bab63338081ab3379d553d",
-    "version": 6
+    "sha256": "8bc002cf57e3e671b5ef34223004a44cf524df8ffb4cb6aa6ef2a02acda67628",
+    "version": 7
   },
   "a17bcc91-297b-459b-b5ce-bc7460d8f82a": {
     "rule_name": "GCP Virtual Private Cloud Route Deletion",
-    "sha256": "a2cf43f683742b3f0b3aaf43aadafc7dba6354013f2f48cbc7d446afad7229ca",
-    "version": 3
+    "sha256": "623706a44007241728253d103e92b255da36c504d8cc514d24a53cea8e891f67",
+    "version": 4
+  },
+  "a1a0375f-22c2-48c0-81a4-7c2d11cc6856": {
+    "rule_name": "Potential Reverse Shell Activity via Terminal",
+    "sha256": "c9bf1fe195602f505c43eda209be7267cf3997e49d86773f719a0a4300d70db8",
+    "version": 1
   },
   "a3ea12f3-0d4e-4667-8b44-4230c63f3c75": {
     "rule_name": "Execution via local SxS Shared Module",
-    "sha256": "99645bfec35b37000af36efc7d7fb9d738ac7087f27b56d65478e7fb90ff6b4a",
-    "version": 2
+    "sha256": "de13eedea23c945a81a12d4393bcbb7d48d4f3459d695538e2c8b232329d8745",
+    "version": 3
   },
   "a4ec1382-4557-452b-89ba-e413b22ed4b8": {
     "rule_name": "Network Connection via Mshta",
@@ -1441,872 +1721,1022 @@
   },
   "a60326d7-dca7-4fb7-93eb-1ca03a1febbd": {
     "rule_name": "AWS IAM Assume Role Policy Update",
-    "sha256": "655573dcfacc3a63d76ad5bfc8d631ccfe68850bd2fb66d0d20d185968fe9285",
-    "version": 3
+    "sha256": "d7bebb3418b06fec41e8e4b9a0bcced408ec615c3f701103e1910a038a9588d7",
+    "version": 4
   },
   "a605c51a-73ad-406d-bf3a-f24cc41d5c97": {
     "rule_name": "Azure Active Directory PowerShell Sign-in",
-    "sha256": "1504dd19c4d00f6fec043813c49e5383a9d0a445ea693c06a7c01a3074efd36d",
-    "version": 2
+    "sha256": "e78212df0e0c85c1d5dfcb9207809ca0c3c63f989d4adc919cfd7b65f9f0e495",
+    "version": 3
   },
   "a624863f-a70d-417f-a7d2-7a404638d47f": {
     "rule_name": "Suspicious MS Office Child Process",
-    "sha256": "2abff3a9f2e9bbf5479f1947bcb032d554167fc8da620100ac3a191f96dfbdd3",
-    "version": 7
+    "sha256": "26f0a12b3dc7a8d4d306fe66945b29413c40506622ed906adc4e102e1fd467f7",
+    "version": 8
+  },
+  "a6bf4dd4-743e-4da8-8c03-3ebd753a6c90": {
+    "rule_name": "Emond Rules Creation or Modification",
+    "sha256": "59289eddd2040bc752795a3b4b65166988f1d4f1444723421c506d184777a7d9",
+    "version": 1
   },
   "a7ccae7b-9d2c-44b2-a061-98e5946971fa": {
     "rule_name": "Suspicious PrintSpooler SPL File Created",
-    "sha256": "980fb95e206349f1bcdae9b5721538026f766a9bdddb9a105251e9deca6e914f",
-    "version": 2
+    "sha256": "2a0914aa97e2201bd9cd4c0871e9e6f6bd7e123b73cdbbb2ee3b5fcaf83343dc",
+    "version": 3
   },
   "a7e7bfa3-088e-4f13-b29e-3986e0e756b8": {
     "rule_name": "Credential Acquisition via Registry Hive Dumping",
-    "sha256": "04dba98361fb9bdbbf82ed28d24fb693e994954a297d9d048988f30663e5ea07",
-    "version": 2
+    "sha256": "474cf205bd36fa0fae3a9a14da72c36ccb1c2ca49a61fc100bbc1900369a28d1",
+    "version": 3
   },
   "a87a4e42-1d82-44bd-b0bf-d9b7f91fb89e": {
     "rule_name": "Web Application Suspicious Activity: POST Request Declined",
-    "sha256": "b96e0e4e371be1ac1c315923d0d704df046678db261463030d33a0a925abb91d",
-    "version": 5
+    "sha256": "402eda0840f057d5745f80da37de2cc12278f41bfdfd97c9565cbb038c4bf02a",
+    "version": 6
   },
   "a9198571-b135-4a76-b055-e3e5a476fd83": {
     "rule_name": "Hex Encoding/Decoding Activity",
-    "sha256": "381b079f59d5ee4f7685a4b792f84ab7840cf0f97a418bc404cc26e5acd7e9a0",
-    "version": 6
+    "sha256": "b6cfa5bf24a78049ee0f873fe01bcc14ef5116a6adf59b8721abeb11ceca01cf",
+    "version": 7
   },
   "a989fa1b-9a11-4dd8-a3e9-f0de9c6eb5f2": {
     "rule_name": "Microsoft 365 Exchange Safe Link Policy Disabled",
-    "sha256": "d11f9e4122aff669f9a82f3e31c714c7e2a662467f55a71c2f23ecac63a6b8bd",
-    "version": 2
+    "sha256": "8aaa0b8723f3b1582fce4296f1c1030b46a9f9b9e3a940cc77e66a00b286668d",
+    "version": 3
   },
   "a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73": {
     "rule_name": "Google Workspace Password Policy Modified",
-    "sha256": "12f14c4749a7fceef70c089a2a38b19d7c33075ecb1f3e17608891313e4b80f9",
-    "version": 2
+    "sha256": "5fbff45220e92791589b63e50e96565c6288a79b9113408ab7d494b85878bd4c",
+    "version": 3
   },
   "a9b05c3b-b304-4bf9-970d-acdfaef2944c": {
     "rule_name": "Persistence via Hidden Run Key Detected",
-    "sha256": "ad61204594077b7918ff7828d8f1a913b3fa87e52848462b6f15207af1bc50fb",
-    "version": 2
+    "sha256": "bee08942fb6982046be076d88c6640400f97eb29a2f2c4f594e16f4fc18793a9",
+    "version": 3
   },
   "a9cb3641-ff4b-4cdc-a063-b4b8d02a67c7": {
     "rule_name": "IPSEC NAT Traversal Port Activity",
-    "sha256": "aad1b5006e2ac2aac28fe8a07e3cad70cbb98e3823b81ba15a9f2c91d8817b5a",
-    "version": 6
+    "sha256": "281775cdb10cfd72c657efd352e0e4e353ebbf76881975360006712205c4fb1b",
+    "version": 7
   },
   "aa8007f0-d1df-49ef-8520-407857594827": {
     "rule_name": "GCP IAM Custom Role Creation",
-    "sha256": "36f09d32f22926b656535eeab37abce2a55146b2efe665237596eeccfc907722",
-    "version": 3
+    "sha256": "3ffc8d0be63b9d659bd057ea434e84c97f892672af10fc0854ed591f2a3dc218",
+    "version": 4
   },
   "aa895aea-b69c-4411-b110-8d7599634b30": {
     "rule_name": "System Log File Deletion",
-    "sha256": "57dccd2cb0d159a8da2832c464b0e427c3f8ddda96824d66bb5ece7d71cf600c",
-    "version": 2
+    "sha256": "0d46a18e785f0b5daee88973ca06fdcadeb743a9736224a965e472343ca74d30",
+    "version": 3
   },
   "aa9a274d-6b53-424d-ac5e-cb8ca4251650": {
     "rule_name": "Remotely Started Services via RPC",
-    "sha256": "378f8ce524eee1aef24018a4a17eb55353559cc57adecc2b6a3ee1ffe71b8f2d",
-    "version": 1
+    "sha256": "8a094bcec3f04942226308fbf29d09e5658a58269cd508cf13370f18f211a00d",
+    "version": 2
   },
   "ab75c24b-2502-43a0-bf7c-e60e662c811e": {
     "rule_name": "Remote Execution via File Shares",
-    "sha256": "b4742a5907688dfb96cac8284d71df61ec5430dfcce9653aa56c82bd8288a9c4",
-    "version": 1
+    "sha256": "a4fa795f24e1eecf02164092ec16a99174eddb8733615dc448b876ebd08b8426",
+    "version": 2
   },
   "abae61a8-c560-4dbd-acca-1e1438bff36b": {
     "rule_name": "Unusual Windows Process Calling the Metadata Service",
-    "sha256": "8e0b773de6395741187c17f254d0d3e6d9c33c2a8dc34067c5dd9689bd1d35f0",
+    "sha256": "d47b8762b1d507f3284720ed4081af8bbd7b798e8487c130de597dc6ef7b7527",
+    "version": 2
+  },
+  "ac412404-57a5-476f-858f-4e8fbb4f48d8": {
+    "rule_name": "Potential Persistence via Login Hook",
+    "sha256": "92a14b8bc9231fe013cddddd37609e98198b47e982944a5ada59181d9c432fbf",
     "version": 1
   },
   "ac5012b8-8da8-440b-aaaf-aedafdea2dff": {
     "rule_name": "Suspicious WerFault Child Process",
-    "sha256": "9006cec4ad27c31db36f6ed910183f2b0fd985304c19bc6e351cb734a18ab080",
-    "version": 2
+    "sha256": "800020ac496ff5c0b902a63bcb062d8826ed18b9b1f39f034672161ac17ce8a8",
+    "version": 3
   },
   "ac706eae-d5ec-4b14-b4fd-e8ba8086f0e1": {
     "rule_name": "Unusual AWS Command for a User",
-    "sha256": "61030c4ed5783a5267a042417e8d7604e0b04eb36a6da6aaa8a630c10fcb0977",
-    "version": 2
+    "sha256": "7159b3c6dbd53b8f52183c0b0b5f45299596e1d7bb1103d53c56edc7be68a465",
+    "version": 3
   },
   "acbc8bb9-2486-49a8-8779-45fb5f9a93ee": {
     "rule_name": "Google Workspace API Access Granted via Domain-Wide Delegation of Authority",
-    "sha256": "e8a4bf103723eb12e3cd69a8149ff0ac55ea66ada671751e0842d58a1cd994f5",
-    "version": 2
+    "sha256": "c6581f03d21ae8a5eb2567a5436e1540f1e47b0b2f197470c75ae91078433c81",
+    "version": 3
   },
   "acd611f3-2b93-47b3-a0a3-7723bcc46f6d": {
     "rule_name": "Potential Command and Control via Internet Explorer",
-    "sha256": "85555d822707d421f4757e862b5cb505544cb9a451c4c2cf04fb4cec5df7d052",
-    "version": 1
+    "sha256": "033bfbf2936df4f89c54f792dc8d26f41d6740ede72c06a677570997ff2f11d7",
+    "version": 2
   },
   "ace1e989-a541-44df-93a8-a8b0591b63c0": {
     "rule_name": "Potential SSH Brute Force Detected",
-    "sha256": "95eee06042a8070b93d08264c73c46771db9bd046e90bacfbbabe54c8d7b4934",
-    "version": 1
+    "sha256": "b098f232c244a6954d4c1f45c6531e642460c20421ba7b1bc4bf6cfc72310bc8",
+    "version": 2
   },
   "acf738b5-b5b2-4acc-bad9-1e18ee234f40": {
     "rule_name": "Suspicious Managed Code Hosting Process",
-    "sha256": "e0437a436bd0809b9767d0771bd7f9ab554e5a269729c9888f4f0c42289c35a7",
-    "version": 2
+    "sha256": "c39f627f7725c511821f5ecf8676fa04e647cd972e28dc000fcf13a2504c4a77",
+    "version": 3
   },
   "ad0e5e75-dd89-4875-8d0a-dfdc1828b5f3": {
     "rule_name": "Proxy Port Activity to the Internet",
-    "sha256": "6daf86b7ae1e77991a8746825cddde9048b4831cd7751c3fc9657b15deadd50e",
-    "version": 7
+    "sha256": "b6ebab2e583cd3bf78d4951f8718ff88b6bbea6dfd4004c586ce00a703ec0a10",
+    "version": 8
   },
   "ad3f2807-2b3e-47d7-b282-f84acbbe14be": {
     "rule_name": "Google Workspace Custom Admin Role Created",
-    "sha256": "e8ce9ad3c57e19411395968326acf2a4c2089d7cfe7f6c6d39d5550ff26c278e",
-    "version": 2
+    "sha256": "ef51da9c29d2dc7632f41325f697fb2a509c98a0b3ed628d2f8f664fa381c3cb",
+    "version": 3
   },
   "ad88231f-e2ab-491c-8fc6-64746da26cfe": {
     "rule_name": "Kerberos Cached Credentials Dumping",
-    "sha256": "a32bc9518e2c0931cd2b9deff09caebba196cdf960d7534786c1002bd4e544f6",
-    "version": 2
+    "sha256": "64ef95d8833c1fbf3a7a6dbb5b14bebf776f6c08908d08649b38b3ce185cbfae",
+    "version": 3
   },
   "adb961e0-cb74-42a0-af9e-29fc41f88f5f": {
     "rule_name": "Netcat Network Activity",
-    "sha256": "484787194ac835658ef3dc707a026b3a0f7c7fadb2fb57b29b8a156e7d213709",
-    "version": 5
+    "sha256": "fbd9235f346b2954a4f2c978d543d34065e3534b0e17101a79a7fdc249a07656",
+    "version": 6
   },
   "afcce5ad-65de-4ed2-8516-5e093d3ac99a": {
     "rule_name": "Local Scheduled Task Commands",
-    "sha256": "1f7db99c01f9a701380826045b7cb199fdb99450481d9b72bc60e152f5353b3f",
-    "version": 6
+    "sha256": "6b39ac27e1a2a39b75e415bc4b32500b6710cea014eca9ec7a2a6bb0aa5c58d8",
+    "version": 7
   },
   "b0046934-486e-462f-9487-0d4cf9e429c6": {
     "rule_name": "Timestomping using Touch Command",
-    "sha256": "85a166495a48e6eebe0ffc43e959711cb77b4fbd10fa986459e46b7f4db17c6c",
-    "version": 2
+    "sha256": "b1f1833e7b0764bd1035d2b800cf4ff321791b7cac554d6dfa01fc7282251f28",
+    "version": 3
+  },
+  "b00bcd89-000c-4425-b94c-716ef67762f6": {
+    "rule_name": "TCC Bypass via Mounted APFS Snapshot Access",
+    "sha256": "fa36d7b890ef23869737bf47f07c4bb54ea4eeaf8d76a9ee04d4764acebba5e7",
+    "version": 1
+  },
+  "b1c14366-f4f8-49a0-bcbb-51d2de8b0bb8": {
+    "rule_name": "Potential Persistence via Cron Job",
+    "sha256": "0c030fdda99d067a509f80bd3faff91ee4d8414e5074a9ef6cf7bf5fc97fcbed",
+    "version": 1
   },
   "b25a7df2-120a-4db2-bd3f-3e4b86b24bee": {
     "rule_name": "Remote File Copy via TeamViewer",
-    "sha256": "00693df432fecce30109abc71f88dbe2b04ae1aa0f8a26475a91e6ab90b0b07b",
-    "version": 2
+    "sha256": "b435103e31234f00d279b4f5134c81c3e2e2da55e4026bcf7a7d3076cfccdae9",
+    "version": 3
   },
   "b29ee2be-bf99-446c-ab1a-2dc0183394b8": {
     "rule_name": "Network Connection via Compiled HTML File",
-    "sha256": "c745562b8799190c0796b1ea6f84e766130818f342c77b4842579ba216e29323",
-    "version": 6
+    "sha256": "019133bd004a19b16a85b00dc9cf843ec062679b58d784a3d08ca99fb63ab292",
+    "version": 7
   },
   "b347b919-665f-4aac-b9e8-68369bf2340c": {
     "rule_name": "Unusual Linux Username",
-    "sha256": "44159cc2fe3ba1252b583e05834febc367f266e66f6cefb6dc5302eab620305f",
-    "version": 3
+    "sha256": "5b9bcfa66a94e8e2af88b1ebba8f7ad2ea6b2836af5703ba6580b11c2d7fa61b",
+    "version": 4
   },
   "b41a13c6-ba45-4bab-a534-df53d0cfed6a": {
     "rule_name": "Suspicious Endpoint Security Parent Process",
-    "sha256": "231d85fb51acbcddcdc5d41cde82d53e3069d08bce27592570c01aced7e6825f",
-    "version": 3
+    "sha256": "f54b395d6dfa7b126c8bd7c5e445821fe436f4e33c99dd76f6beb89929d6e454",
+    "version": 4
+  },
+  "b4449455-f986-4b5a-82ed-e36b129331f7": {
+    "rule_name": "Potential Persistence via Atom Init Script Modification",
+    "sha256": "1f872ba3822ca3fc62b14d06a16c7d41eab825219301e36176e71ce80737b03d",
+    "version": 1
   },
   "b4bb1440-0fcb-4ed1-87e5-b06d58efc5e9": {
     "rule_name": "Attempt to Delete an Okta Policy",
-    "sha256": "bf819443073dbebcc3368bdfe074885ab4bd25693acd6cf03377c1fa41732a46",
-    "version": 4
+    "sha256": "971ab7f8d1f13ec382d2ccc9cc9c9adbcc93dbb3a7bd4d2eaaa9ae31f3f8f76d",
+    "version": 5
   },
   "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921": {
     "rule_name": "Volume Shadow Copy Deletion via VssAdmin",
-    "sha256": "279ef5024f334a402d809055b5c1685f1082f71c0a318531516dbd540ff3ca26",
-    "version": 7
+    "sha256": "17ec523e58ff0c0d228cdd14bc65df380d20a91827091e13fc40bd54e6020a13",
+    "version": 8
   },
   "b64b183e-1a76-422d-9179-7b389513e74d": {
     "rule_name": "Windows Script Interpreter Executing Process via WMI",
-    "sha256": "45cc14e84175cd9bd73d21cddb502b11bc2d6d9984edac3fdda44920ebb1f980",
-    "version": 1
+    "sha256": "10a7503a00c05ce3603ded3a6a5ca6c6cc3087c78881142356ccfa32882f6e71",
+    "version": 2
   },
   "b6dce542-2b75-4ffb-b7d6-38787298ba9d": {
     "rule_name": "Azure Event Hub Authorization Rule Created or Updated",
-    "sha256": "ff09c99de5283ae7e2cb78e43329cd9db62c6b79be25ee481de93cc1aa09110a",
-    "version": 3
+    "sha256": "a84360424dec6a9d0df7d8aff7c9f95d1ed399fc96c9b3b75d43c0f1c6c0e959",
+    "version": 4
   },
   "b719a170-3bdb-4141-b0e3-13e3cf627bfe": {
     "rule_name": "Attempt to Deactivate an Okta Policy",
-    "sha256": "9f73c4e1d01477efa8e3e1984613b6eb3362f6fc89a93888927b7426fa01a9bf",
-    "version": 4
+    "sha256": "5dfd653fffd2aff3f6bec413d999a462b31e2d754d62ff6b29b0b765f4b08cf5",
+    "version": 5
   },
   "b8075894-0b62-46e5-977c-31275da34419": {
     "rule_name": "Administrator Privileges Assigned to an Okta Group",
-    "sha256": "3775382bd5260f71cb15c758f1eed47f78b5bb400bc1baa611b3d28704d79f24",
-    "version": 4
+    "sha256": "95a70200a2c9cf5dc68be723a5ba0e402786a731e0e395b0ab26aabded7f6e5b",
+    "version": 5
   },
   "b83a7e96-2eb3-4edf-8346-427b6858d3bd": {
     "rule_name": "Creation or Modification of Domain Backup DPAPI private key",
-    "sha256": "3079830160ee1e9fa1439d0b3b2547e2594583051655b060e539bbe49c46953b",
-    "version": 3
+    "sha256": "86adaceaff7d0a2bc2ec81db78d82881807861c701e84dc6558aaa84737e4baf",
+    "version": 4
   },
   "b86afe07-0d98-4738-b15d-8d7465f95ff5": {
     "rule_name": "Network Connection via MsXsl",
-    "sha256": "b6730853dd499a1f5bdd7adce3dd750c04b5acb1ad52c08a818be52b790016c9",
-    "version": 5
+    "sha256": "269ffb5fde08edde888f42bebe0a0954e7f0a82188ae6990f305c33b0a7cc044",
+    "version": 6
   },
   "b90cdde7-7e0d-4359-8bf0-2c112ce2008a": {
     "rule_name": "UAC Bypass Attempt with IEditionUpgradeManager Elevated COM Interface",
-    "sha256": "a356c6b552f9b182763acfa38c451360bd70981b848afdc23c5566031f48d5ca",
-    "version": 2
+    "sha256": "564ee89dadb7ffe59426908c9fcfe2d4ae3ed2104fedf217f13af6ecebeceb2c",
+    "version": 3
   },
   "b9666521-4742-49ce-9ddc-b8e84c35acae": {
     "rule_name": "Creation of Hidden Files and Directories",
-    "sha256": "58109147ac539d0dba93b555813d127e0ae42d5ead5a32df50b9b94ebdb87bbc",
-    "version": 5
+    "sha256": "7ec928ddf9f3fd92bf58dad475cc2a4842c4cd781f1fe62c70721421f24aeb6a",
+    "version": 6
   },
   "b9960fef-82c6-4816-befa-44745030e917": {
     "rule_name": "SolarWinds Process Disabling Services via Registry",
-    "sha256": "10851b590f0ff1f675738bd36db07201a6791e08499f094ef66b960ad88dee11",
-    "version": 2
+    "sha256": "e52aa6f4635077b0b0a9044b61f8d454c17dd5f54748c41ccd6624d79937daf4",
+    "version": 3
   },
   "ba342eb2-583c-439f-b04d-1fdd7c1417cc": {
     "rule_name": "Unusual Windows Network Activity",
-    "sha256": "183bc920de288c25759da14909826873e441d5f97faf2b64f82ba501db10e2c8",
-    "version": 3
+    "sha256": "26566d6c946ec7530e1b6af6e8f2b8ec2d1c27e99883ac821a1e25f55134fe66",
+    "version": 4
   },
   "baa5d22c-5e1c-4f33-bfc9-efa73bb53022": {
     "rule_name": "Suspicious Image Load (taskschd.dll) from MS Office",
-    "sha256": "d27cff3d6c5751e9cfd3404e7e0ed3b97a989e0df1e15fd4439bcf5fc7c6942d",
-    "version": 2
+    "sha256": "4359dc522ac5d74051800cc05272be74bda5c0d5a2a914038c13a13642eb25a6",
+    "version": 3
   },
   "bb4fe8d2-7ae2-475c-8b5d-55b449e4264f": {
     "rule_name": "Azure Resource Group Deletion",
-    "sha256": "dc2d60e88c29a05e78f269f6facd482c456a9da301fdfd8c66f89cee0f8a4885",
-    "version": 3
+    "sha256": "7bfb5e62c950a7fcfb8ea6b5141e61a6da9cc96ca78ce4511f9475c3e776bfbe",
+    "version": 4
   },
   "bb9b13b2-1700-48a8-a750-b43b0a72ab69": {
     "rule_name": "AWS EC2 Encryption Disabled",
-    "sha256": "00f1e4824b1ff5a97ebaa7c117a5492decb5225904fd9fefe0d16c6b12d3d6d0",
-    "version": 4
+    "sha256": "55933e0eb52eea93da9b6c0e938794fd084901c1e53cba3625ae2bba79b6d666",
+    "version": 5
   },
   "bbd1a775-8267-41fa-9232-20e5582596ac": {
     "rule_name": "Microsoft 365 Teams Custom Application Interaction Allowed",
-    "sha256": "94b0fb4de4cac4e10566cb8ae4234e58cc66737f391a72915775586e0cbc57f4",
-    "version": 2
+    "sha256": "5d03f2d49b7db7d437ae9117a9a68e0b4ff5f220d258660c1884f2fc6ff9cbb3",
+    "version": 3
   },
   "bc0c6f0d-dab0-47a3-b135-0925f0a333bc": {
     "rule_name": "AWS Root Login Without MFA",
-    "sha256": "585d427e1865ca47021b6701ca3214a0c4c22ee154aabdff05a378c9c9a66ef7",
-    "version": 3
+    "sha256": "92fda82a332bc3f4b5010b4408bacb9bf3b7d71b6bfde1a03d6c993110aa750a",
+    "version": 4
   },
   "bc0f2d83-32b8-4ae2-b0e6-6a45772e9331": {
     "rule_name": "GCP Storage Bucket Deletion",
-    "sha256": "7a809a16bb94956512c514a8fb8f7927700d307537cabcac128600dd9c8632e8",
-    "version": 3
+    "sha256": "dd407aaf6b910d7c9952519485eadb121aff19727a9a86f844de5237d3375e90",
+    "version": 4
+  },
+  "bc1eeacf-2972-434f-b782-3a532b100d67": {
+    "rule_name": "Attempt to Install Root Certificate",
+    "sha256": "7da7e303d7866590beb66ec6718fe019a0c59fabcb29f6c1ba04461784bc8fb6",
+    "version": 1
   },
   "bc48bba7-4a23-4232-b551-eca3ca1e3f20": {
     "rule_name": "Azure Conditional Access Policy Modified",
-    "sha256": "46c90a2ba9b55dc072b15e9d564f941ad603cff49519bde6ee7c79e7ff66b079",
-    "version": 3
+    "sha256": "7618a0825bbeb38f428739abf8aaf89def1c176a613d66652eb94fa810f55ebc",
+    "version": 4
   },
   "bca7d28e-4a48-47b1-adb7-5074310e9a61": {
     "rule_name": "GCP Service Account Disabled",
-    "sha256": "1abc4c8b1f73bd28b79d4b0ab488c95ce1a44f513ade1c5d831519ec2afe813f",
-    "version": 3
+    "sha256": "80e73e310938c8d40a031384144f602807fb3e25559804101e7708b0b3d119ae",
+    "version": 4
   },
   "bd7eefee-f671-494e-98df-f01daf9e5f17": {
     "rule_name": "Suspicious Print Spooler Point and Print DLL",
-    "sha256": "cecd7d93e882686b0f78176c259b17b6b02185cb39a2df6b9d2307f25c0e91b5",
+    "sha256": "21294393322c72a5945721897592b4efd0dc6745d42a1d6a33492120398d13fb",
+    "version": 2
+  },
+  "be8afaed-4bcd-4e0a-b5f9-5562003dde81": {
+    "rule_name": "Searching for Saved Credentials via VaultCmd",
+    "sha256": "6e4bba28f2d2a39b6eea697189e933adb39e73e24a9949d485285db5be65bc7b",
+    "version": 1
+  },
+  "bfeaf89b-a2a7-48a3-817f-e41829dc61ee": {
+    "rule_name": "Suspicious DLL Loaded for Persistence or Privilege Escalation",
+    "sha256": "fdf46a65e1d59ef2f2929dace2b97e19784e242565d236456411e53f87c6d774",
+    "version": 1
+  },
+  "c02c8b9f-5e1d-463c-a1b0-04edcdfe1a3d": {
+    "rule_name": "Potential Privacy Control Bypass via Localhost Secure Copy",
+    "sha256": "56997e25c16d915db541338be6e5a8c2fb86ea53e874dabdb5648b8dac17026b",
     "version": 1
   },
   "c0429aa8-9974-42da-bfb6-53a0a515a145": {
     "rule_name": "Creation or Modification of a new GPO Scheduled Task or Service",
-    "sha256": "a15dc8b9b0d2b27835ebdebc808f5e0849c535d2802be1ae44ab900b29a565ae",
-    "version": 3
+    "sha256": "2bb462336ce0a0b88e9fa9a928fa5691963175450bdbf0191770e42241a3f330",
+    "version": 4
   },
   "c0be5f31-e180-48ed-aa08-96b36899d48f": {
-    "rule_name": "Credential Manipulation - Detected - Endpoint Security",
-    "sha256": "3e27a7e7fda1be83a083f51ec320e2c49e41a3048660137a7d551e30b8c997c3",
-    "version": 4
+    "rule_name": "Credential Manipulation - Detected - Elastic Endgame",
+    "sha256": "a536250a00d6139b67326b7a160bef3ce820b1202add2eb68e37aea8c81b572b",
+    "version": 5
   },
   "c25e9c87-95e1-4368-bfab-9fd34cf867ec": {
     "rule_name": "Microsoft IIS Connection Strings Decryption",
-    "sha256": "79a3b7715efb86fab78e72e5536f6c355077da76471e08e17e16956dbb06abdd",
-    "version": 3
+    "sha256": "e0426acc19d28951632e6d51dc170face86a592f82ae4eb55ee3144a9848b31c",
+    "version": 4
   },
   "c28c4d8c-f014-40ef-88b6-79a1d67cd499": {
     "rule_name": "Unusual Linux Network Connection Discovery",
-    "sha256": "505c5b266419774eaf329af4f0f25e9009c93211214858e730bb637bb665f62c",
-    "version": 1
+    "sha256": "711dd36c9d0eca5be33613044ab9de38bdc703b51e619c57abd6125385dc7bb0",
+    "version": 2
   },
   "c292fa52-4115-408a-b897-e14f684b3cb7": {
     "rule_name": "Persistence via Folder Action Script",
-    "sha256": "c3098f9a8ff4dbe6ddae14bf87cc3ae0dc3b2000ed09029b7b73ab7d3ae2c85b",
-    "version": 1
+    "sha256": "590672436289bc299f3a42eb297c9f29019cb3b32dcdaa2ab7930bb87c5edb48",
+    "version": 2
   },
   "c2d90150-0133-451c-a783-533e736c12d7": {
     "rule_name": "Mshta Making Network Connections",
-    "sha256": "27507954b3e3d4d61214f223d6afd52cc306b2726af409fdf5448619131f7aac",
-    "version": 2
+    "sha256": "a9a47cb844d9dc87e096ed357fc9afd44765c7e8c0fcdc656e8a586f2953d154",
+    "version": 3
   },
   "c3167e1b-f73c-41be-b60b-87f4df707fe3": {
-    "rule_name": "Permission Theft - Detected - Endpoint Security",
-    "sha256": "7b185258dbbaa2a9837362d5bb5f7551cfdf689ccbd0119140c1155c581dd80c",
-    "version": 4
+    "rule_name": "Permission Theft - Detected - Elastic Endgame",
+    "sha256": "b8e5fdd1a58640907a636b837eff2d2740c456b57954eac5fe0325d8f31c156c",
+    "version": 5
   },
   "c4210e1c-64f2-4f48-b67e-b5a8ffe3aa14": {
     "rule_name": "Mounting Hidden or WebDav Remote Shares",
-    "sha256": "b84179def6e28b59ba5234ee8fbdfee37306718e1c7a33cda3451d2e037c90ac",
-    "version": 2
+    "sha256": "fd98829f6683e70e5a3d3fe8ed5fe7ea2a35a9eb323b012ee895ea1e3b563c46",
+    "version": 3
   },
   "c58c3081-2e1d-4497-8491-e73a45d1a6d6": {
     "rule_name": "GCP Virtual Private Cloud Network Deletion",
-    "sha256": "4f290d0d23f951fade6f3f059a997afaeb9df4c69dcc5c8c06be74186577863e",
-    "version": 3
+    "sha256": "6b0813f5d8be94af50cf0a174be37f842a1fde4ca2cb55b480cf3cff34e357ea",
+    "version": 4
   },
   "c5ce48a6-7f57-4ee8-9313-3d0024caee10": {
     "rule_name": "Installation of Custom Shim Databases",
-    "sha256": "6e3ffdadba05c9bab0bb5408eec0fccb6e415111cc005cee2389d35f3d87d1ee",
-    "version": 2
+    "sha256": "81788cf9d61ad308d13bca2f9882ffce48353414414d4bd05235253088b8407b",
+    "version": 3
   },
   "c5dc3223-13a2-44a2-946c-e9dc0aa0449c": {
     "rule_name": "Microsoft Build Engine Started by an Office Application",
-    "sha256": "22d5c4182a90dc3f985da71ab2a79feac45b616a49e9b40ac005ce1b58db1450",
-    "version": 6
+    "sha256": "0017cc9a14815a2ece7b02f5317bc0aad4ed130634380b77b3f10a8302dbbc64",
+    "version": 7
   },
   "c6453e73-90eb-4fe7-a98c-cde7bbfc504a": {
     "rule_name": "Remote File Download via MpCmdRun",
-    "sha256": "ec891f05657fb312a46e46a6ece87ca1e888b953de1120db6c93e0bbc339b3b1",
-    "version": 3
+    "sha256": "3593df23a6d32b6ecb9dfce5a7fc3c9303406e0d9fbebb8925f517fd03aa17f1",
+    "version": 4
   },
   "c6474c34-4953-447a-903e-9fcb7b6661aa": {
     "rule_name": "IRC (Internet Relay Chat) Protocol Activity to the Internet",
-    "sha256": "54df5574036f49aa1c3b1ae83294e6d0bd2906b138bf541e4eaa6332449dc988",
-    "version": 7
+    "sha256": "dba60ab7ccce534b20532548b6aff6b799d54bacbacf3328fd250e65420a998c",
+    "version": 8
   },
   "c749e367-a069-4a73-b1f2-43a3798153ad": {
     "rule_name": "Attempt to Delete an Okta Network Zone",
-    "sha256": "d33b7ddc3848881bdc5fd89eb9c3fdf127e694cb448ab4ad1f226d1ac35cd584",
-    "version": 2
+    "sha256": "c11d4ec637208a3ab9addbdb9a3ff12f60aeffd8a81cecbc9b6e110de5db9908",
+    "version": 3
   },
   "c74fd275-ab2c-4d49-8890-e2943fa65c09": {
     "rule_name": "Attempt to Modify an Okta Application",
-    "sha256": "ef8f0d17bfa1893438e50436c155fb58b423d7c70d49d94b87e5143845f58890",
-    "version": 2
+    "sha256": "63569595577b2895a4bf897233c4b637393ff6b9d26d2e964c98b5060669ada4",
+    "version": 3
   },
   "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9": {
     "rule_name": "Unusual File Modification by dns.exe",
-    "sha256": "89219be0f6a8a3e0939c890ebd17ad0b316bd3328dc94ed6aecd2f91baae5c6c",
-    "version": 3
+    "sha256": "1af709717fea56a51cdb2fa1e90258a832e958394cd7edf744fb8e328cabb566",
+    "version": 4
+  },
+  "c81cefcb-82b9-4408-a533-3c3df549e62d": {
+    "rule_name": "Persistence via Docker Shortcut Modification",
+    "sha256": "fe0f7a5ee7efbe75ef977c4457d16241099e4993f5219064e20272bb2a7059fb",
+    "version": 1
   },
   "c82b2bd8-d701-420c-ba43-f11a155b681a": {
     "rule_name": "SMB (Windows File Sharing) Activity to the Internet",
-    "sha256": "f2216d6fb197d8ebe56b438b60c6c17a2c6fee1272f95b362a62f66ae9d08a26",
-    "version": 7
+    "sha256": "10e7e5d37db0f145e1406fbbae6bf005969c827d4bc0e76dde43ca2026320472",
+    "version": 8
   },
   "c82c7d8f-fb9e-4874-a4bd-fd9e3f9becf1": {
     "rule_name": "Direct Outbound SMB Connection",
-    "sha256": "68c9f903236999653c3561153b05cb3569b2144445be4451d4c02630559d1b57",
-    "version": 5
+    "sha256": "437317e02b02da214489bbab1c65f2f875cb48eaf5121c27a63ef3e9b2642344",
+    "version": 6
   },
   "c87fca17-b3a9-4e83-b545-f30746c53920": {
     "rule_name": "Nmap Process Activity",
-    "sha256": "f7d2316ba6acd2bce179b629a2f2d807c6621fad1e6f4a05ed2e544060baa6f9",
-    "version": 6
+    "sha256": "85b00c642776304ce2f5d7c1374ad4f666c1669ace49cc43ede47f075674581d",
+    "version": 7
   },
   "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa": {
-    "rule_name": "Credential Manipulation - Prevented - Endpoint Security",
-    "sha256": "0734e9a063c5bbf35c5b4b73c95544f1399e648c12d6396698015de1d5d392ef",
-    "version": 4
+    "rule_name": "Credential Manipulation - Prevented - Elastic Endgame",
+    "sha256": "490cbfae68721fb35c3c8b8a0d41bc4b6efed8cc396d829e4afecc2e651c9ae1",
+    "version": 5
   },
   "ca79768e-40e1-4e45-a097-0e5fbc876ac2": {
     "rule_name": "Microsoft 365 Exchange Malware Filter Rule Modification",
-    "sha256": "51b65fec94a20040f5983aeaabdd81528b3dab3911e7e612795171ea64cde6ce",
-    "version": 2
+    "sha256": "0237f4f4bc00913f03f9e9af8e5bc4d31eedaa0903f8b617d6a1fbf0b7853a55",
+    "version": 3
+  },
+  "cab4f01c-793f-4a54-a03e-e5d85b96d7af": {
+    "rule_name": "Auditd Login from Forbidden Location",
+    "sha256": "d113bb2088767739621deaeaeec2cc09bbf142a7cedec2b35c634ebc18bae1bf",
+    "version": 1
   },
   "cad4500a-abd7-4ef3-b5d3-95524de7cfe1": {
     "rule_name": "Google Workspace MFA Enforcement Disabled",
-    "sha256": "b63844150664f0411f2d2d5c878cce77fcdb882611a2588686e1f892d5a7e9e0",
-    "version": 2
+    "sha256": "e4d99a2d70d99d2ba70d5055a5c75720a7aea9b24a0cb5f65399890fdc467818",
+    "version": 3
+  },
+  "cb71aa62-55c8-42f0-b0dd-afb0bb0b1f51": {
+    "rule_name": "Suspicious Calendar File Modification",
+    "sha256": "6ac1c6f9edab1cd65da00e3aace8a3254ccebe8005b2a934ce4337c5d5515228",
+    "version": 1
   },
   "cc16f774-59f9-462d-8b98-d27ccd4519ec": {
     "rule_name": "Process Discovery via Tasklist",
-    "sha256": "c619b62ecb53d348c75792b948ab0b9b8b53374e1d19332bfb78f123bda8e094",
-    "version": 5
+    "sha256": "8612fc7b7e41ef8548eb18803ce4a0ca6e178952add06c716bfbf190fa1788f3",
+    "version": 6
+  },
+  "cc2fd2d0-ba3a-4939-b87f-2901764ed036": {
+    "rule_name": "Attempt to Enable the Root Account",
+    "sha256": "95582925506246d2fa357ea7c342c4e5b50c36bf4ec7ea80ed184b4420c58e21",
+    "version": 1
   },
   "cc89312d-6f47-48e4-a87c-4977bd4633c3": {
     "rule_name": "GCP Pub/Sub Subscription Deletion",
-    "sha256": "e69b031746dcf8715663be0e26e468235a4fdca6a7bd0ab85ebb68984e27e028",
-    "version": 3
+    "sha256": "a80fd1a590247c2fc81456f355e6282d844b4e5db55e546ebceb0b11c13745cf",
+    "version": 4
   },
   "cc92c835-da92-45c9-9f29-b4992ad621a0": {
     "rule_name": "Attempt to Deactivate an Okta Policy Rule",
-    "sha256": "c3d53bc1a5a55116dd350a87ae779d6b74d09897063bab5870c0e164b530fe6c",
-    "version": 4
+    "sha256": "be469b4af0fa7081eb2cf835882f8b442828842a88450a6d6bf989c2201a12dc",
+    "version": 5
   },
   "ccc55af4-9882-4c67-87b4-449a7ae8079c": {
     "rule_name": "Potential Process Herpaderping Attempt",
-    "sha256": "295e8b053ee6f7acf40105fdc9c1e9cf16689482d786246cb96eb0a9be078e8d",
-    "version": 1
+    "sha256": "2b1dac1ccc6843acfa825aa0f250925056ed80d273deef8c7fd10f656fd48f35",
+    "version": 2
   },
   "cd16fb10-0261-46e8-9932-a0336278cdbe": {
     "rule_name": "Modification or Removal of an Okta Application Sign-On Policy",
-    "sha256": "b423d8f1781945d1f743a5ec517fb17d039cbcecfff55dffa2199ed10fc235f7",
-    "version": 4
+    "sha256": "a2321405cd840a1f32d79d96603ee9595d6cbb2b4bf217fb85e7edfaf93a977c",
+    "version": 5
   },
   "cd4d5754-07e1-41d4-b9a5-ef4ea6a0a126": {
     "rule_name": "Socat Process Activity",
-    "sha256": "800f417ab3153b956bf14740aef7bba4409913c8a18c19e4151419aacfdecc61",
-    "version": 6
+    "sha256": "572416fa9eb3b37a9360cbd474d0dccd7844685ad36b022f4a42d3a4525cac25",
+    "version": 7
   },
   "cd66a419-9b3f-4f57-8ff8-ac4cd2d5f530": {
     "rule_name": "Anomalous Linux Compiler Activity",
-    "sha256": "1ccdd79a3d8c423d8fe97857e1ce97a9ecd7e846405f4572bcc911a90b720f2d",
-    "version": 1
+    "sha256": "947c18f1f9fd440ed7b14572febb03c3b60df6a0cc3c3f8d4c9bd718dd47070c",
+    "version": 2
   },
   "cd66a5af-e34b-4bb0-8931-57d0a043f2ef": {
     "rule_name": "Kernel Module Removal",
-    "sha256": "4ff38bae1f36562b3da44c1bfba3df1bfa7357a6fc71416407ab1981dc89d1bc",
-    "version": 6
+    "sha256": "4002d3ed57c9f2e27385ad356a8fc0762aefd4cf26c4de249ebe309685652a9b",
+    "version": 7
   },
   "cd89602e-9db0-48e3-9391-ae3bf241acd8": {
     "rule_name": "Attempt to Deactivate MFA for an Okta User Account",
-    "sha256": "bf3c8c2643d927650b978c33445092099c8f1e4ad946d638f8621d8ff2cf2e1e",
-    "version": 4
+    "sha256": "f4bbb32afedf3c684ba753b08a2a19d41ecbb9449ccd5462dd3c33ccac159a35",
+    "version": 5
   },
   "ce64d965-6cb0-466d-b74f-8d2c76f47f05": {
     "rule_name": "New ActiveSyncAllowedDeviceID Added via PowerShell",
-    "sha256": "cd6eedc231fe502a3bdaa324c47802176e603af08001c6f5b139a414b8baf992",
-    "version": 2
+    "sha256": "7d1e679bae6a2b1456496717dc72d0ce8601b8a388d78284334161f9e9f43de4",
+    "version": 3
   },
   "cf53f532-9cc9-445a-9ae7-fced307ec53c": {
     "rule_name": "Cobalt Strike Command and Control Beacon",
-    "sha256": "22e04005795df325ce598f470c07578306c20b1e2ad4f10552dc734b53abedc9",
-    "version": 3
+    "sha256": "de043669d8aeccb6415b5637679b7c6564a23c246f1285513aabbff8d80e1866",
+    "version": 4
   },
   "cf549724-c577-4fd6-8f9b-d1b8ec519ec0": {
     "rule_name": "Domain Added to Google Workspace Trusted Domains",
-    "sha256": "37bf638366896b35971a2e4ba3b5b763414bb15d9a8d21e55e7cf5785f2ca1da",
-    "version": 2
+    "sha256": "bd9c727a1330fa038faa6902dffbebf579329ea3382ee4ffdb2e7c18bd145d5a",
+    "version": 3
   },
   "cff92c41-2225-4763-b4ce-6f71e5bda5e6": {
     "rule_name": "Execution from Unusual Directory - Command Line",
-    "sha256": "abbc696eef76e67c082c799b1714b9f555ce201910e4123ed3f9573f8bbcc179",
-    "version": 2
+    "sha256": "c2787c84eb693a04421d6abfa4665a506a5c2f33237e2746f8e84162f3c4babb",
+    "version": 3
   },
   "d0e159cf-73e9-40d1-a9ed-077e3158a855": {
     "rule_name": "Registry Persistence via AppInit DLL",
-    "sha256": "a0785cbffecd78f1f38bfdd475f4b2cfc4393c973d799005702ef5196fa95fbc",
-    "version": 2
+    "sha256": "8e0d01f097a813b149534720764b6fdbd833f36728870e242c7c1292ba2dc249",
+    "version": 3
   },
   "d2053495-8fe7-4168-b3df-dad844046be3": {
     "rule_name": "PPTP (Point to Point Tunneling Protocol) Activity",
-    "sha256": "692bca729434e89ffa2c06e474554cdd89568f48c24892047a1a6db742bc5934",
-    "version": 6
+    "sha256": "07e21a98e0a2f05e6d9191ef82577f66f1c1ed1a2f93cd54771faa83ee6ceda6",
+    "version": 7
+  },
+  "d22a85c6-d2ad-4cc4-bf7b-54787473669a": {
+    "rule_name": "Potential Microsoft Office Sandbox Evasion",
+    "sha256": "ed49330a9ef16ef0cb23a1622235f7b72a9f7f70bbc21c0d254fd53c04051d32",
+    "version": 1
+  },
+  "d31f183a-e5b1-451b-8534-ba62bca0b404": {
+    "rule_name": "Disabling User Account Control via Registry Modification",
+    "sha256": "316f46c9fc4bf783df072d40f0c5f38b02abc29e3f59d852494c633c3bc3801e",
+    "version": 1
   },
   "d331bbe2-6db4-4941-80a5-8270db72eb61": {
     "rule_name": "Clearing Windows Event Logs",
-    "sha256": "5a3345b1375898e2d96937c57e97800e36e9b49f13a4180668c6f44b3e549e87",
-    "version": 7
+    "sha256": "331f169dc027e0578a41cbbb35579744a453f04a5ad699ccde4851745482a498",
+    "version": 8
   },
   "d461fac0-43e8-49e2-85ea-3a58fe120b4f": {
     "rule_name": "Shell Execution via Apple Scripting",
-    "sha256": "20cce1e74b134378da1095bbe74784c7c83419746dd9e333c3d77af405448619",
-    "version": 1
+    "sha256": "2a7efdd0409aec9d27b3b22b8c23887e09a49dc56d2e636591bd0966ef26232f",
+    "version": 2
   },
   "d48e1c13-4aca-4d1f-a7b1-a9161c0ad86f": {
     "rule_name": "Attempt to Delete an Okta Application",
-    "sha256": "afb64842c0a54eb3e5cfa2c2666a9af23903e8b4ebfa4dc19d0f616212d22b4f",
-    "version": 2
+    "sha256": "14796a11a57d57f5506411642259e5dbe5b8341de64a466c14c48bc6dbb568ac",
+    "version": 3
   },
   "d49cc73f-7a16-4def-89ce-9fc7127d7820": {
     "rule_name": "Web Application Suspicious Activity: sqlmap User Agent",
-    "sha256": "433ffde338fefd9d64542d5dc81eb073b458a2151131e6fde0768a85fc20843a",
-    "version": 5
+    "sha256": "687ca8052da11de5df83115f646aee96264ed6dad8fcda20900cce276c4cda3b",
+    "version": 6
   },
   "d4af3a06-1e0a-48ec-b96a-faf2309fae46": {
     "rule_name": "Unusual Linux System Information Discovery Activity",
-    "sha256": "e0e46e6ee2027def12fd17f22fae998afd8c4a85057349c80869c06bf44b3f01",
-    "version": 1
+    "sha256": "e6bfd938d1323fddf3554c4c9a5a57d6490c2b23ec7d42a12455a5cd6ab96d14",
+    "version": 2
   },
   "d563aaba-2e72-462b-8658-3e5ea22db3a6": {
     "rule_name": "Privilege Escalation via Windir Environment Variable",
-    "sha256": "99dfd643c2a36c1b6dc871d05f308a697320a34844ad3213783e8637c15808cb",
-    "version": 2
+    "sha256": "7e6ec76881a3e6c716f2b9eebc74918276be1c71040dece25601d337b6ce68ed",
+    "version": 3
   },
   "d5d86bf5-cf0c-4c06-b688-53fdc072fdfd": {
     "rule_name": "Attempt to Delete an Okta Policy Rule",
-    "sha256": "84c5d892ab21a437ebac47aa1a4a817b9e11a65eb520fb910e7d72f6dd2d9164",
-    "version": 2
+    "sha256": "6d9f05167f0f7337735ae593572297e00b95e28dd46043012291611762e2dc38",
+    "version": 3
   },
   "d61cbcf8-1bc1-4cff-85ba-e7b21c5beedc": {
     "rule_name": "Service Command Lateral Movement",
-    "sha256": "e66df2e2111657b7ee9cdd483f6f9611b4d76cb8924ee9fc415a41013c4afd26",
-    "version": 2
+    "sha256": "14fe2ba1367484a6ee97e359ba9b8c5c66987e02d2865d8537b9ae9b1ef6d2ab",
+    "version": 3
   },
   "d624f0ae-3dd1-4856-9aad-ccfe4d4bfa17": {
     "rule_name": "AWS CloudWatch Log Stream Deletion",
-    "sha256": "abb84201e8bfa65651ffb134c8681989181732438dcca96f5b39d2e742f4a797",
-    "version": 4
+    "sha256": "fc8029a8e47bea0a82eaf38501c517425fbb79501efcc3760067c7a75d6e46ab",
+    "version": 5
   },
   "d62b64a8-a7c9-43e5-aee3-15a725a794e7": {
     "rule_name": "GCP Pub/Sub Subscription Creation",
-    "sha256": "5815cf026c54469194103b8a1ddebc04eb5b1ce869a3a41a7f5ac3857285803a",
-    "version": 3
+    "sha256": "1b91588d39021314af52b44e8be4d1712e1a9cb564dbb2df8df0f451462393b3",
+    "version": 4
   },
   "d6450d4e-81c6-46a3-bd94-079886318ed5": {
     "rule_name": "Strace Process Activity",
-    "sha256": "3691ba5a6ea56663b45fc80286b7c51d2dd04d0444a399c0785dc16076644078",
-    "version": 6
+    "sha256": "68cbcddbf04144359c4c2393175fed316e1985fb91b41a750b22ca2ca068f0cb",
+    "version": 7
   },
   "d68eb1b5-5f1c-4b6d-9e63-5b6b145cd4aa": {
     "rule_name": "Microsoft 365 Exchange Anti-Phish Policy Deletion",
-    "sha256": "d11854f903a47b9aa94f16222e6c5cdfd516831fd12ac3f94168476b5838fa51",
-    "version": 2
+    "sha256": "35a34dd03d6e890f2bc57c571d014b0d42bee0f699da5c4273b4ff48080fe865",
+    "version": 3
+  },
+  "d703a5af-d5b0-43bd-8ddb-7a5d500b7da5": {
+    "rule_name": "Modification of WDigest Security Provider",
+    "sha256": "186d80b60ea736c787a1ca61ef2b41e6506683d3cd70811a82d39e6132ebddbc",
+    "version": 1
   },
   "d72e33fc-6e91-42ff-ac8b-e573268c5a87": {
     "rule_name": "Command Execution via SolarWinds Process",
-    "sha256": "bdb98ed41e40d6f7dce270696e535b7fa8983d0b32650807489d7d1f06e9c66c",
-    "version": 2
+    "sha256": "fd80e63af37f8a2a7921dc49a3a6d8c2835e23bc3c4595ae3febaf378127ca72",
+    "version": 3
   },
   "d743ff2a-203e-4a46-a3e3-40512cfe8fbb": {
     "rule_name": "Microsoft 365 Exchange Malware Filter Policy Deletion",
-    "sha256": "dcd757b2c70ffc37336013571378b078e20da74eacdd9597ebd8c86919c83b08",
-    "version": 2
+    "sha256": "3417df0c9b3780d7a5d115e57ce6f937f0345103d6c6853fea9321fd2c4aecc5",
+    "version": 3
+  },
+  "d75991f2-b989-419d-b797-ac1e54ec2d61": {
+    "rule_name": "SystemKey Access via Command Line",
+    "sha256": "a59fae590fb4bc141a082f217d75c09a68188daa738f9272f99fbeabeb62578c",
+    "version": 1
   },
   "d76b02ef-fc95-4001-9297-01cb7412232f": {
     "rule_name": "Interactive Terminal Spawned via Python",
-    "sha256": "56283dfe2653f43fe67949d88fd1c2e175a137c4538e7b6515f1c1c4cf023235",
-    "version": 5
+    "sha256": "4a2c4600a5034552f066401120a8ce5c5795271b1a86f8a5fc9cc0dd658998ac",
+    "version": 6
   },
   "d7e62693-aab9-4f66-a21a-3d79ecdd603d": {
     "rule_name": "SMTP on Port 26/TCP",
-    "sha256": "489757a06a439a07bd987a173a396ad69b90370a3e0acb82277d4ca3925b64ea",
-    "version": 6
+    "sha256": "6a240c0235a8d9411864104c55e5dc2db3f6535204b5fdab884a5a2c3cacaef3",
+    "version": 7
   },
   "d8fc1cca-93ed-43c1-bbb6-c0dd3eff2958": {
     "rule_name": "AWS IAM Deactivation of MFA Device",
-    "sha256": "1b77a57e76ad6dfc79e7d95f7663ea4b9bfef18d0ed0069bb34182bfd2d22b11",
-    "version": 3
+    "sha256": "914638a74ccd18310d5ea716fdbaa27482d1e7f8c13bae39ad347f00da8f6c12",
+    "version": 4
   },
   "dafa3235-76dc-40e2-9f71-1773b96d24cf": {
     "rule_name": "Multi-Factor Authentication Disabled for an Azure User",
-    "sha256": "1a5b13bbbc9e151aac30ea7f4473debea355892cc7a289d052ed4d8b47d6776f",
-    "version": 3
+    "sha256": "1f690e67a2d90393ec43f1f3313f6c963c08304a4543a8c18dc03ca8872bfe5c",
+    "version": 4
   },
   "db8c33a8-03cd-4988-9e2c-d0a4863adb13": {
-    "rule_name": "Credential Dumping - Prevented - Endpoint Security",
-    "sha256": "ce8fd451c2c3bc3c5f9b35f212dc0b75348bb07d1c1c4c1559e575150874345f",
-    "version": 4
+    "rule_name": "Credential Dumping - Prevented - Elastic Endgame",
+    "sha256": "27d6e4256f3c3e790e0339e015ee47e5c922269bdbb9091c04efe12ed0ec4592",
+    "version": 5
   },
   "dc9c1f74-dac3-48e3-b47f-eb79db358f57": {
     "rule_name": "Volume Shadow Copy Deletion via WMIC",
-    "sha256": "a78e869e4a22fbcad724e729eb1f94c711a457d9f046a3856635c2857e38660c",
-    "version": 7
+    "sha256": "b7b3f2827dc1bc96a8c1e5a804e19cce2f509418f2ce52b0923112b5c01d0ea0",
+    "version": 8
   },
   "dca28dee-c999-400f-b640-50a081cc0fd1": {
     "rule_name": "Unusual Country For an AWS Command",
-    "sha256": "707a6d1770899a0eabedae7ba5976fcb00ea9abe77e0d9a7e712f66110d29f0a",
-    "version": 2
+    "sha256": "2f2aa4fe1129b07fb289dc8e70a84d075f42bf1a44c4a01c41cc24c0675c5957",
+    "version": 3
   },
   "de9bd7e0-49e9-4e92-a64d-53ade2e66af1": {
     "rule_name": "Unusual Child Process from a System Virtual Process",
-    "sha256": "c47e2e4e00f67549407ed0ae2d4d7db1532ff50d5293f52b8283d7d841e524bc",
-    "version": 2
+    "sha256": "04edb4316172408505a52e6f43378c345af10c981ed4db2c7e45f8902b6c46e9",
+    "version": 3
   },
   "debff20a-46bc-4a4d-bae5-5cdd14222795": {
     "rule_name": "Base16 or Base32 Encoding/Decoding Activity",
-    "sha256": "a682f3e59e293b99eb3d435effa228cafa3938d325275e68a82b85869d0708f0",
-    "version": 6
+    "sha256": "c345edb4dcc7ab10412b07d3293d643773657193c3527b15c474d96be60c6a99",
+    "version": 7
   },
   "df197323-72a8-46a9-a08e-3f5b04a4a97a": {
     "rule_name": "Unusual Windows User Calling the Metadata Service",
-    "sha256": "12354ef075f45d594f81cd132ed6cd134dcd58e0e4181f55e2ca8fbab4ea1ca6",
-    "version": 1
+    "sha256": "da2ba9b91b45c96faf8b5007dc0ec15693e269318a6203fa90ba2d043f85d3a2",
+    "version": 2
   },
   "df26fd74-1baa-4479-b42e-48da84642330": {
     "rule_name": "Azure Automation Account Created",
-    "sha256": "765cc2c11a3441564214b3fc4b49b1c1684de8da5137c2bfa74572a78ab9b96a",
-    "version": 3
+    "sha256": "6a6c68a107427de0f6838ce00430234a18bf5034f29e805fc48cce986dc0d9e1",
+    "version": 4
   },
   "df959768-b0c9-4d45-988c-5606a2be8e5a": {
     "rule_name": "Unusual Process Execution - Temp",
-    "sha256": "3bc74d9fd01dd0927a435386302afe89bcb60c8bb286e4e1885e06651d25b2ba",
-    "version": 6
+    "sha256": "71e059c24c99903cb975e9f95323e5c9be65e5912fc7eb67acef26cc102524a2",
+    "version": 7
   },
   "e02bd3ea-72c6-4181-ac2b-0f83d17ad969": {
     "rule_name": "Azure Firewall Policy Deletion",
-    "sha256": "32b4d11ac6b6495661cab9e04fc95ef48fd51465591227b0069aae39827a9531",
-    "version": 3
+    "sha256": "010e005af1b2b84dd10de59d5cbccc011c644ea19adc9a472d599e5691f439b6",
+    "version": 4
   },
   "e08ccd49-0380-4b2b-8d71-8000377d6e49": {
     "rule_name": "Attempts to Brute Force an Okta User Account",
-    "sha256": "a3226b1f93c0daf89b90f2eab25d21a8391e9aecac05f35459ac17ed73cc48d2",
-    "version": 2
+    "sha256": "f07fec07d7217a8a6e8dea785e9b8243992c7bba24d966b3a050d7521057dd95",
+    "version": 3
   },
   "e0f36de1-0342-453d-95a9-a068b257b053": {
     "rule_name": "Azure Event Hub Deletion",
-    "sha256": "b99daf7d5024207be1eec7c151ff2e8cad2b7ef7c47a3d2ecd9ba372f40017ce",
-    "version": 3
+    "sha256": "261f158221738446b5fda02954b3c090dc67b73675520f1ad0676b62ce3a3858",
+    "version": 4
   },
   "e14c5fd7-fdd7-49c2-9e5b-ec49d817bc8d": {
     "rule_name": "AWS RDS Cluster Creation",
-    "sha256": "053174e8aba7ee8eef851e60c2edcb41bc14bdcdf162f9683e44b4eedbef0832",
-    "version": 4
+    "sha256": "23369a564ae52cbfd7ed52fe15acad95c978a89e2a3617100d052897fc28fc33",
+    "version": 5
   },
   "e19e64ee-130e-4c07-961f-8a339f0b8362": {
     "rule_name": "Connection to External Network via Telnet",
-    "sha256": "a41f7d4da002a598a64a0c86a8a640bcc3fb38df115244ce462b8350efa17a50",
-    "version": 4
+    "sha256": "f1af1671f7dcae7e1678122ed09e278ba84f64df0a6652f3edaf91187117c4ff",
+    "version": 5
   },
   "e2a67480-3b79-403d-96e3-fdd2992c50ef": {
     "rule_name": "AWS Management Console Root Login",
-    "sha256": "2d8fc8ff84ceed47bca16ef187f6e9b0feef63524eed45db0cfc4a70cb663b0e",
-    "version": 3
+    "sha256": "552ca05a359012daa1c10f17cbb300ae59e0af6e8816bce331bff09883148a6a",
+    "version": 4
   },
   "e2f9fdf5-8076-45ad-9427-41e0e03dc9c2": {
     "rule_name": "Suspicious Process Execution via Renamed PsExec Executable",
-    "sha256": "fcc8d66a6b444e403216ec25372ef32dc19755c1adaf5a10181680cbd51fc884",
-    "version": 3
+    "sha256": "866137e7aaff75679d9cb9daec327239af72cebed02ddf3e877a76afd1116ecf",
+    "version": 4
   },
   "e2fb5b18-e33c-4270-851e-c3d675c9afcd": {
     "rule_name": "GCP IAM Role Deletion",
-    "sha256": "b7cb14b9f86fbd6700de65392846e21e554b97379cba6d77b21ceaa7e1366808",
-    "version": 3
+    "sha256": "c56ffa923af31ec4df6216d5d78247df3561dc46ca522a556ba4e766274ecaec",
+    "version": 4
   },
   "e3343ab9-4245-4715-b344-e11c56b0a47f": {
     "rule_name": "Process Activity via Compiled HTML File",
-    "sha256": "e6c3a918a6fed641a349f992888acfddf7eb7a7f03757d94d78ed227aa364cc2",
-    "version": 6
+    "sha256": "d13eb44ce8c1e9c575b49c967a1cb48a88e92b7fdb1a9d220b5189addf6950fd",
+    "version": 7
   },
   "e3c5d5cb-41d5-4206-805c-f30561eae3ac": {
-    "rule_name": "Ransomware - Prevented - Endpoint Security",
-    "sha256": "911ba16663efb30078217f771edbd6e7356f869662483fac274b09c8097580cb",
-    "version": 4
+    "rule_name": "Ransomware - Prevented - Elastic Endgame",
+    "sha256": "843eb805ba1977ac107e77885fa675b0633fea7cdf90a7437b83997cfe6ff5c8",
+    "version": 5
   },
   "e3cf38fa-d5b8-46cc-87f9-4a7513e4281d": {
     "rule_name": "Connection to Commonly Abused Free SSL Certificate Providers",
-    "sha256": "d5c1778b8b06ec9a97a83ef1ff37b90c881133028c3e73e7d954470004db83a0",
-    "version": 2
+    "sha256": "b055eb46d4206980a676f50c0e7043bca37dabc37a33fcbd47ceb640532adf6f",
+    "version": 3
+  },
+  "e3e904b3-0a8e-4e68-86a8-977a163e21d3": {
+    "rule_name": "Persistence via KDE AutoStart Script or Desktop File Modification",
+    "sha256": "b0987f3c7fe63baa9cf5f7327fcd5eb56ef9c49670d24d64de92f40d958e602d",
+    "version": 1
   },
   "e48236ca-b67a-4b4e-840c-fdc7782bc0c3": {
     "rule_name": "Attempt to Modify an Okta Network Zone",
-    "sha256": "eb22dec56f8a7daf9f3803523f9cceb7972c1b899c633052403b1e992c5424ad",
-    "version": 4
+    "sha256": "7a2279b7eeb6a05d016d7ddefdc6822aa7a9970aa56842c07c41e7d499d23d38",
+    "version": 5
   },
   "e555105c-ba6d-481f-82bb-9b633e7b4827": {
     "rule_name": "MFA Disabled for Google Workspace Organization",
-    "sha256": "9abfadd9fb00097a0bafbd914188789be09de30c2740922791789e3ab53c8a9d",
-    "version": 2
+    "sha256": "724aadbeee971f131fc341654bf461b52ea82fe077e59ebf9914b7807e663067",
+    "version": 3
   },
   "e56993d2-759c-4120-984c-9ec9bb940fd5": {
     "rule_name": "RDP (Remote Desktop Protocol) to the Internet",
-    "sha256": "27b24fb4f81b6583600cf3c68ecd4228c9b541f58ccc9180350dc493ec977b31",
-    "version": 7
+    "sha256": "e2f1607e4ec15d9f1e4cdfb3c307852c151afef4fa9f42ee068ccd4b335543ed",
+    "version": 8
+  },
+  "e6c1a552-7776-44ad-ae0f-8746cc07773c": {
+    "rule_name": "Bash Shell Profile Modification",
+    "sha256": "89d30ce0d3a7a7934c3a31d917bfd1236d723ad3376cf9480c5d8346c44f3861",
+    "version": 1
+  },
+  "e6c98d38-633d-4b3e-9387-42112cd5ac10": {
+    "rule_name": "Authorization Plugin Modification",
+    "sha256": "e44af923e00fc997967568bffa247c4e58c9fd3d60a81bf6d7bf01ce3e03cc1f",
+    "version": 1
   },
   "e6e3ecff-03dd-48ec-acbd-54a04de10c68": {
     "rule_name": "Possible Okta DoS Attack",
-    "sha256": "106ffd7b336d3d2f62e0c565541ef07ebe8b377a7219e678b3f2a337eb35d938",
-    "version": 4
+    "sha256": "7e9f9eae422c39e7db34668d41955de13bdbdce00bcdc6533104ab87baadbbc5",
+    "version": 5
   },
   "e7075e8d-a966-458e-a183-85cd331af255": {
     "rule_name": "Default Cobalt Strike Team Server Certificate",
-    "sha256": "64dfead1ef9066469366e2cadb08f751171478410ad2b034593c46c7cee27bf1",
-    "version": 2
+    "sha256": "bc01c79f9051695dd063de8366b0df7e2db34d60c75d68211fd08f586607a4ed",
+    "version": 3
   },
   "e7125cea-9fe1-42a5-9a05-b0792cf86f5a": {
     "rule_name": "Execution of Persistent Suspicious Program",
-    "sha256": "e3dae289ce5ea3435e8c63dce8fab1b29a46b9acb14027a69f13714a35421945",
-    "version": 1
+    "sha256": "a20d59b00c5cb946794ec2b30277dc754792a46bce3ee1cd6274d512ff418929",
+    "version": 2
   },
   "e8571d5f-bea1-46c2-9f56-998de2d3ed95": {
     "rule_name": "Local Service Commands",
-    "sha256": "cf6d83712cc60526fd908ff8340f3babc2ba382947921e61997418e895755a62",
-    "version": 7
+    "sha256": "7814dde5ffa0cb6d55314e3d635a938cbe1f3c1ff4cb9064489fc7319be15c43",
+    "version": 8
   },
   "e86da94d-e54b-4fb5-b96c-cecff87e8787": {
     "rule_name": "Installation of Security Support Provider",
-    "sha256": "ab3bfc7f12dd37194cf775c83e92a5fb8e10a77d254e80d0cbce3abef3bf9c61",
-    "version": 2
+    "sha256": "1cc2a5b975de38886990ead87582065b5b8c7f032d3034372cf255ffc0fe7329",
+    "version": 3
   },
   "e90ee3af-45fc-432e-a850-4a58cf14a457": {
     "rule_name": "High Number of Okta User Password Reset or Unlock Attempts",
-    "sha256": "0c670e28f62f7e6a59b4e8d2bfb089bdb4b6dd439db64c1946212fc3a071cdfc",
-    "version": 2
+    "sha256": "ae54cec54f65ae013686d6cd34841d666efd26e0f65ad544bd743c1f2a21a7f2",
+    "version": 3
   },
   "e94262f2-c1e9-4d3f-a907-aeab16712e1a": {
     "rule_name": "Unusual Executable File Creation by a System Critical Process",
-    "sha256": "46d831233fa92a30570a7bac5c80cb5772b63e6167798ae2854f6d896f63e431",
-    "version": 2
+    "sha256": "821eca0bcbdff22a5082301443edb973245e33bbc8f31ca70b20b7b47b2060dc",
+    "version": 3
+  },
+  "e9abe69b-1deb-4e19-ac4a-5d5ac00f72eb": {
+    "rule_name": "Potential LSA Authentication Package Abuse",
+    "sha256": "e6431faeb13e0c445d52839605d6ccdce90be6b7f2183d040acae6bb5c66b434",
+    "version": 1
   },
   "e9ff9c1c-fe36-4d0d-b3fd-9e0bf4853a62": {
     "rule_name": "Azure Automation Webhook Created",
-    "sha256": "f60eb699d29e466ef9e88ffc1c5462d2162e2b40a1e5c15a6c928040eda6c09b",
-    "version": 3
+    "sha256": "adc35e58e49925dbe1df80ba70785f41102ce0d32a3f5f3f8379b935eada8fa2",
+    "version": 4
   },
   "ea0784f0-a4d7-4fea-ae86-4baaf27a6f17": {
     "rule_name": "SSH (Secure Shell) from the Internet",
-    "sha256": "5c9f1ae1341311001eb7c14c069f10a81ab5cfad7c8b6d9696819b6e4b996036",
-    "version": 7
+    "sha256": "a5b483bc27ea95cd71683dd2f631a41276da2ab442b4d14e2e843c1df6519efa",
+    "version": 8
   },
   "ea248a02-bc47-4043-8e94-2885b19b2636": {
     "rule_name": "AWS IAM Brute Force of Assume Role Policy",
-    "sha256": "8e0be7cb15dcca220017e99ae2a6ae37f45b6c62427db572043644d06693d155",
-    "version": 2
+    "sha256": "9aeb1b1c1c4b9fb39b564774f25afea20210e5789afbde43998e680892678b7c",
+    "version": 3
   },
   "eb079c62-4481-4d6e-9643-3ca499df7aaa": {
     "rule_name": "External Alerts",
-    "sha256": "b7c6a3082304fb21fe016ceb17e61d5d0f74e9e8661feddd949c4ef71c9c3496",
-    "version": 2
+    "sha256": "9107eb5172f577c66c5ab38340c4c4632a571e69c40b2567d4df76b2d8b5d786",
+    "version": 3
   },
   "eb9eb8ba-a983-41d9-9c93-a1c05112ca5e": {
     "rule_name": "Potential Disabling of SELinux",
-    "sha256": "3b343539b4dc70561e233016bbafa2e521920eec985a5b18a349b91031eb98ec",
-    "version": 6
+    "sha256": "49e14c39aa219a236e6fbb4af269b913d96a1b4a60c92fab7328e6a86f5f753c",
+    "version": 7
   },
   "ebb200e8-adf0-43f8-a0bb-4ee5b5d852c6": {
     "rule_name": "Mimikatz Memssp Log File Detected",
-    "sha256": "b040ed5e6961427ffd09b24310f0fd7b5303573d6f770388a7f1eb181c799d1b",
-    "version": 2
+    "sha256": "2a3514bdbd9aea38dcf49dd803fbdccfb02c7d77f17cbc0d0c4b697611ca6127",
+    "version": 3
   },
   "ebf1adea-ccf2-4943-8b96-7ab11ca173a5": {
     "rule_name": "IIS HTTP Logging Disabled",
-    "sha256": "da21066645a55b63d8fecb808eecf1bd74748457263ef40dab8da1aaec3a51bd",
-    "version": 3
+    "sha256": "9c8cd12bec3bbf0c2631d1a86bed02cc2c1c49c1df9748e5768f61aa429d2968",
+    "version": 4
   },
   "ebfe1448-7fac-4d59-acea-181bd89b1f7f": {
     "rule_name": "Process Execution from an Unusual Directory",
-    "sha256": "64c50e1dbe97849d4f6b0b418d1206190121db260caca612646b457c804c8d3f",
-    "version": 2
+    "sha256": "5aeab7a2f59aecec28d8a1dc26d6183214c0b766a78fe542ffa59d282b42e2db",
+    "version": 3
   },
   "ecf2b32c-e221-4bd4-aa3b-c7d59b3bc01d": {
     "rule_name": "AWS RDS Instance/Cluster Stoppage",
-    "sha256": "31ec9b4252253e348100d49100907f5db68352b72ec0e959b609a9eab4be5c0e",
-    "version": 3
+    "sha256": "7900695a24927077e5cbf12d7c5e64e28d4cdf217e656b48ef3d7bc7d57b6b33",
+    "version": 4
   },
   "ed9ecd27-e3e6-4fd9-8586-7754803f7fc8": {
     "rule_name": "Azure Global Administrator Role Addition to PIM User",
-    "sha256": "181aab572cb5e16c41ef255ad97789d321122d3d0c4a865e257304d19f463298",
-    "version": 3
+    "sha256": "876234fe53ca39b6228fa3994254732fa47c6ecaf36521255bab9106417154e2",
+    "version": 4
   },
   "eda499b8-a073-4e35-9733-22ec71f57f3a": {
     "rule_name": "AdFind Command Activity",
-    "sha256": "773d4d374830376166856b84be6a91ca48b97e1098553fd4153bd5a5514ec128",
-    "version": 2
+    "sha256": "79ed2edf7b89ecad6bcf3fb625c06c3d211b1f77f64cd0021d9c8b195873e334",
+    "version": 3
   },
   "edb91186-1c7e-4db8-b53e-bfa33a1a0a8a": {
     "rule_name": "Attempt to Deactivate an Okta Application",
-    "sha256": "16410686f1addb8ee1d8cc39ff4d33c8f00caf70339e98436662df5ef95e1e2b",
-    "version": 2
+    "sha256": "6eb482908d306cb93ef5c9f9f94e615ee6df658aba85e74c89c00d613b075440",
+    "version": 3
   },
   "edf8ee23-5ea7-4123-ba19-56b41e424ae3": {
     "rule_name": "ImageLoad via Windows Update Auto Update Client",
-    "sha256": "e6052dff19b5557c53e9db1244263626ff01c9988018efbf59923b07250d09d7",
-    "version": 2
+    "sha256": "6f44ec751ed71022884f3953e3b7f63827bdd82eab59cc5f47fbe4322f3f8414",
+    "version": 3
+  },
+  "eea82229-b002-470e-a9e1-00be38b14d32": {
+    "rule_name": "Potential Privacy Control Bypass via TCCDB Modification",
+    "sha256": "dbb7eceffa388039b4218d894c116ba68ff94ef44b2460e074c30209098e5546",
+    "version": 1
   },
   "ef862985-3f13-4262-a686-5f357bbb9bc2": {
     "rule_name": "Whoami Process Activity",
-    "sha256": "0977bd6e10761072797280e93ff365753d0d91c6107098df12bed4963b154122",
-    "version": 5
+    "sha256": "fff740535905b1eb36dbbc7da9296ae022e22848536b5e2418168f42c59e4cc9",
+    "version": 6
   },
   "f036953a-4615-4707-a1ca-dc53bf69dcd5": {
     "rule_name": "Unusual Child Processes of RunDLL32",
-    "sha256": "0fefec116fb90ec262136f0464b0762ea5fb9f6aa26bdfacf18f06bb9bb8ec71",
-    "version": 2
+    "sha256": "1141da2983333989447dc381b71356a6cc55741178d76a77a3df032d2a5583bd",
+    "version": 3
   },
   "f06414a6-f2a4-466d-8eba-10f85e8abf71": {
     "rule_name": "Administrator Role Assigned to an Okta User",
-    "sha256": "f23c21708a33952012b9296311171fdb9f8986310f55c48dba0c486fa7f92083",
-    "version": 2
+    "sha256": "ef90c9bb3f1f8882390ef3f6d5f5443d080ee1290776d4422e39f164125a7774",
+    "version": 3
   },
   "f0b48bbc-549e-4bcf-8ee0-a7a72586c6a7": {
     "rule_name": "Attempt to Remove File Quarantine Attribute",
-    "sha256": "180024780a0971d835e2a44fd9dbb0dd015fb488fbc89be89003e4685a07b538",
-    "version": 2
+    "sha256": "0f27489f0578b5596891555022bb25c63bfe725160ab7d93c8c02efb92a40463",
+    "version": 3
   },
   "f0eb70e9-71e9-40cd-813f-bf8e8c812cb1": {
-    "rule_name": "Execution with Explicit Credentials via Apple Scripting",
-    "sha256": "00f1eeeb4a4f3d2a6b1e225903d6ce431a403154f39b039a05f793128498a371",
+    "rule_name": "Execution with Explicit Credentials via Scripting",
+    "sha256": "9f4bb06f4f7052f9a4d703bb2938bf81a48febfcc3c0f2e03f952979431e604e",
+    "version": 2
+  },
+  "f24bcae1-8980-4b30-b5dd-f851b055c9e7": {
+    "rule_name": "Creation of Hidden Login Item via Apple Script",
+    "sha256": "687a91ad38f1a50dc0a07c13c05aa7655159f7537889038cd0ef4c720ff24fd9",
+    "version": 1
+  },
+  "f28e2be4-6eca-4349-bdd9-381573730c22": {
+    "rule_name": "Potential OpenSSH Backdoor Logging Activity",
+    "sha256": "0bf0f53f6fd19a94d99b558b91d1893ebe242c85c4d77ad0f853700b0be8d614",
+    "version": 1
+  },
+  "f2c7b914-eda3-40c2-96ac-d23ef91776ca": {
+    "rule_name": "SIP Provider Modification",
+    "sha256": "b761a0e62dcf8f650c42dfe807fb62f206efcaa299a68b1f3fb443e3158840d7",
     "version": 1
   },
   "f2f46686-6f3c-4724-bd7d-24e31c70f98f": {
     "rule_name": "LSASS Memory Dump Creation",
-    "sha256": "18df26083a6c02fcaa4e7cee8ad92e03b464dc171dcea36b543b122a2c174982",
-    "version": 2
+    "sha256": "90941235f90bb017456e6ad2ee37ded92e3187f11346b674d676f18c1c5723a8",
+    "version": 3
   },
   "f3475224-b179-4f78-8877-c2bd64c26b88": {
     "rule_name": "WMI Incoming Lateral Movement",
-    "sha256": "1f81a9ebc9304e983f56c73f0d7f3778d17df0ca9281c93b861c5ba0f76489ca",
+    "sha256": "ed25b43fb38cbc23d92775bb0284a9fd055dd53d8824bcda78d2c9ffdc8428c5",
+    "version": 2
+  },
+  "f37f3054-d40b-49ac-aa9b-a786c74c58b8": {
+    "rule_name": "Sudo Heap-Based Buffer Overflow Attempt",
+    "sha256": "4e2f4382ebdd90b0b3e25ca50dfa944f4d50ec58704cf116a92b06a07ab23b6a",
     "version": 1
   },
   "f44fa4b6-524c-4e87-8d9e-a32599e4fb7c": {
     "rule_name": "Persistence via Microsoft Office AddIns",
-    "sha256": "8e08c279331382bd518d79884d5d1ea71193b4eaebeee5349a1198c52fe5622b",
-    "version": 2
+    "sha256": "e10cd34197457df5ffa89b628dfbd7d9ccbb89c295b5b2de5d3a305df3a8d158",
+    "version": 3
   },
   "f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc": {
     "rule_name": "Windows Script Executing PowerShell",
-    "sha256": "59ce3a59bdb9ed1052472602725a34f56538b83c0a90bb8d2954fb07d417fe7a",
-    "version": 7
+    "sha256": "7385ea7c1d0a15ded463637f6632bc97d802590f4a566fcc7098f79f14471002",
+    "version": 8
   },
   "f675872f-6d85-40a3-b502-c0d2ef101e92": {
     "rule_name": "Delete Volume USN Journal with Fsutil",
-    "sha256": "d5f7787b38586f96eba4a09474b220c7eb0378acbe4ac430a7bf766239630d3d",
-    "version": 7
+    "sha256": "8dea91bdeeb9c2f206a4fc9ef2a924dba812b0fcd934d2b8abda6f1a52026f36",
+    "version": 8
+  },
+  "f683dcdf-a018-4801-b066-193d4ae6c8e5": {
+    "rule_name": "SoftwareUpdate Preferences Modification",
+    "sha256": "3c213d93c01717a35630316d34f77ffb086ddefdb6cfb17420ca7446631eced7",
+    "version": 1
   },
   "f772ec8a-e182-483c-91d2-72058f76a44c": {
     "rule_name": "AWS CloudWatch Alarm Deletion",
-    "sha256": "061877c4b789741e0bd2d4bfba5fb30e96a628308269dbbc3b39d49ce33d58e5",
-    "version": 4
+    "sha256": "49431fea2a247593c5efad95447e82c1e91b82f3c19955c60b33f3a5f120501a",
+    "version": 5
   },
   "f7c4dc5a-a58d-491d-9f14-9b66507121c0": {
     "rule_name": "Persistent Scripts in the Startup Directory",
-    "sha256": "cd8c249795eacd3b7a4c748a5794d3e2b48d63eb111e1a7013471e068cf49161",
-    "version": 2
+    "sha256": "e4fc24490738631aa609769246c6540ec8b95528a75c4ba57e34c547985bc047",
+    "version": 3
+  },
+  "f81ee52c-297e-46d9-9205-07e66931df26": {
+    "rule_name": "Microsoft Exchange Worker Spawning Suspicious Processes",
+    "sha256": "7eb3227762aa2a2cf9d9d514b28b2ef6a40eb2c254654b39a93385f44593bf02",
+    "version": 1
+  },
+  "f85ce03f-d8a8-4c83-acdc-5c8cd0592be7": {
+    "rule_name": "Suspicious Child Process of Adobe Acrobat Reader Update Service",
+    "sha256": "68381fd6b57b4c5f03f2078e9a06e98d5e1180659dac5b0e1cb3c61d0b8c65e2",
+    "version": 1
   },
   "f9590f47-6bd5-4a49-bd49-a2f886476fb9": {
     "rule_name": "Unusual Linux System Network Configuration Discovery",
-    "sha256": "7afb429644c3e194451bd0341400e1bd62aa315f1d7477235795f0d8e060f8a7",
-    "version": 1
+    "sha256": "e0d27723f14bfc1f2d57f46507f432ac8447aeedaa48ac60222193653c4ea2a8",
+    "version": 2
   },
   "f994964f-6fce-4d75-8e79-e16ccc412588": {
     "rule_name": "Suspicious Activity Reported by Okta User",
-    "sha256": "fe4f99d829a1426cf43e16b2efff819241cd72b5dfec5144bb4ac0415fe0afb4",
-    "version": 4
+    "sha256": "a4f427b8e45a8b09377f98c48e1738ab08e566534215cbb78cbb8bd29e91971c",
+    "version": 5
   },
   "fa01341d-6662-426b-9d0c-6d81e33c8a9d": {
     "rule_name": "Remote File Copy to a Hidden Share",
-    "sha256": "50d2efa2cce15ad7d8084bc0af8847fd0e6bbf6250234a6fd759276cfc04be15",
-    "version": 2
+    "sha256": "0bcc52e13022bb037d72173ac8df764dc3ed52b276fb65e89798744dcaac3aff",
+    "version": 3
   },
   "fb02b8d3-71ee-4af1-bacd-215d23f17efa": {
     "rule_name": "Network Connection via Registration Utility",
-    "sha256": "3a398bca99d1e42d9d86563ea7a23796f297b26203d69c23e75288d8f5de11dc",
-    "version": 6
+    "sha256": "6633d1f8b6246ece6fc716b697a7b4150c0e67db46bfeeeac669cf59fcfeb038",
+    "version": 7
+  },
+  "fb9937ce-7e21-46bf-831d-1ad96eac674d": {
+    "rule_name": "Auditd Max Failed Login Attempts",
+    "sha256": "b54cabaca98a7b1b1e9f1405a208db6aeb709830026f560b3a1c44428296c339",
+    "version": 1
   },
   "fbd44836-0d69-4004-a0b4-03c20370c435": {
     "rule_name": "AWS Configuration Recorder Stopped",
-    "sha256": "89856060e32329a084c73bbdce355d720cb79aca895202cea39db79ecc704830",
-    "version": 4
+    "sha256": "f77a5039b24fc1587785fd0f3b51aaf211e54760b25772b21f622aa00e1b71ff",
+    "version": 5
   },
   "fc7c0fa4-8f03-4b3e-8336-c5feab0be022": {
     "rule_name": "UAC Bypass Attempt via Elevated COM Internet Explorer Add-On Installer",
-    "sha256": "6067b40a4db1b3f6319eb436fd4aa338eda23b182565f1ae0c5d49da69ecd1d3",
-    "version": 2
+    "sha256": "c5e9aba91dc870407a809cde0429ab1c1f59f2760d66220a857e2dc483148c82",
+    "version": 3
   },
   "fd4a992d-6130-4802-9ff8-829b89ae801f": {
     "rule_name": "Potential Application Shimming via Sdbinst",
-    "sha256": "c321c182cc1a8b7ee15673433fe16f6bd0b87e67010b5128bd7e0486fe493e11",
-    "version": 6
+    "sha256": "d20bd0cedd6be03196e44e9a5fc14e5a8a9ee377ce352088b45709f39b0cf002",
+    "version": 7
   },
   "fd70c98a-c410-42dc-a2e3-761c71848acf": {
     "rule_name": "Encoding or Decoding Files via CertUtil",
-    "sha256": "b4ccf60e28786ecb6902d7a38d49265627c0acc491f7db0ceaf332f4c05586bd",
-    "version": 6
+    "sha256": "461bc75cf19856ebfc5cfb09d8a493cb27c39b4f4d27ccff01276891ca1f41cc",
+    "version": 7
   },
   "fd7a6052-58fa-4397-93c3-4795249ccfa2": {
     "rule_name": "Svchost spawning Cmd",
-    "sha256": "926a6b9f74f9730557ec6eed7aa0a5a4d4c29e9506a8d7b36104e93da5af6118",
-    "version": 6
+    "sha256": "6759df772f8f777e47e7d246d3ccef103f62dfb94cc72616e9e7065eec2e37c5",
+    "version": 7
   },
   "ff013cb4-274d-434a-96bb-fe15ddd3ae92": {
     "rule_name": "Roshal Archive (RAR) or PowerShell File Downloaded from the Internet",
-    "sha256": "3239bfe296eb7c63506903d43dcf09dabe9b83387d6d6e9840abcfea2a7d6a1a",
-    "version": 2
+    "sha256": "aa23e0632177249272262d3a6a5e1077ae75a2c69215f4bc538f7c020e07f204",
+    "version": 3
   },
   "ff4dd44a-0ac6-44c4-8609-3f81bc820f02": {
     "rule_name": "Microsoft 365 Exchange Transport Rule Creation",
-    "sha256": "13c44d617fe906b97d8cc74566aa68faf1d450d2813b3975fc23c3bc9ab1e658",
-    "version": 2
+    "sha256": "72bae97021b3cfe8ac1d561a532ee5e976fc0b09e97e0e067f03c55746a42b64",
+    "version": 3
   },
   "ff9b571e-61d6-4f6c-9561-eb4cca3bafe1": {
     "rule_name": "GCP Firewall Rule Deletion",
-    "sha256": "0d1109d0ef4e0bb769ea14addf28c8e4e60fa5f83f8cacfa7d678ec811fa5661",
-    "version": 3
+    "sha256": "e69d584ed79e77116f0f985069ecfc8f441e9a057ec2873fcd4037a4830bc797",
+    "version": 4
   }
 }

--- a/rules/promotions/endgame_adversary_behavior_detected.toml
+++ b/rules/promotions/endgame_adversary_behavior_detected.toml
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "77a3c3df-8ec4-4da4-b758-878f551dee69"
 severity = "medium"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_cred_dumping_detected.toml
+++ b/rules/promotions/endgame_cred_dumping_detected.toml
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "571afc56-5ed9-465d-a2a9-045f099f6e7e"
 severity = "high"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_cred_dumping_prevented.toml
+++ b/rules/promotions/endgame_cred_dumping_prevented.toml
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "db8c33a8-03cd-4988-9e2c-d0a4863adb13"
 severity = "medium"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_cred_manipulation_detected.toml
+++ b/rules/promotions/endgame_cred_manipulation_detected.toml
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "c0be5f31-e180-48ed-aa08-96b36899d48f"
 severity = "high"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_cred_manipulation_prevented.toml
+++ b/rules/promotions/endgame_cred_manipulation_prevented.toml
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa"
 severity = "medium"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_exploit_detected.toml
+++ b/rules/promotions/endgame_exploit_detected.toml
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "2003cdc8-8d83-4aa5-b132-1f9a8eb48514"
 severity = "high"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_exploit_prevented.toml
+++ b/rules/promotions/endgame_exploit_prevented.toml
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "2863ffeb-bf77-44dd-b7a5-93ef94b72036"
 severity = "medium"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_malware_detected.toml
+++ b/rules/promotions/endgame_malware_detected.toml
@@ -19,6 +19,7 @@ risk_score = 99
 rule_id = "0a97b20f-4144-49ea-be32-b540ecc445de"
 severity = "critical"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_malware_prevented.toml
+++ b/rules/promotions/endgame_malware_prevented.toml
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "3b382770-efbb-44f4-beed-f5e0a051b895"
 severity = "high"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_permission_theft_detected.toml
+++ b/rules/promotions/endgame_permission_theft_detected.toml
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "c3167e1b-f73c-41be-b60b-87f4df707fe3"
 severity = "high"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_permission_theft_prevented.toml
+++ b/rules/promotions/endgame_permission_theft_prevented.toml
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "453f659e-0429-40b1-bfdb-b6957286e04b"
 severity = "medium"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_process_injection_detected.toml
+++ b/rules/promotions/endgame_process_injection_detected.toml
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "80c52164-c82a-402c-9964-852533d58be1"
 severity = "high"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_process_injection_prevented.toml
+++ b/rules/promotions/endgame_process_injection_prevented.toml
@@ -19,6 +19,7 @@ risk_score = 47
 rule_id = "990838aa-a953-4f3e-b3cb-6ddf7584de9e"
 severity = "medium"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_ransomware_detected.toml
+++ b/rules/promotions/endgame_ransomware_detected.toml
@@ -19,6 +19,7 @@ risk_score = 99
 rule_id = "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd"
 severity = "critical"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''

--- a/rules/promotions/endgame_ransomware_prevented.toml
+++ b/rules/promotions/endgame_ransomware_prevented.toml
@@ -19,6 +19,7 @@ risk_score = 73
 rule_id = "e3c5d5cb-41d5-4206-805c-f30561eae3ac"
 severity = "high"
 tags = ["Elastic", "Elastic Endgame"]
+timestamp_override = "event.ingested"
 type = "query"
 
 query = '''


### PR DESCRIPTION
## Issues
None

## Summary
lock versions for 7.12 rules

To reconcile, the promotion rules needed to have a version bump and the `event_override` field added (ref: #1082)

## Details

```
 python -m detection_rules dev kibana-diff -b 7.12 -t 100

Downloading rules from elastic/kibana 7.12 branch in kibana repo using 100 threads ...
{
  "diff": [],
  "missing_from_kibana": [],
  "missing_from_repo": [],
  "stats": {
    "diff": 0,
    "missing_from_kibana": 0,
    "missing_from_repo": 0,
    "total_gh_prod_rules": 546,
    "total_repo_prod_rules": 546
  }
}
```