### PR TITLE
Cleanup note field in rules

### DIFF
--- a/rules/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/aws/collection_cloudtrail_logging_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/aws/collection_cloudtrail_logging_created.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudTrail Log Created"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_CreateTrail.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudtrail/create-trail.html",

--- a/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -15,7 +15,9 @@ index = ["filebeat-*", "logs-aws*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Brute Force of Assume Role Policy"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://www.praetorian.com/blog/aws-iam-assume-role-vulnerabilities",
     "https://rhinosecuritylabs.com/aws/assume-worst-aws-assume-role-enumeration/",

--- a/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/aws/credential_access_iam_user_addition_to_group.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/04"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM User Addition to Group"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddUserToGroup.html"]
 risk_score = 21
 rule_id = "333de828-8190-4cf5-8d7c-7575846f6fe0"

--- a/rules/aws/credential_access_root_console_failure_brute_force.toml
+++ b/rules/aws/credential_access_root_console_failure_brute_force.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-aws*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Management Console Brute Force of Root User Identity"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]
 risk_score = 73
 rule_id = "4d50a94f-2844-43fa-8395-6afbd5e1c5ef"

--- a/rules/aws/credential_access_root_console_failure_brute_force.toml
+++ b/rules/aws/credential_access_root_console_failure_brute_force.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
+++ b/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Nick Jones", "Elastic"]

--- a/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
+++ b/rules/aws/credential_access_secretsmanager_getsecretvalue.toml
@@ -21,7 +21,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Access Secret in Secrets Manager"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_GetSecretValue.html",
     "http://detectioninthe.cloud/credential_access/access_secret_in_secrets_manager/",

--- a/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudTrail Log Deleted"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_DeleteTrail.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudtrail/delete-trail.html",

--- a/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -23,7 +23,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudTrail Log Suspended"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_StopLogging.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudtrail/stop-logging.html",

--- a/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/15"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudWatch Alarm Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudwatch/delete-alarms.html",
     "https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DeleteAlarms.html",

--- a/rules/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/aws/defense_evasion_config_service_rule_deletion.toml
@@ -23,7 +23,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Config Service Tampering"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/config/latest/developerguide/how-does-config-work.html",
     "https://docs.aws.amazon.com/config/latest/APIReference/API_Operations.html",

--- a/rules/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/aws/defense_evasion_config_service_rule_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/26"
 maturity = "production"
-updated_date = "2021/04/13"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Configuration Recorder Stopped"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/configservice/stop-configuration-recorder.html",
     "https://docs.aws.amazon.com/config/latest/APIReference/API_StopConfigurationRecorder.html",

--- a/rules/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/16"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Flow Log Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/delete-flow-logs.html",
     "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteFlowLogs.html",

--- a/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/15"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Network Access Control List Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/delete-network-acl.html",
     "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteNetworkAcl.html",

--- a/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS GuardDuty Detector Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/guardduty/delete-detector.html",
     "https://docs.aws.amazon.com/guardduty/latest/APIReference/API_DeleteDetector.html",

--- a/rules/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/28"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS S3 Bucket Configuration Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketPolicy.html",
     "https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html",

--- a/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/27"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/aws/defense_evasion_waf_acl_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/aws/defense_evasion_waf_acl_deletion.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS WAF Access Control List Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/waf-regional/delete-web-acl.html",
     "https://docs.aws.amazon.com/waf/latest/APIReference/API_wafRegional_DeleteWebACL.html",

--- a/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS WAF Rule or Rule Group Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/waf/delete-rule-group.html",
     "https://docs.aws.amazon.com/waf/latest/APIReference/API_waf_DeleteRuleGroup.html",

--- a/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/09"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Snapshot Activity"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/modify-snapshot-attribute.html",
     "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifySnapshotAttribute.html",

--- a/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/24"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/aws/impact_cloudtrail_logging_updated.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/10"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/aws/impact_cloudtrail_logging_updated.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudTrail Log Updated"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_UpdateTrail.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudtrail/update-trail.html",

--- a/rules/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_group_deletion.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudWatch Log Group Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/logs/delete-log-group.html",
     "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DeleteLogGroup.html",

--- a/rules/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/18"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudWatch Log Stream Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/logs/delete-log-stream.html",
     "https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DeleteLogStream.html",

--- a/rules/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/aws/impact_ec2_disable_ebs_encryption.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/05"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/aws/impact_ec2_disable_ebs_encryption.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Encryption Disabled"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/disable-ebs-encryption-by-default.html",

--- a/rules/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/aws/impact_iam_deactivate_mfa_device.toml
@@ -23,7 +23,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Deactivation of MFA Device"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/deactivate-mfa-device.html",
     "https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeactivateMFADevice.html",

--- a/rules/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/aws/impact_iam_deactivate_mfa_device.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/26"
 maturity = "production"
-updated_date = "2021/04/20"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/aws/impact_iam_group_deletion.toml
+++ b/rules/aws/impact_iam_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_iam_group_deletion.toml
+++ b/rules/aws/impact_iam_group_deletion.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Group Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/delete-group.html",
     "https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteGroup.html",

--- a/rules/aws/impact_rds_cluster_deletion.toml
+++ b/rules/aws/impact_rds_cluster_deletion.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Cluster Deletion"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/delete-db-cluster.html",
     "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBCluster.html",

--- a/rules/aws/impact_rds_cluster_deletion.toml
+++ b/rules/aws/impact_rds_cluster_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/aws/impact_rds_instance_cluster_stoppage.toml
@@ -19,7 +19,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Instance/Cluster Stoppage"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/stop-db-cluster.html",
     "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StopDBCluster.html",

--- a/rules/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/aws/impact_rds_instance_cluster_stoppage.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/initial_access_console_login_root.toml
+++ b/rules/aws/initial_access_console_login_root.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/11"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/initial_access_console_login_root.toml
+++ b/rules/aws/initial_access_console_login_root.toml
@@ -20,7 +20,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Management Console Root Login"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]
 risk_score = 73
 rule_id = "e2a67480-3b79-403d-96e3-fdd2992c50ef"

--- a/rules/aws/initial_access_password_recovery.toml
+++ b/rules/aws/initial_access_password_recovery.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/02"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/initial_access_password_recovery.toml
+++ b/rules/aws/initial_access_password_recovery.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Password Recovery Requested"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://www.cadosecurity.com/2020/06/11/an-ongoing-aws-phishing-campaign/"]
 risk_score = 21
 rule_id = "69c420e8-6c9e-4d28-86c0-8a2be2d1e78c"

--- a/rules/aws/initial_access_via_system_manager.toml
+++ b/rules/aws/initial_access_via_system_manager.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/initial_access_via_system_manager.toml
+++ b/rules/aws/initial_access_via_system_manager.toml
@@ -23,7 +23,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Execution via System Manager"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-plugins.html"]
 risk_score = 21
 rule_id = "37b211e8-4e2f-440f-86d8-06cc8f158cfa"

--- a/rules/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/aws/persistence_ec2_network_acl_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/04"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/aws/persistence_ec2_network_acl_creation.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Network Access Control List Creation"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/create-network-acl.html",
     "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateNetworkAcl.html",

--- a/rules/aws/persistence_iam_group_creation.toml
+++ b/rules/aws/persistence_iam_group_creation.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Group Creation"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/iam/create-group.html",
     "https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateGroup.html",

--- a/rules/aws/persistence_iam_group_creation.toml
+++ b/rules/aws/persistence_iam_group_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/06/05"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/persistence_rds_cluster_creation.toml
+++ b/rules/aws/persistence_rds_cluster_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/persistence_rds_cluster_creation.toml
+++ b/rules/aws/persistence_rds_cluster_creation.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Cluster Creation"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-cluster.html",
     "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBCluster.html",

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -21,7 +21,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Root Login Without MFA"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]
 risk_score = 73
 rule_id = "bc0c6f0d-dab0-47a3-b135-0925f0a333bc"

--- a/rules/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/aws/privilege_escalation_root_login_without_mfa.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -22,7 +22,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Assume Role Policy Update"
-note = "The AWS Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://labs.bishopfox.com/tech-blog/5-privesc-attack-vectors-in-aws"]
 risk_score = 21
 rule_id = "a60326d7-dca7-4fb7-93eb-1ca03a1febbd"

--- a/rules/azure/collection_update_event_hub_auth_rule.toml
+++ b/rules/azure/collection_update_event_hub_auth_rule.toml
@@ -24,7 +24,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Event Hub Authorization Rule Created or Updated"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-shared-access-signature"]
 risk_score = 47
 rule_id = "b6dce542-2b75-4ffb-b7d6-38787298ba9d"

--- a/rules/azure/collection_update_event_hub_auth_rule.toml
+++ b/rules/azure/collection_update_event_hub_auth_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/credential_access_key_vault_modified.toml
+++ b/rules/azure/credential_access_key_vault_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/credential_access_key_vault_modified.toml
+++ b/rules/azure/credential_access_key_vault_modified.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Key Vault Modified"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/azure/key-vault/general/basic-concepts",
     "https://docs.microsoft.com/en-us/azure/key-vault/general/secure-your-key-vault",

--- a/rules/azure/credential_access_storage_account_key_regenerated.toml
+++ b/rules/azure/credential_access_storage_account_key_regenerated.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/credential_access_storage_account_key_regenerated.toml
+++ b/rules/azure/credential_access_storage_account_key_regenerated.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Storage Account Key Regenerated"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal",
 ]

--- a/rules/azure/defense_evasion_azure_application_credential_modification.toml
+++ b/rules/azure/defense_evasion_azure_application_credential_modification.toml
@@ -24,7 +24,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Application Credential Modification"
-note = "The Azure Fleet Integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/",
 ]

--- a/rules/azure/defense_evasion_azure_application_credential_modification.toml
+++ b/rules/azure/defense_evasion_azure_application_credential_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
+++ b/rules/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
+++ b/rules/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Diagnostic Settings Deletion"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings"]
 risk_score = 47
 rule_id = "5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de"

--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/azure/defense_evasion_azure_service_principal_addition.toml
@@ -23,7 +23,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Service Principal Addition"
-note = "The Azure Fleet Integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/",
     "https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal",

--- a/rules/azure/defense_evasion_event_hub_deletion.toml
+++ b/rules/azure/defense_evasion_event_hub_deletion.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Event Hub Deletion"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-about",
     "https://azure.microsoft.com/en-in/services/event-hubs/",

--- a/rules/azure/defense_evasion_event_hub_deletion.toml
+++ b/rules/azure/defense_evasion_event_hub_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_firewall_policy_deletion.toml
+++ b/rules/azure/defense_evasion_firewall_policy_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_firewall_policy_deletion.toml
+++ b/rules/azure/defense_evasion_firewall_policy_deletion.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Firewall Policy Deletion"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/firewall-manager/policy-overview"]
 risk_score = 21
 rule_id = "e02bd3ea-72c6-4181-ac2b-0f83d17ad969"

--- a/rules/azure/defense_evasion_network_watcher_deletion.toml
+++ b/rules/azure/defense_evasion_network_watcher_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/defense_evasion_network_watcher_deletion.toml
+++ b/rules/azure/defense_evasion_network_watcher_deletion.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Network Watcher Deletion"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/network-watcher/network-watcher-monitoring-overview"]
 risk_score = 47
 rule_id = "323cb487-279d-4218-bcbd-a568efe930c6"

--- a/rules/azure/discovery_blob_container_access_mod.toml
+++ b/rules/azure/discovery_blob_container_access_mod.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Blob Container Access Level Modification"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-prevent"]
 risk_score = 21
 rule_id = "2636aa6c-88b5-4337-9c31-8d0192a8ef45"

--- a/rules/azure/discovery_blob_container_access_mod.toml
+++ b/rules/azure/discovery_blob_container_access_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/execution_command_virtual_machine.toml
+++ b/rules/azure/execution_command_virtual_machine.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/execution_command_virtual_machine.toml
+++ b/rules/azure/execution_command_virtual_machine.toml
@@ -24,7 +24,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Command Execution on Virtual Machine"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://adsecurity.org/?p=4277",
     "https://posts.specterops.io/attacking-azure-azure-ad-and-introducing-powerzure-ca70b330511a",

--- a/rules/azure/impact_azure_automation_runbook_deleted.toml
+++ b/rules/azure/impact_azure_automation_runbook_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/impact_azure_automation_runbook_deleted.toml
+++ b/rules/azure/impact_azure_automation_runbook_deleted.toml
@@ -14,7 +14,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Automation Runbook Deleted"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://powerzure.readthedocs.io/en/latest/Functions/operational.html#create-backdoor",
     "https://github.com/hausec/PowerZure",

--- a/rules/azure/impact_resource_group_deletion.toml
+++ b/rules/azure/impact_resource_group_deletion.toml
@@ -23,7 +23,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Resource Group Deletion"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal",
 ]

--- a/rules/azure/impact_resource_group_deletion.toml
+++ b/rules/azure/impact_resource_group_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/initial_access_azure_active_directory_high_risk_signin.toml
+++ b/rules/azure/initial_access_azure_active_directory_high_risk_signin.toml
@@ -16,7 +16,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Active Directory High Risk Sign-in"
-note = "The Azure Fleet Integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/howto-conditional-access-policy-risk",
     "https://docs.microsoft.com/en-us/azure/active-directory/identity-protection/overview-identity-protection",

--- a/rules/azure/initial_access_azure_active_directory_high_risk_signin.toml
+++ b/rules/azure/initial_access_azure_active_directory_high_risk_signin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic", "Willem D'Haese"]

--- a/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
+++ b/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Active Directory PowerShell Sign-in"
-note = "The Azure Fleet Integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://msrc-blog.microsoft.com/2020/12/13/customer-guidance-on-recent-nation-state-cyber-attacks/",
     "https://docs.microsoft.com/en-us/microsoft-365/enterprise/connect-to-microsoft-365-powershell?view=o365-worldwide",

--- a/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
+++ b/rules/azure/initial_access_azure_active_directory_powershell_signin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -15,11 +15,16 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Possible Consent Grant Attack via Azure-Registered Application"
-note = """- The Azure Filebeat module must be enabled to use this rule.
+note = """## Triage and analysis
+
 - In a consent grant attack, an attacker tricks an end user into granting a malicious application consent to access their data, usually via a phishing attack. After the malicious application has been granted consent, it has account-level access to data without the need for an organizational account.
 - Normal remediation steps, like resetting passwords for breached accounts or requiring Multi-Factor Authentication (MFA) on accounts, are not effective against this type of attack, since these are third-party applications and are external to the organization.
 - Security analysts should review the list of trusted applications for any suspicious items.
-"""
+
+
+## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/detect-and-remediate-illicit-consent-grants?view=o365-worldwide",
 ]

--- a/rules/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/initial_access_external_guest_user_invite.toml
+++ b/rules/azure/initial_access_external_guest_user_invite.toml
@@ -23,7 +23,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure External Guest User Invitation"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/governance/policy/samples/cis-azure-1-1-0"]
 risk_score = 21
 rule_id = "141e9b3a-ff37-4756-989d-05d7cbf35b0e"

--- a/rules/azure/initial_access_external_guest_user_invite.toml
+++ b/rules/azure/initial_access_external_guest_user_invite.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_automation_account_created.toml
+++ b/rules/azure/persistence_azure_automation_account_created.toml
@@ -15,7 +15,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Automation Account Created"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://powerzure.readthedocs.io/en/latest/Functions/operational.html#create-backdoor",
     "https://github.com/hausec/PowerZure",

--- a/rules/azure/persistence_azure_automation_account_created.toml
+++ b/rules/azure/persistence_azure_automation_account_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_automation_runbook_created_or_modified.toml
+++ b/rules/azure/persistence_azure_automation_runbook_created_or_modified.toml
@@ -14,7 +14,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Automation Runbook Created or Modified"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://powerzure.readthedocs.io/en/latest/Functions/operational.html#create-backdoor",
     "https://github.com/hausec/PowerZure",

--- a/rules/azure/persistence_azure_automation_runbook_created_or_modified.toml
+++ b/rules/azure/persistence_azure_automation_runbook_created_or_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_automation_webhook_created.toml
+++ b/rules/azure/persistence_azure_automation_webhook_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_automation_webhook_created.toml
+++ b/rules/azure/persistence_azure_automation_webhook_created.toml
@@ -15,7 +15,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Automation Webhook Created"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://powerzure.readthedocs.io/en/latest/Functions/operational.html#create-backdoor",
     "https://github.com/hausec/PowerZure",

--- a/rules/azure/persistence_azure_conditional_access_policy_modified.toml
+++ b/rules/azure/persistence_azure_conditional_access_policy_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_conditional_access_policy_modified.toml
+++ b/rules/azure/persistence_azure_conditional_access_policy_modified.toml
@@ -16,7 +16,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Conditional Access Policy Modified"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/overview"]
 risk_score = 47
 rule_id = "bc48bba7-4a23-4232-b551-eca3ca1e3f20"

--- a/rules/azure/persistence_azure_pim_user_added_global_admin.toml
+++ b/rules/azure/persistence_azure_pim_user_added_global_admin.toml
@@ -23,7 +23,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Global Administrator Role Addition to PIM User"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/directory-assign-admin-roles",
 ]

--- a/rules/azure/persistence_azure_pim_user_added_global_admin.toml
+++ b/rules/azure/persistence_azure_pim_user_added_global_admin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/24"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_privileged_identity_management_role_modified.toml
+++ b/rules/azure/persistence_azure_privileged_identity_management_role_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_azure_privileged_identity_management_role_modified.toml
+++ b/rules/azure/persistence_azure_privileged_identity_management_role_modified.toml
@@ -16,7 +16,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Privilege Identity Management Role Modified"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-resource-roles-assign-roles",
     "https://docs.microsoft.com/en-us/azure/active-directory/privileged-identity-management/pim-configure",

--- a/rules/azure/persistence_mfa_disabled_for_azure_user.toml
+++ b/rules/azure/persistence_mfa_disabled_for_azure_user.toml
@@ -14,7 +14,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Multi-Factor Authentication Disabled for an Azure User"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 47
 rule_id = "dafa3235-76dc-40e2-9f71-1773b96d24cf"
 severity = "medium"

--- a/rules/azure/persistence_mfa_disabled_for_azure_user.toml
+++ b/rules/azure/persistence_mfa_disabled_for_azure_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_user_added_as_owner_for_azure_application.toml
+++ b/rules/azure/persistence_user_added_as_owner_for_azure_application.toml
@@ -15,7 +15,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "User Added as Owner for Azure Application"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 21
 rule_id = "774f5e28-7b75-4a58-b94e-41bf060fdd86"
 severity = "low"

--- a/rules/azure/persistence_user_added_as_owner_for_azure_application.toml
+++ b/rules/azure/persistence_user_added_as_owner_for_azure_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
+++ b/rules/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
@@ -17,7 +17,9 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "User Added as Owner for Azure Service Principal"
-note = "The Azure Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals",
 ]

--- a/rules/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
+++ b/rules/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/07"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -16,7 +16,9 @@ index = ["auditbeat-*", "winlogbeat-*", "logs-endpoint.events.*", "logs-windows.
 language = "eql"
 license = "Elastic License v2"
 name = "Hosts File Modified"
-note = "For Windows systems using Auditbeat, this rule requires adding 'C:/Windows/System32/drivers/etc' as an additional path in the 'file_integrity' module of auditbeat.yml."
+note = """## Config
+
+For Windows systems using Auditbeat, this rule requires adding 'C:/Windows/System32/drivers/etc' as an additional path in the 'file_integrity' module of auditbeat.yml."""
 references = ["https://www.elastic.co/guide/en/beats/auditbeat/current/auditbeat-reference-yml.html"]
 risk_score = 47
 rule_id = "9c260313-c811-4ec8-ab89-8f6530e0246c"

--- a/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
+++ b/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
@@ -16,7 +16,9 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Zoom Meeting with no Passcode"
-note = "This rule requires the Zoom Filebeat module."
+note = """## Config
+
+The Zoom Filebeat module or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://blog.zoom.us/a-message-to-our-users/",
     "https://www.fbi.gov/contact-us/field-offices/boston/news/press-releases/fbi-warns-of-teleconferencing-and-online-classroom-hijacking-during-covid-19-pandemic",

--- a/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
+++ b/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/threat_intel_module_match.toml
+++ b/rules/cross-platform/threat_intel_module_match.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/04/21"
 maturity = "production"
-updated_date = "2021/04/21"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/threat_intel_module_match.toml
+++ b/rules/cross-platform/threat_intel_module_match.toml
@@ -14,8 +14,8 @@ interval = "9m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Threat Intel Filebeat Module Indicator Match"
-note = """
-## Triage and Analysis
+note = """## Triage and Analysis
+
 If an indicator matches a local observation, the following enriched fields will be generated to identify the indicator, field, and type matched.
 
 - `threatintel.indicator.matched.atomic` - this identifies the atomic indicator that matched the local observation

--- a/rules/gcp/collection_gcp_pub_sub_subscription_creation.toml
+++ b/rules/gcp/collection_gcp_pub_sub_subscription_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/collection_gcp_pub_sub_subscription_creation.toml
+++ b/rules/gcp/collection_gcp_pub_sub_subscription_creation.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Pub/Sub Subscription Creation"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/pubsub/docs/overview"]
 risk_score = 21
 rule_id = "d62b64a8-a7c9-43e5-aee3-15a725a794e7"

--- a/rules/gcp/collection_gcp_pub_sub_topic_creation.toml
+++ b/rules/gcp/collection_gcp_pub_sub_topic_creation.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Pub/Sub Topic Creation"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/pubsub/docs/admin"]
 risk_score = 21
 rule_id = "a10d3d9d-0f65-48f1-8b25-af175e2594f5"

--- a/rules/gcp/collection_gcp_pub_sub_topic_creation.toml
+++ b/rules/gcp/collection_gcp_pub_sub_topic_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_created.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_created.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_created.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Firewall Rule Creation"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/firewalls"]
 risk_score = 21
 rule_id = "30562697-9859-4ae0-a8c5-dab45d664170"

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Firewall Rule Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/firewalls"]
 risk_score = 47
 rule_id = "ff9b571e-61d6-4f6c-9561-eb4cca3bafe1"

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_modified.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Firewall Rule Modification"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/firewalls"]
 risk_score = 47
 rule_id = "2783d84f-5091-4d7d-9319-9fceda8fa71b"

--- a/rules/gcp/defense_evasion_gcp_firewall_rule_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_firewall_rule_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
@@ -23,7 +23,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Logging Bucket Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/logging/docs/buckets", "https://cloud.google.com/logging/docs/storage"]
 risk_score = 47
 rule_id = "5663b693-0dea-4f2e-8275-f1ae5ff2de8e"

--- a/rules/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_logging_sink_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_logging_sink_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_logging_sink_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_logging_sink_deletion.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Logging Sink Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/logging/docs/export"]
 risk_score = 47
 rule_id = "51859fa0-d86b-4214-bf48-ebb30ed91305"

--- a/rules/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Pub/Sub Subscription Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/pubsub/docs/overview"]
 risk_score = 21
 rule_id = "cc89312d-6f47-48e4-a87c-4977bd4633c3"

--- a/rules/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Pub/Sub Topic Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/pubsub/docs/overview"]
 risk_score = 21
 rule_id = "3202e172-01b1-4738-a932-d024c514ba72"

--- a/rules/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
+++ b/rules/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Storage Bucket Configuration Modification"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/storage/docs/key-terms#buckets"]
 risk_score = 47
 rule_id = "97359fd8-757d-4b1d-9af1-ef29e4a8680e"

--- a/rules/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Storage Bucket Permissions Modification"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/storage/docs/access-control/iam-permissions"]
 risk_score = 47
 rule_id = "2326d1b2-9acf-4dee-bd21-867ea7378b4d"

--- a/rules/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
+++ b/rules/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/exfiltration_gcp_logging_sink_modification.toml
+++ b/rules/gcp/exfiltration_gcp_logging_sink_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/exfiltration_gcp_logging_sink_modification.toml
+++ b/rules/gcp/exfiltration_gcp_logging_sink_modification.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Logging Sink Modification"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/logging/docs/export#how_sinks_work"]
 risk_score = 21
 rule_id = "184dfe52-2999-42d9-b9d1-d1ca54495a61"

--- a/rules/gcp/impact_gcp_iam_role_deletion.toml
+++ b/rules/gcp/impact_gcp_iam_role_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_iam_role_deletion.toml
+++ b/rules/gcp/impact_gcp_iam_role_deletion.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP IAM Role Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/understanding-roles"]
 risk_score = 21
 rule_id = "e2fb5b18-e33c-4270-851e-c3d675c9afcd"

--- a/rules/gcp/impact_gcp_service_account_deleted.toml
+++ b/rules/gcp/impact_gcp_service_account_deleted.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Service Account Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/service-accounts"]
 risk_score = 47
 rule_id = "8fb75dda-c47a-4e34-8ecd-34facf7aad13"

--- a/rules/gcp/impact_gcp_service_account_deleted.toml
+++ b/rules/gcp/impact_gcp_service_account_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_service_account_disabled.toml
+++ b/rules/gcp/impact_gcp_service_account_disabled.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Service Account Disabled"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/service-accounts"]
 risk_score = 47
 rule_id = "bca7d28e-4a48-47b1-adb7-5074310e9a61"

--- a/rules/gcp/impact_gcp_service_account_disabled.toml
+++ b/rules/gcp/impact_gcp_service_account_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_storage_bucket_deleted.toml
+++ b/rules/gcp/impact_gcp_storage_bucket_deleted.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Storage Bucket Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/storage/docs/key-terms#buckets"]
 risk_score = 47
 rule_id = "bc0f2d83-32b8-4ae2-b0e6-6a45772e9331"

--- a/rules/gcp/impact_gcp_storage_bucket_deleted.toml
+++ b/rules/gcp/impact_gcp_storage_bucket_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Virtual Private Cloud Network Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/vpc"]
 risk_score = 47
 rule_id = "c58c3081-2e1d-4497-8491-e73a45d1a6d6"

--- a/rules/gcp/impact_gcp_virtual_private_cloud_route_created.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_route_created.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Virtual Private Cloud Route Creation"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/routes", "https://cloud.google.com/vpc/docs/using-routes"]
 risk_score = 21
 rule_id = "9180ffdf-f3d0-4db3-bf66-7a14bcff71b8"

--- a/rules/gcp/impact_gcp_virtual_private_cloud_route_created.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_route_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Virtual Private Cloud Route Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/routes", "https://cloud.google.com/vpc/docs/using-routes"]
 risk_score = 47
 rule_id = "a17bcc91-297b-459b-b5ce-bc7460d8f82a"

--- a/rules/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
+++ b/rules/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/initial_access_gcp_iam_custom_role_creation.toml
+++ b/rules/gcp/initial_access_gcp_iam_custom_role_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/initial_access_gcp_iam_custom_role_creation.toml
+++ b/rules/gcp/initial_access_gcp_iam_custom_role_creation.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP IAM Custom Role Creation"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/understanding-custom-roles"]
 risk_score = 47
 rule_id = "aa8007f0-d1df-49ef-8520-407857594827"

--- a/rules/gcp/persistence_gcp_iam_service_account_key_deletion.toml
+++ b/rules/gcp/persistence_gcp_iam_service_account_key_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/persistence_gcp_iam_service_account_key_deletion.toml
+++ b/rules/gcp/persistence_gcp_iam_service_account_key_deletion.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP IAM Service Account Key Deletion"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://cloud.google.com/iam/docs/service-accounts",
     "https://cloud.google.com/iam/docs/creating-managing-service-account-keys",

--- a/rules/gcp/persistence_gcp_key_created_for_service_account.toml
+++ b/rules/gcp/persistence_gcp_key_created_for_service_account.toml
@@ -23,7 +23,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Service Account Key Creation"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://cloud.google.com/iam/docs/service-accounts",
     "https://cloud.google.com/iam/docs/creating-managing-service-account-keys",

--- a/rules/gcp/persistence_gcp_key_created_for_service_account.toml
+++ b/rules/gcp/persistence_gcp_key_created_for_service_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/gcp/persistence_gcp_service_account_created.toml
+++ b/rules/gcp/persistence_gcp_service_account_created.toml
@@ -23,7 +23,9 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Service Account Creation"
-note = "The GCP Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/service-accounts"]
 risk_score = 21
 rule_id = "7ceb2216-47dd-4e64-9433-cddc99727623"

--- a/rules/gcp/persistence_gcp_service_account_created.toml
+++ b/rules/gcp/persistence_gcp_service_account_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/22"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/application_added_to_google_workspace_domain.toml
+++ b/rules/google-workspace/application_added_to_google_workspace_domain.toml
@@ -22,7 +22,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Application Added to Google Workspace Domain"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/application_added_to_google_workspace_domain.toml
+++ b/rules/google-workspace/application_added_to_google_workspace_domain.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
@@ -21,7 +21,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Domain Added to Google Workspace Trusted Domains"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/google-workspace/domain_added_to_google_workspace_trusted_domains.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/google_workspace_admin_role_deletion.toml
+++ b/rules/google-workspace/google_workspace_admin_role_deletion.toml
@@ -21,7 +21,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Admin Role Deletion"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/google_workspace_admin_role_deletion.toml
+++ b/rules/google-workspace/google_workspace_admin_role_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/google-workspace/google_workspace_mfa_enforcement_disabled.toml
@@ -21,7 +21,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace MFA Enforcement Disabled"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/google-workspace/google_workspace_mfa_enforcement_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/google_workspace_policy_modified.toml
+++ b/rules/google-workspace/google_workspace_policy_modified.toml
@@ -21,7 +21,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Password Policy Modified"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/google_workspace_policy_modified.toml
+++ b/rules/google-workspace/google_workspace_policy_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/google-workspace/mfa_disabled_for_google_workspace_organization.toml
@@ -21,7 +21,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "MFA Disabled for Google Workspace Organization"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/google-workspace/mfa_disabled_for_google_workspace_organization.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -21,7 +21,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Admin Role Assigned to a User"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/google-workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
+++ b/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
@@ -22,7 +22,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace API Access Granted via Domain-Wide Delegation of Authority"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
+++ b/rules/google-workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/12"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/persistence_google_workspace_custom_admin_role_created.toml
+++ b/rules/google-workspace/persistence_google_workspace_custom_admin_role_created.toml
@@ -21,7 +21,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Custom Admin Role Created"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/persistence_google_workspace_custom_admin_role_created.toml
+++ b/rules/google-workspace/persistence_google_workspace_custom_admin_role_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/google-workspace/persistence_google_workspace_role_modified.toml
+++ b/rules/google-workspace/persistence_google_workspace_role_modified.toml
@@ -21,7 +21,11 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Role Modified"
-note = """### Important Information Regarding Google Workspace Event Lag Times
+note = """## Config
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/google-workspace/persistence_google_workspace_role_modified.toml
+++ b/rules/google-workspace/persistence_google_workspace_role_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_loginwindow_plist_modification.toml
+++ b/rules/macos/persistence_loginwindow_plist_modification.toml
@@ -14,7 +14,9 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Potential Persistence via Login Hook"
-note = "Starting in Mac OS X 10.7 (Lion), users can specify certain applications to be re-opened when a user reboots their machine. This can be abused to establish or maintain persistence on a compromised system."
+note = """## Triage and analysis
+
+Starting in Mac OS X 10.7 (Lion), users can specify certain applications to be re-opened when a user reboots their machine. This can be abused to establish or maintain persistence on a compromised system."""
 references = ["https://github.com/D00MFist/PersistentJXA/blob/master/LoginScript.js"]
 risk_score = 47
 rule_id = "ac412404-57a5-476f-858f-4e8fbb4f48d8"

--- a/rules/macos/persistence_loginwindow_plist_modification.toml
+++ b/rules/macos/persistence_loginwindow_plist_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/collection_microsoft_365_new_inbox_rule.toml
+++ b/rules/microsoft-365/collection_microsoft_365_new_inbox_rule.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 New Inbox Rule Created"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/responding-to-a-compromised-email-account?view=o365-worldwide",
     "https://docs.microsoft.com/en-us/powershell/module/exchange/new-inboxrule?view=exchange-ps",

--- a/rules/microsoft-365/collection_microsoft_365_new_inbox_rule.toml
+++ b/rules/microsoft-365/collection_microsoft_365_new_inbox_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/29"
 maturity = "production"
-updated_date = "2021/03/29"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic", "Gary Blackwell", "Austin Songer"]

--- a/rules/microsoft-365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
+++ b/rules/microsoft-365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempts to Brute Force a Microsoft 365 User Account"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 73
 rule_id = "26f68dba-ce29-497b-8e13-b4fde1db5a2d"
 severity = "high"

--- a/rules/microsoft-365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
+++ b/rules/microsoft-365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/30"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/credential_access_microsoft_365_potential_password_spraying_attack.toml
+++ b/rules/microsoft-365/credential_access_microsoft_365_potential_password_spraying_attack.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Potential Password Spraying of Microsoft 365 User Accounts"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 73
 rule_id = "3efee4f0-182a-40a8-a835-102c68a4175d"
 severity = "high"

--- a/rules/microsoft-365/credential_access_microsoft_365_potential_password_spraying_attack.toml
+++ b/rules/microsoft-365/credential_access_microsoft_365_potential_password_spraying_attack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/01"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange DLP Policy Removed"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-dlppolicy?view=exchange-ps",
     "https://docs.microsoft.com/en-us/microsoft-365/compliance/data-loss-prevention-policies?view=o365-worldwide",

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Malware Filter Policy Deletion"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-malwarefilterpolicy?view=exchange-ps",
 ]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Malware Filter Rule Modification"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-malwarefilterrule?view=exchange-ps",
     "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-malwarefilterrule?view=exchange-ps",

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Safe Attachment Rule Disabled"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-safeattachmentrule?view=exchange-ps",
 ]

--- a/rules/microsoft-365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
+++ b/rules/microsoft-365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
+++ b/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
+++ b/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Transport Rule Creation"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/new-transportrule?view=exchange-ps",
     "https://docs.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules",

--- a/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
+++ b/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
+++ b/rules/microsoft-365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Transport Rule Modification"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-transportrule?view=exchange-ps",
     "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-transportrule?view=exchange-ps",

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Anti-Phish Policy Deletion"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-antiphishpolicy?view=exchange-ps",
     "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/set-up-anti-phishing-policies?view=o365-worldwide",

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Anti-Phish Rule Modification"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/remove-antiphishrule?view=exchange-ps",
     "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-antiphishrule?view=exchange-ps",

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
+++ b/rules/microsoft-365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Safe Link Policy Disabled"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/disable-safelinksrule?view=exchange-ps",
     "https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/atp-safe-links?view=o365-worldwide",

--- a/rules/microsoft-365/microsoft_365_exchange_dkim_signing_config_disabled.toml
+++ b/rules/microsoft-365/microsoft_365_exchange_dkim_signing_config_disabled.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange DKIM Signing Configuration Disabled"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/set-dkimsigningconfig?view=exchange-ps",
 ]

--- a/rules/microsoft-365/microsoft_365_exchange_dkim_signing_config_disabled.toml
+++ b/rules/microsoft-365/microsoft_365_exchange_dkim_signing_config_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/microsoft_365_teams_custom_app_interaction_allowed.toml
+++ b/rules/microsoft-365/microsoft_365_teams_custom_app_interaction_allowed.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Teams Custom Application Interaction Allowed"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload"]
 risk_score = 47
 rule_id = "bbd1a775-8267-41fa-9232-20e5582596ac"

--- a/rules/microsoft-365/microsoft_365_teams_custom_app_interaction_allowed.toml
+++ b/rules/microsoft-365/microsoft_365_teams_custom_app_interaction_allowed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/30"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/persistence_microsoft_365_exchange_management_role_assignment.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_exchange_management_role_assignment.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/persistence_microsoft_365_exchange_management_role_assignment.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_exchange_management_role_assignment.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Management Group Role Assignment"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/exchange/new-managementroleassignment?view=exchange-ps",
     "https://docs.microsoft.com/en-us/microsoft-365/admin/add-users/about-admin-roles?view=o365-worldwide",

--- a/rules/microsoft-365/persistence_microsoft_365_teams_external_access_enabled.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_teams_external_access_enabled.toml
@@ -21,7 +21,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Teams External Access Enabled"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/microsoftteams/manage-external-access"]
 risk_score = 47
 rule_id = "27f7c15a-91f8-4c3d-8b9e-1f99cc030a51"

--- a/rules/microsoft-365/persistence_microsoft_365_teams_external_access_enabled.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_teams_external_access_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/30"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/persistence_microsoft_365_teams_guest_access_enabled.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_teams_guest_access_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/microsoft-365/persistence_microsoft_365_teams_guest_access_enabled.toml
+++ b/rules/microsoft-365/persistence_microsoft_365_teams_guest_access_enabled.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Teams Guest Access Enabled"
-note = "The Microsoft 365 Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/skype/get-csteamsclientconfiguration?view=skype-ps",
 ]

--- a/rules/ml/ml_cloudtrail_error_message_spike.toml
+++ b/rules/ml/ml_cloudtrail_error_message_spike.toml
@@ -22,7 +22,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "high_distinct_count_error_message"
 name = "Spike in AWS Error Messages"
-note = """### Investigating Spikes in CloudTrail Errors ###
+note = """## Triage and analysis
+
+### Investigating Spikes in CloudTrail Errors
 Detection alerts from this rule indicate a large spike in the number of CloudTrail log messages that contain a particular error message. The error message in question was associated with the response to an AWS API command or method call. Here are some possible avenues of investigation:
 - Examine the history of the error. Has it manifested before? If the error, which is visible in the `aws.cloudtrail.error_message` field, manifested only very recently, it might be related to recent changes in an automation module or script.
 - Examine the request parameters. These may provide indications as to the nature of the task being performed when the error occurred. Is the error related to unsuccessful attempts to enumerate or access objects, data or secrets? If so, this can sometimes be a byproduct of discovery, privilege escalation or lateral movement attempts.

--- a/rules/ml/ml_cloudtrail_error_message_spike.toml
+++ b/rules/ml/ml_cloudtrail_error_message_spike.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_cloudtrail_rare_error_code.toml
+++ b/rules/ml/ml_cloudtrail_rare_error_code.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-updated_date = "2021/04/12"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50
@@ -22,7 +22,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "rare_error_code"
 name = "Rare AWS Error Code"
-note = """### Investigating Unusual CloudTrail Error Activity ###
+note = """## Triage and analysis
+
+Investigating Unusual CloudTrail Error Activity ###
 Detection alerts from this rule indicate a rare and unusual error code that was associated with the response to an AWS API command or method call. Here are some possible avenues of investigation:
 - Examine the history of the error. Has it manifested before? If the error, which is visible in the `aws.cloudtrail.error_code field`, manifested only very recently, it might be related to recent changes in an automation module or script.
 - Examine the request parameters. These may provide indications as to the nature of the task being performed when the error occurred. Is the error related to unsuccessful attempts to enumerate or access objects, data, or secrets? If so, this can sometimes be a byproduct of discovery, privilege escalation, or lateral movement attempts.

--- a/rules/ml/ml_cloudtrail_rare_method_by_city.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_city.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-updated_date = "2021/04/12"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_cloudtrail_rare_method_by_city.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_city.toml
@@ -23,7 +23,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "rare_method_for_a_city"
 name = "Unusual City For an AWS Command"
-note = """### Investigating an Unusual CloudTrail Event ###
+note = """## Triage and analysis
+
+### Investigating an Unusual CloudTrail Event
 Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the geolocation of the source IP address. Here are some possible avenues of investigation:
 - Consider the source IP address and geolocation for the calling user who issued the command. Do they look normal for the calling user? If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or could it be sourcing from an EC2 instance not under your control? If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
 - Consider the user as identified by the `user.name` field. Is this command part of an expected workflow for the user context? Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key id in the `aws.cloudtrail.user_identity.access_key_id` field which can help identify the precise user context. The user agent details in the `user_agent.original` field may also indicate what kind of a client made the request.

--- a/rules/ml/ml_cloudtrail_rare_method_by_country.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_country.toml
@@ -23,7 +23,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "rare_method_for_a_country"
 name = "Unusual Country For an AWS Command"
-note = """### Investigating an Unusual CloudTrail Event ###
+note = """## Triage and analysis
+
+### Investigating an Unusual CloudTrail Event
 Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the geolocation of the source IP address. Here are some possible avenues of investigation:
 - Consider the source IP address and geolocation for the calling user who issued the command. Do they look normal for the calling user? If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or could it be sourcing from an EC2 instance not under your control? If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
 - Consider the user as identified by the `user.name` field. Is this command part of an expected workflow for the user context? Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key id in the `aws.cloudtrail.user_identity.access_key_id` field which can help identify the precise user context. The user agent details in the `user_agent.original` field may also indicate what kind of a client made the request.

--- a/rules/ml/ml_cloudtrail_rare_method_by_country.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_country.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-updated_date = "2021/04/12"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_cloudtrail_rare_method_by_user.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-updated_date = "2021/04/12"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 75

--- a/rules/ml/ml_cloudtrail_rare_method_by_user.toml
+++ b/rules/ml/ml_cloudtrail_rare_method_by_user.toml
@@ -22,7 +22,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "rare_method_for_a_username"
 name = "Unusual AWS Command for a User"
-note = """### Investigating an Unusual CloudTrail Event ###
+note = """## Triage and analysis
+
+### Investigating an Unusual CloudTrail Event
 Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the calling IAM user. Here are some possible avenues of investigation:
 - Consider the user as identified by the `user.name` field. Is this command part of an expected workflow for the user context? Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key id in the `aws.cloudtrail.user_identity.access_key_id` field which can help identify the precise user context. The user agent details in the `user_agent.original` field may also indicate what kind of a client made the request.
 - Consider the source IP address and geolocation for the calling user who issued the command. Do they look normal for the calling user? If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or could it be sourcing from an EC2 instance not under your control? If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?

--- a/rules/ml/ml_linux_anomalous_network_activity.toml
+++ b/rules/ml/ml_linux_anomalous_network_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_linux_anomalous_network_activity.toml
+++ b/rules/ml/ml_linux_anomalous_network_activity.toml
@@ -18,7 +18,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "linux_anomalous_network_activity_ecs"
 name = "Unusual Linux Network Activity"
-note = """### Investigating Unusual Network Activity ###
+note = """## Triage and analysis
+
+### Investigating Unusual Network Activity
 Detection alerts from this rule indicate the presence of network activity from a Linux process for which network activity is rare and unusual.  Here are some possible avenues of investigation:
 - Consider the IP addresses and ports. Are these used by normal but infrequent network workflows? Are they expected or unexpected?
 - If the destination IP address is remote or external, does it associate with an expected domain, organization or geography? Note: avoid interacting directly with suspected malicious IP addresses.

--- a/rules/ml/ml_linux_anomalous_process_all_hosts.toml
+++ b/rules/ml/ml_linux_anomalous_process_all_hosts.toml
@@ -22,7 +22,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "linux_anomalous_process_all_hosts_ecs"
 name = "Anomalous Process For a Linux Population"
-note = """### Investigating an Unusual Linux Process ###
+note = """## Triage and analysis
+
+### Investigating an Unusual Linux Process
 Detection alerts from this rule indicate the presence of a Linux process that is rare and unusual for all of the monitored Linux hosts for which Auditbeat data is available. Here are some possible avenues of investigation:
 - Consider the user as identified by the username field. Is this program part of an expected workflow for the user who ran this program on this host?
 - Examine the history of execution. If this process manifested only very recently, it might be part of a new software package. If it has a consistent cadence - for example if it runs monthly or quarterly - it might be part of a monthly or quarterly business process.

--- a/rules/ml/ml_linux_anomalous_process_all_hosts.toml
+++ b/rules/ml/ml_linux_anomalous_process_all_hosts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_linux_anomalous_user_name.toml
+++ b/rules/ml/ml_linux_anomalous_user_name.toml
@@ -27,7 +27,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "linux_anomalous_user_name_ecs"
 name = "Unusual Linux Username"
-note = """### Investigating an Unusual Linux User ###
+note = """## Triage and analysis
+
+### Investigating an Unusual Linux User
 Detection alerts from this rule indicate activity for a Linux user name that is rare and unusual. Here are some possible avenues of investigation:
 - Consider the user as identified by the username field. Is this program part of an expected workflow for the user who ran this program on this host? Could this be related to troubleshooting or debugging activity by a developer or site reliability engineer?
 - Examine the history of user activity. If this user manifested only very recently, it might be a service account for a new software package. If it has a consistent cadence - for example if it runs monthly or quarterly - it might be part of a monthly or quarterly business process.

--- a/rules/ml/ml_linux_anomalous_user_name.toml
+++ b/rules/ml/ml_linux_anomalous_user_name.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_rare_process_by_host_linux.toml
+++ b/rules/ml/ml_rare_process_by_host_linux.toml
@@ -22,7 +22,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "rare_process_by_host_linux_ecs"
 name = "Unusual Process For a Linux Host"
-note = """### Investigating an Unusual Linux Process ###
+note = """## Triage and analysis
+
+### Investigating an Unusual Linux Process
 Detection alerts from this rule indicate the presence of a Linux process that is rare and unusual for the host it ran on. Here are some possible avenues of investigation:
 - Consider the user as identified by the username field. Is this program part of an expected workflow for the user who ran this program on this host?
 - Examine the history of execution. If this process manifested only very recently, it might be part of a new software package. If it has a consistent cadence - for example if it runs monthly or quarterly - it might be part of a monthly or quarterly business process.

--- a/rules/ml/ml_rare_process_by_host_linux.toml
+++ b/rules/ml/ml_rare_process_by_host_linux.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_rare_process_by_host_windows.toml
+++ b/rules/ml/ml_rare_process_by_host_windows.toml
@@ -22,7 +22,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "rare_process_by_host_windows_ecs"
 name = "Unusual Process For a Windows Host"
-note = """### Investigating an Unusual Windows Process ###
+note = """## Triage and analysis
+
+### Investigating an Unusual Windows Process
 Detection alerts from this rule indicate the presence of a Windows process that is rare and unusual for the host it ran on. Here are some possible avenues of investigation:
 - Consider the user as identified by the username field. Is this program part of an expected workflow for the user who ran this program on this host?
 - Examine the history of execution. If this process manifested only very recently, it might be part of a new software package. If it has a consistent cadence - for example if it runs monthly or quarterly - it might be part of a monthly or quarterly business process.

--- a/rules/ml/ml_rare_process_by_host_windows.toml
+++ b/rules/ml/ml_rare_process_by_host_windows.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_windows_anomalous_network_activity.toml
+++ b/rules/ml/ml_windows_anomalous_network_activity.toml
@@ -19,7 +19,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "windows_anomalous_network_activity_ecs"
 name = "Unusual Windows Network Activity"
-note = """### Investigating Unusual Network Activity ###
+note = """## Triage and analysis
+
+### Investigating Unusual Network Activity
 Detection alerts from this rule indicate the presence of network activity from a Windows process for which network activity is very unusual.  Here are some possible avenues of investigation:
 - Consider the IP addresses, protocol and ports. Are these used by normal but infrequent network workflows? Are they expected or unexpected?
 - If the destination IP address is remote or external, does it associate with an expected domain, organization or geography? Note: avoid interacting directly with suspected malicious IP addresses.

--- a/rules/ml/ml_windows_anomalous_network_activity.toml
+++ b/rules/ml/ml_windows_anomalous_network_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_windows_anomalous_process_all_hosts.toml
+++ b/rules/ml/ml_windows_anomalous_process_all_hosts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_windows_anomalous_process_all_hosts.toml
+++ b/rules/ml/ml_windows_anomalous_process_all_hosts.toml
@@ -22,7 +22,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "windows_anomalous_process_all_hosts_ecs"
 name = "Anomalous Process For a Windows Population"
-note = """### Investigating an Unusual Windows Process ###
+note = """## Triage and analysis
+
+### Investigating an Unusual Windows Process
 Detection alerts from this rule indicate the presence of a Windows process that is rare and unusual for all of the Windows hosts for which Winlogbeat data is available. Here are some possible avenues of investigation:
 - Consider the user as identified by the username field. Is this program part of an expected workflow for the user who ran this program on this host?
 - Examine the history of execution. If this process manifested only very recently, it might be part of a new software package. If it has a consistent cadence - for example if it runs monthly or quarterly - it might be part of a monthly or quarterly business process.

--- a/rules/ml/ml_windows_anomalous_user_name.toml
+++ b/rules/ml/ml_windows_anomalous_user_name.toml
@@ -27,7 +27,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "windows_anomalous_user_name_ecs"
 name = "Unusual Windows Username"
-note = """### Investigating an Unusual Windows User ###
+note = """## Triage and analysis
+
+### Investigating an Unusual Windows User
 Detection alerts from this rule indicate activity for a Windows user name that is rare and unusual. Here are some possible avenues of investigation:
 - Consider the user as identified by the username field. Is this program part of an expected workflow for the user who ran this program on this host? Could this be related to occasional troubleshooting or support activity?
 - Examine the history of user activity. If this user manifested only very recently, it might be a service account for a new software package. If it has a consistent cadence - for example if it runs monthly or quarterly - it might be part of a monthly or quarterly business process.

--- a/rules/ml/ml_windows_anomalous_user_name.toml
+++ b/rules/ml/ml_windows_anomalous_user_name.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/ml/ml_windows_rare_user_type10_remote_login.toml
+++ b/rules/ml/ml_windows_rare_user_type10_remote_login.toml
@@ -22,7 +22,9 @@ interval = "15m"
 license = "Elastic License v2"
 machine_learning_job_id = "windows_rare_user_type10_remote_login"
 name = "Unusual Windows Remote User"
-note = """### Investigating an Unusual Windows User ###
+note = """## Triage and analysis
+
+### Investigating an Unusual Windows User
 Detection alerts from this rule indicate activity for a rare and unusual Windows RDP (remote desktop) user. Here are some possible avenues of investigation:
 - Consider the user as identified by the username field. Is the user part of a group who normally logs into Windows hosts using RDP (remote desktop protocol)? Is this logon activity part of an expected workflow for the user?
 - Consider the source of the login. If the source is remote, could this be related to occasional troubleshooting or support activity by a vendor or an employee working remotely?"""

--- a/rules/ml/ml_windows_rare_user_type10_remote_login.toml
+++ b/rules/ml/ml_windows_rare_user_type10_remote_login.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 anomaly_threshold = 50

--- a/rules/network/command_and_control_cobalt_strike_beacon.toml
+++ b/rules/network/command_and_control_cobalt_strike_beacon.toml
@@ -20,7 +20,9 @@ index = ["packetbeat-*"]
 language = "lucene"
 license = "Elastic License v2"
 name = "Cobalt Strike Command and Control Beacon"
-note = "This activity has been observed in FIN7 campaigns."
+note = """## Threat intel
+
+This activity has been observed in FIN7 campaigns."""
 references = [
     "https://blog.morphisec.com/fin7-attacks-restaurant-industry",
     "https://www.fireeye.com/blog/threat-research/2017/04/fin7-phishing-lnk.html",

--- a/rules/network/command_and_control_cobalt_strike_beacon.toml
+++ b/rules/network/command_and_control_cobalt_strike_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
+++ b/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/05"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
+++ b/rules/network/command_and_control_cobalt_strike_default_teamserver_cert.toml
@@ -16,7 +16,9 @@ index = ["filebeat-*", "packetbeat-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Default Cobalt Strike Team Server Certificate"
-note = "While Cobalt Strike is intended to be used for penetration tests and IR training, it is frequently used by actual threat actors (TA) such as APT19, APT29, APT32, APT41, FIN6, DarkHydrus, CopyKittens, Cobalt Group, Leviathan, and many other unnamed criminal TAs. This rule uses high-confidence atomic indicators, alerts should be investigated rapidly."
+note = """## Threat intel
+
+While Cobalt Strike is intended to be used for penetration tests and IR training, it is frequently used by actual threat actors (TA) such as APT19, APT29, APT32, APT41, FIN6, DarkHydrus, CopyKittens, Cobalt Group, Leviathan, and many other unnamed criminal TAs. This rule uses high-confidence atomic indicators, alerts should be investigated rapidly."""
 references = [
     "https://attack.mitre.org/software/S0154/",
     "https://www.cobaltstrike.com/help-setup-collaboration",

--- a/rules/network/command_and_control_download_rar_powershell_from_internet.toml
+++ b/rules/network/command_and_control_download_rar_powershell_from_internet.toml
@@ -21,7 +21,9 @@ index = ["packetbeat-*"]
 language = "lucene"
 license = "Elastic License v2"
 name = "Roshal Archive (RAR) or PowerShell File Downloaded from the Internet"
-note = "This activity has been observed in FIN7 campaigns."
+note = """## Threat intel
+
+This activity has been observed in FIN7 campaigns."""
 references = [
     "https://www.fireeye.com/blog/threat-research/2017/04/fin7-phishing-lnk.html",
     "https://www.justice.gov/opa/press-release/file/1084361/download",

--- a/rules/network/command_and_control_download_rar_powershell_from_internet.toml
+++ b/rules/network/command_and_control_download_rar_powershell_from_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/02"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -19,7 +19,9 @@ index = ["packetbeat-*"]
 language = "lucene"
 license = "Elastic License v2"
 name = "Possible FIN7 DGA Command and Control Behavior"
-note = "In the event this rule identifies benign domains in your environment, the `destination.domain` field in the rule can be modified to include those domains. Example: `...AND NOT destination.domain:(zoom.us OR benign.domain1 OR benign.domain2)`."
+note = """## Triage and analysis
+
+In the event this rule identifies benign domains in your environment, the `destination.domain` field in the rule can be modified to include those domains. Example: `...AND NOT destination.domain:(zoom.us OR benign.domain1 OR benign.domain2)`."""
 references = [
     "https://www.fireeye.com/blog/threat-research/2018/08/fin7-pursuing-an-enigmatic-and-evasive-global-criminal-operation.html",
 ]

--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_halfbaked_beacon.toml
+++ b/rules/network/command_and_control_halfbaked_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_halfbaked_beacon.toml
+++ b/rules/network/command_and_control_halfbaked_beacon.toml
@@ -19,7 +19,9 @@ index = ["packetbeat-*"]
 language = "lucene"
 license = "Elastic License v2"
 name = "Halfbaked Command and Control Beacon"
-note = "This activity has been observed in FIN7 campaigns."
+note = """## Threat intel
+
+This activity has been observed in FIN7 campaigns."""
 references = [
     "https://www.fireeye.com/blog/threat-research/2017/04/fin7-phishing-lnk.html",
     "https://attack.mitre.org/software/S0151/",

--- a/rules/network/initial_access_unsecure_elasticsearch_node.toml
+++ b/rules/network/initial_access_unsecure_elasticsearch_node.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/11"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/initial_access_unsecure_elasticsearch_node.toml
+++ b/rules/network/initial_access_unsecure_elasticsearch_node.toml
@@ -19,7 +19,9 @@ index = ["packetbeat-*"]
 language = "lucene"
 license = "Elastic License v2"
 name = "Inbound Connection to an Unsecure Elasticsearch Node"
-note = "This rule requires the addition of port `9200` and `send_all_headers` to the `HTTP` protocol configuration in `packetbeat.yml`. See the References section for additional configuration documentation."
+note = """## Config
+
+This rule requires the addition of port `9200` and `send_all_headers` to the `HTTP` protocol configuration in `packetbeat.yml`. See the References section for additional configuration documentation."""
 references = [
     "https://www.elastic.co/guide/en/elasticsearch/reference/current/configuring-security.html",
     "https://www.elastic.co/guide/en/beats/packetbeat/current/packetbeat-http-options.html#_send_all_headers",

--- a/rules/okta/attempt_to_deactivate_okta_network_zone.toml
+++ b/rules/okta/attempt_to_deactivate_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/attempt_to_deactivate_okta_network_zone.toml
+++ b/rules/okta/attempt_to_deactivate_okta_network_zone.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate an Okta Network Zone"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/network/network-zones.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/attempt_to_delete_okta_network_zone.toml
+++ b/rules/okta/attempt_to_delete_okta_network_zone.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Delete an Okta Network Zone"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/network/network-zones.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/attempt_to_delete_okta_network_zone.toml
+++ b/rules/okta/attempt_to_delete_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -13,7 +13,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempted Bypass of Okta MFA"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
+++ b/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
+++ b/rules/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
@@ -15,7 +15,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempts to Brute Force an Okta User Account"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/credential_access_okta_brute_force_or_password_spraying.toml
+++ b/rules/okta/credential_access_okta_brute_force_or_password_spraying.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Okta Brute Force or Password Spraying Attack"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/credential_access_okta_brute_force_or_password_spraying.toml
+++ b/rules/okta/credential_access_okta_brute_force_or_password_spraying.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/defense_evasion_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/defense_evasion_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/defense_evasion_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/okta/defense_evasion_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -22,7 +22,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "High Number of Okta User Password Reset or Unlock Attempts"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Revoke Okta API Token"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/okta/impact_possible_okta_dos_attack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/okta/impact_possible_okta_dos_attack.toml
@@ -13,7 +13,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Possible Okta DoS Attack"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -14,7 +14,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Suspicious Activity Reported by Okta User"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_deactivate_okta_application.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_deactivate_okta_application.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_application.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate an Okta Application"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Apps/Apps_Apps.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_deactivate_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_policy.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate an Okta Policy"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/Security_Policies.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_deactivate_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate an Okta Policy Rule"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/Security_Policies.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_delete_okta_application.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_delete_okta_application.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_application.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Delete an Okta Application"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_delete_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Delete an Okta Policy"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/Security_Policies.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_delete_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/28"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_delete_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_delete_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_delete_okta_policy_rule.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Delete an Okta Policy Rule"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/Security_Policies.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_modify_okta_application.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_application.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Modify an Okta Application"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Apps/Apps_Apps.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_modify_okta_application.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_application.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_network_zone.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Modify an Okta Network Zone"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/network/network-zones.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_modify_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Modify an Okta Policy"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/okta_attempt_to_modify_okta_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy_rule.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Modify an Okta Policy Rule"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/Security_Policies.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_modify_okta_policy_rule.toml
+++ b/rules/okta/okta_attempt_to_modify_okta_policy_rule.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Modification or Removal of an Okta Application Sign-On Policy"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/App_Based_Signon.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/01"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
+++ b/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
+++ b/rules/okta/okta_threat_detected_by_okta_threatinsight.toml
@@ -14,7 +14,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Threat Detected by Okta ThreatInsight"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Administrator Privileges Assigned to an Okta Group"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Administrator Role Assigned to an Okta User"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://help.okta.com/en/prod/Content/Topics/Security/administrators-admin-comparison.htm",
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Create Okta API Token"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -19,7 +19,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate MFA for an Okta User Account"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -20,7 +20,9 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Reset MFA Factors for an Okta User Account"
-note = "The Okta Fleet integration or Filebeat module must be enabled to use this rule."
+note = """## Config
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -11,7 +11,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote File Download via MpCmdRun"
-note = """### Investigating Remote File Download via MpCmdRun
+note = """## Triage and analysis
+
+### Investigating Remote File Download via MpCmdRun
 Verify details such as the parent process, URL reputation, and downloaded file details. Additionally, `MpCmdRun` logs this information in the Appdata Temp folder in `MpCmdRun.log`."""
 references = [
     "https://twitter.com/mohammadaskar2/status/1301263551638761477",

--- a/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
+++ b/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
@@ -14,7 +14,9 @@ index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "SUNBURST Command and Control Activity"
-note = "The SUNBURST malware attempts to hide within the Orion Improvement Program (OIP) network traffic. As this rule detects post-exploitation network traffic, investigations into this should be prioritized."
+note = """## Triage and analysis
+
+The SUNBURST malware attempts to hide within the Orion Improvement Program (OIP) network traffic. As this rule detects post-exploitation network traffic, investigations into this should be prioritized."""
 references = [
     "https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html",
 ]

--- a/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
+++ b/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -14,7 +14,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation or Modification of Domain Backup DPAPI private key"
-note = "### Domain DPAPI Backup keys are stored on domain controllers and can be dumped remotely with tools such as Mimikatz. The resulting .pvk private key can be used to decrypt ANY domain user masterkeys, which then can be used to decrypt any secrets protected by those keys."
+note = """## Triage and analysis
+
+Domain DPAPI Backup keys are stored on domain controllers and can be dumped remotely with tools such as Mimikatz. The resulting .pvk private key can be used to decrypt ANY domain user masterkeys, which then can be used to decrypt any secrets protected by those keys."""
 references = [
     "https://www.dsinternals.com/en/retrieving-dpapi-backup-keys-from-active-directory/",
     "https://www.harmj0y.net/blog/redteaming/operational-guidance-for-offensive-user-dpapi-abuse/",

--- a/rules/windows/credential_access_mimikatz_powershell_module.toml
+++ b/rules/windows/credential_access_mimikatz_powershell_module.toml
@@ -15,7 +15,9 @@ index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Mimikatz Powershell Module Activity Detected"
-note = "This rule identifies an adversary attempt to collect, decrypt, and/or use cached credentials. Alerts from this rule should be prioritized because an adversary has an initial foothold onto an endpoint."
+note = """## Triage and analysis
+
+This rule identifies an adversary attempt to collect, decrypt, and/or use cached credentials. Alerts from this rule should be prioritized because an adversary has an initial foothold onto an endpoint."""
 references = ["https://attack.mitre.org/software/S0002/"]
 risk_score = 99
 rule_id = "ac96ceb8-4399-4191-af1d-4feeac1f1f46"

--- a/rules/windows/credential_access_mimikatz_powershell_module.toml
+++ b/rules/windows/credential_access_mimikatz_powershell_module.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/07"
 maturity = "development"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_defender_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_defender_disabled_via_registry.toml
@@ -14,7 +14,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Windows Defender Disabled via Registry Modification"
-note = "Detections should be investigated to identify if the hosts and users are authorized to use this tool. As this rule detects post-exploitation process activity, investigations into this should be prioritized"
+note = """## Triage and analysis
+
+Detections should be investigated to identify if the hosts and users are authorized to use this tool. As this rule detects post-exploitation process activity, investigations into this should be prioritized"""
 references = ["https://thedfirreport.com/2020/12/13/defender-control/"]
 risk_score = 21
 rule_id = "2ffa1f1e-b6db-47fa-994b-1512743847eb"

--- a/rules/windows/defense_evasion_defender_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_defender_disabled_via_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
+++ b/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
+++ b/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
@@ -14,7 +14,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Secure File Deletion via SDelete Utility"
-note = "Verify process details such as command line and hash to confirm this activity legitimacy."
+note = """## Triage and analysis
+
+Verify process details such as command line and hash to confirm this activity legitimacy."""
 risk_score = 21
 rule_id = "5aee924b-6ceb-4633-980e-1bde8cdb40c5"
 severity = "low"

--- a/rules/windows/discovery_adfind_command_activity.toml
+++ b/rules/windows/discovery_adfind_command_activity.toml
@@ -15,7 +15,9 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "AdFind Command Activity"
-note = "`AdFind.exe` is a legitimate domain query tool. Rule alerts should be investigated to identify if the user has a role that would explain using this tool and that it is being run from an expected directory and endpoint. Leverage the exception workflow in the Kibana Security App or Elasticsearch API to tune this rule to your environment."
+note = """## Triage and analysis
+
+`AdFind.exe` is a legitimate domain query tool. Rule alerts should be investigated to identify if the user has a role that would explain using this tool and that it is being run from an expected directory and endpoint. Leverage the exception workflow in the Kibana Security App or Elasticsearch API to tune this rule to your environment."""
 references = [
     "http://www.joeware.net/freetools/tools/adfind/",
     "https://thedfirreport.com/2020/05/08/adfind-recon/",

--- a/rules/windows/discovery_adfind_command_activity.toml
+++ b/rules/windows/discovery_adfind_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_from_unusual_path_cmdline.toml
+++ b/rules/windows/execution_from_unusual_path_cmdline.toml
@@ -14,7 +14,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Execution from Unusual Directory - Command Line"
-note = "This is related to the Process Execution from an Unusual Directory rule"
+note = """## Triage and analysis
+
+This is related to the `Process Execution from an Unusual Directory rule`."""
 risk_score = 47
 rule_id = "cff92c41-2225-4763-b4ce-6f71e5bda5e6"
 severity = "medium"

--- a/rules/windows/execution_from_unusual_path_cmdline.toml
+++ b/rules/windows/execution_from_unusual_path_cmdline.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/30"
 maturity = "production"
-updated_date = "2021/03/09"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/execution_shared_modules_local_sxs_dll.toml
+++ b/rules/windows/execution_shared_modules_local_sxs_dll.toml
@@ -15,7 +15,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Execution via local SxS Shared Module"
-note = "The SxS DotLocal folder is a legitimate feature that can be abused to hijack standard modules loading order by forcing an executable on the same application.exe.local folder to load a malicious DLL module from the same directory."
+note = """## Triage and analysis
+
+The SxS DotLocal folder is a legitimate feature that can be abused to hijack standard modules loading order by forcing an executable on the same application.exe.local folder to load a malicious DLL module from the same directory."""
 references = ["https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-redirection"]
 risk_score = 47
 rule_id = "a3ea12f3-0d4e-4667-8b44-4230c63f3c75"

--- a/rules/windows/execution_shared_modules_local_sxs_dll.toml
+++ b/rules/windows/execution_shared_modules_local_sxs_dll.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_suspicious_ms_exchange_files.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_files.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/04"
 maturity = "production"
-updated_date = "2021/03/09"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/windows/initial_access_suspicious_ms_exchange_files.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_files.toml
@@ -26,6 +26,7 @@ language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Exchange Server UM Writing Suspicious Files"
 note = """## Triage and analysis
+
 Positive hits can be checked against the established Microsoft [baselines](https://github.com/microsoft/CSS-Exchange/tree/main/Security/Baselines).
 
 Microsoft highly recommends that the best course of action is patching, but this may not protect already compromised systems

--- a/rules/windows/initial_access_unusual_dns_service_children.toml
+++ b/rules/windows/initial_access_unusual_dns_service_children.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_unusual_dns_service_children.toml
+++ b/rules/windows/initial_access_unusual_dns_service_children.toml
@@ -21,7 +21,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Child Process of dns.exe"
-note = """### Investigating Unusual Child Process
+note = """## Triage and analysis
+
+### Investigating Unusual Child Process
 Detection alerts from this rule indicate potential suspicious child processes spawned after exploitation from CVE-2020-1350 (SigRed) has occurred. Here are some possible avenues of investigation:
 - Any suspicious or abnormal child process spawned from dns.exe should be reviewed and investigated with care. It's impossible to predict what an adversary may deploy as the follow-on process after the exploit, but built-in discovery/enumeration utilities should be top of mind (whoami.exe, netstat.exe, systeminfo.exe, tasklist.exe).
 - Built-in Windows programs that contain capabilities used to download and execute additional payloads should also be considered. This is not an exhaustive list, but ideal candidates to start out would be: mshta.exe, powershell.exe, regsvr32.exe, rundll32.exe, wscript.exe, wmic.exe.

--- a/rules/windows/initial_access_unusual_dns_service_file_writes.toml
+++ b/rules/windows/initial_access_unusual_dns_service_file_writes.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_unusual_dns_service_file_writes.toml
+++ b/rules/windows/initial_access_unusual_dns_service_file_writes.toml
@@ -14,7 +14,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual File Modification by dns.exe"
-note = """### Investigating Unusual File Write
+note = """## Triage and analysis
+
+### Investigating Unusual File Write
 Detection alerts from this rule indicate potential unusual/abnormal file writes from the DNS Server service process (`dns.exe`) after exploitation from CVE-2020-1350 (SigRed) has occurred. Here are some possible avenues of investigation:
 - Post-exploitation, adversaries may write additional files or payloads to the system as additional discovery/exploitation/persistence mechanisms.
 - Any suspicious or abnormal files written from `dns.exe` should be reviewed and investigated with care."""

--- a/rules/windows/lateral_movement_dns_server_overflow.toml
+++ b/rules/windows/lateral_movement_dns_server_overflow.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_dns_server_overflow.toml
+++ b/rules/windows/lateral_movement_dns_server_overflow.toml
@@ -20,7 +20,9 @@ index = ["packetbeat-*", "filebeat-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Abnormally Large DNS Response"
-note = """### Investigating Large DNS Responses
+note = """## Triage and analysis
+
+### Investigating Large DNS Responses
 Detection alerts from this rule indicate an attempt was made to exploit CVE-2020-1350 (SigRed) through the use of large DNS responses on a Windows DNS server. Here are some possible avenues of investigation:
 - Investigate any corresponding Intrusion Detection Signatures (IDS) alerts that can validate this detection alert.
 - Examine the `dns.question_type` network fieldset with a protocol analyzer, such as Zeek, Packetbeat, or Suricata, for `SIG` or `RRSIG` data.

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -11,7 +11,9 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote Scheduled Task Creation"
-note = "Decode the base64 encoded tasks actions registry value to investigate the task configured action."
+note = """## Triage and analysis
+
+Decode the base64 encoded tasks actions registry value to investigate the task configured action."""
 risk_score = 47
 rule_id = "954ee7c8-5437-49ae-b2d6-2960883898e9"
 severity = "medium"

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
+++ b/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
@@ -14,7 +14,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Startup Shell Folder Modification"
-note = "Verify file creation events in the new Windows Startup folder location."
+note = """## Triage and analysis
+
+Verify file creation events in the new Windows Startup folder location."""
 risk_score = 73
 rule_id = "c8b150f0-0164-475b-a75e-74b47800a9ff"
 severity = "high"

--- a/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
+++ b/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/15"
 maturity = "production"
-updated_date = "2021/03/15"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_local_scheduled_task_scripting.toml
+++ b/rules/windows/persistence_local_scheduled_task_scripting.toml
@@ -15,7 +15,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Scheduled Task Created by a Windows Script"
-note = "Decode the base64 encoded Tasks Actions registry value to investigate the task's configured action."
+note = """## Triage and analysis
+
+Decode the base64 encoded Tasks Actions registry value to investigate the task's configured action."""
 risk_score = 47
 rule_id = "689b9d57-e4d5-4357-ad17-9c334609d79a"
 severity = "medium"

--- a/rules/windows/persistence_local_scheduled_task_scripting.toml
+++ b/rules/windows/persistence_local_scheduled_task_scripting.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/29"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2021/05/10"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -14,7 +14,9 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious PrintSpooler SPL File Created"
-note = "Refer to CVEs, CVE-2020-1048 and CVE-2020-1337 for further information on the vulnerability and exploit. Verify that the relevant system is patched."
+note = """## Threat intel
+
+Refer to CVEs, CVE-2020-1048 and CVE-2020-1337 for further information on the vulnerability and exploit. Verify that the relevant system is patched."""
 references = ["https://safebreach.com/Post/How-we-bypassed-CVE-2020-1048-Patch-and-got-CVE-2020-1337"]
 risk_score = 73
 rule_id = "a7ccae7b-9d2c-44b2-a061-98e5946971fa"


### PR DESCRIPTION
## Issues
related to #569

## Summary
This cleans up and standardizes the `note` field (_investigation guide_ in Kibana). Categorizes information into:
* `Triage and analysis`
* `Threat intel`
* `Config`

`Config` is a temporary solution until a more permanent place is added within Kibana