### PR TITLE
[Fleet] Update template and packaging code for fleet packages

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,15 +1,15 @@
 Detection Rules
-Copyright 2020 Elasticsearch B.V.
+Copyright 2021 Elasticsearch B.V.
 
 ---
 This product bundles rules based on https://github.com/BlueTeamLabs/sentinel-attack
-which is available under a "MIT" license. The files based on this license are:
+which is available under a "MIT" license. The rules based on this license are:
 
-- defense_evasion_via_filter_manager
-- discovery_process_discovery_via_tasklist_command
-- persistence_priv_escalation_via_accessibility_features
-- persistence_via_application_shimming
-- defense_evasion_execution_via_trusted_developer_utilities
+- "Potential Evasion via Filter Manager" (06dceabf-adca-48af-ac79-ffdf4c3b1e9a)
+- "Process Discovery via Tasklist" (cc16f774-59f9-462d-8b98-d27ccd4519ec)
+- "Potential Modification of Accessibility Binaries" (7405ddf1-6c8e-41ce-818f-48bea6bcaed8)
+- "Potential Application Shimming via Sdbinst" (fd4a992d-6130-4802-9ff8-829b89ae801f)
+- "Trusted Developer Application Usage" (9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1)
 
 MIT License
 
@@ -35,9 +35,9 @@ SOFTWARE.
 
 ---
 This product bundles rules based on https://github.com/FSecureLABS/leonidas
-which is available under a "MIT" license. The files based on this license are:
+which is available under a "MIT" license. The rules based on this license are:
 
-- credential_access_secretsmanager_getsecretvalue.toml
+- "AWS Access Secret in Secrets Manager" (a00681e3-9ed6-447c-ab2c-be648821c622)
 
 MIT License
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -503,16 +503,16 @@ class Package(object):
         notice_contents = Path(NOTICE_FILE).read_text()
         readme_text = textwrap.dedent("""
         # Detection rules
-        
+
         The detection rules package stores the prebuilt security rules for the Elastic Security [detection engine](https://www.elastic.co/guide/en/security/7.13/detection-engine-overview.html).
-        
+
         To download or update the rules, click **Settings** > **Install Prebuilt Security Detection Rules assets**.
         Then [import](https://www.elastic.co/guide/en/security/master/rules-ui-management.html#load-prebuilt-rules)
         the rules into the Detection engine.
-        
+
         ## License Notice
 
-        """) + textwrap.indent(notice_contents, prefix="    ")
+        """) + textwrap.indent(notice_contents, prefix="    ")  # noqa: E501
 
         readme_file.write_text(readme_text)
         notice_file.write_text(notice_contents)

--- a/detection_rules/schemas/registry_package.py
+++ b/detection_rules/schemas/registry_package.py
@@ -6,7 +6,7 @@
 """Definitions for packages destined for the registry."""
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Type
+from typing import Dict, List, Optional, Type
 
 from marshmallow import Schema, validate
 from marshmallow_dataclass import class_schema
@@ -18,22 +18,22 @@ from .definitions import ConditionSemVer, SemVer
 class RegistryPackageManifest:
     """Base class for registry packages."""
 
+    categories: List[str]
     conditions: Dict[str, ConditionSemVer]
+    description: str
+    format_version: SemVer
+    icons: list
+    license: str
+    name: str
+    owner: Dict[str, str]
+    release: str
+    title: str
+    type: str
     version: SemVer
 
-    categories: List[str] = field(default_factory=lambda: ['security'])
-    description: str = 'Rules for the detection engine in the Security application.'
-    format_version: SemVer = field(metadata=dict(validate=validate.Equal('1.0.0')), default='1.0.0')
-    icons: list = field(default_factory=list)
-    internal: bool = True
-    license: str = 'basic'
-    name: str = 'detection_rules'
-    owner: Dict[str, str] = field(default_factory=lambda: dict(github='elastic/protections'))
+    internal: Optional[bool] = None
     policy_templates: list = field(default_factory=list)
-    release: str = 'experimental'
     screenshots: list = field(default_factory=list)
-    title: str = 'Detection rules'
-    type: str = 'integration'
 
     @classmethod
     def get_schema(cls) -> Type[Schema]:

--- a/detection_rules/schemas/registry_package.py
+++ b/detection_rules/schemas/registry_package.py
@@ -8,7 +8,7 @@
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Type
 
-from marshmallow import Schema, validate
+from marshmallow import Schema
 from marshmallow_dataclass import class_schema
 
 from .definitions import ConditionSemVer, SemVer

--- a/etc/packages.yml
+++ b/etc/packages.yml
@@ -24,9 +24,20 @@ package:
 
   # elastic/integrations
   registry_data:
-    # integration package schema version
-    format_version: "1.0.0"
+    categories: ["security"]
     conditions:
       kibana_version: "^7.13.0"
-    # this determines the version for the package-storage generated artifact
-    version: "0.0.1-dev.3"
+    description: "Prebuilt detection rules for Elastic Security"
+    format_version: "1.0.0"
+    icons:
+    - src: "/img/security-logo-color-64px.svg"
+      size: "16x16"
+      type: "image/svg+xml"
+    license: basic
+    name: "detection_rules"
+    owner:
+      github: elastic/protections
+    release: "beta"
+    title: "Prebuilt Security Detection Rules"
+    type: "integration"
+    version: "0.13.0"

--- a/etc/security-logo-color-64px.svg
+++ b/etc/security-logo-color-64px.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 63.1 (92452) - https://sketch.com -->
+    <title>security-logo-color-64px</title>
+    <desc>Created with Sketch.</desc>
+    <g id="security-logo-color-64px" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <rect id="bounding-box" x="0" y="0" width="64" height="64"></rect>
+        <g id="Group" transform="translate(9.000000, 4.000000)">
+            <path d="M11,13 L11,5.68434189e-14 L47,5.68434189e-14 L47,30 C47,37.0111899 34.7467341,41.6043834 30,43 L30,13 L11,13 Z" id="Shape" fill="#FA744E"></path>
+            <path d="M0,35.3983993 L0,18 L25,18 L25,56 C8.33333333,49.0564437 0,42.1892435 0,35.3983993 Z" id="Path" fill="#1DBAB0"></path>
+            <path d="M10,18 L25,18 L25,43 C19.4060122,40.9626041 10,36.2920291 10,30.4224321 L10,18 Z" id="Path" fill="#343741"></path>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
## Issues
Partial dependency of https://github.com/elastic/detection-rules/issues/1206

## Summary
Noticed some drift since https://github.com/elastic/integrations/tree/master/packages/security_detection_engine. Also since 7.13 has been released, we need to get a 0.13.0 package out to replace the temporary 0.0.2 package.