### PR TITLE
[CI] Add missing clone for Fleet on-demand job

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -27,6 +27,11 @@ jobs:
               core.setFailed('Forbidden branch')
             }
 
+      - name: Checkout detection-rules
+        uses: actions/checkout@v2
+        with:
+          path: detection-rules
+
       - name: Checkout elastic/integrations
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Issues
Fix missing command from #1340

Was accidentally removed in commit https://github.com/elastic/detection-rules/pull/1340/commits/d1350678b76b883a4fad14851490b0b358c6dd03

## Summary
Fleet jobs weren't publishing because we never cloned detection-rules.
This wasn't tested, but that's nontrivial for GitHub workflows. Should be a straightforward fix 🤞 