### PR TITLE
Fix encoding of 'Any' type in jsonschema

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -42,7 +42,7 @@ class RuleMeta(MarshmallowDataclassMixin):
     related_endpoint_rules: Optional[List[str]]
 
     # Extended information as an arbitrary dictionary
-    extended: Optional[dict]
+    extended: Optional[Dict[str, Any]]
 
     def get_validation_stack_versions(self) -> Dict[str, dict]:
         """Get a dict of beats and ecs versions per stack release."""
@@ -157,7 +157,7 @@ class BaseRuleData(MarshmallowDataclassMixin):
 
     interval: Optional[definitions.Interval]
     max_signals: Optional[definitions.MaxSignals]
-    meta: Optional[dict]
+    meta: Optional[Dict[str, Any]]
     name: str
     note: Optional[definitions.Markdown]
     # can we remove this comment?

--- a/etc/api_schemas/master/master.base.json
+++ b/etc/api_schemas/master/master.base.json
@@ -4,7 +4,13 @@
   "properties": {
     "actions": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -25,7 +31,13 @@
     },
     "exceptions_list": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -38,7 +50,13 @@
     "filters": {
       "items": {
         "additionalProperties": {
-          "type": "string"
+          "type": [
+            "string",
+            "number",
+            "object",
+            "array",
+            "boolean"
+          ]
         },
         "type": "object"
       },
@@ -63,7 +81,13 @@
     },
     "meta": {
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "object"
     },

--- a/etc/api_schemas/master/master.eql.json
+++ b/etc/api_schemas/master/master.eql.json
@@ -4,7 +4,13 @@
   "properties": {
     "actions": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -25,7 +31,13 @@
     },
     "exceptions_list": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -38,7 +50,13 @@
     "filters": {
       "items": {
         "additionalProperties": {
-          "type": "string"
+          "type": [
+            "string",
+            "number",
+            "object",
+            "array",
+            "boolean"
+          ]
         },
         "type": "object"
       },
@@ -75,7 +93,13 @@
     },
     "meta": {
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "object"
     },

--- a/etc/api_schemas/master/master.machine_learning.json
+++ b/etc/api_schemas/master/master.machine_learning.json
@@ -4,7 +4,13 @@
   "properties": {
     "actions": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -29,7 +35,13 @@
     },
     "exceptions_list": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -42,7 +54,13 @@
     "filters": {
       "items": {
         "additionalProperties": {
-          "type": "string"
+          "type": [
+            "string",
+            "number",
+            "object",
+            "array",
+            "boolean"
+          ]
         },
         "type": "object"
       },
@@ -80,7 +98,13 @@
     },
     "meta": {
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "object"
     },

--- a/etc/api_schemas/master/master.query.json
+++ b/etc/api_schemas/master/master.query.json
@@ -4,7 +4,13 @@
   "properties": {
     "actions": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -25,7 +31,13 @@
     },
     "exceptions_list": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -38,7 +50,13 @@
     "filters": {
       "items": {
         "additionalProperties": {
-          "type": "string"
+          "type": [
+            "string",
+            "number",
+            "object",
+            "array",
+            "boolean"
+          ]
         },
         "type": "object"
       },
@@ -77,7 +95,13 @@
     },
     "meta": {
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "object"
     },

--- a/etc/api_schemas/master/master.threat_match.json
+++ b/etc/api_schemas/master/master.threat_match.json
@@ -4,7 +4,13 @@
   "properties": {
     "actions": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -31,7 +37,13 @@
     },
     "exceptions_list": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -44,7 +56,13 @@
     "filters": {
       "items": {
         "additionalProperties": {
-          "type": "string"
+          "type": [
+            "string",
+            "number",
+            "object",
+            "array",
+            "boolean"
+          ]
         },
         "type": "object"
       },
@@ -89,7 +107,13 @@
     },
     "meta": {
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "object"
     },
@@ -285,7 +309,13 @@
     "threat_filters": {
       "items": {
         "additionalProperties": {
-          "type": "string"
+          "type": [
+            "string",
+            "number",
+            "object",
+            "array",
+            "boolean"
+          ]
         },
         "type": "object"
       },

--- a/etc/api_schemas/master/master.threshold.json
+++ b/etc/api_schemas/master/master.threshold.json
@@ -4,7 +4,13 @@
   "properties": {
     "actions": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -25,7 +31,13 @@
     },
     "exceptions_list": {
       "items": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "array"
     },
@@ -38,7 +50,13 @@
     "filters": {
       "items": {
         "additionalProperties": {
-          "type": "string"
+          "type": [
+            "string",
+            "number",
+            "object",
+            "array",
+            "boolean"
+          ]
         },
         "type": "object"
       },
@@ -77,7 +95,13 @@
     },
     "meta": {
       "additionalProperties": {
-        "type": "string"
+        "type": [
+          "string",
+          "number",
+          "object",
+          "array",
+          "boolean"
+        ]
       },
       "type": "object"
     },


### PR DESCRIPTION
## Issues
Identified in https://github.com/elastic/detection-rules/pull/1073#discussion_r689026441

## Summary
Marshmallow dataclass interprets `typing.Any` as `fields.Raw` but `marshmallow_jsonschema` encodes that as a string.
Now we check pre-encoding if it looks like a string and if it does, we encode it properly.

I didn't backport any old schemas, just fixed Python and the `master` schema.