### PR TITLE
Fix metadata.extended

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -42,7 +42,7 @@ class RuleMeta(MarshmallowDataclassMixin):
     related_endpoint_rules: Optional[List[str]]
 
     # Extended information as an arbitrary dictionary
-    extended = Optional[dict]
+    extended: Optional[dict]
 
     def get_validation_stack_versions(self) -> Dict[str, dict]:
         """Get a dict of beats and ecs versions per stack release."""


### PR DESCRIPTION
## Issues
Fix #1305

## Summary
Dataclass type definition fail. Fixed now and confirmed locally.