### PR TITLE
Fix rules which were not using v2 license

### DIFF
--- a/rules/ml/ml_high_count_network_denies.toml
+++ b/rules/ml/ml_high_count_network_denies.toml
@@ -22,7 +22,7 @@ false_positives = [
 ]
 from = "now-30m"
 interval = "15m"
-license = "Elastic License"
+license = "Elastic License v2"
 machine_learning_job_id = "high_count_network_denies"
 name = "Spike in Firewall Denies"
 references = ["https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html"]

--- a/rules/ml/ml_high_count_network_events.toml
+++ b/rules/ml/ml_high_count_network_events.toml
@@ -22,7 +22,7 @@ false_positives = [
 ]
 from = "now-30m"
 interval = "15m"
-license = "Elastic License"
+license = "Elastic License v2"
 machine_learning_job_id = "high_count_network_events"
 name = "Spike in Network Traffic"
 references = ["https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html"]

--- a/rules/ml/ml_rare_destination_country.toml
+++ b/rules/ml/ml_rare_destination_country.toml
@@ -27,7 +27,7 @@ false_positives = [
 ]
 from = "now-30m"
 interval = "15m"
-license = "Elastic License"
+license = "Elastic License v2"
 machine_learning_job_id = "rare_destination_country"
 name = "Network Traffic to Rare Destination Country"
 references = ["https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html"]

--- a/rules/ml/ml_spike_in_traffic_to_a_country.toml
+++ b/rules/ml/ml_spike_in_traffic_to_a_country.toml
@@ -25,7 +25,7 @@ false_positives = [
 ]
 from = "now-30m"
 interval = "15m"
-license = "Elastic License"
+license = "Elastic License v2"
 machine_learning_job_id = "high_count_by_destination_country"
 name = "Spike in Network Traffic To a Country"
 references = ["https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html"]

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -470,3 +470,15 @@ class TestTuleTiming(BaseRuleTest):
             rules_str = '\n '.join(self.rule_str(r, trailer=None) for r in missing)
             err_msg = f'The following rules should have a longer `from` defined, due to indexes used\n {rules_str}'
             self.fail(err_msg)
+
+
+class TestLicense(BaseRuleTest):
+    """Test rule license."""
+
+    def test_elastic_license_only_v2(self):
+        """Test to ensure that production rules with the elastic license are only v2."""
+        for rule in self.production_rules:
+            rule_license = rule.contents.data.license
+            if 'elastic license' in rule_license.lower():
+                err_msg = f'{self.rule_str(rule)} If Elastic License is used, only v2 should be used'
+                self.assertEqual(rule_license, 'Elastic License v2', err_msg)


### PR DESCRIPTION
## Issues
None

## Summary
@ajosh0504 noticed in #1283 that some rules were not using the v2 license of the Elastic License, so this corrects it and adds a test.

So long as all of these rules existed in 7.13, this is ok to backport