### PR TITLE
Add RuleCollection.load_git_branch

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -279,7 +279,7 @@ def kibana_commit(ctx, local_repo: str, github_repo: str, ssh: bool, kibana_dire
 
         branch_name = branch_name or f"detection-rules/{package_name}-{short_commit_hash}"
 
-        git("checkout", "-b", branch_name, show_output=True)
+        git("checkout", "-b", branch_name, print_output=True)
         git("rm", "-r", kibana_directory)
 
         source_dir = os.path.join(release_dir, "rules")
@@ -295,7 +295,7 @@ def kibana_commit(ctx, local_repo: str, github_repo: str, ssh: bool, kibana_dire
 
         git("add", kibana_directory)
         git("commit", "--no-verify", "-m", message)
-        git("status", show_output=True)
+        git("status", print_output=True)
 
         if push:
             git("push", "origin", branch_name)

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -330,13 +330,18 @@ def make_git(*prefix_args) -> Optional[Callable]:
 
         return
 
-    def git(*args, show_output=False):
+    def git(*args, print_output=False):
         full_args = [git_exe] + prefix_args + [str(arg) for arg in args]
-        if show_output:
-            return subprocess.check_output(full_args, encoding="utf-8").rstrip()
-        return subprocess.check_call(full_args)
+        if print_output:
+            return subprocess.check_call(full_args)
+        return subprocess.check_output(full_args, encoding="utf-8").rstrip()
 
     return git
+
+
+def git(*args, **kwargs):
+    """Find and run a one-off Git command."""
+    return make_git()(*args, **kwargs)
 
 
 def add_params(*params):


### PR DESCRIPTION
## Issues
Possibly a dependency for #1171 

## Summary
In brainstorming some ways to solve the cross-branch version locking, I realized this method could be helpful. It's not very fast (~20s-30s for a branch) but for some reason multiprocessing doesn't seem to speed it up either.

Might be useful for some other things, so I'll break it off here. Also I fixed some backwards flags for `show_output` while at it.