### PR TITLE
Add job for 'backport: auto' labeled PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
     types:
+      - labeled
       - closed
 
 jobs:
@@ -41,7 +42,7 @@ jobs:
       - name: Backport commit
         run: |
           echo "Cherry-pick from $GITHUB_SHA to ${{matrix.target_branch}}"
-          git cherry-pick -x $GITHUB_SHA
+          git cherry-pick -x ${{github.event.pull_request.merge_commit_sha}}
 
           # See https://github.com/elastic/detection-rules/issues/1171
           # Eventually, this cherry pick command will be:
@@ -56,4 +57,4 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{matrix.target_branch}}"\
+          branch: ${{matrix.target_branch}}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,6 +18,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         target_branch: [7.13]
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,58 @@
+name: backport
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  backport:
+    name: on merge
+    if: |
+      github.event.pull_request.merged == true
+      && contains(github.event.pull_request.labels.*.name, 'backport: auto')
+      && (
+        (github.event.action == 'labeled' && github.event.label.name == 'backport: auto')
+        || (github.event.action == 'closed')
+      )
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target_branch: [7.13]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Set github config
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Update branches
+        run: |
+          git fetch origin ${{matrix.target_branch}} --unshallow
+          git checkout -f ${{matrix.target_branch}}
+          git status
+          git log -1 --format='%H'
+
+      - name: Backport commit
+        run: |
+          echo "Cherry-pick from $GITHUB_SHA to ${{matrix.target_branch}}"
+          git cherry-pick -x $GITHUB_SHA
+
+          # See https://github.com/elastic/detection-rules/issues/1171
+          # Eventually, this cherry pick command will be:
+          # git-cherry-pick --no-commit
+          # <python code to remove irrelevant rules>
+          # git commit --author ... --message ...
+
+          echo "Push new commit to ${{matrix.target_branch}}"
+          git push
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{matrix.target_branch}}"\

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,6 +24,12 @@ jobs:
         target_branch: [7.13]
 
     steps:
+      - uses: craftech-io/slack-action@v1
+        with:
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: failure
+        if: failure()
+
       - name: Checkout repo
         uses: actions/checkout@v2
 


### PR DESCRIPTION
## Issues

Part of #1171 

## Summary
Added a new job that will automatically backport commits to the branches in our matrix if a `backport: auto` label is detected.
Today, this means 7.13.

I'll add more jobs to follow on for labeling, so that `backport: auto` is automatically set, and if `backport: skip` is set then it will automatically be removed.

More to come!

### Screenshots
Example from my fork (https://github.com/rw-access/detection-rules/pull/13)

![image](https://user-images.githubusercontent.com/31489089/117224497-51f76200-adcd-11eb-8342-0446d139f682.png)
