### PR TITLE
Skip etc/packages.yml from backport: auto

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -128,6 +128,10 @@ class GitChangeEntry:
 @click.option("--dry-run", is_flag=True, help="List the changes that would be made")
 def prune_staging_area(target_stack_version: str, dry_run: bool):
     """Prune the git staging area to remove changes to incompatible rules."""
+    exceptions = {
+        "etc/packages.yml",
+    }
+
     target_stack_version = Version(target_stack_version)[:2]
 
     # load a structured summary of the diff from git
@@ -138,6 +142,11 @@ def prune_staging_area(target_stack_version: str, dry_run: bool):
     reversions: List[GitChangeEntry] = []
 
     for change in changes:
+        if str(change.path) in exceptions:
+            # Don't backport any changes to files matching the list of exceptions
+            reversions.append(change)
+            continue
+
         # it's a change to a rule file, load it and check the version
         if str(change.path.absolute()).startswith(RULES_DIR) and change.path.suffix == ".toml":
             # bypass TOML validation in case there were schema changes


### PR DESCRIPTION
## Issues
Dependency for PR #1418 

## Summary
Make `etc/packages.yml` exempt from the backport.

Tested by making a change to the file, then running

```console
$ python -m detection_rules dev unstage-incompatible-rules --dry-run -t 7.15

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Restoring 1 changes from the staging area...
git restore --staged etc/packages.yml
```

Running it without `--dry-run`:
```console
$ python -m detection_rules dev unstage-incompatible-rules -t 7.15          

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Restoring 1 changes from the staging area...
git restore --staged etc/packages.yml

$ git status 
On branch ci/backport-skip-packages-file
Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   detection_rules/devtools.py

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   etc/packages.yml
```