### PR TITLE
Add command to unstage incompatible rules from git

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -76,6 +76,20 @@ jobs:
           git status
           git log -1 --format='%H'
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Checkout the commit to a temporary branch and restore it to the staging area
+        env:
+          BRANCH_NAME: backport/${{matrix.target_branch}}/${{github.run_number}}
+        run: |
+          git checkout -b $BRANCH_NAME ${{github.event.pull_request.merge_commit_sha}}
+          git reset HEAD~1
+
+
+
       - name: Backport commit
         run: |
           echo "Cherry-pick from $GITHUB_SHA to ${{matrix.target_branch}}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -76,20 +76,6 @@ jobs:
           git status
           git log -1 --format='%H'
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Checkout the commit to a temporary branch and restore it to the staging area
-        env:
-          BRANCH_NAME: backport/${{matrix.target_branch}}/${{github.run_number}}
-        run: |
-          git checkout -b $BRANCH_NAME ${{github.event.pull_request.merge_commit_sha}}
-          git reset HEAD~1
-
-
-
       - name: Backport commit
         run: |
           echo "Cherry-pick from $GITHUB_SHA to ${{matrix.target_branch}}"

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -103,7 +103,7 @@ class GitChangeEntry:
                 subprocess.check_call(command_line)
 
         if self.status.startswith("R"):
-            # renames are actually Delete (D) and Add (D)
+            # renames are actually Delete (D) and Add (A)
             # revert in opposite order
             GitChangeEntry("A", self.new_path).revert(dry_run=dry_run)
             GitChangeEntry("D", self.previous_path).revert(dry_run=dry_run)

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -104,11 +104,9 @@ class GitChangeEntry:
 
         if self.status.startswith("R"):
             # renames are actually Delete (D) and Add (D)
-            # for renames, first undo the creation of the added file (A)
-            git("restore", "--staged", self.new_path)
-
-            # restore the deleted original file (D)
-            git("restore", "--staged", self.previous_path)
+            # revert in opposite order
+            GitChangeEntry("A", self.new_path).revert(dry_run=dry_run)
+            GitChangeEntry("D", self.previous_path).revert(dry_run=dry_run)
             return
 
         # remove the file from the staging area (A|M|D)

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -13,11 +13,11 @@ import shutil
 import subprocess
 import textwrap
 import time
-import typing
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, List
 
 import click
+import typing
 from elasticsearch import Elasticsearch
 
 from kibana.connector import Kibana
@@ -30,6 +30,7 @@ from .misc import PYTHON_LICENSE, add_client, client_error
 from .packaging import PACKAGE_FILE, Package, RELEASE_DIR, current_stack_version, manage_versions
 from .rule import AnyRuleData, BaseRuleData, QueryRuleData, TOMLRule
 from .rule_loader import RuleCollection, production_filter
+from .semver import Version
 from .utils import dict_hash, get_path, load_dump
 
 RULES_DIR = get_path('rules')
@@ -72,6 +73,88 @@ def build_release(config_file, update_version_lock, release=None, verbose=True):
         click.echo(f'- {len(package.rules)} rules included')
 
     return package
+
+
+@dataclasses.dataclass
+class GitChangeEntry:
+    status: str
+    previous_path: Path
+    new_path: Optional[Path] = None
+
+    @classmethod
+    def from_line(cls, text: str) -> 'GitChangeEntry':
+        columns = text.split("\t")
+        assert 2 <= len(columns) <= 3
+
+        columns[1:] = [Path(c) for c in columns[1:]]
+        return cls(*columns)
+
+    @property
+    def path(self) -> Path:
+        return self.new_path or self.previous_path
+
+    def revert(self, dry_run=False):
+        """Run a git command to revert this change."""
+        def git(*args):
+            command_line = ["git"] + [str(arg) for arg in args]
+            click.echo(subprocess.list2cmdline(command_line))
+
+            if not dry_run:
+                subprocess.check_call(command_line)
+
+        if self.status.startswith("R"):
+            # renames are actually Delete (D) and Add (D)
+            # for renames, first undo the creation of the added file (A)
+            git("restore", "--staged", self.new_path)
+
+            # restore the deleted original file (D)
+            git("restore", "--staged", self.previous_path)
+            return
+
+        # remove the file from the staging area (A|M|D)
+        git("restore", "--staged", self.previous_path)
+
+    def read(self, git_tree="HEAD") -> bytes:
+        """Read the file from disk or git."""
+        if self.status == "D":
+            # deleted files need to be recovered from git
+            return subprocess.check_output(["git", "show", f"{git_tree}:{self.path}"])
+
+        return self.path.read_bytes()
+
+
+@dev_group.command("unstage-incompatible-rules")
+@click.option("--target-stack-version", "-t", help="Minimum stack version to filter the staging area", required=True)
+@click.option("--dry-run", is_flag=True, help="List the changes that would be made")
+def prune_staging_area(target_stack_version: str, dry_run: bool):
+    """Prune the git staging area to remove changes to incompatible rules."""
+    target_stack_version = Version(target_stack_version)[:2]
+
+    # load a structured summary of the diff from git
+    git_output = subprocess.check_output(["git", "diff", "--name-status", "HEAD"])
+    changes = [GitChangeEntry.from_line(line) for line in git_output.decode("utf-8").splitlines()]
+
+    # track which changes need to be reverted because of incompatibilities
+    reversions: List[GitChangeEntry] = []
+
+    for change in changes:
+        # it's a change to a rule file, load it and check the version
+        if str(change.path.absolute()).startswith(RULES_DIR) and change.path.suffix == ".toml":
+            # bypass TOML validation in case there were schema changes
+            dict_contents = RuleCollection.deserialize_toml_string(change.read())
+            min_stack_version: Optional[str] = dict_contents.get("metadata", {}).get("min_stack_version")
+
+            if min_stack_version is not None and target_stack_version < Version(min_stack_version)[:2]:
+                # rule is incompatible, add to the list of reversions to make later
+                reversions.append(change)
+
+    if len(reversions) == 0:
+        click.echo("No files restored from staging area")
+        return
+
+    click.echo(f"Restoring {len(reversions)} changes from the staging area...")
+    for change in reversions:
+        change.revert(dry_run=dry_run)
 
 
 @dev_group.command('update-lock-versions')

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -78,7 +78,7 @@ def build_release(config_file, update_version_lock, release=None, verbose=True):
 @dataclasses.dataclass
 class GitChangeEntry:
     status: str
-    previous_path: Path
+    original_path: Path
     new_path: Optional[Path] = None
 
     @classmethod
@@ -91,7 +91,7 @@ class GitChangeEntry:
 
     @property
     def path(self) -> Path:
-        return self.new_path or self.previous_path
+        return self.new_path or self.original_path
 
     def revert(self, dry_run=False):
         """Run a git command to revert this change."""
@@ -106,11 +106,11 @@ class GitChangeEntry:
             # renames are actually Delete (D) and Add (A)
             # revert in opposite order
             GitChangeEntry("A", self.new_path).revert(dry_run=dry_run)
-            GitChangeEntry("D", self.previous_path).revert(dry_run=dry_run)
+            GitChangeEntry("D", self.original_path).revert(dry_run=dry_run)
             return
 
         # remove the file from the staging area (A|M|D)
-        git("restore", "--staged", self.previous_path)
+        git("restore", "--staged", self.original_path)
 
     def read(self, git_tree="HEAD") -> bytes:
         """Read the file from disk or git."""


### PR DESCRIPTION
## Issues
Part of #1171
Related to PR #1173, but can be merged independently. 

## Summary
I added a command that can look at the staging area of Git and move out any changes to rules with incompatible versions.


Here's how I've been testing it. I made a few changes locally that are staged:
```console
$ git status

On branch cli/unstage-incompatible-rules
Your branch is up to date with 'rw-access/cli/unstage-incompatible-rules'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   rules/macos/credential_access_access_to_browser_credentials_procargs.toml
        modified:   rules/network/command_and_control_fin7_c2_behavior.toml
        renamed:    rules/network/command_and_control_halfbaked_beacon.toml -> rules/network/command_and_control_halfbaked_beacon_renamed.toml
        modified:   rules/windows/defense_evasion_modification_of_boot_config.toml
```

Inspect those actual changes that were made
```diff
$ git diff HEAD 
diff --git a/rules/macos/credential_access_access_to_browser_credentials_procargs.toml b/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
index f8595b3..8772e8d 100644
--- a/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
+++ b/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/01/04"
 maturity = "production"
 updated_date = "2021/03/03"
+min_stack_version = "7.13.0"
 
 [rule]
 author = ["Elastic"]
diff --git a/rules/network/command_and_control_fin7_c2_behavior.toml b/rules/network/command_and_control_fin7_c2_behavior.toml
index 92cb6a2..71b24f6 100644
--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/07/06"
 maturity = "production"
 updated_date = "2021/05/10"
+min_stack_version = "7.14.0"
 
 [rule]
 author = ["Elastic"]
diff --git a/rules/network/command_and_control_halfbaked_beacon.toml b/rules/network/command_and_control_halfbaked_beacon_renamed.toml
similarity index 98%
rename from rules/network/command_and_control_halfbaked_beacon.toml
rename to rules/network/command_and_control_halfbaked_beacon_renamed.toml
index 963bf0c..b2407b6 100644
--- a/rules/network/command_and_control_halfbaked_beacon.toml
+++ b/rules/network/command_and_control_halfbaked_beacon_renamed.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/07/06"
 maturity = "production"
 updated_date = "2021/05/10"
+min_stack_version = "7.13.0"
 
 [rule]
 author = ["Elastic"]
diff --git a/rules/windows/defense_evasion_modification_of_boot_config.toml b/rules/windows/defense_evasion_modification_of_boot_config.toml
index 7621855..96289f4 100644
--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/03/16"
 maturity = "production"
 updated_date = "2021/04/14"
+min_stack_version = "7.14.0"
 
 [rule]
 author = ["Elastic"]
```

Now run the dry-run command to get a preview of the files that will be moved out of the staging area.
```console
$ python -m detection_rules dev  unstage-incompatible-rules -t 7.13 --dry-run
Restoring 2 changes from the staging area...
git restore --staged rules/network/command_and_control_fin7_c2_behavior.toml
git restore --staged rules/windows/defense_evasion_modification_of_boot_config.toml

$ git status
On branch cli/unstage-incompatible-rules
Your branch is up to date with 'rw-access/cli/unstage-incompatible-rules'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   rules/macos/credential_access_access_to_browser_credentials_procargs.toml
	modified:   rules/network/command_and_control_fin7_c2_behavior.toml
	renamed:    rules/network/command_and_control_halfbaked_beacon.toml -> rules/network/command_and_control_halfbaked_beacon_renamed.toml
	modified:   rules/windows/defense_evasion_modification_of_boot_config.toml
```

Run the command for real this time
```console
$ python -m detection_rules dev  unstage-incompatible-rules -t 7.13          

Restoring 2 changes from the staging area...
git restore --staged rules/network/command_and_control_fin7_c2_behavior.toml
git restore --staged rules/windows/defense_evasion_modification_of_boot_config.toml

$ git status
On branch cli/unstage-incompatible-rules
Your branch is up to date with 'rw-access/cli/unstage-incompatible-rules'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   rules/macos/credential_access_access_to_browser_credentials_procargs.toml
        renamed:    rules/network/command_and_control_halfbaked_beacon.toml -> rules/network/command_and_control_halfbaked_beacon_renamed.toml

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   rules/network/command_and_control_fin7_c2_behavior.toml
        modified:   rules/windows/defense_evasion_modification_of_boot_config.toml
```

Confirm which files are dirty. Looks, it's both the 7.14 rules!
```diff
$ git diff

diff --git a/rules/network/command_and_control_fin7_c2_behavior.toml b/rules/network/command_and_control_fin7_c2_behavior.toml
index 92cb6a2..71b24f6 100644
--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/07/06"
 maturity = "production"
 updated_date = "2021/05/10"
+min_stack_version = "7.14.0"
 
 [rule]
 author = ["Elastic"]
diff --git a/rules/windows/defense_evasion_modification_of_boot_config.toml b/rules/windows/defense_evasion_modification_of_boot_config.toml
index 7621855..96289f4 100644
--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/03/16"
 maturity = "production"
 updated_date = "2021/04/14"
+min_stack_version = "7.14.0"
 
 [rule]
 author = ["Elastic"]
```

Look at the complete diff, staged and unstaged
```diff
$ git diff HEAD

diff --git a/rules/macos/credential_access_access_to_browser_credentials_procargs.toml b/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
index f8595b3..8772e8d 100644
--- a/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
+++ b/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/01/04"
 maturity = "production"
 updated_date = "2021/03/03"
+min_stack_version = "7.13.0"
 
 [rule]
 author = ["Elastic"]
diff --git a/rules/network/command_and_control_fin7_c2_behavior.toml b/rules/network/command_and_control_fin7_c2_behavior.toml
index 92cb6a2..71b24f6 100644
--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/07/06"
 maturity = "production"
 updated_date = "2021/05/10"
+min_stack_version = "7.14.0"
 
 [rule]
 author = ["Elastic"]
diff --git a/rules/network/command_and_control_halfbaked_beacon.toml b/rules/network/command_and_control_halfbaked_beacon_renamed.toml
similarity index 98%
rename from rules/network/command_and_control_halfbaked_beacon.toml
rename to rules/network/command_and_control_halfbaked_beacon_renamed.toml
index 963bf0c..b2407b6 100644
--- a/rules/network/command_and_control_halfbaked_beacon.toml
+++ b/rules/network/command_and_control_halfbaked_beacon_renamed.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/07/06"
 maturity = "production"
 updated_date = "2021/05/10"
+min_stack_version = "7.13.0"
 
 [rule]
 author = ["Elastic"]
diff --git a/rules/windows/defense_evasion_modification_of_boot_config.toml b/rules/windows/defense_evasion_modification_of_boot_config.toml
index 7621855..96289f4 100644
--- a/rules/windows/defense_evasion_modification_of_boot_config.toml
+++ b/rules/windows/defense_evasion_modification_of_boot_config.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/03/16"
 maturity = "production"
 updated_date = "2021/04/14"
+min_stack_version = "7.14.0"
 
 [rule]
 author = ["Elastic"]
```
