### PR TITLE
[CI] Only upload  build artifacts for `push` events

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -36,8 +36,10 @@ jobs:
       run: |
         python -m detection_rules dev build-release
 
-    - name: Archive production artifacts
+    - name: Archive production artifacts for branch builds
       uses: actions/upload-artifact@v2
+      if: |
+        github.event_name == 'push'
       with:
         name: release-files
         path: |


### PR DESCRIPTION
## Issues
Closes #1204

## Summary
Archiving artifacts to GitHub is really slow for some reason. One making commits on a PR, we shouldn't have to wait for these to build. It also creates new artifacts for every commit, which is unnecessary.

Now, we only build artifacts on `push` events to any of our target branches: `7.x`, `8.x` and `main`.

## Testing

Here's me running it on a `push` event to `main` on my fork:
![Screen Shot 2021-06-30 at 5 08 52 PM](https://user-images.githubusercontent.com/31489089/124042503-345a0980-d9c6-11eb-9b81-41bdf05d0113.png)


and here's it running on a temporary PR:
![Screen Shot 2021-06-30 at 5 09 16 PM](https://user-images.githubusercontent.com/31489089/124042519-3ae88100-d9c6-11eb-9614-c41ec011961a.png)
