### PR TITLE
Update threshold rule schema to disallow empty field string

### DIFF
--- a/detection_rules/schemas/base.py
+++ b/detection_rules/schemas/base.py
@@ -15,7 +15,6 @@ from ..utils import cached
 
 DATE_PATTERN = r'\d{4}/\d{2}/\d{2}'
 MATURITY_LEVELS = ['development', 'experimental', 'beta', 'production', 'deprecated']
-NON_EMPTY_STR = r'.+'
 OS_OPTIONS = ['windows', 'linux', 'macos', 'solaris']
 UUID_PATTERN = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 VERSION_PATTERN = r'\d+\.\d+\.\d+|master'

--- a/detection_rules/schemas/base.py
+++ b/detection_rules/schemas/base.py
@@ -15,6 +15,7 @@ from ..utils import cached
 
 DATE_PATTERN = r'\d{4}/\d{2}/\d{2}'
 MATURITY_LEVELS = ['development', 'experimental', 'beta', 'production', 'deprecated']
+NON_EMPTY_STR = r'.+'
 OS_OPTIONS = ['windows', 'linux', 'macos', 'solaris']
 UUID_PATTERN = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 VERSION_PATTERN = r'\d+\.\d+\.\d+|master'

--- a/detection_rules/schemas/v7_12.py
+++ b/detection_rules/schemas/v7_12.py
@@ -7,7 +7,6 @@
 
 import jsl
 
-from .base import NON_EMPTY_STR
 from .v7_9 import ThresholdMapping
 from .v7_11 import ApiSchema711
 
@@ -32,7 +31,7 @@ class ApiSchema712(ApiSchema711):
             field = jsl.StringField(required=True)
             value = jsl.IntField(minimum=1, required=True)
 
-        field = jsl.ArrayField(jsl.StringField(required=False, pattern=NON_EMPTY_STR), required=True)
+        field = jsl.ArrayField(jsl.StringField(required=False, min_length=1), required=True)
         cardinality = jsl.DocumentField(ThresholdCardinality, required=False)
 
     threshold_scope = ApiSchema711.threshold_scope

--- a/detection_rules/schemas/v7_12.py
+++ b/detection_rules/schemas/v7_12.py
@@ -7,6 +7,7 @@
 
 import jsl
 
+from .base import NON_EMPTY_STR
 from .v7_9 import ThresholdMapping
 from .v7_11 import ApiSchema711
 
@@ -31,7 +32,7 @@ class ApiSchema712(ApiSchema711):
             field = jsl.StringField(required=True)
             value = jsl.IntField(minimum=1, required=True)
 
-        field = jsl.ArrayField(jsl.StringField(required=True, default=""))
+        field = jsl.ArrayField(jsl.StringField(required=False, pattern=NON_EMPTY_STR), required=True)
         cardinality = jsl.DocumentField(ThresholdCardinality, required=False)
 
     threshold_scope = ApiSchema711.threshold_scope

--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -2521,8 +2521,8 @@
   },
   "ea248a02-bc47-4043-8e94-2885b19b2636": {
     "rule_name": "AWS IAM Brute Force of Assume Role Policy",
-    "sha256": "9aeb1b1c1c4b9fb39b564774f25afea20210e5789afbde43998e680892678b7c",
-    "version": 3
+    "sha256": "9aee800e271c99dfee70b36fbe34a3607ad2b2c9030f77b26db66977cce7621f",
+    "version": 4
   },
   "eb079c62-4481-4d6e-9643-3ca499df7aaa": {
     "rule_name": "External Alerts",

--- a/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -47,6 +47,6 @@ name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
 
 [rule.threshold]
-field = [""]
+field = []
 value = 25
 


### PR DESCRIPTION
## Issues
related to #1097 
related to #1099 (same change targeting main)

## Summary
Changes `threshold.field` to disallow empty strings and instead just use an empty array for non-defined values.