### PR TITLE
[CI] Apply `backport: auto` label on PRs to `main` by default

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,12 +4,47 @@ on:
     branches:
       - main
     types:
+      - opened
+      - reopened
+      - unlabeled
       - labeled
       - closed
 
 jobs:
-  backport:
-    name: on merge
+  label:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.state == 'open' && !github.event.pull_request.draft
+    steps:
+      - name: 'Apply default "backport: auto" label'
+        uses: actions/github-script@v4
+        if: |
+          !contains(github.event.pull_request.labels.*.name, 'backport: auto') &&
+          !contains(github.event.pull_request.labels.*.name, 'backport: skip')
+        with:
+          script: |
+            github.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['backport: auto']
+            })
+      - name: 'Remove "backport: auto" if "backport: skip" is set'
+        uses: actions/github-script@v4
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'backport: auto') &&
+          contains(github.event.pull_request.labels.*.name, 'backport: skip')
+        with:
+          script: |
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'backport: auto'
+            })
+
+
+  commit:
     if: |
       github.event.pull_request.merged == true
       && contains(github.event.pull_request.labels.*.name, 'backport: auto')


### PR DESCRIPTION
## Issues
Part of #1171

## Summary
Works like this on a PR to main:
* If no backport labels are specified, it gets set to `backport: auto`
* If any other backport labels are specified, then `backport: auto` is removed


So if you have two conflicting `backport: auto` and `backport: label` labels, it'll remove the `backport: auto` one.