### PR TITLE
[Bug] Tighten definitions validation patterns

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -623,19 +623,18 @@ def search_rule_prs(ctx, no_loop, query, columns, language, token, threads):
 
 
 @dev_group.command('deprecate-rule')
-@click.argument('rule-file', type=click.Path(dir_okay=False))
+@click.argument('rule-file', type=Path)
 @click.pass_context
-def deprecate_rule(ctx: click.Context, rule_file: str):
+def deprecate_rule(ctx: click.Context, rule_file: Path):
     """Deprecate a rule."""
-    import pytoml
     from .packaging import load_versions
 
     version_info = load_versions()
-    rule_file = Path(rule_file)
-    contents = pytoml.loads(rule_file.read_text())
+    rule_collection = RuleCollection()
+    contents = rule_collection.load_file(rule_file).contents
     rule = TOMLRule(path=rule_file, contents=contents)
 
-    if rule.id not in version_info:
+    if rule.contents.id not in version_info:
         click.echo('Rule has not been version locked and so does not need to be deprecated. '
                    'Delete the file or update the maturity to `development` instead')
         ctx.exit()

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -13,22 +13,22 @@ from marshmallow_dataclass import NewType
 ASSET_TYPE = "security_rule"
 SAVED_OBJECT_TYPE = "security-rule"
 
-DATE_PATTERN = r'\d{4}/\d{2}/\d{2}'
+DATE_PATTERN = r'^\d{4}/\d{2}/\d{2}$'
 MATURITY_LEVELS = ['development', 'experimental', 'beta', 'production', 'deprecated']
 OS_OPTIONS = ['windows', 'linux', 'macos']
-PR_PATTERN = r'^$|\d+'
-SHA256_PATTERN = r'[a-fA-F0-9]{64}'
-UUID_PATTERN = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+PR_PATTERN = r'^$|\d+$'
+SHA256_PATTERN = r'^[a-fA-F0-9]{64}$'
+UUID_PATTERN = r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 
 _version = r'\d+\.\d+(\.\d+[\w-]*)*'
 CONDITION_VERSION_PATTERN = rf'^\^{_version}$'
 VERSION_PATTERN = f'^{_version}$'
 BRANCH_PATTERN = f'{VERSION_PATTERN}|^master$'
 
-INTERVAL_PATTERN = r'\d+[mshd]'
-TACTIC_URL = r'https://attack.mitre.org/tactics/TA[0-9]+/'
-TECHNIQUE_URL = r'https://attack.mitre.org/techniques/T[0-9]+/'
-SUBTECHNIQUE_URL = r'https://attack.mitre.org/techniques/T[0-9]+/[0-9]+/'
+INTERVAL_PATTERN = r'^\d+[mshd]$'
+TACTIC_URL = r'^https://attack.mitre.org/tactics/TA[0-9]+/$'
+TECHNIQUE_URL = r'^https://attack.mitre.org/techniques/T[0-9]+/$'
+SUBTECHNIQUE_URL = r'^https://attack.mitre.org/techniques/T[0-9]+/[0-9]+/$'
 MACHINE_LEARNING = 'machine_learning'
 SAVED_QUERY = 'saved_query'
 QUERY = 'query'

--- a/rules/_deprecated/exfiltration_rds_snapshot_export.toml
+++ b/rules/_deprecated/exfiltration_rds_snapshot_export.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2021/06/06"
-maturity = "production"
-updated_date = "2021/08/02"
+deprecation_date = "2021/08/02"
 integration = "aws"
+maturity = "deprecated"
+updated_date = "2021/08/02"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +26,7 @@ note = """## Config
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartExportTask.html"]
 risk_score = 21
-rule_id = "119c8877-8613-416d-a98a-96b6664ee73a"
+rule_id = "119c8877-8613-416d-a98a-96b6664ee73a5"
 severity = "low"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Asset Visibility"]
 timestamp_override = "event.ingested"

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -39,7 +39,7 @@ class TestValidRules(BaseRuleTest):
         self.assertIsNone(re.match(file_pattern, 'still_not_a_valid_file_name.not_json'),
                           f'Incorrect pattern for verifying rule names: {file_pattern}')
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             file_name = str(rule.path.name)
             self.assertIsNotNone(re.match(file_pattern, file_name), f'Invalid file name for {rule.path}')
 
@@ -73,7 +73,7 @@ class TestValidRules(BaseRuleTest):
         """Test that no file names are duplicated."""
         name_map = defaultdict(list)
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             name_map[rule.path.name].append(rule.path.name)
 
         duplicates = {name: paths for name, paths in name_map.items() if len(paths) > 1}
@@ -90,7 +90,7 @@ class TestThreatMappings(BaseRuleTest):
         revoked = list(attack.revoked)
         deprecated = list(attack.deprecated)
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             revoked_techniques = {}
             threat_mapping = rule.contents.data.threat
 
@@ -107,7 +107,7 @@ class TestThreatMappings(BaseRuleTest):
 
     def test_tactic_to_technique_correlations(self):
         """Ensure rule threat info is properly related to a single tactic and technique."""
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             threat_mapping = rule.contents.data.threat or []
             if threat_mapping:
                 for entry in threat_mapping:
@@ -165,7 +165,7 @@ class TestThreatMappings(BaseRuleTest):
 
     def test_duplicated_tactics(self):
         """Check that a tactic is only defined once."""
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             threat_mapping = rule.contents.data.threat
             tactics = [t.tactic.name for t in threat_mapping or []]
             duplicates = sorted(set(t for t in tactics if tactics.count(t) > 1))
@@ -191,7 +191,7 @@ class TestRuleTags(BaseRuleTest):
         ]
         expected_case = {normalize(t): t for t in expected_tags}
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             rule_tags = rule.contents.data.tags
 
             if rule_tags:
@@ -224,7 +224,7 @@ class TestRuleTags(BaseRuleTest):
             'winlogbeat-*': {'all': ['Windows']}
         }
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             rule_tags = rule.contents.data.tags
             error_msg = f'{self.rule_str(rule)} Missing tags:\nActual tags: {", ".join(rule_tags)}'
 
@@ -262,7 +262,7 @@ class TestRuleTags(BaseRuleTest):
         invalid = []
         tactics = set(tactics)
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             rule_tags = rule.contents.data.tags
 
             if 'Continuous Monitoring' in rule_tags or rule.contents.data.type == 'machine_learning':
@@ -306,7 +306,7 @@ class TestRuleTimelines(BaseRuleTest):
         """Ensure rules with timelines have a corresponding title."""
         from detection_rules.schemas.definitions import TIMELINE_TEMPLATES
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             timeline_id = rule.contents.data.timeline_id
             timeline_title = rule.contents.data.timeline_title
 
@@ -333,7 +333,7 @@ class TestRuleFiles(BaseRuleTest):
         """Test to ensure rule files have the primary tactic prepended to the filename."""
         bad_name_rules = []
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             rule_path = rule.path.resolve()
             filename = rule_path.name
 
@@ -423,7 +423,7 @@ class TestRuleTiming(BaseRuleTest):
         """Test that rules have defined an timestamp_override if needed."""
         missing = []
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             required = False
 
             if isinstance(rule.contents.data, QueryRuleData) and 'endgame-*' in rule.contents.data.index:
@@ -448,7 +448,7 @@ class TestRuleTiming(BaseRuleTest):
         long_indexes = {'logs-endpoint.events.*'}
         missing = []
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             contents = rule.contents
 
             if isinstance(contents.data, QueryRuleData):
@@ -466,7 +466,7 @@ class TestRuleTiming(BaseRuleTest):
         invalids = []
         ten_minutes = 10 * 60 * 1000
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             if rule.contents.data.type == 'eql' and rule.contents.data.max_span:
                 if rule.contents.data.look_back == 'unknown':
                     unknowns.append(self.rule_str(rule, trailer=None))
@@ -492,7 +492,7 @@ class TestRuleTiming(BaseRuleTest):
         invalids = []
         five_minutes = 5 * 60 * 1000
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             if rule.contents.data.type == 'eql':
                 interval = rule.contents.data.interval or five_minutes
                 maxspan = rule.contents.data.max_span
@@ -541,7 +541,7 @@ class TestIntegrationRules(BaseRuleTest):
             'okta': render('Okta'),
         }
 
-        for rule in self.all_rules:
+        for rule in self.production_rules:
             integration = rule.contents.metadata.integration
             note_str = integration_notes.get(integration)
 


### PR DESCRIPTION
## Issues
resolves #1395

## Summary
This anchors all patterns to the beginning and end with `^$` to ensure more stringent validation of the patterns.

There was only 1 rule with invalid data. The rule was deprecated and duplicated