### PR TITLE
Lock versions for Fleet package 0.13.2

### DIFF
--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -44,6 +44,11 @@
     "sha256": "b98a066f2cf74984ac8e04ea0db6503d30605711ac54d6d341f42c09a64bb515",
     "version": 7
   },
+  "053a0387-f3b5-4ba5-8245-8002cca2bd08": {
+    "rule_name": "Potential DLL Side-Loading via Microsoft Antimalware Service Executable",
+    "sha256": "0f184faf7f0c7af2ea9955885ea9d4a4258cc9d025ed50d265079c466c4ad2cb",
+    "version": 1
+  },
   "0564fb9d-90b9-4234-a411-82a546dc1343": {
     "rule_name": "Microsoft IIS Service Account Password Dumped",
     "sha256": "bcda2313ca40b6fb5e29b30a8a4a34392c0e5ec339b88f2b93e391657b5e3dc6",
@@ -168,6 +173,16 @@
     "rule_name": "UAC Bypass via Windows Firewall Snap-In Hijack",
     "sha256": "cf1509c89e66ee7021944e2946913d7844fc2b785ebd32eaeda9be63b774118a",
     "version": 3
+  },
+  "119c8877-8613-416d-a98a-96b6664ee73a5": {
+    "rule_name": "AWS RDS Snapshot Export",
+    "sha256": "68f44e7c9ac63e164010178bf95b4e93cc0dabf879694165d36cc8a9b83dcd8a",
+    "version": 1
+  },
+  "12051077-0124-4394-9522-8f4f4db1d674": {
+    "rule_name": "AWS Route 53 Domain Transfer Lock Disabled",
+    "sha256": "8ad6cbdd0db141f7bd71e7d4b28197c28f709d99d8a641eaee4b763c35a8514f",
+    "version": 1
   },
   "120559c6-5e24-49f4-9e30-8ffe697df6b9": {
     "rule_name": "User Discovery via Whoami",
@@ -374,6 +389,11 @@
     "sha256": "530e80dcf00f3d075008dc84df00d8ae307d4cafe4bb16d2f9afe00d7a66e8d6",
     "version": 1
   },
+  "2045567e-b0af-444a-8c0b-0b6e2dae9e13": {
+    "rule_name": "AWS Route 53 Domain Transferred to Another Account",
+    "sha256": "927ea25a70453624aa091c7fbb432f35923391e79036d62806e4d9aef78dc909",
+    "version": 1
+  },
   "20457e4f-d1de-4b92-ae69-142e27a4342a": {
     "rule_name": "Access of Stored Browser Credentials",
     "sha256": "70475c97c91896aca0fdd68519bec234ff444f48d2bbbdafb7da5a1da5944868",
@@ -426,8 +446,8 @@
   },
   "26f68dba-ce29-497b-8e13-b4fde1db5a2d": {
     "rule_name": "Attempts to Brute Force a Microsoft 365 User Account",
-    "sha256": "4509c990b6afc653b5ce7ee74cd0866f17caf580091b972f31ceca58a26901d8",
-    "version": 4
+    "sha256": "f0d04d20b2c11a0ebe206fe8773ea13430da51c1da73a9cf755fd344fa983d15",
+    "version": 5
   },
   "272a6484-2663-46db-a532-ef734bf9a796": {
     "rule_name": "Microsoft 365 Exchange Transport Rule Modification",
@@ -589,6 +609,11 @@
     "sha256": "922ec3de8ec673c8094683d428592de1ad4d44af9afd45caa9a4cf8b0e7289eb",
     "version": 3
   },
+  "378f9024-8a0c-46a5-aa08-ce147ac73a4e": {
+    "rule_name": "AWS RDS Security Group Creation",
+    "sha256": "c3a3b11a08ec456c879abee36a388e915e6a327abcf0602ffa21a02db22ef5ca",
+    "version": 1
+  },
   "37994bca-0611-4500-ab67-5588afe73b77": {
     "rule_name": "Azure Active Directory High Risk Sign-in",
     "sha256": "ad1d5ab615b56e896714a88a89354cae4da732caf80542b588d03e6424cceb17",
@@ -691,8 +716,8 @@
   },
   "3efee4f0-182a-40a8-a835-102c68a4175d": {
     "rule_name": "Potential Password Spraying of Microsoft 365 User Accounts",
-    "sha256": "b0980e6fca207c792d7843fe87577c47e8cf247f5792fc338d293f06dc856b76",
-    "version": 3
+    "sha256": "963f664114823b11c4a4728f07135d64b207cc28e9181a0ed1536682458cec56",
+    "version": 4
   },
   "403ef0d3-8259-40c9-a5b6-d48354712e49": {
     "rule_name": "Unusual Persistence via Services Registry",
@@ -1014,6 +1039,11 @@
     "sha256": "b9d412c9321b3e83222714985fa57d21f61c631f0c564e171a5e934724fba4b8",
     "version": 4
   },
+  "5e87f165-45c2-4b80-bfa5-52822552c997": {
+    "rule_name": "Potential PrintNightmare File Modification",
+    "sha256": "cce3c92801296f877a7b98b1d40e5eb47cc9843149d203377272809894e0c933",
+    "version": 1
+  },
   "60884af6-f553-4a6c-af13-300047455491": {
     "rule_name": "Azure Command Execution on Virtual Machine",
     "sha256": "abb1da4a93de07129c1b5b615752a4b9824c9cf4fd8c0c555614dd029d6d7e8b",
@@ -1057,6 +1087,11 @@
   "6482255d-f468-45ea-a5b3-d3a7de1331ae": {
     "rule_name": "Modification of Safari Settings via Defaults Command",
     "sha256": "1291f8e74a129e13387f515122286762491f4a8a98539f725f35893c9e519257",
+    "version": 1
+  },
+  "6506c9fd-229e-4722-8f0f-69be759afd2a": {
+    "rule_name": "Potential PrintNightmare Exploit Registry Modification",
+    "sha256": "9ad6dc163992a21c58bb77d8738169cdbae4dd13bda4ef4afc98c4c21326f5f9",
     "version": 1
   },
   "661545b4-1a90-4f45-85ce-2ebd7c6a15d0": {
@@ -1374,6 +1409,11 @@
     "sha256": "3449f44c9a5177d0452aa0f21d1f8623a3e11180cb49cf76fdf227ee1f8be526",
     "version": 6
   },
+  "863cdf31-7fd3-41cf-a185-681237ea277b": {
+    "rule_name": "AWS RDS Security Group Deletion",
+    "sha256": "0c59c5ee488dfc981273c884809553bf72a97d1ab8513483745cd5f65ccc6709",
+    "version": 1
+  },
   "867616ec-41e5-4edc-ada2-ab13ab45de8a": {
     "rule_name": "AWS IAM Group Deletion",
     "sha256": "ffaa732069c6a1b16566f70e5098d4564f451e921161a6a860a3b34c0c4e1825",
@@ -1442,6 +1482,11 @@
   "8b2b3a62-a598-4293-bc14-3d5fa22bb98f": {
     "rule_name": "Executable File Creation with Multiple Extensions",
     "sha256": "c71bb3f63edeb09cc751265c0bb466c34b9f916dcc6e9bebdeddd1c7c684c19f",
+    "version": 1
+  },
+  "8b4f0816-6a65-4630-86a6-c21c179c0d09": {
+    "rule_name": "Enable Host Network Discovery via Netsh",
+    "sha256": "f7abeca09d05a47415e4ae1c6befa323c4f11bf2027921e674e266c6d0e309bb",
     "version": 1
   },
   "8c1bdde8-4204-45c0-9e0c-c85ca3902488": {
@@ -2074,6 +2119,11 @@
     "sha256": "12a78ccad8ab58509933133ec1744e27bf37d404718c54a47f796a7e6eb86180",
     "version": 6
   },
+  "c1812764-0788-470f-8e74-eb4a14d47573": {
+    "rule_name": "AWS EC2 Full Network Packet Capture Detected",
+    "sha256": "6b5fa981352600a2076763795ca79f22851bb1a7b28d7573a715f5827d4196aa",
+    "version": 1
+  },
   "c25e9c87-95e1-4368-bfab-9fd34cf867ec": {
     "rule_name": "Microsoft IIS Connection Strings Decryption",
     "sha256": "e0426acc19d28951632e6d51dc170face86a592f82ae4eb55ee3144a9848b31c",
@@ -2086,8 +2136,8 @@
   },
   "c292fa52-4115-408a-b897-e14f684b3cb7": {
     "rule_name": "Persistence via Folder Action Script",
-    "sha256": "590672436289bc299f3a42eb297c9f29019cb3b32dcdaa2ab7930bb87c5edb48",
-    "version": 2
+    "sha256": "7ae7840be1d7ddc5db5b1d13b765d54ab085321f8b3b77ebda3d58548c503573",
+    "version": 3
   },
   "c2d90150-0133-451c-a783-533e736c12d7": {
     "rule_name": "Mshta Making Network Connections",
@@ -2108,6 +2158,11 @@
     "rule_name": "Mounting Hidden or WebDav Remote Shares",
     "sha256": "fd98829f6683e70e5a3d3fe8ed5fe7ea2a35a9eb323b012ee895ea1e3b563c46",
     "version": 3
+  },
+  "c4818812-d44f-47be-aaef-4cfb2f9cc799": {
+    "rule_name": "Suspicious Print Spooler File Deletion",
+    "sha256": "d3e940a5c8517168cdd443783e02286039c72a78c5c9f24dad0eb7be0b1fffb3",
+    "version": 1
   },
   "c57f8579-e2a5-4804-847f-f2732edc5156": {
     "rule_name": "Potential Remote Desktop Shadowing Activity",
@@ -2171,8 +2226,8 @@
   },
   "c82b2bd8-d701-420c-ba43-f11a155b681a": {
     "rule_name": "SMB (Windows File Sharing) Activity to the Internet",
-    "sha256": "163112dd69e87ecc6ca848d4231df956cda7684f020f26ff600ce24495af9698",
-    "version": 8
+    "sha256": "fc77eb32fff68465f4147c2373f54c206217704bc464b7cff185429ac05d0769",
+    "version": 9
   },
   "c82c7d8f-fb9e-4874-a4bd-fd9e3f9becf1": {
     "rule_name": "Direct Outbound SMB Connection",
@@ -2187,6 +2242,11 @@
   "c8b150f0-0164-475b-a75e-74b47800a9ff": {
     "rule_name": "Suspicious Startup Shell Folder Modification",
     "sha256": "73592f3bf7a304f413433934022d07f75af6301df302ff33e8d876396c3cf782",
+    "version": 1
+  },
+  "c8cccb06-faf2-4cd5-886e-2c9636cfcb87": {
+    "rule_name": "Disabling Windows Defender Security Settings via PowerShell",
+    "sha256": "fe8467442755a077a9833057c8622fec49bb3aaa321e8231a45db4f6769c2a63",
     "version": 1
   },
   "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa": {
@@ -2311,8 +2371,8 @@
   },
   "d461fac0-43e8-49e2-85ea-3a58fe120b4f": {
     "rule_name": "Shell Execution via Apple Scripting",
-    "sha256": "2a7efdd0409aec9d27b3b22b8c23887e09a49dc56d2e636591bd0966ef26232f",
-    "version": 2
+    "sha256": "81d944d6e43616c8ce9d52f1959afb89444b9972b4c8269b28c8d7c74485e4b8",
+    "version": 3
   },
   "d48e1c13-4aca-4d1f-a7b1-a9161c0ad86f": {
     "rule_name": "Attempt to Delete an Okta Application",
@@ -2571,8 +2631,8 @@
   },
   "e919611d-6b6f-493b-8314-7ed6ac2e413b": {
     "rule_name": "AWS EC2 VM Export Failure",
-    "sha256": "b84ca0431b650ae06a30ff5b647c5b67526c1b234a93c8e85d30a26d7d4c1446",
-    "version": 1
+    "sha256": "106155918013377d2c3d72ff9b2d607114595c86cde344092595ee3340b5a9aa",
+    "version": 2
   },
   "e94262f2-c1e9-4d3f-a907-aeab16712e1a": {
     "rule_name": "Unusual Executable File Creation by a System Critical Process",
@@ -2659,6 +2719,11 @@
     "sha256": "6f44ec751ed71022884f3953e3b7f63827bdd82eab59cc5f47fbe4322f3f8414",
     "version": 3
   },
+  "ee5300a7-7e31-4a72-a258-250abb8b3aa1": {
+    "rule_name": "Unusual Print Spooler Child Process",
+    "sha256": "4716dcae5bd95755297e57624cf567d545de92d986a221b3ca61f9bb6f7d9c53",
+    "version": 1
+  },
   "eea82229-b002-470e-a9e1-00be38b14d32": {
     "rule_name": "Potential Privacy Control Bypass via TCCDB Modification",
     "sha256": "dbb7eceffa388039b4218d894c116ba68ff94ef44b2460e074c30209098e5546",
@@ -2709,6 +2774,11 @@
     "sha256": "79631e38ec873ab7281bd533d4827e487ce9da67c8af72a09ee12bc1cef3b04a",
     "version": 4
   },
+  "f30f3443-4fbb-4c27-ab89-c3ad49d62315": {
+    "rule_name": "AWS RDS Instance Creation",
+    "sha256": "8510cdcc19e7d92882fbb86ed39ae27d39dc16f4bdbe64d58d1e45a3fcc2ed3d",
+    "version": 1
+  },
   "f3475224-b179-4f78-8877-c2bd64c26b88": {
     "rule_name": "WMI Incoming Lateral Movement",
     "sha256": "ed25b43fb38cbc23d92775bb0284a9fd055dd53d8824bcda78d2c9ffdc8428c5",
@@ -2737,6 +2807,11 @@
   "f683dcdf-a018-4801-b066-193d4ae6c8e5": {
     "rule_name": "SoftwareUpdate Preferences Modification",
     "sha256": "baedc4fcc8fd933fc5bf8e2f76c4ebb6acb9bded48fe91f102727b5978c797fa",
+    "version": 1
+  },
+  "f766ffaf-9568-4909-b734-75d19b35cbf4": {
+    "rule_name": "Azure Service Principal Credentials Added",
+    "sha256": "4b1671042f16430f483118a068274d7d28eb2e09124df8365a96a357899dd742",
     "version": 1
   },
   "f772ec8a-e182-483c-91d2-72058f76a44c": {


### PR DESCRIPTION
## Issues
None

## Summary
Switched to the 7.13 branch, locked the versions, then copied the file into `main`.
The lock will be backported via `backport: auto`.
