### PR TITLE
Fix create-rule bug

### DIFF
--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -16,7 +16,6 @@ from uuid import uuid4
 
 import click
 
-from . import rule_loader
 from .cli_utils import rule_prompt, multi_collection
 from .misc import nested_set, parse_config
 from .rule import TOMLRule, TOMLRuleContents

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -49,10 +49,7 @@ def root(ctx, debug):
 def create_rule(path, config, required_only, rule_type):
     """Create a detection rule."""
     contents = load_rule_contents(config, single_only=True)[0] if config else {}
-    try:
-        return rule_prompt(path, rule_type=rule_type, required_only=required_only, save=True, **contents)
-    finally:
-        rule_loader.reset()
+    return rule_prompt(path, rule_type=rule_type, required_only=required_only, save=True, **contents)
 
 
 @root.command('generate-rules-index')

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -402,7 +402,7 @@ class TOMLRuleContents(MarshmallowDataclassMixin):
         """Transform the converted API in place before sending to Kibana."""
 
         # cleanup the whitespace in the rule
-        obj = nested_normalize(obj, eql_rule=obj.get("language") == "eql")
+        obj = nested_normalize(obj)
 
         # fill in threat.technique so it's never missing
         for threat_entry in obj.get("threat", []):

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -52,7 +52,8 @@ def nested_normalize(d, skip_cleanup=False, eql_rule=False):
                     # do not normalize eql queries
                     d.update({k: v})
                 else:
-                    d.update({k: nested_normalize(v)})
+                    # nor any queries
+                    d.update({k: v})
             elif k in get_preserved_fmt_fields():
                 # let these maintain newlines and whitespace for markdown support
                 d.update({k: nested_normalize(v, skip_cleanup=True, eql_rule=eql_rule)})

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -39,26 +39,22 @@ def cleanup_whitespace(val):
     return val
 
 
-def nested_normalize(d, skip_cleanup=False, eql_rule=False):
+def nested_normalize(d, skip_cleanup=False):
     if isinstance(d, str):
         return d if skip_cleanup else cleanup_whitespace(d)
     elif isinstance(d, list):
-        return [nested_normalize(val, eql_rule=eql_rule) for val in d]
+        return [nested_normalize(val) for val in d]
     elif isinstance(d, dict):
         for k, v in d.items():
             if k == 'query':
                 # TODO: the linter still needs some work, but once up to par, uncomment to implement - kql.lint(v)
-                if eql_rule:
-                    # do not normalize eql queries
-                    d.update({k: v})
-                else:
-                    # nor any queries
-                    d.update({k: v})
+                # do not normalize queries
+                d.update({k: v})
             elif k in get_preserved_fmt_fields():
                 # let these maintain newlines and whitespace for markdown support
-                d.update({k: nested_normalize(v, skip_cleanup=True, eql_rule=eql_rule)})
+                d.update({k: nested_normalize(v, skip_cleanup=True)})
             else:
-                d.update({k: nested_normalize(v, eql_rule=eql_rule)})
+                d.update({k: nested_normalize(v)})
         return d
     else:
         return d


### PR DESCRIPTION
## Issues
None

## Summary
Fix bug in `create-rule`:
```
  File "C:\dev\Elastic repos\fork-detection-rules\detection-rules\detection_rules\main.py", line 55, in create_rule
    rule_loader.reset()
AttributeError: module 'detection_rules.rule_loader' has no attribute 'reset'
```

This also updates `toml-lint` to preserve formatting for all queries