### PR TITLE
[APM] Adds APM data stream 'traces-apm*' to apm rules (#105334)

### DIFF
--- a/rules/apm/apm_403_response_to_a_post.toml
+++ b/rules/apm/apm_403_response_to_a_post.toml
@@ -16,7 +16,7 @@ false_positives = [
     suspicious or malicious activity.
     """,
 ]
-index = ["apm-*-transaction*"]
+index = ["apm-*-transaction*", "traces-apm*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Web Application Suspicious Activity: POST Request Declined"

--- a/rules/apm/apm_403_response_to_a_post.toml
+++ b/rules/apm/apm_403_response_to_a_post.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/07/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/apm/apm_405_response_method_not_allowed.toml
+++ b/rules/apm/apm_405_response_method_not_allowed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/07/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/apm/apm_405_response_method_not_allowed.toml
+++ b/rules/apm/apm_405_response_method_not_allowed.toml
@@ -16,7 +16,7 @@ false_positives = [
     suspicious or malicious activity.
     """,
 ]
-index = ["apm-*-transaction*"]
+index = ["apm-*-transaction*", "traces-apm*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Web Application Suspicious Activity: Unauthorized Method"

--- a/rules/apm/apm_null_user_agent.toml
+++ b/rules/apm/apm_null_user_agent.toml
@@ -13,7 +13,7 @@ false_positives = [
     unexpected, the user unauthorized, or the request unusual, these may indicate suspicious or malicious activity.
     """,
 ]
-index = ["apm-*-transaction*"]
+index = ["apm-*-transaction*", "traces-apm*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Web Application Suspicious Activity: No User Agent"

--- a/rules/apm/apm_null_user_agent.toml
+++ b/rules/apm/apm_null_user_agent.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/07/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/apm/apm_sqlmap_user_agent.toml
+++ b/rules/apm/apm_sqlmap_user_agent.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/07/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/apm/apm_sqlmap_user_agent.toml
+++ b/rules/apm/apm_sqlmap_user_agent.toml
@@ -16,7 +16,7 @@ false_positives = [
     suspicious or malicious activity.
     """,
 ]
-index = ["apm-*-transaction*"]
+index = ["apm-*-transaction*", "traces-apm*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Web Application Suspicious Activity: sqlmap User Agent"

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -9,7 +9,7 @@ description = """
 Generates a detection alert for each external alert written to the configured indices. Enabling this rule allows you to
 immediately begin investigating external alerts in the app.
 """
-index = ["apm-*-transaction*", "auditbeat-*", "filebeat-*", "logs-*", "packetbeat-*", "winlogbeat-*"]
+index = ["apm-*-transaction*", "traces-apm*", "auditbeat-*", "filebeat-*", "logs-*", "packetbeat-*", "winlogbeat-*"]
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/08"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/07/13"
 
 [rule]
 author = ["Elastic"]

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -205,11 +205,12 @@ class TestRuleTags(BaseRuleTest):
     def test_required_tags(self):
         """Test that expected tags are present within rules."""
         # indexes considered; only those with obvious relationships included
-        # 'apm-*-transaction*', 'auditbeat-*', 'endgame-*', 'filebeat-*', 'logs-*', 'logs-aws*',
+        # 'apm-*-transaction*', 'traces-apm*', 'auditbeat-*', 'endgame-*', 'filebeat-*', 'logs-*', 'logs-aws*',
         # 'logs-endpoint.alerts-*', 'logs-endpoint.events.*', 'logs-okta*', 'packetbeat-*', 'winlogbeat-*'
 
         required_tags_map = {
             'apm-*-transaction*': {'all': ['APM']},
+            'traces-apm*': {'all': ['APM']},
             'auditbeat-*': {'any': ['Windows', 'macOS', 'Linux']},
             'endgame-*': {'all': ['Elastic Endgame']},
             'logs-aws*': {'all': ['AWS']},


### PR DESCRIPTION
## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/kibana/pull/105334
https://github.com/elastic/kibana/issues/94702
https://github.com/elastic/kibana/pull/102682
## Summary

This addresses feedback given in the related Kibana pull request (https://github.com/elastic/kibana/pull/105334) which fixes support for APM data streams in the security solution.
