### PR TITLE
Convert windows rules from KQL to EQL

### DIFF
--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/07"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ RHEL) and macOS systems.
 """
 from = "now-9m"
 index = ["auditbeat-*", "winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Hosts File Modified"
 note = "For Windows systems using Auditbeat, this rule requires adding 'C:/Windows/System32/drivers/etc' as an additional path in the 'file_integrity' module of auditbeat.yml."
@@ -23,10 +23,11 @@ rule_id = "9c260313-c811-4ec8-ab89-8f6530e0246c"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Windows", "macOS", "Threat Detection", "Impact"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and event.type:(change or creation) and file.path:("/private/etc/hosts" or "/etc/hosts" or "C:\Windows\System32\drivers\etc\hosts")
+file where event.type in ("change", "creation") and
+  file.path : ("/private/etc/hosts", "/etc/hosts", "C:\\Windows\\System32\\drivers\\etc\\hosts")
 '''
 
 
@@ -34,17 +35,17 @@ event.category:file and event.type:(change or creation) and file.path:("/private
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1565"
-name = "Data Manipulation"
 reference = "https://attack.mitre.org/techniques/T1565/"
+name = "Data Manipulation"
 [[rule.threat.technique.subtechnique]]
 id = "T1565.001"
-name = "Stored Data Manipulation"
 reference = "https://attack.mitre.org/techniques/T1565/001/"
+name = "Stored Data Manipulation"
 
 
 
 [rule.threat.tactic]
 id = "TA0040"
-name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+name = "Impact"
 

--- a/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
+++ b/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ download arbitrary files as an alternative to certutil.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Remote File Download via Desktopimgdownldr Utility"
 references = ["https://labs.sentinelone.com/living-off-windows-land-a-new-native-file-downldr/"]
@@ -20,12 +20,12 @@ rule_id = "15c0b7a7-9c34-4869-b25b-fa6518414899"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  (process.name:desktopimgdownldr.exe or process.pe.original_file_name:desktopimgdownldr.exe) and
-  process.args:/lockscreenurl\:http*
+process where event.type in ("start", "process_started") and
+  (process.name : "desktopimgdownldr.exe" or process.pe.original_file_name == "desktopimgdownldr.exe") and
+  process.args : "/lockscreenurl:http*"
 '''
 
 
@@ -33,12 +33,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1105"
-name = "Ingress Tool Transfer"
 reference = "https://attack.mitre.org/techniques/T1105/"
+name = "Ingress Tool Transfer"
 
 
 [rule.threat.tactic]
 id = "TA0011"
-name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+name = "Command and Control"
 

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -27,7 +27,7 @@ type = "eql"
 query = '''
 process where event.type == "start" and
   (process.name : "MpCmdRun.exe" or process.pe.original_file_name == "MpCmdRun.exe") and
-  process.args : (("-DownloadFile" or "-downloadfile") and "-url" and "-path")
+  (process.args : ("-DownloadFile", "-downloadfile") and process.args : "-url" and process.args : "-path")
 '''
 
 

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies the Windows Defender configuration utility (MpCmdRun.exe) being used to download a remote file."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Remote File Download via MpCmdRun"
 note = """### Investigating Remote File Download via MpCmdRun
@@ -22,12 +22,12 @@ rule_id = "c6453e73-90eb-4fe7-a98c-cde7bbfc504a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  (process.name:MpCmdRun.exe or process.pe.original_file_name:MpCmdRun.exe) and
-  process.args:(("-DownloadFile" or "-downloadfile") and "-url" and "-path")
+process where event.type == "start" and
+  (process.name : "MpCmdRun.exe" or process.pe.original_file_name == "MpCmdRun.exe") and
+  process.args : (("-DownloadFile" or "-downloadfile") and "-url" and "-path")
 '''
 
 
@@ -35,12 +35,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1105"
-name = "Ingress Tool Transfer"
 reference = "https://attack.mitre.org/techniques/T1105/"
+name = "Ingress Tool Transfer"
 
 
 [rule.threat.tactic]
 id = "TA0011"
-name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+name = "Command and Control"
 

--- a/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
+++ b/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ post-exploitation command and control activity of the SUNBURST backdoor.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "SUNBURST Command and Control Activity"
 note = "The SUNBURST malware attempts to hide within the Orion Improvement Program (OIP) network traffic. As this rule detects post-exploitation network traffic, investigations into this should be prioritized."
@@ -23,24 +23,22 @@ rule_id = "22599847-5d13-48cb-8872-5796fee8692b"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:network and event.type:protocol and network.protocol:http and
-	process.name:(
-		ConfigurationWizard.exe or
-		NetFlowService.exe or
-		NetflowDatabaseMaintenance.exe or
-		SolarWinds.Administration.exe or
-		SolarWinds.BusinessLayerHost.exe or
-		SolarWinds.BusinessLayerHostx64.exe or
-		SolarWinds.Collector.Service.exe or
-		SolarwindsDiagnostics.exe) and
-  http.request.body.content:((
-    (*/swip/Upload.ashx* and (POST* or PUT*)) or
-    (*/swip/SystemDescription* and (GET* or HEAD*)) or
-    (*/swip/Events* and (GET* or HEAD*))) and not
-    *solarwinds.com*)
+network where event.type == "protocol" and network.protocol == "http" and
+  process.name : ("ConfigurationWizard.exe",
+                  "NetFlowService.exe",
+                  "NetflowDatabaseMaintenance.exe",
+                  "SolarWinds.Administration.exe",
+                  "SolarWinds.BusinessLayerHost.exe",
+                  "SolarWinds.BusinessLayerHostx64.exe",
+                  "SolarWinds.Collector.Service.exe",
+                  "SolarwindsDiagnostics.exe") and
+  http.request.body.content:(("*/swip/Upload.ashx*" and ("POST*" or "PUT*")) or
+                             ("*/swip/SystemDescription*" and ("GET*" or "HEAD*")) or
+                             ("*/swip/Events*" and ("GET*" or "HEAD*"))) and
+  not http.request.body.content : "*solarwinds.com*"
 '''
 
 
@@ -48,34 +46,34 @@ event.category:network and event.type:protocol and network.protocol:http and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1071"
-name = "Application Layer Protocol"
 reference = "https://attack.mitre.org/techniques/T1071/"
+name = "Application Layer Protocol"
 [[rule.threat.technique.subtechnique]]
 id = "T1071.001"
-name = "Web Protocols"
 reference = "https://attack.mitre.org/techniques/T1071/001/"
+name = "Web Protocols"
 
 
 
 [rule.threat.tactic]
 id = "TA0011"
-name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+name = "Command and Control"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1195"
-name = "Supply Chain Compromise"
 reference = "https://attack.mitre.org/techniques/T1195/"
+name = "Supply Chain Compromise"
 [[rule.threat.technique.subtechnique]]
 id = "T1195.002"
-name = "Compromise Software Supply Chain"
 reference = "https://attack.mitre.org/techniques/T1195/002/"
+name = "Compromise Software Supply Chain"
 
 
 
 [rule.threat.tactic]
 id = "TA0001"
-name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+name = "Initial Access"
 

--- a/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
+++ b/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
@@ -35,9 +35,9 @@ network where event.type == "protocol" and network.protocol == "http" and
                   "SolarWinds.BusinessLayerHostx64.exe",
                   "SolarWinds.Collector.Service.exe",
                   "SolarwindsDiagnostics.exe") and
-  http.request.body.content:(("*/swip/Upload.ashx*" and ("POST*" or "PUT*")) or
-                             ("*/swip/SystemDescription*" and ("GET*" or "HEAD*")) or
-                             ("*/swip/Events*" and ("GET*" or "HEAD*"))) and
+  (http.request.body.content : "*/swip/Upload.ashx*" and http.request.body.content : ("POST*", "PUT*")) or
+  (http.request.body.content : "*/swip/SystemDescription*" and http.request.body.content : ("GET*", "HEAD*")) or
+  (http.request.body.content : "*/swip/Events*" and http.request.body.content : ("GET*", "HEAD*")) and
   not http.request.body.content : "*solarwinds.com*"
 '''
 

--- a/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
+++ b/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies an executable or script file remotely downloaded via a TeamViewer transfer session."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Remote File Copy via TeamViewer"
 references = ["https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html"]
@@ -17,12 +17,11 @@ rule_id = "b25a7df2-120a-4db2-bd3f-3e4b86b24bee"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and event.type:creation and
- process.name:TeamViewer.exe and
- file.extension:(exe or dll or scr or com or bat or ps1 or vbs or vbe or js or wsh or hta)
+file where event.type == "creation" and process.name : "TeamViewer.exe" and
+  file.extension : ("exe", "dll", "scr", "com", "bat", "ps1", "vbs", "vbe", "js", "wsh", "hta")
 '''
 
 
@@ -30,12 +29,12 @@ event.category:file and event.type:creation and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1105"
-name = "Ingress Tool Transfer"
 reference = "https://attack.mitre.org/techniques/T1105/"
+name = "Ingress Tool Transfer"
 
 
 [rule.threat.tactic]
 id = "TA0011"
-name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+name = "Command and Control"
 

--- a/rules/windows/credential_access_credential_dumping_msbuild.toml
+++ b/rules/windows/credential_access_credential_dumping_msbuild.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ credential management. This technique is sometimes used for credential dumping.
 false_positives = ["The Build Engine is commonly used by Windows developers but use by non-engineers is unusual."]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Loading Windows Credential Libraries"
 risk_score = 73
@@ -20,13 +20,12 @@ rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:change and
-  (process.pe.original_file_name:(vaultcli.dll or SAMLib.DLL) or
-    dll.name:(vaultcli.dll or SAMLib.DLL)) and
-  process.name: MSBuild.exe
+process where event.type == "change" and
+  (process.pe.original_file_name in ("vaultcli.dll", "SAMLib.DLL") or
+  dll.name : ("vaultcli.dll", "SAMLib.DLL")) and process.name : "MSBuild.exe"
 '''
 
 
@@ -34,12 +33,12 @@ event.category:process and event.type:change and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1003"
-name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+name = "OS Credential Dumping"
 
 
 [rule.threat.tactic]
 id = "TA0006"
-name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+name = "Credential Access"
 

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ Identifies the creation or modification of Domain Backup private keys. Adversari
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Creation or Modification of Domain Backup DPAPI private key"
 note = "### Domain DPAPI Backup keys are stored on domain controllers and can be dumped remotely with tools such as Mimikatz. The resulting .pvk private key can be used to decrypt ANY domain user masterkeys, which then can be used to decrypt any secrets protected by those keys."
@@ -24,11 +24,10 @@ rule_id = "b83a7e96-2eb3-4edf-8346-427b6858d3bd"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and not event.type:deletion and
- file.name:(ntds_capi_*.pfx or ntds_capi_*.pvk)
+file where event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
 '''
 
 
@@ -36,17 +35,17 @@ event.category:file and not event.type:deletion and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1552"
-name = "Unsecured Credentials"
 reference = "https://attack.mitre.org/techniques/T1552/"
+name = "Unsecured Credentials"
 [[rule.threat.technique.subtechnique]]
 id = "T1552.004"
-name = "Private Keys"
 reference = "https://attack.mitre.org/techniques/T1552/004/"
+name = "Private Keys"
 
 
 
 [rule.threat.tactic]
 id = "TA0006"
-name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+name = "Credential Access"
 

--- a/rules/windows/credential_access_lsass_memdump_file_created.toml
+++ b/rules/windows/credential_access_lsass_memdump_file_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ indicate a credential access attempt via trusted system utilities such as Task M
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "LSASS Memory Dump Creation"
 references = ["https://github.com/outflanknl/Dumpert", "https://github.com/hoangprod/AndrewSpecial"]
@@ -21,10 +21,11 @@ rule_id = "f2f46686-6f3c-4724-bd7d-24e31c70f98f"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and file.name:(lsass.DMP or lsass*.dmp or dumpert.dmp or Andrew.dmp or SQLDmpr*.mdmp or Coredump.dmp)
+file where
+  file.name : ("lsass.DMP", "lsass*.dmp", "dumpert.dmp", "Andrew.dmp", "SQLDmpr*.mdmp", "Coredump.dmp")
 '''
 
 
@@ -32,12 +33,12 @@ event.category:file and file.name:(lsass.DMP or lsass*.dmp or dumpert.dmp or And
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1003"
-name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+name = "OS Credential Dumping"
 
 
 [rule.threat.tactic]
 id = "TA0006"
-name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+name = "Credential Access"
 

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies the password log file from the default Mimikatz memssp module."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Mimikatz Memssp Log File Detected"
 risk_score = 73
@@ -16,10 +16,10 @@ rule_id = "ebb200e8-adf0-43f8-a0bb-4ee5b5d852c6"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and file.name:mimilsa.log and process.name:lsass.exe
+file where file.name : "mimilsa.log" and process.name : "lsass.exe"
 '''
 
 
@@ -27,12 +27,12 @@ event.category:file and file.name:mimilsa.log and process.name:lsass.exe
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1003"
-name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+name = "OS Credential Dumping"
 
 
 [rule.threat.tactic]
 id = "TA0006"
-name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+name = "Credential Access"
 

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Adversaries can add the 'hidden' attribute to files to hide them from the user in an attempt to evade detection."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Adding Hidden File Attribute via Attrib"
 risk_score = 21
@@ -16,10 +16,11 @@ rule_id = "4630d948-40d4-4cef-ac69-4002e29bc3db"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:attrib.exe and process.args:+h
+process where event.type in ("start", "process_started") and
+  process.name : "attrib.exe" and process.args : "+h"
 '''
 
 
@@ -27,24 +28,24 @@ event.category:process and event.type:(start or process_started) and process.nam
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1564"
-name = "Hide Artifacts"
 reference = "https://attack.mitre.org/techniques/T1564/"
+name = "Hide Artifacts"
 [[rule.threat.technique.subtechnique]]
 id = "T1564.001"
-name = "Hidden Files and Directories"
 reference = "https://attack.mitre.org/techniques/T1564/001/"
+name = "Hidden Files and Directories"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0003"
-name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+name = "Persistence"
 

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ attackers in an attempt to evade detection or destroy forensic evidence on a sys
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Clearing Windows Event Logs"
 risk_score = 21
@@ -19,12 +19,13 @@ rule_id = "d331bbe2-6db4-4941-80a5-8270db72eb61"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(process_started or start) and 
-(process.name:"wevtutil.exe" or process.pe.original_file_name:"wevtutil.exe") and 
-process.args:("/e:false" or cl or "clear-log") or process.name:"powershell.exe" and process.args:"Clear-EventLog"
+process where event.type in ("process_started", "start") and
+  (process.name : "wevtutil.exe" or process.pe.original_file_name == "wevtutil.exe") and
+    process.args : ("/e:false", "cl", "clear-log") or
+  process.name : "powershell.exe" and process.args : "Clear-EventLog"
 '''
 
 
@@ -32,12 +33,12 @@ process.args:("/e:false" or cl or "clear-log") or process.name:"powershell.exe" 
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
-name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+name = "Indicator Removal on Host"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_code_injection_conhost.toml
+++ b/rules/windows/defense_evasion_code_injection_conhost.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies a suspicious Conhost child process which may be an indication of code injection activity."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Process from Conhost"
 references = [
@@ -20,12 +20,12 @@ rule_id = "28896382-7d4f-4d50-9b72-67091901fd26"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.name:conhost.exe and
-  not process.executable:("C:\Windows\splwow64.exe" or "C:\Windows\System32\WerFault.exe" or "C:\\Windows\System32\conhost.exe")
+process where event.type in ("start", "process_started") and
+  process.parent.name : "conhost.exe" and
+  not process.executable : ("C:\\Windows\\splwow64.exe", "C:\\Windows\\System32\\WerFault.exe", "C:\\Windows\\System32\\conhost.exe")
 '''
 
 
@@ -33,12 +33,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1055"
-name = "Process Injection"
 reference = "https://attack.mitre.org/techniques/T1055/"
+name = "Process Injection"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
+++ b/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ of files created during post-exploitation activities.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Delete Volume USN Journal with Fsutil"
 risk_score = 21
@@ -19,11 +19,11 @@ rule_id = "f675872f-6d85-40a3-b502-c0d2ef101e92"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:fsutil.exe and process.args:(deletejournal and usn)
+process where event.type in ("start", "process_started") and
+  process.name : "fsutil.exe" and process.args : "deletejournal" and process.args : "usn"
 '''
 
 
@@ -31,17 +31,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
-name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+name = "Indicator Removal on Host"
 [[rule.threat.technique.subtechnique]]
 id = "T1070.004"
-name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+name = "File Deletion"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/defense_evasion_deleting_backup_catalogs_with_wbadmin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ system recovery.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Deleting Backup Catalogs with Wbadmin"
 risk_score = 21
@@ -19,11 +19,12 @@ rule_id = "581add16-df76-42bb-af8e-c979bfb39a59"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:wbadmin.exe and process.args:(catalog and delete)
+process where event.type in ("start", "process_started") and
+  process.name : "wbadmin.exe" and
+  process.args : "catalog" and process.args : "delete"
 '''
 
 
@@ -31,17 +32,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
-name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+name = "Indicator Removal on Host"
 [[rule.threat.technique.subtechnique]]
 id = "T1070.004"
-name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+name = "File Deletion"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ disable the firewall during troubleshooting or to enable network mobility.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Disable Windows Firewall Rules via Netsh"
 risk_score = 47
@@ -19,12 +19,13 @@ rule_id = "4b438734-3793-4fda-bd42-ceeada0be8f9"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:netsh.exe and
-  process.args:(disable and firewall and set) or process.args:(advfirewall and off and state)
+process where event.type in ("start", "process_started") and
+  process.name : "netsh.exe" and
+  (process.args : "disable" and process.args : "firewall" and process.args : "set") or
+  (process.args : "advfirewall" and process.args : "off" and process.args : "state")
 '''
 
 
@@ -32,17 +33,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1562"
-name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
+name = "Impair Defenses"
 [[rule.threat.technique.subtechnique]]
 id = "T1562.001"
-name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+name = "Disable or Modify Tools"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
+++ b/rules/windows/defense_evasion_encoding_or_decoding_files_via_certutil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ control or exfiltration.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Encoding or Decoding Files via CertUtil"
 risk_score = 47
@@ -20,11 +20,11 @@ rule_id = "fd70c98a-c410-42dc-a2e3-761c71848acf"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:certutil.exe and process.args:(-decode or -encode or /decode or /encode)
+process where event.type in ("start", "process_started") and
+  process.name : "certutil.exe" and process.args : ("-decode", "-encode", "/decode", "/encode")
 '''
 
 
@@ -32,12 +32,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1140"
-name = "Deobfuscate/Decode Files or Information"
 reference = "https://attack.mitre.org/techniques/T1140/"
+name = "Deobfuscate/Decode Files or Information"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by an Office Application"
 references = ["https://blog.talosintelligence.com/2020/02/building-bypass-with-msbuild.html"]
@@ -26,13 +26,19 @@ rule_id = "c5dc3223-13a2-44a2-946c-e9dc0aa0449c"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:MSBuild.exe and
-  process.parent.name:(eqnedt32.exe or excel.exe or fltldr.exe or msaccess.exe or
-                       mspub.exe or outlook.exe or powerpnt.exe or winword.exe)
+procesds where event.type in ("start", "process_started") and
+  process.name : "MSBuild.exe" and
+  process.parent.name : ("eqnedt32.exe",
+                         "excel.exe",
+                         "fltldr.exe",
+                         "msaccess.exe",
+                         "mspub.exe",
+                         "outlook.exe",
+                         "powerpnt.exe",
+                         "winword.exe" )
 '''
 
 
@@ -40,19 +46,19 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1127"
-name = "Trusted Developer Utilities Proxy Execution"
 reference = "https://attack.mitre.org/techniques/T1127/"
+name = "Trusted Developer Utilities Proxy Execution"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ behavior is unusual and is sometimes used by malicious payloads.
 false_positives = ["The Build Engine is commonly used by Windows developers but use by non-engineers is unusual."]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by a Script Process"
 risk_score = 21
@@ -20,12 +20,12 @@ rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type: start and
-  process.name:MSBuild.exe and
-  process.parent.name:(cmd.exe or powershell.exe or cscript.exe or wscript.exe)
+process where event.type == "start" and
+  process.name : "MSBuild.exe" and
+  process.parent.name : ("cmd.exe", "powershell.exe", "cscript.exe", "wscript.exe")
 '''
 
 
@@ -33,19 +33,19 @@ event.category:process and event.type: start and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1127"
-name = "Trusted Developer Utilities Proxy Execution"
 reference = "https://attack.mitre.org/techniques/T1127/"
+name = "Trusted Developer Utilities Proxy Execution"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Instrumentation) subsystem. This behavior is unusual and is sometimes used by ma
 false_positives = ["The Build Engine is commonly used by Windows developers but use by non-engineers is unusual."]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by a System Process"
 risk_score = 47
@@ -20,12 +20,12 @@ rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae3"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:MSBuild.exe and
-  process.parent.name:(explorer.exe or wmiprvse.exe)
+process where event.type in ("start", "process_started") and
+  process.name : "MSBuild.exe" and
+  process.parent.name : ("explorer.exe", "wmiprvse.exe")
 '''
 
 
@@ -33,19 +33,19 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1127"
-name = "Trusted Developer Utilities Proxy Execution"
 reference = "https://attack.mitre.org/techniques/T1127/"
+name = "Trusted Developer Utilities Proxy Execution"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ indicate an attempt to run unnoticed or undetected.
 false_positives = ["The Build Engine is commonly used by Windows developers but use by non-engineers is unusual."]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Using an Alternate Name"
 risk_score = 21
@@ -20,12 +20,12 @@ rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae4"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.pe.original_file_name:MSBuild.exe and
-  not process.name: MSBuild.exe
+process where event.type in ("start", "process_started") and
+  process.pe.original_file_name == "MSBuild.exe" and
+  not process.name : "MSBuild.exe"
 '''
 
 
@@ -33,12 +33,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1036"
-name = "Masquerading"
 reference = "https://attack.mitre.org/techniques/T1036/"
+name = "Masquerading"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started an Unusual Process"
 references = ["https://blog.talosintelligence.com/2020/02/building-bypass-with-msbuild.html"]
@@ -26,11 +26,12 @@ rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae6"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.name:MSBuild.exe and process.name:(csc.exe or iexplore.exe or powershell.exe)
+process where event.type in ("start", "process_started") and
+  process.parent.name : "MSBuild.exe" and
+  process.name : ("csc.exe", "iexplore.exe", "powershell.exe")
 '''
 
 
@@ -38,17 +39,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1027"
-name = "Obfuscated Files or Information"
 reference = "https://attack.mitre.org/techniques/T1027/"
+name = "Obfuscated Files or Information"
 [[rule.threat.technique.subtechnique]]
 id = "T1027.004"
-name = "Compile After Delivery"
 reference = "https://attack.mitre.org/techniques/T1027/004/"
+name = "Compile After Delivery"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
+++ b/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ defenses via side loading a malicious DLL within the memory space of one of thos
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Potential DLL SideLoading via Trusted Microsoft Programs"
 risk_score = 73
@@ -20,17 +20,19 @@ rule_id = "1160dcdb-0a0a-4a79-91d8-9b84616edebd"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.pe.original_file_name:(WinWord.exe or EXPLORER.EXE or w3wp.exe or DISM.EXE) and
-  not (process.name:(winword.exe or WINWORD.EXE or explorer.exe or w3wp.exe or Dism.exe) or
-             process.executable:("C:\Windows\explorer.exe" or
-                                  C\:\\Program?Files\\Microsoft?Office\\root\\Office*\\WINWORD.EXE or
-                                  C\:\\Program?Files?\(x86\)\\Microsoft?Office\\root\\Office*\\WINWORD.EXE or
-                                 "C:\Windows\System32\Dism.exe" or "C:\Windows\SysWOW64\Dism.exe" or
-                                 "C:\Windows\System32\inetsrv\w3wp.exe"))
+process where event.type in ("start", "process_started") and
+  process.pe.original_file_name in ( "WinWord.exe", "EXPLORER.EXE", "w3wp.exe", "DISM.EXE" ) and
+  not (process.name : ( "winword.exe", "explorer.exe", "w3wp.exe", "Dism.exe" ) or
+         process.executable : ("C:\\Windows\\explorer.exe",
+                               "C:\\Program?Files\\Microsoft?Office\\root\\Office*\\WINWORD.EXE",
+                               "C:\\Program?Files?(x86)\\Microsoft?Office\\root\\Office*\\WINWORD.EXE",
+                               "C:\\Windows\\System32\\Dism.exe",
+                               "C:\\Windows\\SysWOW64\\Dism.exe",
+                               "C:\\Windows\\System32\\inetsrv\\w3wp.exe")
+         )
 '''
 
 
@@ -38,12 +40,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1036"
-name = "Masquerading"
 reference = "https://attack.mitre.org/techniques/T1036/"
+name = "Masquerading"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
+++ b/rules/windows/defense_evasion_execution_via_trusted_developer_utilities.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -9,7 +9,7 @@ description = "Identifies possibly suspicious activity using trusted Windows dev
 false_positives = ["These programs may be used by Windows developers but use by non-engineers is unusual."]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Trusted Developer Application Usage"
 risk_score = 21
@@ -17,10 +17,10 @@ rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:(MSBuild.exe or msxsl.exe)
+process where event.type in ("start", "process_started") and process.name : ("MSBuild.exe", "msxsl.exe")
 '''
 
 
@@ -28,19 +28,19 @@ event.category:process and event.type:(start or process_started) and process.nam
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1127"
-name = "Trusted Developer Utilities Proxy Execution"
 reference = "https://attack.mitre.org/techniques/T1127/"
+name = "Trusted Developer Utilities Proxy Execution"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/defense_evasion_iis_httplogging_disabled.toml
+++ b/rules/windows/defense_evasion_iis_httplogging_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ access via a webshell or other mechanism can disable HTTP Logging as an effectiv
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "IIS HTTP Logging Disabled"
@@ -20,13 +20,13 @@ rule_id = "ebf1adea-ccf2-4943-8b96-7ab11ca173a5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  (process.name:appcmd.exe or process.pe.original_file_name:appcmd.exe) and
-  process.args:/dontLog\:\"True\" and
-  not process.parent.name:iissetup.exe
+process where event.type in ("start", "process_started") and
+  (process.name : "appcmd.exe" or process.pe.original_file_name == "appcmd.exe") and
+  process.args : """/dontLog:"True"""" and
+  not process.parent.name : "iissetup.exe"
 '''
 
 
@@ -34,12 +34,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
-name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+name = "Indicator Removal on Host"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
+++ b/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/24"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ such as command line, network connections, file writes and parent process detail
 false_positives = ["Custom Windows error reporting debugger or applications restarted by WerFault after a crash."]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Suspicious WerFault Child Process"
 references = [
@@ -25,13 +25,24 @@ rule_id = "ac5012b8-8da8-440b-aaaf-aedafdea2dff"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
- process.parent.name:WerFault.exe and
- not process.name:(cofire.exe or psr.exe or VsJITDebugger.exe or TTTracer.exe or rundll32.exe or LogiOptionsMgr.exe) and
- not process.args:("/LOADSAVEDWINDOWS" or "/restore" or RestartByRestartManager* or "--restarted" or createdump or dontsend or /watson)
+process where event.type in ("start", "process_started") and
+  process.parent.name : "WerFault.exe" and
+  not process.name : ("cofire.exe",
+                      "psr.exe",
+                      "VsJITDebugger.exe",
+                      "TTTracer.exe",
+                      "rundll32.exe",
+                      "LogiOptionsMgr.exe") and
+  not process.args : ("/LOADSAVEDWINDOWS",
+                      "/restore",
+                      "RestartByRestartManager*",
+                      "--restarted",
+                      "createdump",
+                      "dontsend",
+                      "/watson" )
 '''
 
 
@@ -39,11 +50,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1036"
-name = "Masquerading"
 reference = "https://attack.mitre.org/techniques/T1036/"
+name = "Masquerading"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
+

--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/16"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ attacker as a destructive technique.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Modification of Boot Configuration"
 risk_score = 21
@@ -19,13 +19,13 @@ rule_id = "69c251fb-a5d6-4035-b5ec-40438bd829ff"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:bcdedit.exe and
-  process.args:(/set and
-    (bootstatuspolicy and ignoreallfailures or no and recoveryenabled))
+process where event.type in ("start", "process_started") and
+  process.name : "bcdedit.exe" and
+  (process.args : "/set" and process.args == "bootstatuspolicy" and process.args == "ignoreallfailures") or
+  (process.args : "no" and process.args : "recoveryenabled")
 '''
 
 
@@ -33,17 +33,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
-name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+name = "Indicator Removal on Host"
 [[rule.threat.technique.subtechnique]]
 id = "T1070.004"
-name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+name = "File Deletion"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
+++ b/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ code execution.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Managed Code Hosting Process"
 references = ["https://blog.menasec.net/2019/07/interesting-difr-traces-of-net-clr.html"]
@@ -20,11 +20,17 @@ rule_id = "acf738b5-b5b2-4acc-bad9-1e18ee234f40"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and not event.type:deletion and
-  file.name:(wscript.exe.log or mshta.exe.log or wscript.exe.log or wmic.exe.log or svchost.exe.log or dllhost.exe.log or cmstp.exe.log or regsvr32.exe.log)
+file where event.type != "deletion" and
+  file.name : ("wscript.exe.log",
+               "mshta.exe.log",
+               "wmic.exe.log",
+               "svchost.exe.log",
+               "dllhost.exe.log",
+               "cmstp.exe.log",
+               "regsvr32.exe.log")
 '''
 
 
@@ -32,12 +38,12 @@ event.category:file and not event.type:deletion and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1055"
-name = "Process Injection"
 reference = "https://attack.mitre.org/techniques/T1055/"
+name = "Process Injection"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
+++ b/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ indicate activity related to remote code execution or other forms of exploitatio
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Unusual Executable File Creation by a System Critical Process"
 risk_score = 73
@@ -19,12 +19,20 @@ rule_id = "e94262f2-c1e9-4d3f-a907-aeab16712e1a"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and not event.type:deletion and
-  file.extension:(exe or dll) and
-  process.name:(smss.exe or autochk.exe or csrss.exe or wininit.exe or services.exe or lsass.exe or winlogon.exe or userinit.exe or LogonUI.exe)
+file where event.type != "deletion" and
+  file.extension : ("exe", "dll") and
+  process.name : ("smss.exe",
+                  "autochk.exe",
+                  "csrss.exe",
+                  "wininit.exe",
+                  "services.exe",
+                  "lsass.exe",
+                  "winlogon.exe",
+                  "userinit.exe",
+                  "LogonUI.exe" )
 '''
 
 
@@ -32,12 +40,12 @@ event.category:file and not event.type:deletion and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1211"
-name = "Exploitation for Defense Evasion"
 reference = "https://attack.mitre.org/techniques/T1211/"
+name = "Exploitation for Defense Evasion"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
+++ b/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies a suspicious child process of the Windows virtual system process, which could indicate code injection."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Unusual Child Process from a System Virtual Process"
 risk_score = 73
@@ -16,12 +16,12 @@ rule_id = "de9bd7e0-49e9-4e92-a64d-53ade2e66af1"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.pid:4 and
-  not process.executable:(Registry or MemCompression or "C:\Windows\System32\smss.exe")
+process where event.type in ("start", "process_started") and
+  process.parent.pid == 4 and
+  not process.executable : ("Registry", "MemCompression", "C:\\Windows\\System32\\smss.exe")
 '''
 
 
@@ -29,12 +29,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1055"
-name = "Process Injection"
 reference = "https://attack.mitre.org/techniques/T1055/"
+name = "Process Injection"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ defenses.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Potential Evasion via Filter Manager"
 risk_score = 21
@@ -19,10 +19,10 @@ rule_id = "06dceabf-adca-48af-ac79-ffdf4c3b1e9a"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:fltMC.exe
+process where and event.type in ("start", "process_started") and process.name : "fltMC.exe"
 '''
 
 
@@ -30,12 +30,12 @@ event.category:process and event.type:(start or process_started) and process.nam
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1222"
-name = "File and Directory Permissions Modification"
 reference = "https://attack.mitre.org/techniques/T1222/"
+name = "File and Directory Permissions Modification"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -22,7 +22,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where and event.type in ("start", "process_started") and process.name : "fltMC.exe"
+process where event.type in ("start", "process_started") and process.name : "fltMC.exe"
 '''
 
 

--- a/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/defense_evasion_volume_shadow_copy_deletion_via_wmic.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ other destructive attacks.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Volume Shadow Copy Deletion via WMIC"
 risk_score = 73
@@ -19,11 +19,12 @@ rule_id = "dc9c1f74-dac3-48e3-b47f-eb79db358f57"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:WMIC.exe and process.args:(delete and shadowcopy)
+process where event.type in ("start", "process_started") and
+  process.name : "WMIC.exe" and
+  process.args : "delete" and process.args : "shadowcopy"
 '''
 
 
@@ -31,17 +32,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
-name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+name = "Indicator Removal on Host"
 [[rule.threat.technique.subtechnique]]
 id = "T1070.004"
-name = "File Deletion"
 reference = "https://attack.mitre.org/techniques/T1070/004/"
+name = "File Deletion"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -23,7 +23,7 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and user.name == "SYSTEM" and
-  (process.name : ("whoami.exe", "net.exe") or
+  process.name : ("whoami.exe", "net.exe") or
   (process.name : "net1.exe" and not process.parent.name : "net.exe")
 '''
 

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ adversary has achieved privilege escalation.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Net command via SYSTEM account"
 risk_score = 21
@@ -19,12 +19,12 @@ rule_id = "2856446a-34e6-435b-9fb5-f8f040bfa7ed"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  (process.name:(whoami.exe or net.exe) or process.name:net1.exe and not process.parent.name:net.exe) and
-  user.name:SYSTEM
+process where event.type in ("start", "process_started") and user.name == "SYSTEM" and
+  (process.name : ("whoami.exe", "net.exe") or
+  (process.name : "net1.exe" and not process.parent.name : "net.exe")
 '''
 
 
@@ -32,12 +32,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1087"
-name = "Account Discovery"
 reference = "https://attack.mitre.org/techniques/T1087/"
+name = "Account Discovery"
 
 
 [rule.threat.tactic]
 id = "TA0007"
-name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+name = "Discovery"
 

--- a/rules/windows/discovery_process_discovery_via_tasklist_command.toml
+++ b/rules/windows/discovery_process_discovery_via_tasklist_command.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +15,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Process Discovery via Tasklist"
 risk_score = 21
@@ -23,10 +23,10 @@ rule_id = "cc16f774-59f9-462d-8b98-d27ccd4519ec"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:tasklist.exe
+process where event.type in ("start", "process_started") and process.name : "tasklist.exe"
 '''
 
 
@@ -34,12 +34,12 @@ event.category:process and event.type:(start or process_started) and process.nam
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1057"
-name = "Process Discovery"
 reference = "https://attack.mitre.org/techniques/T1057/"
+name = "Process Discovery"
 
 
 [rule.threat.tactic]
 id = "TA0007"
-name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+name = "Discovery"
 

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Whoami Process Activity"
 risk_score = 21
@@ -25,10 +25,10 @@ rule_id = "ef862985-3f13-4262-a686-5f357bbb9bc2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:whoami.exe
+process where event.type in ("start", "process_started") and process.name : "whoami.exe"
 '''
 
 
@@ -36,12 +36,12 @@ event.category:process and event.type:(start or process_started) and process.nam
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1033"
-name = "System Owner/User Discovery"
 reference = "https://attack.mitre.org/techniques/T1033/"
+name = "System Owner/User Discovery"
 
 
 [rule.threat.tactic]
 id = "TA0007"
-name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+name = "Discovery"
 

--- a/rules/windows/execution_command_shell_started_by_powershell.toml
+++ b/rules/windows/execution_command_shell_started_by_powershell.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies a suspicious parent child process relationship with cmd.exe descending from PowerShell.exe."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "PowerShell spawning Cmd"
 risk_score = 21
@@ -16,11 +16,11 @@ rule_id = "0f616aee-8161-4120-857e-742366f5eeb3"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.name:powershell.exe and process.name:cmd.exe
+process where event.type in ("start", "process_started") and
+  process.parent.name : "powershell.exe" and process.name : "cmd.exe"
 '''
 
 
@@ -28,17 +28,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
+name = "Command and Scripting Interpreter"
 [[rule.threat.technique.subtechnique]]
 id = "T1059.001"
-name = "PowerShell"
 reference = "https://attack.mitre.org/techniques/T1059/001/"
+name = "PowerShell"
 
 
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies a suspicious parent child process relationship with cmd.exe descending from svchost.exe"
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Svchost spawning Cmd"
 risk_score = 21
@@ -16,11 +16,11 @@ rule_id = "fd7a6052-58fa-4397-93c3-4795249ccfa2"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.name:svchost.exe and process.name:cmd.exe
+process where event.type in ("start", "process_started") and
+  process.parent.name : "svchost.exe" and process.name : "cmd.exe"
 '''
 
 
@@ -28,12 +28,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
+name = "Command and Scripting Interpreter"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies a suspicious parent child process relationship with cmd.exe descending from an unusual process."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Unusual Parent Process for cmd.exe"
 risk_score = 47
@@ -16,14 +16,35 @@ rule_id = "3b47900d-e793-49e8-968f-c90dc3526aa1"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:cmd.exe and
-  process.parent.name:(lsass.exe or csrss.exe or notepad.exe or regsvr32.exe or dllhost.exe or LogonUI.exe or wermgr.exe or spoolsv.exe or
-   jucheck.exe or jusched.exe or ctfmon.exe or taskhostw.exe or GoogleUpdate.exe or sppsvc.exe or sihost.exe or slui.exe or
-   SIHClient.exe or SearchIndexer.exe or SearchProtocolHost.exe or FlashPlayerUpdateService.exe or WerFault.exe or WUDFHost.exe or unsecapp.exe or wlanext.exe)
+process where event.type in ("start", "process_started") and
+  process.name : "cmd.exe" and
+  process.parent.name : ("lsass.exe",
+                         "csrss.exe",
+                         "epad.exe",
+                         "regsvr32.exe",
+                         "dllhost.exe",
+                         "LogonUI.exe",
+                         "wermgr.exe",
+                         "spoolsv.exe",
+                         "jucheck.exe",
+                         "jusched.exe",
+                         "ctfmon.exe",
+                         "taskhostw.exe",
+                         "GoogleUpdate.exe",
+                         "sppsvc.exe",
+                         "sihost.exe",
+                         "slui.exe",
+                         "SIHClient.exe",
+                         "SearchIndexer.exe",
+                         "SearchProtocolHost.exe",
+                         "FlashPlayerUpdateService.exe",
+                         "WerFault.exe",
+                         "WUDFHost.exe",
+                         "unsecapp.exe",
+                         "wlanext.exe" )
 '''
 
 
@@ -31,12 +52,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
+name = "Command and Scripting Interpreter"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/30"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ exploitation of PDF applications or social engineering.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Suspicious PDF Reader Child Process"
 risk_score = 21
@@ -19,19 +19,22 @@ rule_id = "53a26770-9cbd-40c5-8b57-61d01a325e14"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.name:(AcroRd32.exe or Acrobat.exe or FoxitPhantomPDF.exe or FoxitReader.exe) and
-  process.name:(arp.exe or dsquery.exe or dsget.exe or gpresult.exe or hostname.exe or ipconfig.exe or nbtstat.exe or
-                net.exe or net1.exe or netsh.exe or netstat.exe or nltest.exe or ping.exe or qprocess.exe or
-                quser.exe or qwinsta.exe or reg.exe or sc.exe or systeminfo.exe or tasklist.exe or tracert.exe or
-                whoami.exe or bginfo.exe or cdb.exe or cmstp.exe or csi.exe or dnx.exe or fsi.exe or ieexec.exe or
-                iexpress.exe or installutil.exe or Microsoft.Workflow.Compiler.exe or msbuild.exe or mshta.exe or
-                msxsl.exe or odbcconf.exe or rcsi.exe or regsvr32.exe or xwizard.exe or atbroker.exe or forfiles.exe or
-                schtasks.exe or regasm.exe or regsvcs.exe or cmd.exe or cscript.exe or powershell.exe or pwsh.exe or
-                wmic.exe or wscript.exe or bitsadmin.exe or certutil.exe or ftp.exe)
+process where event.type in ("start", "process_started") and
+  process.parent.name : ("AcroRd32.exe",
+                         "Acrobat.exe",
+                         "FoxitPhantomPDF.exe",
+                         "FoxitReader.exe") and
+  process.name : ("arp.exe", "dsquery.exe", "dsget.exe", "gpresult.exe", "hostname.exe", "ipconfig.exe", "nbtstat.exe",
+                  "net.exe", "net1.exe", "netsh.exe", "netstat.exe", "nltest.exe", "ping.exe", "qprocess.exe",
+                  "quser.exe", "qwinsta.exe", "reg.exe", "sc.exe", "systeminfo.exe", "tasklist.exe", "tracert.exe",
+                  "whoami.exe", "bginfo.exe", "cdb.exe", "cmstp.exe", "csi.exe", "dnx.exe", "fsi.exe", "ieexec.exe",
+                  "iexpress.exe", "installutil.exe", "Microsoft.Workflow.Compiler.exe", "msbuild.exe", "mshta.exe",
+                  "msxsl.exe", "odbcconf.exe", "rcsi.exe", "regsvr32.exe", "xwizard.exe", "atbroker.exe",
+                  "forfiles.exe", "schtasks.exe", "regasm.exe", "regsvcs.exe", "cmd.exe", "cscript.exe",
+                  "powershell.exe", "pwsh.exe", "wmic.exe", "wscript.exe", "bitsadmin.exe", "certutil.exe", "ftp.exe")
 '''
 
 
@@ -39,12 +42,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1204"
-name = "User Execution"
 reference = "https://attack.mitre.org/techniques/T1204/"
+name = "User Execution"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/execution_via_compiled_html_file.toml
+++ b/rules/windows/execution_via_compiled_html_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Process Activity via Compiled HTML File"
 risk_score = 21
@@ -27,10 +27,10 @@ rule_id = "e3343ab9-4245-4715-b344-e11c56b0a47f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:hh.exe
+process where event.type in ("start", "process_started") and process.name : "hh.exe"
 '''
 
 
@@ -39,23 +39,23 @@ framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1218"
-name = "Signed Binary Proxy Execution"
 reference = "https://attack.mitre.org/techniques/T1218/"
+name = "Signed Binary Proxy Execution"
 [[rule.threat.technique.subtechnique]]
 id = "T1218.001"
-name = "Compiled HTML File"
 reference = "https://attack.mitre.org/techniques/T1218/001/"
+name = "Compiled HTML File"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
 

--- a/rules/windows/execution_via_hidden_shell_conhost.toml
+++ b/rules/windows/execution_via_hidden_shell_conhost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ indicative of code injection.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Conhost Spawned By Suspicious Parent Process"
 references = [
@@ -22,12 +22,14 @@ rule_id = "05b358de-aa6d-4f6c-89e6-78f74018b43b"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
- process.name:conhost.exe and
- process.parent.name:(svchost.exe or lsass.exe or services.exe or smss.exe or winlogon.exe or explorer.exe or dllhost.exe or rundll32.exe or regsvr32.exe or userinit.exe or wininit.exe or spoolsv.exe or wermgr.exe or csrss.exe or ctfmon.exe)
+process where event.type in ("start", "process_started") and
+  process.name : "conhost.exe" and
+  process.parent.name : ("svchost.exe", "lsass.exe", "services.exe", "smss.exe", "winlogon.exe", "explorer.exe",
+                         "dllhost.exe", "rundll32.exe", "regsvr32.exe", "userinit.exe", "wininit.exe", "spoolsv.exe",
+                         "wermgr.exe", "csrss.exe", "ctfmon.exe" )
 '''
 
 
@@ -35,12 +37,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
+name = "Command and Scripting Interpreter"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ using xp_cmdshell, which is disabled by default, thus, it's important to review 
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Execution via MSSQL xp_cmdshell Stored Procedure"
 risk_score = 73
@@ -19,12 +19,11 @@ rule_id = "4ed493fc-d637-4a36-80ff-ac84937e5461"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:cmd.exe and
-  process.parent.name:sqlservr.exe
+process where event.type in ("start", "process_started") and
+  process.name : "cmd.exe" and process.parent.name : "sqlservr.exe"
 '''
 
 
@@ -32,12 +31,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
+name = "Command and Scripting Interpreter"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+name = "Execution"
 

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_vssadmin.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_vssadmin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ other destructive attacks.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Volume Shadow Copy Deletion via VssAdmin"
 risk_score = 73
@@ -19,10 +19,12 @@ rule_id = "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Impact"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:vssadmin.exe and process.args:(delete and shadows)
+process where event.type in ("start", "process_started") and
+  process.name : "vssadmin.exe" and
+  process.args : "delete" and process.args : "shadows"
 '''
 
 
@@ -30,12 +32,12 @@ event.category:process and event.type:(start or process_started) and process.nam
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1490"
-name = "Inhibit System Recovery"
 reference = "https://attack.mitre.org/techniques/T1490/"
+name = "Inhibit System Recovery"
 
 
 [rule.threat.tactic]
 id = "TA0040"
-name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+name = "Impact"
 

--- a/rules/windows/initial_access_script_executing_powershell.toml
+++ b/rules/windows/initial_access_script_executing_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ executing a PowerShell script, may be indicative of malicious activity.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Windows Script Executing PowerShell"
 risk_score = 21
@@ -19,10 +19,11 @@ rule_id = "f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Initial Access"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.parent.name:(cscript.exe or wscript.exe) and process.name:powershell.exe
+process where event.type in ("start", "process_started") and
+  process.parent.name : ("cscript.exe", "wscript.exe") and process.name : "powershell.exe"
 '''
 
 
@@ -30,17 +31,17 @@ event.category:process and event.type:(start or process_started) and process.par
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1566"
-name = "Phishing"
 reference = "https://attack.mitre.org/techniques/T1566/"
+name = "Phishing"
 [[rule.threat.technique.subtechnique]]
 id = "T1566.001"
-name = "Spearphishing Attachment"
 reference = "https://attack.mitre.org/techniques/T1566/001/"
+name = "Spearphishing Attachment"
 
 
 
 [rule.threat.tactic]
 id = "TA0001"
-name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+name = "Initial Access"
 

--- a/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ phishing activity.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Suspicious MS Outlook Child Process"
 risk_score = 21
@@ -19,10 +19,19 @@ rule_id = "32f4675e-6c49-4ace-80f9-97c9259dca2e"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Initial Access"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.parent.name:outlook.exe and process.name:(Microsoft.Workflow.Compiler.exe or arp.exe or atbroker.exe or  bginfo.exe or bitsadmin.exe or cdb.exe or certutil.exe or cmd.exe or cmstp.exe or cscript.exe or csi.exe or dnx.exe or dsget.exe or dsquery.exe or forfiles.exe or fsi.exe or ftp.exe or gpresult.exe or hostname.exe or ieexec.exe or iexpress.exe or installutil.exe or ipconfig.exe or mshta.exe or msxsl.exe or nbtstat.exe or net.exe or net1.exe or netsh.exe or netstat.exe or nltest.exe or odbcconf.exe or ping.exe or powershell.exe or pwsh.exe or qprocess.exe or quser.exe or qwinsta.exe or rcsi.exe or reg.exe or regasm.exe or regsvcs.exe or regsvr32.exe or sc.exe or schtasks.exe or systeminfo.exe or tasklist.exe or tracert.exe or whoami.exe or wmic.exe or wscript.exe or xwizard.exe)
+process where event.type in ("start", "process_started") and
+  process.parent.name : "outlook.exe" and
+  process.name : ("Microsoft.Workflow.Compiler.exe", "arp.exe", "atbroker.exe", "bginfo.exe", "bitsadmin.exe",
+                  "cdb.exe", "certutil.exe", "cmd.exe", "cmstp.exe", "cscript.exe", "csi.exe", "dnx.exe", "dsget.exe",
+                  "dsquery.exe", "forfiles.exe", "fsi.exe", "ftp.exe", "gpresult.exe", "hostname.exe", "ieexec.exe",
+                  "iexpress.exe", "installutil.exe", "ipconfig.exe", "mshta.exe", "msxsl.exe", "nbtstat.exe", "net.exe",
+                  "net1.exe", "netsh.exe", "netstat.exe", "nltest.exe", "odbcconf.exe", "ping.exe", "powershell.exe",
+                  "pwsh.exe", "qprocess.exe", "quser.exe", "qwinsta.exe", "rcsi.exe", "reg.exe", "regasm.exe",
+                  "regsvcs.exe", "regsvr32.exe", "sc.exe", "schtasks.exe", "systeminfo.exe", "tasklist.exe",
+                  "tracert.exe", "whoami.exe", "wmic.exe", "wscript.exe", "xwizard.exe")
 '''
 
 
@@ -30,17 +39,17 @@ event.category:process and event.type:(start or process_started) and process.par
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1566"
-name = "Phishing"
 reference = "https://attack.mitre.org/techniques/T1566/"
+name = "Phishing"
 [[rule.threat.technique.subtechnique]]
 id = "T1566.001"
-name = "Spearphishing Attachment"
 reference = "https://attack.mitre.org/techniques/T1566/001/"
+name = "Spearphishing Attachment"
 
 
 
 [rule.threat.tactic]
 id = "TA0001"
-name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+name = "Initial Access"
 

--- a/rules/windows/initial_access_unusual_dns_service_children.toml
+++ b/rules/windows/initial_access_unusual_dns_service_children.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Unusual Child Process of dns.exe"
 note = """### Investigating Unusual Child Process
@@ -37,10 +37,11 @@ rule_id = "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Initial Access"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:start and process.parent.name:dns.exe and not process.name:conhost.exe
+process where event.type == "start" and process.parent.name : "dns.exe" and
+  not process.name : "conhost.exe"
 '''
 
 
@@ -48,12 +49,12 @@ event.category:process and event.type:start and process.parent.name:dns.exe and 
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1133"
-name = "External Remote Services"
 reference = "https://attack.mitre.org/techniques/T1133/"
+name = "External Remote Services"
 
 
 [rule.threat.tactic]
 id = "TA0001"
-name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+name = "Initial Access"
 

--- a/rules/windows/initial_access_unusual_dns_service_file_writes.toml
+++ b/rules/windows/initial_access_unusual_dns_service_file_writes.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ may indicate activity related to remote code execution or other forms of exploit
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Unusual File Modification by dns.exe"
 note = """### Investigating Unusual File Write
@@ -27,10 +27,11 @@ rule_id = "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Initial Access"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and process.name:dns.exe and event.type:(creation or deletion or change) and not file.name:dns.log
+file where process.name : "dns.exe" and event.type in ("creation", "deletion", "change") and
+  not file.name : "dns.log"
 '''
 
 
@@ -38,12 +39,12 @@ event.category:file and process.name:dns.exe and event.type:(creation or deletio
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1133"
-name = "External Remote Services"
 reference = "https://attack.mitre.org/techniques/T1133/"
+name = "External Remote Services"
 
 
 [rule.threat.tactic]
 id = "TA0001"
-name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+name = "Initial Access"
 

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
 description = "Detects writing executable files that will be automatically launched by Adobe on launch."
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Adobe Hijack Persistence"
 risk_score = 21
@@ -16,13 +16,13 @@ rule_id = "2bf78aa2-9c56-48de-b139-f169bf99cf86"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and event.type:creation and
-  file.path:("C:\Program Files (x86)\Adobe\Acrobat Reader DC\Reader\AcroCEF\RdrCEF.exe" or
-             "C:\Program Files\Adobe\Acrobat Reader DC\Reader\AcroCEF\RdrCEF.exe") and
-  not process.name:msiexec.exe
+file where event.type == "creation" and
+  file.path : ("?:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
+               "?:\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe") and
+  not process.name : "msiexec.exe"
 '''
 
 
@@ -30,17 +30,17 @@ event.category:file and event.type:creation and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1574"
-name = "Hijack Execution Flow"
 reference = "https://attack.mitre.org/techniques/T1574/"
+name = "Hijack Execution Flow"
 [[rule.threat.technique.subtechnique]]
 id = "T1574.010"
-name = "Services File Permissions Weakness"
 reference = "https://attack.mitre.org/techniques/T1574/010/"
+name = "Services File Permissions Weakness"
 
 
 
 [rule.threat.tactic]
 id = "TA0003"
-name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+name = "Persistence"
 

--- a/rules/windows/persistence_gpo_schtask_service_creation.toml
+++ b/rules/windows/persistence_gpo_schtask_service_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ malicious payload remotely on all or a subset of the domain joined machines.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Creation or Modification of a new GPO Scheduled Task or Service"
 risk_score = 21
@@ -20,13 +20,13 @@ rule_id = "c0429aa8-9974-42da-bfb6-53a0a515a145"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and not event.type:deletion and
-  file.path:(C\:\\Windows\\SYSVOL\\domain\\Policies\\*\\MACHINE\\Preferences\\ScheduledTasks\\ScheduledTasks.xml or
-             C\:\\Windows\\SYSVOL\\domain\\Policies\\*\\MACHINE\\Preferences\\Preferences\\Services\\Services.xml) and
-  not process.name:dfsrs.exe
+file where event.type != "deletion" and
+  file.path : ("C:\\Windows\\SYSVOL\\domain\\Policies\\*\\MACHINE\\Preferences\\ScheduledTasks\\ScheduledTasks.xml",
+               "C:\\Windows\\SYSVOL\\domain\\Policies\\*\\MACHINE\\Preferences\\Preferences\\Services\\Services.xml") and
+  not process.name : "dfsrs.exe"
 '''
 
 
@@ -34,12 +34,12 @@ event.category:file and not event.type:deletion and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1053"
-name = "Scheduled Task/Job"
 reference = "https://attack.mitre.org/techniques/T1053/"
+name = "Scheduled Task/Job"
 
 
 [rule.threat.tactic]
 id = "TA0003"
-name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+name = "Persistence"
 

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ testers may run a shell as a service to gain SYSTEM permissions.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "System Shells via Services"
 risk_score = 47
@@ -19,12 +19,12 @@ rule_id = "0022d47d-39c7-4f69-a232-4fe9dc7a3acd"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.name:services.exe and
-  process.name:(cmd.exe or powershell.exe)
+process where event.type in ("start", "process_started") and
+  process.parent.name : "services.exe" and
+  process.name : ("cmd.exe", "powershell.exe")
 '''
 
 
@@ -32,17 +32,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1543"
-name = "Create or Modify System Process"
 reference = "https://attack.mitre.org/techniques/T1543/"
+name = "Create or Modify System Process"
 [[rule.threat.technique.subtechnique]]
 id = "T1543.003"
-name = "Windows Service"
 reference = "https://attack.mitre.org/techniques/T1543/003/"
+name = "Windows Service"
 
 
 
 [rule.threat.tactic]
 id = "TA0003"
-name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+name = "Persistence"
 

--- a/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
+++ b/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/09"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic", "Skoetting"]
@@ -12,7 +12,7 @@ any action in Active Directory and on domain-joined systems.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "User Added to Privileged Group in Active Directory"
 references = [
@@ -23,12 +23,17 @@ rule_id = "5cd8e1f7-0050-4afc-b2df-904e40b2f5ae"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:iam and event.action:"added-member-to-group" and
-  group.name:(Administrators or "Local Administrators" or "Domain Admins" or
-              "Enterprise Admins" or "Backup Admins" or "Schema Admins" or "DnsAdmins")
+iam where event.action == "added-member-to-group" and
+  group.name : ("Administrators",
+                "Local Administrators",
+                "Domain Admins",
+                "Enterprise Admins",
+                "Backup Admins",
+                "Schema Admins",
+                "DnsAdmins")
 '''
 
 
@@ -36,17 +41,17 @@ event.category:iam and event.action:"added-member-to-group" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1136"
-name = "Create Account"
 reference = "https://attack.mitre.org/techniques/T1136/"
+name = "Create Account"
 [[rule.threat.technique.subtechnique]]
 id = "T1136.001"
-name = "Local Account"
 reference = "https://attack.mitre.org/techniques/T1136/001/"
+name = "Local Account"
 
 
 
 [rule.threat.tactic]
 id = "TA0003"
-name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+name = "Persistence"
 

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ domain.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "User Account Creation"
 risk_score = 21
@@ -19,13 +19,13 @@ rule_id = "1aa9181a-492b-4c01-8b16-fa0735786b2b"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.name:(net.exe or net1.exe) and
-  not process.parent.name:net.exe and
-  process.args:(user and (/ad or /add))
+process where event.type in ("start" or "process_started") and
+  process.name : ("net.exe", "net1.exe") and
+  not process.parent.name : "net.exe" and
+  (process.args : "user" and process.args : ("/ad" or "/add"))
 '''
 
 
@@ -33,12 +33,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1136"
-name = "Create Account"
 reference = "https://attack.mitre.org/techniques/T1136/"
+name = "Create Account"
 
 
 [rule.threat.tactic]
 id = "TA0003"
-name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+name = "Persistence"
 

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -22,10 +22,10 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start" or "process_started") and
+process where event.type in ("start", "process_started") and
   process.name : ("net.exe", "net1.exe") and
   not process.parent.name : "net.exe" and
-  (process.args : "user" and process.args : ("/ad" or "/add"))
+  (process.args : "user" and process.args : ("/ad", "/add"))
 '''
 
 

--- a/rules/windows/persistence_via_application_shimming.toml
+++ b/rules/windows/persistence_via_application_shimming.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ code execution in legitimate Windows processes.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Potential Application Shimming via Sdbinst"
 risk_score = 21
@@ -20,10 +20,10 @@ rule_id = "fd4a992d-6130-4802-9ff8-829b89ae801f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:sdbinst.exe
+process where event.type in ("start", "process_started") and process.name : "sdbinst.exe"
 '''
 
 
@@ -31,34 +31,34 @@ event.category:process and event.type:(start or process_started) and process.nam
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1546"
-name = "Event Triggered Execution"
 reference = "https://attack.mitre.org/techniques/T1546/"
+name = "Event Triggered Execution"
 [[rule.threat.technique.subtechnique]]
 id = "T1546.011"
-name = "Application Shimming"
 reference = "https://attack.mitre.org/techniques/T1546/011/"
+name = "Application Shimming"
 
 
 
 [rule.threat.tactic]
 id = "TA0003"
-name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+name = "Persistence"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1546"
-name = "Event Triggered Execution"
 reference = "https://attack.mitre.org/techniques/T1546/"
+name = "Event Triggered Execution"
 [[rule.threat.technique.subtechnique]]
 id = "T1546.011"
-name = "Application Shimming"
 reference = "https://attack.mitre.org/techniques/T1546/011/"
+name = "Application Shimming"
 
 
 
 [rule.threat.tactic]
 id = "TA0004"
-name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+name = "Privilege Escalation"
 

--- a/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
+++ b/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ integrity level of system.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Persistence via TelemetryController Scheduled Task Hijack"
 references = [
@@ -22,12 +22,17 @@ rule_id = "68921d85-d0dc-48b3-865f-43291ca2c4f2"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.name:(CompatTelRunner.exe or compattelrunner.exe) and process.args:-cv* and
-  not process.name:(conhost.exe or DeviceCensus.exe or devicecensus.exe or CompatTelRunner.exe or compattelrunner.exe or DismHost.exe or dismhost.exe or rundll32.exe or powershell.exe)
+process where event.type in ("start", "process_started") and
+  process.parent.name : ("CompatTelRunner.exe", "compattelrunner.exe") and process.args : "-cv*" and
+  not process.name : ("conhost.exe",
+                      "DeviceCensus.exe",
+                      "CompatTelRunner.exe",
+                      "DismHost.exe",
+                      "rundll32.exe",
+                      "powershell.exe")
 '''
 
 
@@ -35,12 +40,12 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1053"
-name = "Scheduled Task/Job"
 reference = "https://attack.mitre.org/techniques/T1053/"
+name = "Scheduled Task/Job"
 
 
 [rule.threat.tactic]
 id = "TA0003"
-name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+name = "Persistence"
 

--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ system is patched.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Suspicious PrintSpooler Service Executable File Creation"
 references = [
@@ -24,13 +24,12 @@ rule_id = "5bb4a95d-5a08-48eb-80db-4c3a63ec78a8"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and not event.type:deletion and
-  process.name:spoolsv.exe and
-  file.extension:(exe or dll) and
-  not file.path:(C\:\\Windows\\System32\\spool\\* or C\:\\Windows\\Temp\\* or C\:\\Users\\*)
+file where event.type != "deletion" and process.name : "spoolsv.exe" and
+  file.extension : ("exe", "dll") and
+  not file.path : ("?:\\Windows\\System32\\spool\\*", "?:\\Windows\\Temp\\*", "?:\\Users\\*")
 '''
 
 
@@ -38,12 +37,12 @@ event.category:file and not event.type:deletion and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1068"
-name = "Exploitation for Privilege Escalation"
 reference = "https://attack.mitre.org/techniques/T1068/"
+name = "Exploitation for Privilege Escalation"
 
 
 [rule.threat.tactic]
 id = "TA0004"
-name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+name = "Privilege Escalation"
 

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ CVE-2020-1048 and CVE-2020-1337. .
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Suspicious PrintSpooler SPL File Created"
 note = "Refer to CVEs, CVE-2020-1048 and CVE-2020-1337 for further information on the vulnerability and exploit. Verify that the relevant system is patched."
@@ -21,13 +21,18 @@ rule_id = "a7ccae7b-9d2c-44b2-a061-98e5946971fa"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:file and not event.type:deletion and
- file.extension:(spl or SPL) and
- file.path:C\:\\Windows\\System32\\spool\\PRINTERS\\* and
- not process.name:(spoolsv.exe or printfilterpipelinesvc.exe or PrintIsolationHost.exe or splwow64.exe or msiexec.exe or poqexec.exe)
+file where event.type != "deletion" and
+  file.extension : ("spl", "SPL") and
+  file.path : "C:\\Windows\\System32\\spool\\PRINTERS\\*" and
+  not process.name : ("spoolsv.exe",
+                      "printfilterpipelinesvc.exe",
+                      "PrintIsolationHost.exe",
+                      "splwow64.exe",
+                      "msiexec.exe",
+                      "poqexec.exe")
 '''
 
 
@@ -35,12 +40,12 @@ event.category:file and not event.type:deletion and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1068"
-name = "Exploitation for Privilege Escalation"
 reference = "https://attack.mitre.org/techniques/T1068/"
+name = "Exploitation for Privilege Escalation"
 
 
 [rule.threat.tactic]
 id = "TA0004"
-name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+name = "Privilege Escalation"
 

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ elevated permissions.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Bypass UAC via Event Viewer"
 risk_score = 21
@@ -19,12 +19,12 @@ rule_id = "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and
-  process.parent.name:eventvwr.exe and
-  not process.executable:("C:\Windows\SysWOW64\mmc.exe" or "C:\Windows\System32\mmc.exe")
+process where event.type in ("start", "process_started") and
+  process.parent.name : "eventvwr.exe" and
+  not process.executable : ("C:\\Windows\\SysWOW64\\mmc.exe", "C:\\Windows\\System32\\mmc.exe")
 '''
 
 
@@ -32,17 +32,17 @@ event.category:process and event.type:(start or process_started) and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1548"
-name = "Abuse Elevation Control Mechanism"
 reference = "https://attack.mitre.org/techniques/T1548/"
+name = "Abuse Elevation Control Mechanism"
 [[rule.threat.technique.subtechnique]]
 id = "T1548.002"
-name = "Bypass User Access Control"
 reference = "https://attack.mitre.org/techniques/T1548/002/"
+name = "Bypass User Access Control"
 
 
 
 [rule.threat.tactic]
 id = "TA0004"
-name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+name = "Privilege Escalation"
 


### PR DESCRIPTION
## Issues
resolves #1113 

## Summary
Converts all windows KQL rules to EQL  for case resiliency.

## For reviewers
The most important thing for this review (in order)
* Ensure logic wasn't unintentionally changed as a result of a conversion
* Verify all necessary case-insensitive syntax was applied (where necessary) (`==` to `:` and `in` to `:`)
* everything else