### PR TITLE
Remove event triggers from community workflow

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -4,17 +4,9 @@ on:
   pull_request_target:
     types:
       - opened
-      - reopened
-      - edited
-      - labeled
-      - unlabeled
   issues:
     types:
       - opened
-      - reopened
-      - edited
-      - labeled
-      - unlabeled
 jobs:
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issues
None

## Summary
Removed event types that would trigger an improper community label (such as labels added by a bot, causing the community tag to not apply)