### PR TITLE
Allow ML rules to accept a single or array of job IDs

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -217,7 +217,7 @@ class MachineLearningRuleData(BaseRuleData):
     type: Literal["machine_learning"]
 
     anomaly_threshold: int
-    machine_learning_job_id: str
+    machine_learning_job_id: Union[str, List[str]]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Issues
resolves #1161

## Summary
Machine learning rule job IDs can now be a single str or list of strings