### PR TITLE
Disable persist-credentials from checkout job

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Set github config
         run: |

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
         with:
-          persist-credentials: false
+          token: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
+          ref: ${{matrix.target_branch}}
 
       - name: Set github config
         run: |
@@ -53,13 +54,5 @@ jobs:
           # git commit --author ... --message ...
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
-          branch: ${{matrix.target_branch}}
-
-      - uses: craftech-io/slack-action@v1
-        with:
-          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          status: failure
-        if: failure()
+        run: |
+          git push


### PR DESCRIPTION
## Summary
Continuing down the rabbit hole of #1186.

It appears that $GITHUB_TOKEN is set during the checkout action and interferes with the push action. Now the right token is used for everything.

Also, slack was removed because it's too loud.

See https://github.com/ad-m/github-push-action/issues/44#issuecomment-590010727