### PR TITLE
Update privilege_escalation_port_monitor_print_pocessor_abuse.toml

### DIFF
--- a/rules/windows/privilege_escalation_port_monitor_print_pocessor_abuse.toml
+++ b/rules/windows/privilege_escalation_port_monitor_print_pocessor_abuse.toml
@@ -26,7 +26,7 @@ type = "eql"
 query = '''
 registry where event.type in ("creation", "change") and
   registry.path : ("HKLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Monitors\\*",
-    "HLLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Environments\\Windows*\\Print Processors\\*") and
+    "HKLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Environments\\Windows*\\Print Processors\\*") and
   registry.data.strings : "*.dll" and
   /* exclude SYSTEM SID - look for changes by non-SYSTEM user */
   not user.id : "S-1-5-18"


### PR DESCRIPTION
Typo in registry path

Current-    "HLLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Environments\\Windows*\\Print Processors\\*") and

Proposed-    "HKLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Environments\\Windows*\\Print Processors\\*")
