### PR TITLE
Update the version lock for 7.14.0 and 0.13.3

### DIFF
--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -6,8 +6,8 @@
   },
   "00140285-b827-4aee-aa09-8113f58a08f3": {
     "rule_name": "Potential Credential Access via Windows Utilities",
-    "sha256": "7f7b7468fdb5d4a7f71e670479c4d12175299d39c22e487219b50fe24a54c78a",
-    "version": 3
+    "sha256": "819b97e921f748a95d389f35f4e7e485b52ee736654131c03752b127d7e0743a",
+    "version": 4
   },
   "0022d47d-39c7-4f69-a232-4fe9dc7a3acd": {
     "rule_name": "System Shells via Services",
@@ -131,8 +131,8 @@
   },
   "0d8ad79f-9025-45d8-80c1-4f0cd3c5e8e5": {
     "rule_name": "Execution of File Written or Modified by Microsoft Office",
-    "sha256": "008f38d1a423c52ee58b69430efc29490f468a1f60691783a2bdeebe8ba3a376",
-    "version": 3
+    "sha256": "365d0c3cd21f3eb2d56c7780271b0f2b9c9728578edba1f89f7021ad0470f389",
+    "version": 4
   },
   "0e5acaae-6a64-4bbc-adb8-27649c03f7e1": {
     "rule_name": "GCP Service Account Key Creation",
@@ -204,6 +204,11 @@
     "sha256": "efd7d2aa298941d3d4d452f08ace97c0c6a5bd2a26f9da698d06bae893f899e8",
     "version": 1
   },
+  "138c5dd5-838b-446e-b1ac-c995c7f8108a": {
+    "rule_name": "Rare User Logon",
+    "sha256": "0f58d631c0e3181b8d45b1df57e496be523f9725dd66e00035885cdc9ec60154",
+    "version": 1
+  },
   "139c7458-566a-410c-a5cd-f80238d6a5cd": {
     "rule_name": "SQL Traffic to the Internet",
     "sha256": "26fce2242bdb3d7341ec772772151eae5dfe28e3f14a60bbe586e0d5d5842ad7",
@@ -216,8 +221,8 @@
   },
   "143cb236-0956-4f42-a706-814bcaa0cf5a": {
     "rule_name": "RPC (Remote Procedure Call) from the Internet",
-    "sha256": "7451263e28396036b27ed324111bcec3e9c69fe87505c05b284e835ede9c5ca8",
-    "version": 9
+    "sha256": "ed650b805675aa2923aa204ce1296e1808ada8a0875e9ce9179b97d95033cc0e",
+    "version": 10
   },
   "14ed1aa9-ebfd-4cf9-a463-0ac59ec55204": {
     "rule_name": "Potential Persistence via Time Provider Modification",
@@ -296,8 +301,8 @@
   },
   "19de8096-e2b0-4bd8-80c9-34a820813fff": {
     "rule_name": "Rare AWS Error Code",
-    "sha256": "b95e0be3b71b1baa53dfb17cf053edb48f4d0c29d12ae4cc565cc34a231bd431",
-    "version": 4
+    "sha256": "0cb88efa8fdffeb98c561e637a64c2df9210aa04ea18d0fcf653a5d5b5842f9a",
+    "version": 5
   },
   "1a36cace-11a7-43a8-9a10-b497c5a02cd3": {
     "rule_name": "Azure Application Credential Modification",
@@ -341,8 +346,8 @@
   },
   "1d72d014-e2ab-4707-b056-9b96abe7b511": {
     "rule_name": "External IP Lookup fron Non-Browser Process",
-    "sha256": "74f970cf5b235ba112b15830a51eb59ecfb8ca1a7c5f654c10e9ff7a6a28e132",
-    "version": 4
+    "sha256": "8e317b098213baeec68427dc7472490fb68519d6bd0ee0dd4ebb46f2e39ae954",
+    "version": 5
   },
   "1dcc51f6-ba26-49e7-9ef4-2655abb2361e": {
     "rule_name": "UAC Bypass via DiskCleanup Scheduled Task Hijack",
@@ -351,8 +356,8 @@
   },
   "1defdd62-cd8d-426e-a246-81a37751bb2b": {
     "rule_name": "Execution of File Written or Modified by PDF Reader",
-    "sha256": "3969c9f3230d84375fb447b14e9979360ab9e90b5dcce2e9382eb1d8e0cad454",
-    "version": 3
+    "sha256": "addced6abf8dc7f24872880d268564ecb42c37637279c57f635c19123b951d91",
+    "version": 4
   },
   "1e0b832e-957e-43ae-b319-db82d228c908": {
     "rule_name": "Azure Storage Account Key Regenerated",
@@ -494,10 +499,20 @@
     "sha256": "b855256f23054ec5025f78c2ec0ddd70e36ef7b16856700f208936300525f544",
     "version": 9
   },
+  "2c17e5d7-08b9-43b2-b58a-0270d65ac85b": {
+    "rule_name": "Windows Defender Exclusions Added via PowerShell",
+    "sha256": "02bb248113cc4d221af52a3108fc8975f60ea9262491f4c3498681f4e0ea83f6",
+    "version": 1
+  },
   "2d8043ed-5bda-4caf-801c-c1feb7410504": {
     "rule_name": "Enumeration of Kernel Modules",
     "sha256": "f78114d6df86b5c2843abb41b8c64f807f94962e9ac46f1e19b5775d401ce38b",
     "version": 6
+  },
+  "2de10e77-c144-4e69-afb7-344e7127abd0": {
+    "rule_name": "O365 Excessive Single Sign-On Logon Errors",
+    "sha256": "8d2a8deeea6630015f258b4a15219dc05413514e251382f33694f3c1be5b4686",
+    "version": 1
   },
   "2e1e835d-01e5-48ca-b9fc-7a61f7f11902": {
     "rule_name": "Renamed AutoIt Scripts Interpreter",
@@ -506,8 +521,8 @@
   },
   "2e580225-2a58-48ef-938b-572933be06fe": {
     "rule_name": "Halfbaked Command and Control Beacon",
-    "sha256": "31030aa4c70fd9144e6a59e40685b41c2be5699d13f5a039c957cf9345006e89",
-    "version": 5
+    "sha256": "85ef581fbbbf8ee9caeac93bf4e6a8fb80e01ff41ddc66b44474e8ddd9c66954",
+    "version": 6
   },
   "2edc8076-291e-41e9-81e4-e3fcbc97ae5e": {
     "rule_name": "Creation of a Hidden Local User Account",
@@ -534,10 +549,15 @@
     "sha256": "33b768a4456770f5a2eb024ab81e723b4ed3a53b57ebcea0b5130fc245fd6b85",
     "version": 5
   },
+  "3115bd2c-0baa-4df0-80ea-45e474b5ef93": {
+    "rule_name": "Agent Spoofing - Mismatched Agent ID",
+    "sha256": "64619f9caffb2d5207658b5ddb16c86462b4c19c8567280b74c5191166c42a25",
+    "version": 1
+  },
   "31295df3-277b-4c56-a1fb-84e31b4222a9": {
     "rule_name": "Inbound Connection to an Unsecure Elasticsearch Node",
-    "sha256": "a98ad9e22ab55a94f482cc8407cf7c072b80f53c858e9b115e018287b47d9f5e",
-    "version": 4
+    "sha256": "c30b4dbb58d32a0f0bb0e4cd56091741708bc6a1a3532af6bf2bf17b00a21861",
+    "version": 5
   },
   "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62": {
     "rule_name": "Bypass UAC via Event Viewer",
@@ -556,8 +576,8 @@
   },
   "32923416-763a-4531-bb35-f33b9232ecdb": {
     "rule_name": "RPC (Remote Procedure Call) to the Internet",
-    "sha256": "290eff512616935ff53c5fec73bddbcfb8a68c5cfaa6f403c4de8cbdc732f5b6",
-    "version": 9
+    "sha256": "4e9e882afade7a01106ba542c190ee37ede7cadb7a90ab4338e182a84e405cde",
+    "version": 10
   },
   "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14": {
     "rule_name": "Program Files Directory Masquerading",
@@ -581,8 +601,8 @@
   },
   "34fde489-94b0-4500-a76f-b8a157cf9269": {
     "rule_name": "Telnet Port Activity",
-    "sha256": "cdabefe4b5d10a79ff258d4effdfa7f9eb4cf946f6eb43c547dc08fe13f44621",
-    "version": 7
+    "sha256": "e5306bdd6e6acb922e80f74e2a23afe8f0f416006c8d0a0c39b724d60a2c3f43",
+    "version": 8
   },
   "35330ba2-c859-4c98-8b7f-c19159ea0e58": {
     "rule_name": "Execution via Electron Child Process Node.js Module",
@@ -676,8 +696,8 @@
   },
   "3ad49c61-7adc-42c1-b788-732eda2f5abf": {
     "rule_name": "VNC (Virtual Network Computing) to the Internet",
-    "sha256": "38600c025a0aab30c26b5eb880d9b9e0d1a6e66c9adc6c48361cd0988b1eee30",
-    "version": 9
+    "sha256": "359cf75a16af7cdcefa73e7d69bc87512aad497106159c41fa221183c10c2c33",
+    "version": 10
   },
   "3b382770-efbb-44f4-beed-f5e0a051b895": {
     "rule_name": "Malware - Prevented - Elastic Endgame",
@@ -719,6 +739,11 @@
     "sha256": "963f664114823b11c4a4728f07135d64b207cc28e9181a0ed1536682458cec56",
     "version": 4
   },
+  "3f0e5410-a4bf-4e8c-bcfc-79d67a285c54": {
+    "rule_name": "CyberArk Privileged Access Security Error",
+    "sha256": "420e91f52a8fb273a099a96a3b3e8beb4c682a608f9ce67d763b32fa803a83dd",
+    "version": 1
+  },
   "403ef0d3-8259-40c9-a5b6-d48354712e49": {
     "rule_name": "Unusual Persistence via Services Registry",
     "sha256": "0ec360815683ac95dccca9d337385dfc1389dd03b5d923f929ab310a2a3c8ad0",
@@ -746,8 +771,8 @@
   },
   "43303fd4-4839-4e48-b2b2-803ab060758d": {
     "rule_name": "Web Application Suspicious Activity: No User Agent",
-    "sha256": "e7a80d2e9a35839780f87221305e6ee50fde768b34c00dbb3563bc4a114b47c4",
-    "version": 6
+    "sha256": "e4e4fed016f2f7f95e0547e9880feb0a83a077b476bc20dd27ac1cd3a58b577d",
+    "version": 7
   },
   "440e2db4-bc7f-4c96-a068-65b78da59bde": {
     "rule_name": "Shortcut File Written or Modified for Persistence",
@@ -804,10 +829,15 @@
     "sha256": "6cc74d6a74abae157494c559cbc80c499212df19327c2345e899fc8d77a1a089",
     "version": 1
   },
+  "493834ca-f861-414c-8602-150d5505b777": {
+    "rule_name": "Agent Spoofing - Multiple Hosts Using Same Agent",
+    "sha256": "f8e4481e5c38326daea5818415a4f06be1da64247686974940283c6b7a31f81f",
+    "version": 1
+  },
   "4a4e23cf-78a2-449c-bac3-701924c269d3": {
     "rule_name": "Possible FIN7 DGA Command and Control Behavior",
-    "sha256": "daf5012d72d5b808c18913125114e203c60be3702079f90e2e28d9098dbef69e",
-    "version": 5
+    "sha256": "38a9ef4430e706f69e3f25e3775ef9ab5247933a6448daed8075c460dd5d4369",
+    "version": 6
   },
   "4b438734-3793-4fda-bd42-ceeada0be8f9": {
     "rule_name": "Disable Windows Firewall Rules via Netsh",
@@ -827,6 +857,11 @@
   "4da13d6e-904f-4636-81d8-6ab14b4e6ae9": {
     "rule_name": "Attempt to Disable Gatekeeper",
     "sha256": "0ae822fec1abd33c32277f40e993668c09ec575f0f6580a760937417c7d50e32",
+    "version": 1
+  },
+  "4de76544-f0e5-486a-8f84-eae0b6063cdc": {
+    "rule_name": "Disable Windows Event and Security Logs Using Built-in Tools",
+    "sha256": "aa01a46fab350db3345bf79795effecf5b1ae98e59739a796682c4c066b7bf52",
     "version": 1
   },
   "4ed493fc-d637-4a36-80ff-ac84937e5461": {
@@ -936,8 +971,8 @@
   },
   "5700cb81-df44-46aa-a5d7-337798f53eb8": {
     "rule_name": "VNC (Virtual Network Computing) from the Internet",
-    "sha256": "8575892e76f9b091979957bb6e78ba24b0d230753a3d74f5c8e0e6f99113ab1b",
-    "version": 9
+    "sha256": "12fa6d14a0c65fcda3474c13dcf2442d8512ebf358247156a5932e9ef036b2c7",
+    "version": 10
   },
   "571afc56-5ed9-465d-a2a9-045f099f6e7e": {
     "rule_name": "Credential Dumping - Detected - Elastic Endgame",
@@ -1136,8 +1171,8 @@
   },
   "6839c821-011d-43bd-bd5b-acff00257226": {
     "rule_name": "Image File Execution Options Injection",
-    "sha256": "4a98f9ffc77d8325feab58efcc9434c8126e081df4f08581d71f4252481b85ef",
-    "version": 3
+    "sha256": "cb9f8ab520ca0272536e6f61744c52bd7dae188a52f40d4587e9c233786de795",
+    "version": 4
   },
   "6885d2ae-e008-4762-b98a-e8e1cd3a81e9": {
     "rule_name": "Threat Detected by Okta ThreatInsight",
@@ -1226,8 +1261,8 @@
   },
   "6ea71ff0-9e95-475b-9506-2580d1ce6154": {
     "rule_name": "DNS Activity to the Internet",
-    "sha256": "b6eaf970237f2fd397a64c592f8d01ede1038f2f3c0d68b7d2ffffcadc7129f3",
-    "version": 9
+    "sha256": "f26e3c006339a242c5e290b073fec3a0766ac72bc7606247d3b2cadb0673fd7b",
+    "version": 10
   },
   "6f1500bc-62d7-4eb9-8601-7485e87da2f4": {
     "rule_name": "SSH (Secure Shell) to the Internet",
@@ -1289,6 +1324,11 @@
     "sha256": "b9eee6e8e6eb2c238952d35b40ebd2ef4d70e4a462e513ac0bf3f939a447c986",
     "version": 2
   },
+  "745b0119-0560-43ba-860a-7235dd8cee8d": {
+    "rule_name": "Unusual Hour for a User to Logon",
+    "sha256": "cfc6d020a4aff760e43c4f33a76f8e3f56c9aca58b2199c4c498bb3f6f966b42",
+    "version": 1
+  },
   "746edc4c-c54c-49c6-97a1-651223819448": {
     "rule_name": "Unusual DNS Activity",
     "sha256": "af51bdc27c86e87d19b50f0daa04da3c6df9a80227f61e73e44e86db37f30006",
@@ -1296,8 +1336,8 @@
   },
   "75ee75d8-c180-481c-ba88-ee50129a6aef": {
     "rule_name": "Web Application Suspicious Activity: Unauthorized Method",
-    "sha256": "6bbf3c4cc80aa8bf0fcabd381be36d6299344c6945026c8d480781d97c17d1da",
-    "version": 6
+    "sha256": "4656da919aac7ab36d793ea09ee9a9d6fcf1854930bc9c395dabd66ec1a048af",
+    "version": 7
   },
   "76152ca1-71d0-4003-9e37-0983e12832da": {
     "rule_name": "Potential Privilege Escalation via Sudoers File Modification",
@@ -1336,8 +1376,8 @@
   },
   "78d3d8d9-b476-451d-a9e0-7a5addd70670": {
     "rule_name": "Spike in AWS Error Messages",
-    "sha256": "b5bc993d6c5413b2d00802b37b709393a23dc41d7369ef8089211d0abdd6babd",
-    "version": 4
+    "sha256": "5f22b5ac82f652a13f93b4754379abe3bb9950efbfb1dfa11517af248b026be2",
+    "version": 5
   },
   "792dd7a6-7e00-4a0a-8a9a-a7c24720b5ec": {
     "rule_name": "Azure Key Vault Modified",
@@ -1381,8 +1421,8 @@
   },
   "809b70d3-e2c3-455e-af1b-2626a5a1a276": {
     "rule_name": "Unusual City For an AWS Command",
-    "sha256": "6a1b3c8d1cdd11b75a62b07d8d8bcb0d3c861634dd34dc9ad7b99fbd05a1ddf0",
-    "version": 4
+    "sha256": "49b3bc881b9af321e0ddda6357f5150847ae0adb2898abf98a38e98743f51963",
+    "version": 5
   },
   "80c52164-c82a-402c-9964-852533d58be1": {
     "rule_name": "Process Injection - Detected - Elastic Endgame",
@@ -1401,8 +1441,8 @@
   },
   "852c1f19-68e8-43a6-9dce-340771fe1be3": {
     "rule_name": "Suspicious PowerShell Engine ImageLoad",
-    "sha256": "b2f8c881e1a8035f71937f423f8575b0bcbf1aa09c17cfd35e2bdb86f03040ae",
-    "version": 3
+    "sha256": "2d64484c1819eab787cf8dd38ba726a52646aeaac9cc644db872b9cbc99fb254",
+    "version": 4
   },
   "8623535c-1e17-44e1-aa97-7a0699c3037d": {
     "rule_name": "AWS EC2 Network Access Control List Deletion",
@@ -1481,8 +1521,8 @@
   },
   "8b2b3a62-a598-4293-bc14-3d5fa22bb98f": {
     "rule_name": "Executable File Creation with Multiple Extensions",
-    "sha256": "c71bb3f63edeb09cc751265c0bb466c34b9f916dcc6e9bebdeddd1c7c684c19f",
-    "version": 1
+    "sha256": "78b068f32b6f2ea26024a9e07219d32464cee7ed641339bc7aa5bede56086f35",
+    "version": 2
   },
   "8b4f0816-6a65-4630-86a6-c21c179c0d09": {
     "rule_name": "Enable Host Network Discovery via Netsh",
@@ -1491,8 +1531,8 @@
   },
   "8c1bdde8-4204-45c0-9e0c-c85ca3902488": {
     "rule_name": "RDP (Remote Desktop Protocol) from the Internet",
-    "sha256": "4d93ac2658ab5f45d146f08374be7a656986c2f8b23869ba686cd7ea3380eb34",
-    "version": 9
+    "sha256": "9bdc9382a39d2512199371d13da379c0c7ff2732cdac39c9b4214abe77a53882",
+    "version": 10
   },
   "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45": {
     "rule_name": "Unusual Child Process of dns.exe",
@@ -1669,6 +1709,11 @@
     "sha256": "9c685eb3133fc81f65b95648e73cf483f68d8c33378b9af971fdd78349e4d048",
     "version": 2
   },
+  "99dcf974-6587-4f65-9252-d866a3fdfd9c": {
+    "rule_name": "Spike in Failed Logon Events",
+    "sha256": "2638483670e005d8b56dfdea27e389782690b3216a07adb454110f0d1a27e141",
+    "version": 1
+  },
   "9a1a2dae-0b5f-4c3d-8305-a268d404c306": {
     "rule_name": "Endpoint Security",
     "sha256": "35d86aa3177f1e13febf07e1a2921393a63e9661a1a326ef641997855f1eff09",
@@ -1826,8 +1871,8 @@
   },
   "a87a4e42-1d82-44bd-b0bf-d9b7f91fb89e": {
     "rule_name": "Web Application Suspicious Activity: POST Request Declined",
-    "sha256": "7f353ebd8f16d4c4a3b7dad87ae483b9066963da676549c7ee9e1c15fd05b743",
-    "version": 6
+    "sha256": "c2baa30b4d23f42150a38858824b8814ec1d3d920635abc6cdabda80b68a9b1d",
+    "version": 7
   },
   "a9198571-b135-4a76-b055-e3e5a476fd83": {
     "rule_name": "Hex Encoding/Decoding Activity",
@@ -1841,8 +1886,8 @@
   },
   "a99f82f5-8e77-4f8b-b3ce-10c0f6afbc73": {
     "rule_name": "Google Workspace Password Policy Modified",
-    "sha256": "11ee39429935e0f7e5c0a8aac027869c23d59bf4cabf4509fcd3a37efb6f40d0",
-    "version": 4
+    "sha256": "ef95ae931a66522f0132d340e3fbdfd869e645bd25978c1ff427f9ded3fd339b",
+    "version": 5
   },
   "a9b05c3b-b304-4bf9-970d-acdfaef2944c": {
     "rule_name": "Persistence via Hidden Run Key Detected",
@@ -1851,8 +1896,8 @@
   },
   "a9cb3641-ff4b-4cdc-a063-b4b8d02a67c7": {
     "rule_name": "IPSEC NAT Traversal Port Activity",
-    "sha256": "bda40067c1d339d646167ed025118e572c4cd7e85e6e664d43594056a35fab79",
-    "version": 7
+    "sha256": "f3e51f33c8c8fda2a728a1e73185ef757441a7a1fe4d4c7e057ba1ba00e8fd4c",
+    "version": 8
   },
   "aa8007f0-d1df-49ef-8520-407857594827": {
     "rule_name": "GCP IAM Custom Role Creation",
@@ -1891,8 +1936,8 @@
   },
   "ac706eae-d5ec-4b14-b4fd-e8ba8086f0e1": {
     "rule_name": "Unusual AWS Command for a User",
-    "sha256": "8c2587b7bb22ffc9e8c5342d92aa8f5ab5bb229855d76d62619b91d0b73758d2",
-    "version": 4
+    "sha256": "24389351eb7c25629b3b2cc1a7f95930806c1dd0f7f9f31b3beceb10833e91f4",
+    "version": 5
   },
   "acbc8bb9-2486-49a8-8779-45fb5f9a93ee": {
     "rule_name": "Google Workspace API Access Granted via Domain-Wide Delegation of Authority",
@@ -2031,8 +2076,8 @@
   },
   "b9666521-4742-49ce-9ddc-b8e84c35acae": {
     "rule_name": "Creation of Hidden Files and Directories",
-    "sha256": "b77c134e2c672646234f8b9181dfc74b88aad6591310100b27bad31f7176a5ed",
-    "version": 6
+    "sha256": "8e1e234b34a64f445bf854bc5c68bfa88bb2958a08ffcb995ccfe2db81e123e6",
+    "version": 7
   },
   "b9960fef-82c6-4816-befa-44745030e917": {
     "rule_name": "SolarWinds Process Disabling Services via Registry",
@@ -2141,8 +2186,8 @@
   },
   "c2d90150-0133-451c-a783-533e736c12d7": {
     "rule_name": "Mshta Making Network Connections",
-    "sha256": "a9a47cb844d9dc87e096ed357fc9afd44765c7e8c0fcdc656e8a586f2953d154",
-    "version": 3
+    "sha256": "2fd4b7c7bf96fc6da0580bc2d775d1eabbb4adcb0d8bda9e1e6eb7f9205cf0c2",
+    "version": 4
   },
   "c3167e1b-f73c-41be-b60b-87f4df707fe3": {
     "rule_name": "Permission Theft - Detected - Elastic Endgame",
@@ -2183,6 +2228,11 @@
     "rule_name": "Microsoft Build Engine Started by an Office Application",
     "sha256": "ee3ab5606f836c98a65ede43ac5c1d0c7fbdb968b0054830dfd47af55de52f62",
     "version": 8
+  },
+  "c5f81243-56e0-47f9-b5bb-55a5ed89ba57": {
+    "rule_name": "CyberArk Privileged Access Security Recommended Monitor",
+    "sha256": "0c5ec551b85d7e7e8775c4c1508a831c6019881d679e137e6f0531968d3ab03c",
+    "version": 1
   },
   "c6453e73-90eb-4fe7-a98c-cde7bbfc504a": {
     "rule_name": "Remote File Download via MpCmdRun",
@@ -2226,8 +2276,8 @@
   },
   "c82b2bd8-d701-420c-ba43-f11a155b681a": {
     "rule_name": "SMB (Windows File Sharing) Activity to the Internet",
-    "sha256": "fc77eb32fff68465f4147c2373f54c206217704bc464b7cff185429ac05d0769",
-    "version": 9
+    "sha256": "60a1113981b24d94273f04c8c2eecc2aba19f2e8a5e412ef38dd1a6e9bda82c5",
+    "version": 10
   },
   "c82c7d8f-fb9e-4874-a4bd-fd9e3f9becf1": {
     "rule_name": "Direct Outbound SMB Connection",
@@ -2238,6 +2288,11 @@
     "rule_name": "Nmap Process Activity",
     "sha256": "85b00c642776304ce2f5d7c1374ad4f666c1669ace49cc43ede47f075674581d",
     "version": 7
+  },
+  "c88d4bd0-5649-4c52-87ea-9be59dbfbcf2": {
+    "rule_name": "Parent Process PID Spoofing",
+    "sha256": "1fef8434702bfb1e375a190414def78e6ee6a6523b0ab47eab82953922195230",
+    "version": 1
   },
   "c8b150f0-0164-475b-a75e-74b47800a9ff": {
     "rule_name": "Suspicious Startup Shell Folder Modification",
@@ -2266,8 +2321,8 @@
   },
   "cad4500a-abd7-4ef3-b5d3-95524de7cfe1": {
     "rule_name": "Google Workspace MFA Enforcement Disabled",
-    "sha256": "fc32fc89f62378a14d4ea384b312368f9626a4b8e461abe33e8afc2a7b9b1399",
-    "version": 4
+    "sha256": "b3ac3a475c508108712c1fa7d134ce923d1addf8d4d489f3fb5e82840717f8d2",
+    "version": 5
   },
   "cb71aa62-55c8-42f0-b0dd-afb0bb0b1f51": {
     "rule_name": "Suspicious Calendar File Modification",
@@ -2331,8 +2386,8 @@
   },
   "cf53f532-9cc9-445a-9ae7-fced307ec53c": {
     "rule_name": "Cobalt Strike Command and Control Beacon",
-    "sha256": "0a6002faf9de25741761baff24faccdd17b528cb5230891cd2f8ec3a05515e05",
-    "version": 5
+    "sha256": "251ce0bab9c64891a65817cbbe623561d5a89f168d844da108c03562d4e2266e",
+    "version": 6
   },
   "cf549724-c577-4fd6-8f9b-d1b8ec519ec0": {
     "rule_name": "Domain Added to Google Workspace Trusted Domains",
@@ -2381,13 +2436,18 @@
   },
   "d49cc73f-7a16-4def-89ce-9fc7127d7820": {
     "rule_name": "Web Application Suspicious Activity: sqlmap User Agent",
-    "sha256": "d88d17c4e3a52a407447872f4791d77d827a21e31877415051656d25e3b18a5c",
-    "version": 6
+    "sha256": "4b9eead51bdd9860f02d47c1a20fc4892ba90960f2151ebe61c89e07ed3f4263",
+    "version": 7
   },
   "d4af3a06-1e0a-48ec-b96a-faf2309fae46": {
     "rule_name": "Unusual Linux System Information Discovery Activity",
     "sha256": "e6bfd938d1323fddf3554c4c9a5a57d6490c2b23ec7d42a12455a5cd6ab96d14",
     "version": 2
+  },
+  "d4b73fa0-9d43-465e-b8bf-50230da6718b": {
+    "rule_name": "Unusual Source IP for a User to Logon from",
+    "sha256": "eaec6ceda71a7d7f2ef470443ab29248249a5782241bd0d422c6c5201dff280f",
+    "version": 1
   },
   "d563aaba-2e72-462b-8658-3e5ea22db3a6": {
     "rule_name": "Privilege Escalation via Windir Environment Variable",
@@ -2449,10 +2509,15 @@
     "sha256": "1b8e9ea27c151d2de3fd5c94f0ff8de14098ccc0348a81ac3a39dc28f0dd118f",
     "version": 6
   },
+  "d7d5c059-c19a-4a96-8ae3-41496ef3bcf9": {
+    "rule_name": "Spike in Logon Events",
+    "sha256": "f597878752cb6e91544579901584b4938249c29026da834e202622b3194aac5b",
+    "version": 1
+  },
   "d7e62693-aab9-4f66-a21a-3d79ecdd603d": {
     "rule_name": "SMTP on Port 26/TCP",
-    "sha256": "29bb5b04d88c72fbc2d1446bb6137cfa342c46c539cd05476869fbea71f2353f",
-    "version": 7
+    "sha256": "7e8d3c2560ac6a468f7701f9ee237e39bc51231edf8d5b94ab0055d60286730b",
+    "version": 8
   },
   "d8fc1cca-93ed-43c1-bbb6-c0dd3eff2958": {
     "rule_name": "AWS IAM Deactivation of MFA Device",
@@ -2481,8 +2546,8 @@
   },
   "dca28dee-c999-400f-b640-50a081cc0fd1": {
     "rule_name": "Unusual Country For an AWS Command",
-    "sha256": "74067a1bafe61469a5555b6fffc68a96e2746e45c3c5a55bc453fd53e6c52150",
-    "version": 4
+    "sha256": "d8c00c7f9462d3218ddbebbc2c864dc3b1eb8449120e3f26b284165d2ae1e28c",
+    "version": 5
   },
   "ddab1f5f-7089-44f5-9fda-de5b11322e77": {
     "rule_name": "NullSessionPipe Registry Modification",
@@ -2539,6 +2604,11 @@
     "sha256": "a45edaf4d918bf73f99e232fcd351f941cfa4f924fd8e1178dc914370f3c706a",
     "version": 6
   },
+  "e26aed74-c816-40d3-a810-48d6fbd8b2fd": {
+    "rule_name": "Spike in Logon Events from a Source IP",
+    "sha256": "fb4afa427f0347f94517a7191fb7a7f880941fbd2bd47289ce54bcbf5bfc67c9",
+    "version": 1
+  },
   "e2a67480-3b79-403d-96e3-fdd2992c50ef": {
     "rule_name": "AWS Management Console Root Login",
     "sha256": "94dcf7938345325b7cca64d3a410cffbb9e2503ddb509afb63a9721087a0b906",
@@ -2581,8 +2651,8 @@
   },
   "e555105c-ba6d-481f-82bb-9b633e7b4827": {
     "rule_name": "MFA Disabled for Google Workspace Organization",
-    "sha256": "65040d81fb2f4106c2816c529b620842ee4b50427b2f97aa763b8e201dd7908e",
-    "version": 4
+    "sha256": "21b0163193173a7b44d923a963f2d26c901d4980383fe215fa733ea8c33ff030",
+    "version": 5
   },
   "e56993d2-759c-4120-984c-9ec9bb940fd5": {
     "rule_name": "RDP (Remote Desktop Protocol) to the Internet",
@@ -2606,8 +2676,8 @@
   },
   "e7075e8d-a966-458e-a183-85cd331af255": {
     "rule_name": "Default Cobalt Strike Team Server Certificate",
-    "sha256": "b899b9419a4b24b77421765474521deb2de93b5d9784581ed9fd261ed1951409",
-    "version": 4
+    "sha256": "6a0b9f5e96f7a9d33b40d108303f27415683c6fe0600e4ff4586dab72b2afd92",
+    "version": 5
   },
   "e7125cea-9fe1-42a5-9a05-b0792cf86f5a": {
     "rule_name": "Execution of Persistent Suspicious Program",
@@ -2666,8 +2736,8 @@
   },
   "eb079c62-4481-4d6e-9643-3ca499df7aaa": {
     "rule_name": "External Alerts",
-    "sha256": "ede87f21df9ef4874fde0720c5a1050b79ec63509d7fc140cadb2d1b2fbd72aa",
-    "version": 3
+    "sha256": "3c761c7b1a22a38d6334369cd822c00a6b2d954f9c650ffc564cf84ff8f8f403",
+    "version": 4
   },
   "eb9eb8ba-a983-41d9-9c93-a1c05112ca5e": {
     "rule_name": "Potential Disabling of SELinux",
@@ -2721,8 +2791,8 @@
   },
   "ee5300a7-7e31-4a72-a258-250abb8b3aa1": {
     "rule_name": "Unusual Print Spooler Child Process",
-    "sha256": "4716dcae5bd95755297e57624cf567d545de92d986a221b3ca61f9bb6f7d9c53",
-    "version": 1
+    "sha256": "0bd82ae0595d90f291e7c8ad80cb1f93a0d28033c0bb861c4d3b2ca232374bb1",
+    "version": 2
   },
   "eea82229-b002-470e-a9e1-00be38b14d32": {
     "rule_name": "Potential Privacy Control Bypass via TCCDB Modification",
@@ -2736,8 +2806,8 @@
   },
   "f036953a-4615-4707-a1ca-dc53bf69dcd5": {
     "rule_name": "Unusual Child Processes of RunDLL32",
-    "sha256": "1141da2983333989447dc381b71356a6cc55741178d76a77a3df032d2a5583bd",
-    "version": 3
+    "sha256": "779861ae9a5a6d779252d3f50f03be4b3b396c034d7cb7d558b8742884bd10d8",
+    "version": 4
   },
   "f06414a6-f2a4-466d-8eba-10f85e8abf71": {
     "rule_name": "Administrator Role Assigned to an Okta User",
@@ -2880,9 +2950,9 @@
     "version": 8
   },
   "fd70c98a-c410-42dc-a2e3-761c71848acf": {
-    "rule_name": "Encoding or Decoding Files via CertUtil",
-    "sha256": "9e50d4deeb60f96f6fcab96ef64ca154647683c59393e99f14c3a95aa7119ad9",
-    "version": 8
+    "rule_name": "Suspicious CertUtil Commands",
+    "sha256": "a9355d7b7c316691fcd6fa8cb53a27ba316ae71ea6c79e21e908ff3ee5302dda",
+    "version": 9
   },
   "fd7a6052-58fa-4397-93c3-4795249ccfa2": {
     "rule_name": "Svchost spawning Cmd",
@@ -2891,8 +2961,8 @@
   },
   "ff013cb4-274d-434a-96bb-fe15ddd3ae92": {
     "rule_name": "Roshal Archive (RAR) or PowerShell File Downloaded from the Internet",
-    "sha256": "b0766c2b5081f2da958a910b2935bf0773cef1af695c072f059551a4a1fee871",
-    "version": 5
+    "sha256": "6744cb7938669d606730140fb69f3fb0df4ad7c7a9996203806cace31426e25c",
+    "version": 6
   },
   "ff4dd44a-0ac6-44c4-8609-3f81bc820f02": {
     "rule_name": "Microsoft 365 Exchange Transport Rule Creation",


### PR DESCRIPTION
## Issues
None, just updating the lock for the next release

## Summary
Here's what I did:
```console
$ python -m detection_rules dev build-release -u
[+] Building package 7.13
 - 36 rules excluded from package
Rule changes detected!
Updated version.lock.json file
 - 41 changed rules
 - 4 new rules
 - 0 newly deprecated rules
Package saved to: releases/7.13
- sha256: 8225832f4baced3f8d8611c3b6b04f94c9ffc1652479eb0cea9423119758a4f8
- 558 rules included

$ git checkout 7.14
M	etc/version.lock.json
Switched to branch '7.14'
Your branch is up to date with 'origin/7.14'.


$ python -m detection_rules dev build-release -u
[+] Building package 7.14
 - 36 rules excluded from package
Rule changes detected!
Updated version.lock.json file
 - 0 changed rules
 - 10 new rules
 - 0 newly deprecated rules
Package saved to: releases/7.14
- sha256: 4a7ee770e6fe3560b6dbda887e0a23785010badb999d553cda7215f3e033987b
- 568 rules included
```