### PR TITLE
[Bug] Error when attempting to export all rules from a directory

### DIFF
--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -74,7 +74,7 @@ def multi_collection(f):
 
         rules = RuleCollection()
 
-        if not (rule_name or rule_id or rule_files):
+        if not (rule_name or rule_id or rule_files or directories):
             client_error('Required: at least one of --rule-id, --rule-file, or --directory')
 
         rules.load_files(Path(p) for p in rule_files)


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

None

## Summary

The following error is displayed when a user attempts to export all rules from a directory.

```console
(.venv) $ python -m detection_rules export-rules -d rules/ --stack-version 7.13 -o ./exported_rules.ndjson

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

CLI Error : Required: at least one of --rule-id, --rule-file, or --directory
```

This PR adds a check for `directories` in `detection_rules.cli_utils.multi_collection`

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
