### PR TITLE
[CI/CD] Create on-demand job to release from Kibana

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,7 +43,6 @@ jobs:
               name: 'backport: auto'
             })
 
-
   commit:
     if: |
       github.event.pull_request.merged == true

--- a/.github/workflows/release-kibana.yml
+++ b/.github/workflows/release-kibana.yml
@@ -57,3 +57,10 @@ jobs:
         run: |
           cd detection-rules
           python -m detection_rules dev kibana-pr --assign ${{github.actor}} $LABEL_ARGS $DRAFT_ARGS $BRANCH_ARGS
+
+    - name: Archive production artifacts for branch builds
+      uses: actions/upload-artifact@v2
+      with:
+        name: release-files
+        path: |
+          detection-rules/releases

--- a/.github/workflows/release-kibana.yml
+++ b/.github/workflows/release-kibana.yml
@@ -7,10 +7,11 @@ on:
         required: true
         default: 'master'
       labels:
-        description: 'Additional labels to assign to the PR'
-        required: false
+        description: 'Labels to assign to the PR (comma-separated)'
+        required: true
+        default: 'release_note:skip,release_note:enhancement,auto-backport'
       draft:
-        description: 'Create a PR as draft (Y)'
+        description: 'Create a PR as draft (y/n)'
         required: false
 
 jobs:
@@ -50,7 +51,7 @@ jobs:
       - name: Create the PR to Kibana
         env:
           DRAFT_ARGS: "${{startsWith(github.event.inputs.draft,'y') && '--draft' || ' '}}"
-          LABEL_ARGS: "--label release_note:skip,${{github.event.inputs.labels}}"
+          LABEL_ARGS: "--label ${{github.event.inputs.labels}}"
           BRANCH_ARGS: "--base-branch ${{github.event.inputs.kibana_branch}}"
           GITHUB_TOKEN: "${{ secrets.PROTECTIONS_MACHINE_TOKEN }}"
         run: |

--- a/.github/workflows/release-kibana.yml
+++ b/.github/workflows/release-kibana.yml
@@ -1,0 +1,58 @@
+name: release-kibana
+on:
+  workflow_dispatch:
+    inputs:
+      kibana_branch:
+        description: 'Target branch for a Kibana PR'
+        required: true
+        default: 'master'
+      labels:
+        description: 'Additional labels to assign to the PR'
+        required: false
+      draft:
+        description: 'Create a PR as draft (Y)'
+        required: false
+
+jobs:
+  kibana-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout detection-rules
+        uses: actions/checkout@v2
+        with:
+          path: detection-rules
+
+      - name: Checkout Kibana
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
+          ref: ${{github.event.inputs.kibana_branch}}
+          repository: elastic/kibana
+          path: kibana
+
+      - name: Install dependencies
+        run: |
+          cd detection-rules
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Build release package
+        run: |
+          cd detection-rules
+          python -m detection_rules dev build-release
+
+      - name: Set github config
+        run: |
+          git config --global user.email "72879786+protectionsmachine@users.noreply.github.com"
+          git config --global user.name "protectionsmachine"
+
+      - name: Create the PR to Kibana
+        env:
+          DRAFT_ARGS: "${{startsWith(github.event.inputs.draft,'y') && '--draft' || ' '}}"
+          LABEL_ARGS: "--label release_note:skip,${{github.event.inputs.labels}}"
+          BRANCH_ARGS: "--base-branch ${{github.event.inputs.kibana_branch}}"
+          GITHUB_TOKEN: "${{ secrets.PROTECTIONS_MACHINE_TOKEN }}"
+        run: |
+          cd detection-rules
+          python -m detection_rules dev kibana-pr --assign ${{github.actor}} $LABEL_ARGS $DRAFT_ARGS $BRANCH_ARGS


### PR DESCRIPTION
## Issues
- First half of #1206

## Summary
Creates a PR to Kibana from a source branch in this repository.

The version labels still aren't very smart. But since this is an on-demand job, each branch actually holds its own definition. Once this PR is backported to the 7.13 branch, we can edit that branch directly to change its defaults, such as the target branch of Kibana and the release labels.

Here's an example PR generated from the 7.13 branch, targeting 7.13.3:
- https://github.com/elastic/kibana/pull/105128

The information says `7.14` in that branch because my 7.13 branch in the fork is actually this `ci/kibana-deploy-job`. I can change that if we want to be more confident that it's working right.