### PR TITLE
Make "config" in note field consistent

### DIFF
--- a/rules/aws/exfiltration_ec2_vm_export_failure.toml
+++ b/rules/aws/exfiltration_ec2_vm_export_failure.toml
@@ -22,6 +22,7 @@ language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 VM Export Failure"
 note = """## Config
+
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/vm-import/latest/userguide/vmexport.html#export-instance"]
 risk_score = 21

--- a/rules/aws/exfiltration_ec2_vm_export_failure.toml
+++ b/rules/aws/exfiltration_ec2_vm_export_failure.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/04/22"
 maturity = "production"
-updated_date = "2021/04/22"
+updated_date = "2021/06/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -503,7 +503,8 @@ class TestRuleInvestigationGuide(BaseRuleTest):
 
         for rule in self.all_rules:
             rule_dir = rule.path.parts[-2]
-            if note_str := required.get(rule_dir):
+            note_str = required.get(rule_dir):
+            if note_str:
                 self.assert_(rule.contents.data.note, f'{self.rule_str(rule)} note required for config information')
 
                 if note_str not in rule.contents.data.note:

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -510,4 +510,3 @@ class TestRuleInvestigationGuide(BaseRuleTest):
                     self.fail(f'{self.rule_str(rule)} expected config missing\n\n'
                               f'Expected: {note_str}\n\n'
                               f'Actual: {rule.contents.data.note}')
-

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -503,7 +503,7 @@ class TestRuleInvestigationGuide(BaseRuleTest):
 
         for rule in self.all_rules:
             rule_dir = rule.path.parts[-2]
-            note_str = required.get(rule_dir):
+            note_str = required.get(rule_dir)
             if note_str:
                 self.assert_(rule.contents.data.note, f'{self.rule_str(rule)} note required for config information')
 

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -8,13 +8,14 @@ import os
 import re
 from collections import defaultdict
 from pathlib import Path
+from typing import List
 
 import eql
 
 import kql
 from detection_rules import attack, beats, ecs
 from detection_rules.packaging import load_versions
-from detection_rules.rule import QueryRuleData
+from detection_rules.rule import QueryRuleData, TOMLRule
 from detection_rules.rule_loader import FILE_PATTERN
 from detection_rules.utils import get_path, load_etc_dump
 from rta import get_ttp_names
@@ -427,12 +428,13 @@ class TestRuleMetadata(BaseRuleTest):
             self.assertIn(rule_id, deprecated_rules, f'{rule_str} is logged in "deprecated_rules.json" but is missing')
 
 
-class TestTuleTiming(BaseRuleTest):
+class TestRuleTiming(BaseRuleTest):
     """Test rule timing and timestamps."""
 
     def test_event_override(self):
-        """Test that rules have defined an timestamp_override if needed."""
-        missing = []
+        """Test that rules have defined an timestamp_override if needed and don't if forbidden."""
+        missing: List[TOMLRule] = []
+        invalid: List[(TOMLRule, str)] = []
 
         for rule in self.all_rules:
             required = False
@@ -442,17 +444,29 @@ class TestTuleTiming(BaseRuleTest):
 
             if rule.contents.data.type == 'query':
                 required = True
-            elif rule.contents.data.type == 'eql' and \
-                    eql.utils.get_query_type(rule.contents.data.ast) != 'sequence':
-                required = True
+            elif rule.contents.data.type == 'eql':
+                # beats do not populate event.ingested and EQL rules do not have a timestamp fallback
+                if any(beats_indexes := [i for i in rule.contents.data.index if 'beat' in i]):
+                    invalid.append((rule, ', '.join(beats_indexes)))
+                if eql.utils.get_query_type(rule.contents.data.ast) != 'sequence':
+                    required = True
 
             if required and rule.contents.data.timestamp_override != 'event.ingested':
                 missing.append(rule)
 
+        err_msg = []
         if missing:
             rules_str = '\n '.join(self.rule_str(r, trailer=None) for r in missing)
-            err_msg = f'The following rules should have the `timestamp_override` set to `event.ingested`\n {rules_str}'
-            self.fail(err_msg)
+            err_msg.append(f'The following rules should have the `timestamp_override` set to `event.ingested`:\n '
+                           f'{rules_str}')
+        if invalid:
+            rules_str = '\n '.join(self.rule_str(r, trailer=f' -> {index_str}') for r, index_str in invalid)
+            err_msg.append(f'Beats indexes do not populate `event.ingested` and EQL rules do not fallback on '
+                           f'`timestamp_override`, so it should not be set. The following rules should be revised:\n '
+                           f'{rules_str}')
+
+        if missing or invalid:
+            self.fail('\n\n'.join(err_msg))
 
     def test_required_lookback(self):
         """Ensure endpoint rules have the proper lookback time."""
@@ -482,3 +496,32 @@ class TestLicense(BaseRuleTest):
             if 'elastic license' in rule_license.lower():
                 err_msg = f'{self.rule_str(rule)} If Elastic License is used, only v2 should be used'
                 self.assertEqual(rule_license, 'Elastic License v2', err_msg)
+
+
+class TestRuleInvestigationGuide(BaseRuleTest):
+    """Test the note field of a rule."""
+
+    def test_config(self):
+        """Test that rules which require a config note are using standard verbiage."""
+        config = '## Config\n\n'
+        beats_integration_pattern = config + 'The {} Fleet integration, Filebeat module, or similarly ' \
+                                             'structured data is required to be compatible with this rule.'
+        required = {
+            'aws': beats_integration_pattern.format('AWS'),
+            'azure': beats_integration_pattern.format('Azure'),
+            'gcp': beats_integration_pattern.format('GCP'),
+            'google-workspace': beats_integration_pattern.format('Google Workspace'),
+            'microsoft-365': beats_integration_pattern.format('Microsoft 365'),
+            'okta': beats_integration_pattern.format('Okta'),
+        }
+
+        for rule in self.all_rules:
+            rule_dir = rule.path.parts[-2]
+            if note_str := required.get(rule_dir):
+                self.assert_(rule.contents.data.note, f'{self.rule_str(rule)} note required for config information')
+
+                if note_str not in rule.contents.data.note:
+                    self.fail(f'{self.rule_str(rule)} expected config missing\n\n'
+                              f'Expected: {note_str}\n\n'
+                              f'Actual: {rule.contents.data.note}')
+


### PR DESCRIPTION
## Issues
None

## Summary
Make all rules which require a `Config` in their `note` field match the expected format