### PR TITLE
[Bug] Flatten method improperly added subtechniques

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -103,8 +103,8 @@ class ThreatMapping(MarshmallowDataclassMixin):
                 technique_ids.add(technique.id)
 
                 for subtechnique in (technique.subtechnique or []):
-                    sub_technique_ids.update(subtechnique.id)
-                    sub_technique_names.update(subtechnique.name)
+                    sub_technique_ids.add(subtechnique.id)
+                    sub_technique_names.add(subtechnique.name)
 
         return FlatThreatMapping(
             tactic_names=sorted(tactic_names),


### PR DESCRIPTION
## Issues
None

## Summary
Found bug in `ThreatMapping.flatten` method which `updated` items to set rather than `add`ing