### PR TITLE
[Bug] Update main.py to fix toml-lint

### DIFF
--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -113,8 +113,8 @@ def import_rules(input_file, directory):
 
 
 @root.command('toml-lint')
-@click.option('--rule-file', '-f', type=click.Path(), multiple=True,
-              help='Optionally specify rule files')
+@click.option('--rule-file', '-f', multiple=True, type=click.Path('r'),
+              help='Optionally specify a specific rule file only')
 def toml_lint(rule_file):
     """Cleanup files with some simple toml formatting."""
     if rule_file:

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -113,8 +113,8 @@ def import_rules(input_file, directory):
 
 
 @root.command('toml-lint')
-@click.option('--rule-file', '-f', multiple=True, type=click.Path('r'),
-              help='Optionally specify a specific rule file only')
+@click.option('--rule-file', '-f', multiple=True, type=click.Path(exists=True),
+              help='Specify one or more rule files.')
 def toml_lint(rule_file):
     """Cleanup files with some simple toml formatting."""
     if rule_file:


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Summary
Toml-lint wasn't working correctly. This small change updates `main.py` and fixes it. 

### Before
```bash
Error loading rule in C
Traceback (most recent call last):
  File "c:\users\bmurphy\appdata\local\programs\python\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\bmurphy\appdata\local\programs\python\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\detection_rules\__main__.py", line 34, in <module>
    main()
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\detection_rules\__main__.py", line 31, in main
    root(prog_name="detection_rules")
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\rulez\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\rulez\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\rulez\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\rulez\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\rulez\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\detection_rules\main.py", line 121, in toml_lint
    rules.load_files(Path(p) for p in rule_file)
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\detection_rules\rule_loader.py", line 169, in load_files
    self.load_file(path)
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\detection_rules\rule_loader.py", line 160, in load_file
    obj = self._deserialize_toml(path)
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\detection_rules\rule_loader.py", line 121, in _deserialize_toml
    with io.open(str(path.resolve()), "r", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'C'
```
### After
![image](https://user-images.githubusercontent.com/56412096/118037732-3a275d00-b33c-11eb-9513-4bd895412de0.png)


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
