### PR TITLE
[Rule Tuning] Convert unusual extension rule to regex

### DIFF
--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -25,7 +25,7 @@ type = "eql"
 
 query = '''
 file where event.type == "creation" and file.extension : "exe" and
-  file.name regex~ """.*\.(vbs|vbe|bat|js|cmd|wsh|ps1|pdf|docx?|xlsx?|pptx?|txt|rtf|gif|jpg|png|bmc|hta|txt|img|iso)\.exe"""
+  file.name regex~ """.*\.(vbs|vbe|bat|js|cmd|wsh|ps1|pdf|docx?|xlsx?|pptx?|txt|rtf|gif|jpg|png|bmp|hta|txt|img|iso)\.exe"""
 '''
 
 
@@ -46,4 +46,3 @@ reference = "https://attack.mitre.org/techniques/T1036/004/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -2,6 +2,7 @@
 creation_date = "2021/01/19"
 maturity = "production"
 updated_date = "2021/03/03"
+min_stack_version = "7.12.0"
 
 [rule]
 author = ["Elastic"]
@@ -23,34 +24,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where event.type == "creation" and file.extension:"exe" and
-  file.name:
-  (
-    "*.vbs.exe",
-    "*.vbe.exe",
-    "*.bat.exe",
-    "*.js.exe",
-    "*.cmd.exe",
-    "*.wsh.exe",
-    "*.ps1.exe",
-    "*.pdf.exe",
-    "*.docx.exe",
-    "*.doc.exe",
-    "*.xlsx.exe",
-    "*.xls.exe",
-    "*.pptx.exe",
-    "*.ppt.exe",
-    "*.txt.exe",
-    "*.rtf.exe",
-    "*.gif.exe",
-    "*.jpg.exe",
-    "*.png.exe",
-    "*.bmp.exe",
-    "*.hta.exe",
-    "*.txt.exe",
-    "*.img.exe",
-    "*.iso.exe"
-  )
+file where event.type == "creation" and file.extension : "exe" and
+  file.name regex~ """.*\.(vbs|vbe|bat|js|cmd|wsh|ps1|pdf|docx?|xlsx?|pptx?|txt|rtf|gif|jpg|png|bmc|hta|txt|img|iso)\.exe"""
 '''
 
 

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/19"
 maturity = "production"
-updated_date = "2021/07/21"
+updated_date = "2021/07/20"
 min_stack_version = "7.12.0"
 
 [rule]

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/07/21"
 min_stack_version = "7.12.0"
 
 [rule]


### PR DESCRIPTION
## Issues
Part of #1023

## Summary
Convert the multiple extensions rule to use `regex~`.
This might help performance and generate less expensive Lucene automata. It's possible that if the field is a wildcard field (unlikely) that search performance is worse, but that depends on how regex vs wildcard searches are implemented.