### PR TITLE
[CI] Update backport job to filter out incompatible rules

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
-          ref: ${{matrix.target_branch}}
+          ref: main
 
       - name: Set github config
         run: |
@@ -72,21 +72,77 @@ jobs:
 
       - name: Get branch histories
         run: |
-          git fetch origin main --unshallow
+          git fetch origin main --depth 100
+          git fetch origin ${{matrix.target_branch}} --depth 1
           git status
           git log -1 --format='%H'
 
-      - name: Backport commit
+      - name: Checkout the commit into the staging area
         run: |
-          echo "Cherry-pick from $GITHUB_SHA to ${{matrix.target_branch}}"
-          git cherry-pick -x ${{github.event.pull_request.merge_commit_sha}}
+          # Checkout the merged commit
+          git checkout ${{github.event.pull_request.merge_commit_sha}}
 
-          # See https://github.com/elastic/detection-rules/issues/1171
-          # Eventually, this cherry pick command will be:
-          # git-cherry-pick --no-commit
-          # <python code to remove irrelevant rules>
-          # git commit --author ... --message ...
+          # Move it to the staging area
+          git reset --soft HEAD^
 
-      - name: Push changes
+      - name: Install dependencies
         run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Prune non-${{matrix.target_branch}} rules
+        env:
+          UNSTAGED_LIST_FILE: "../unstaged-rules.txt"
+        run: |
+          python -m detection_rules dev unstage-incompatible-rules --target-stack-version ${{matrix.target_branch}}
+
+          # Track which rules were unstaged
+          git diff --name-only > $UNSTAGED_LIST_FILE
+
+          # Since they've been tracked, remove any untracked files
+          git checkout -- .
+
+      - name: Commit and push to ${{matrix.target_branch}}
+        env:
+          COMMIT_MSG_FILE: "../commit-message.txt"
+          UNSTAGED_LIST_FILE: "../unstaged-rules.txt"
+        run: |
+          set -x
+
+          echo "Switch to the target branch and keep the staged changes"
+          git checkout ${{matrix.target_branch}}
+
+          NEEDS_BACKPORT=$(git diff HEAD --quiet --exit-code && echo y || echo n)
+
+          if [ "y" = "$NEEDS_BACKPORT" ]
+          then
+            echo "No changes to backport"
+            exit 0
+          fi
+
+          echo "Create the new commit with the same author"
+          git commit --reuse-message ${{github.event.pull_request.merge_commit_sha}}
+
+          echo "Save the commit message"
+          git log ${{github.event.pull_request.merge_commit_sha}} --format=%B -n1 > $COMMIT_MSG_FILE
+
+          echo "Append to the commit message"
+          if [ -s "$UNSTAGED_LIST_FILE" ]
+          then
+            echo "Track note for the removed files"
+
+            echo "" >> $COMMIT_MSG_FILE
+            echo "Removed changes from:" >> $COMMIT_MSG_FILE
+            awk '{print "- " $0}' $UNSTAGED_LIST_FILE >> $COMMIT_MSG_FILE
+            echo "" >> $COMMIT_MSG_FILE
+            echo '(selectively cherry picked from commit ${{github.event.pull_request.merge_commit_sha}})' >> $COMMIT_MSG_FILE
+          else
+            echo "No removed files"
+
+            echo "" >> $COMMIT_MSG_FILE
+            echo '(cherry picked from commit ${{github.event.pull_request.merge_commit_sha}})' >> $COMMIT_MSG_FILE
+          fi
+
+          echo "Amend the commit message and push"
+          git commit --amend -F $COMMIT_MSG_FILE
           git push

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -112,9 +112,9 @@ jobs:
           echo "Switch to the target branch and keep the staged changes"
           git checkout ${{matrix.target_branch}}
 
-          NEEDS_BACKPORT=$(git diff HEAD --quiet --exit-code && echo y || echo n)
+          NEEDS_BACKPORT=$(git diff HEAD --quiet --exit-code && echo n || echo y)
 
-          if [ "y" = "$NEEDS_BACKPORT" ]
+          if [ "n" = "$NEEDS_BACKPORT" ]
           then
             echo "No changes to backport"
             exit 0


### PR DESCRIPTION
## Issues
- Next step (and almost last) for #1171 

## Summary
Updated the GitHub actions job to use the recent command #1317 to remove incompatible rules when targeting a branch. As a matrix job, there's a separate one will run for each target branch, but we don't have to worry about testing that.

I think we need to think through `etc/version.lock.json`, but can follow up with that in a separate PR. We'll also have to decide that if a rule went through a breaking change, we mark it as immutable in the old branch so that we can't release new versions of it.

### Here's this in action in my fork

####  PR with 7.13 and 7.14 
The squashed merge commit in main
![image](https://user-images.githubusercontent.com/31489089/125005217-7ca5a700-e018-11eb-8676-066ac6bdf0d3.png)
The selectively cherry-picked commit in 7.13
![image](https://user-images.githubusercontent.com/31489089/125005180-63045f80-e018-11eb-80f1-6dada73cefe4.png)


#### PR with 7.14 only
![Screen Shot 2021-07-08 at 6 05 14 PM](https://user-images.githubusercontent.com/31489089/125005017-f9845100-e017-11eb-8d3d-a2940ad5c5ab.png)

#### PR with 7.13 only
Squashed merge commit in main
![Screen Shot 2021-07-08 at 6 04 49 PM](https://user-images.githubusercontent.com/31489089/125005021-fa1ce780-e017-11eb-93a3-a882e179df8a.png)

Cherry picked in 7.13
![image](https://user-images.githubusercontent.com/31489089/125005282-9a730c00-e018-11eb-80bf-8338b013637a.png)

### Branch history of main

![Screen Shot 2021-07-08 at 6 04 58 PM](https://user-images.githubusercontent.com/31489089/125005020-f9845100-e017-11eb-8931-cc1e8cd98d8c.png)

### Branch history of 7.13
![Screen Shot 2021-07-08 at 6 05 05 PM](https://user-images.githubusercontent.com/31489089/125005019-f9845100-e017-11eb-9809-760735419186.png)

