### PR TITLE
[Rule Tuning] Netcat Network Activity fix

### DIFF
--- a/rules/linux/linux_netcat_network_connection.toml
+++ b/rules/linux/linux_netcat_network_connection.toml
@@ -34,7 +34,7 @@ tags = ["Elastic", "Host", "Linux", "Threat Detection"]
 type = "eql"
 
 query = '''
-sequence by process.entity_id
+sequence by host.name, process.pid with maxspan=30s
   [process where (process.name == "nc" or process.name == "ncat" or process.name == "netcat" or
                   process.name == "netcat.openbsd" or process.name == "netcat.traditional") and
      event.type == "start"]


### PR DESCRIPTION
After updating elastic-agent and auditbeat to 7.12.1 the current rule
does not get triggered on Detections because auditbeat does not include
the field "process.entity_id" and the "sequence" fails. The idea is to
use another field such as "pid" to fix this bug, which seems to be working
fine after testing it.

## Summary
As mentioned on the commit message this rule does not get triggered on
Detections at all due to the fact that auditbeat is missing the "process.entity_id"
field and the query fails to catch it. This might be an update issue because we
recently bumped from version 7.10.2 to 7.12.1 or a generic issue. We chose to
go with another field such as "process.name" or "process.pid", or a combination of
fields (this one seems the best solution to reduce noise) such as "host.name, process.pid".
We are currently using our custom rule instead of this pre-packaged one and it works
like a charm.
We are using elastic-agent 7.12.1 in addition with auditbeat 7.12.1 and our whole
stack is in the same version. Everything was updated from 7.10.2.
