### PR TITLE
Disable missing rule check for the version lock

### DIFF
--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -402,8 +402,7 @@ class TestRuleMetadata(BaseRuleTest):
                 err_msg = f'{self.rule_str(rule)} deprecation_date and updated_date should match'
                 self.assertEqual(meta.deprecation_date, meta.updated_date, err_msg)
 
-
-        # skip this so the lock file can be shared across branches 
+        # skip this so the lock file can be shared across branches
         #
         # missing_rules = sorted(set(versions).difference(set(self.rule_lookup)))
         # missing_rule_strings = '\n '.join(f'{r} - {versions[r]["rule_name"]}' for r in missing_rules)

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -402,12 +402,15 @@ class TestRuleMetadata(BaseRuleTest):
                 err_msg = f'{self.rule_str(rule)} deprecation_date and updated_date should match'
                 self.assertEqual(meta.deprecation_date, meta.updated_date, err_msg)
 
-        missing_rules = sorted(set(versions).difference(set(self.rule_lookup)))
-        missing_rule_strings = '\n '.join(f'{r} - {versions[r]["rule_name"]}' for r in missing_rules)
-        err_msg = f'Deprecated rules should not be removed, but moved to the rules/_deprecated folder instead. ' \
-                  f'The following rules have been version locked and are missing. ' \
-                  f'Re-add to the deprecated folder and update maturity to "deprecated": \n {missing_rule_strings}'
-        self.assertEqual([], missing_rules, err_msg)
+
+        # skip this so the lock file can be shared across branches 
+        #
+        # missing_rules = sorted(set(versions).difference(set(self.rule_lookup)))
+        # missing_rule_strings = '\n '.join(f'{r} - {versions[r]["rule_name"]}' for r in missing_rules)
+        # err_msg = f'Deprecated rules should not be removed, but moved to the rules/_deprecated folder instead. ' \
+        #           f'The following rules have been version locked and are missing. ' \
+        #           f'Re-add to the deprecated folder and update maturity to "deprecated": \n {missing_rule_strings}'
+        # self.assertEqual([], missing_rules, err_msg)
 
         for rule_id, entry in deprecations.items():
             rule_str = f'{rule_id} - {entry["rule_name"]} ->'


### PR DESCRIPTION
## Issues
There was a failed 7.13 backport for #1383 because the lock file had a superset of rules.

## Summary
Disabled a test so the lock file can reference rules that don't exist.
Since we're revisiting the lock file soon, this won't be the long term solution.