### PR TITLE
Add threat_match rule type

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -263,8 +263,8 @@ class ThreatMatchRuleData(QueryRuleData):
 
     type: Literal["threat_match"]
 
-    concurrent_searches: Optional[definitions.IntegerGreaterThanZero]
-    items_per_search: Optional[definitions.IntegerGreaterThanZero]
+    concurrent_searches: Optional[definitions.PositiveInteger]
+    items_per_search: Optional[definitions.PositiveInteger]
 
     threat_mapping: List[Entries]
     threat_filters: Optional[List[dict]]
@@ -284,6 +284,8 @@ class ThreatMatchRuleData(QueryRuleData):
             threat_query_validator = KQLValidator(self.threat_query)
         elif self.threat_language == "eql":
             threat_query_validator = EQLValidator(self.threat_query)
+        else:
+            return
 
         threat_query_validator.validate(self, meta)
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Literal, Union, Optional, List, Any
 from uuid import uuid4
 
-from marshmallow import validates_schema
+from marshmallow import ValidationError, validates_schema
 
 from . import utils
 from .mixins import MarshmallowDataclassMixin
@@ -246,8 +246,50 @@ class EQLRuleData(QueryRuleData):
     language: Literal["eql"]
 
 
+@dataclass(frozen=True)
+class ThreatMatchRuleData(QueryRuleData):
+    """Specific fields for indicator (threat) match rule."""
+
+    @dataclass(frozen=True)
+    class Entries:
+
+        @dataclass(frozen=True)
+        class ThreatMapEntry:
+            field: definitions.NonEmptyStr
+            type: Literal["mapping"]
+            value: definitions.NonEmptyStr
+
+        entries: List[ThreatMapEntry]
+
+    type: Literal["threat_match"]
+
+    concurrent_searches: Optional[definitions.IntegerGreaterThanZero]
+    items_per_search: Optional[definitions.IntegerGreaterThanZero]
+
+    threat_mapping: List[Entries]
+    threat_filters: Optional[List[dict]]
+    threat_query: Optional[str]
+    threat_language: Optional[definitions.FilterLanguages]
+    threat_index: List[str]
+    threat_indicator_path: Optional[str]
+
+    def validate_query(self, meta: RuleMeta) -> None:
+        super(ThreatMatchRuleData, self).validate_query(meta)
+
+        if self.threat_query:
+            if not self.threat_language:
+                raise ValidationError('`threat_language` required when a `threat_query` is defined')
+
+        if self.threat_language == "kuery":
+            threat_query_validator = KQLValidator(self.threat_query)
+        elif self.threat_language == "eql":
+            threat_query_validator = EQLValidator(self.threat_query)
+
+        threat_query_validator.validate(self, meta)
+
+
 # All of the possible rule types
-AnyRuleData = Union[QueryRuleData, EQLRuleData, MachineLearningRuleData, ThresholdQueryRuleData]
+AnyRuleData = Union[QueryRuleData, EQLRuleData, MachineLearningRuleData, ThresholdQueryRuleData, ThreatMatchRuleData]
 
 
 @dataclass(frozen=True)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -280,14 +280,14 @@ class ThreatMatchRuleData(QueryRuleData):
             if not self.threat_language:
                 raise ValidationError('`threat_language` required when a `threat_query` is defined')
 
-        if self.threat_language == "kuery":
-            threat_query_validator = KQLValidator(self.threat_query)
-        elif self.threat_language == "eql":
-            threat_query_validator = EQLValidator(self.threat_query)
-        else:
-            return
+            if self.threat_language == "kuery":
+                threat_query_validator = KQLValidator(self.threat_query)
+            elif self.threat_language == "eql":
+                threat_query_validator = EQLValidator(self.threat_query)
+            else:
+                return
 
-        threat_query_validator.validate(self, meta)
+            threat_query_validator.validate(self, meta)
 
 
 # All of the possible rule types

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -39,6 +39,7 @@ OPERATORS = ['equals']
 CodeString = NewType("CodeString", str)
 ConditionSemVer = NewType('ConditionSemVer', str, validate=validate.Regexp(CONDITION_VERSION_PATTERN))
 Date = NewType('Date', str, validate=validate.Regexp(DATE_PATTERN))
+IntegerGreaterThanZero = NewType('IntegerGreaterThanZero', int, validate=validate.Range(min=1))
 Interval = NewType('Interval', str, validate=validate.Regexp(INTERVAL_PATTERN))
 FilterLanguages = Literal["kuery", "lucene"]
 Markdown = NewType("MarkdownField", CodeString)

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -39,9 +39,9 @@ OPERATORS = ['equals']
 CodeString = NewType("CodeString", str)
 ConditionSemVer = NewType('ConditionSemVer', str, validate=validate.Regexp(CONDITION_VERSION_PATTERN))
 Date = NewType('Date', str, validate=validate.Regexp(DATE_PATTERN))
-IntegerGreaterThanZero = NewType('IntegerGreaterThanZero', int, validate=validate.Range(min=1))
-Interval = NewType('Interval', str, validate=validate.Regexp(INTERVAL_PATTERN))
 FilterLanguages = Literal["kuery", "lucene"]
+Interval = NewType('Interval', str, validate=validate.Regexp(INTERVAL_PATTERN))
+PositiveInteger = NewType('PositiveInteger', int, validate=validate.Range(min=1))
 Markdown = NewType("MarkdownField", CodeString)
 Maturity = Literal['development', 'experimental', 'beta', 'production', 'deprecated']
 MaxSignals = NewType("MaxSignals", int, validate=validate.Range(min=1))


### PR DESCRIPTION
## Issues
related to #305

## Summary
This creates the rule type for `threat_match` (Indicator match) rules, which will allow these rules to be added and validated.

This does not include support for adding these rules via the CLI. That will come in a separate PR since the CLI still builds rules exclusively off the old schemas.

<details>
<summary>I tested this with a modified version of the rule from #1133</summary>

```toml
[metadata]
creation_date = "2020/02/18"
maturity = "production"
updated_date = "2021/03/03"

[rule]
author = [ "Elastic",]
description = "This rule is triggered when indicators from the Threat Intel Filebeat module has a match against local file or network observations.\n"
enabled = true
from = "now-600s"
index = [ "auditbeat-*", "filebeat-*", "logs-*",]
interval = "9m"
rule_id = "dc672cb7-d5df-4d1f-a6d7-0841b1caafb9"
language = "kuery"
license = "Elastic License v2"
max_signals = 100
risk_score = 99
name = "Threat Intel Filebeat Module Indicator Match"
query = "file.name:burger"
references = [ "https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-threatintel.html",]
severity = "critical"
tags = [ "Elastic", "Continuous Monitoring", "SecOps", "Monitoring",]
to = "now"
type = "threat_match"
threat_index = [ "filebeat-*",]
threat_indicator_path = ""
threat_query = "process.name:ham"
threat_language = "kuery"
throttle = "no_actions"
note = "If an indicator matches a local observation, the following enriched fields will be generated to identify the indicator, field, and type matched.\n- `threatintel.indicator.matched.atomic` - this identifies the atomic indicator that matched the local observation\n- `threatintel.indicator.matched.field` - this identifies the indicator field that matched the local observation\n- `threatintel.indicator.matched.type` - this identifies the indicator type that matched the local observation"
# version = 5

[[rule.threat_filters]]
[rule.threat_filters."$state"]
store = "appState"
[rule.threat_filters.meta]
negate = false
disabled = false
type = "phrase"
key = "event.module"
[rule.threat_filters.meta.params]
query = "threatintel"
[rule.threat_filters.query.match_phrase]
"event.module" = "threatintel"
[[rule.threat_filters]]
[rule.threat_filters."$state"]
store = "appState"
[rule.threat_filters.meta]
negate = false
disabled = false
type = "phrase"
key = "event.category"
[rule.threat_filters.meta.params]
query = "threat"
[rule.threat_filters.query.match_phrase]
"event.category" = "threat"
[[rule.threat_filters]]
[rule.threat_filters."$state"]
store = "appState"
[rule.threat_filters.meta]
negate = false
disabled = false
type = "phrase"
key = "event.kind"
[rule.threat_filters.meta.params]
query = "enrichment"
[rule.threat_filters.query.match_phrase]
"event.kind" = "enrichment"
[[rule.threat_filters]]
[rule.threat_filters."$state"]
store = "appState"
[rule.threat_filters.meta]
negate = false
disabled = false
type = "phrase"
key = "event.type"
[rule.threat_filters.meta.params]
query = "indicator"
[rule.threat_filters.query.match_phrase]
"event.type" = "indicator"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "file.hash.md5"
type = "mapping"
value = "threatintel.indicator.file.hash.md5"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "file.hash.sha1"
type = "mapping"
value = "threatintel.indicator.file.hash.sha1"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "file.hash.sha256"
type = "mapping"
value = "threatintel.indicator.file.hash.sha256"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "file.pe.imphash"
type = "mapping"
value = "threatintel.indicator.file.pe.imphash"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "source.ip"
type = "mapping"
value = "threatintel.indicator.ip"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "destination.ip"
type = "mapping"
value = "threatintel.indicator.ip"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "url.full"
type = "mapping"
value = "threatintel.indicator.url.full"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "registry.path"
type = "mapping"
value = "threatintel.indicator.registry.path"

#[[rule.exceptions_list]]
#list_id = "ee1242d3-43df-41a4-8570-15d5e3c33d27"
#namespace_type = "single"
#id = "7b282b70-8747-11eb-ac13-d5ca87cb8fa2"
#type = "detection"

```

</details>