### PR TITLE
Extend metadata with `[metadata.extended]` section

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -39,7 +39,7 @@ class RuleMeta(MarshmallowDataclassMixin):
     os_type_list: Optional[List[definitions.OSType]]
     query_schema_validation: Optional[bool]
     related_endpoint_rules: Optional[List[str]]
-        
+
     # Extended information
     extended = Optional[dict]
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -40,7 +40,7 @@ class RuleMeta(MarshmallowDataclassMixin):
     query_schema_validation: Optional[bool]
     related_endpoint_rules: Optional[List[str]]
 
-    # Extended information
+    # Extended information as an arbitrary dictionary
     extended = Optional[dict]
 
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -39,6 +39,9 @@ class RuleMeta(MarshmallowDataclassMixin):
     os_type_list: Optional[List[definitions.OSType]]
     query_schema_validation: Optional[bool]
     related_endpoint_rules: Optional[List[str]]
+        
+    # Extended information
+    extended = Optional[dict]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Issues
Closes #1305

## Summary
Added an optional `extended` dictionary under metadata.
This can be done by creating a new table called `[metadata.extended]` in TOML.