### PR TITLE
Draft: load rules without validation

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -182,7 +182,7 @@ def update_lock_versions(rule_ids):
     if not click.confirm(f'Are you sure you want to update hashes for {len(rules)} rules without a version bump?'):
         return
 
-    changed, new, _ = manage_versions(rules, exclude_version_update=True, add_new=False, save_changes=True)
+    changed, new, _ = manage_versions(rules.rules, exclude_version_update=True, add_new=False, save_changes=True)
 
     if not changed:
         click.echo('No hashes updated')

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -6,6 +6,7 @@
 """Util functions."""
 import base64
 import contextlib
+import dataclasses
 import distutils.spawn
 import functools
 import glob
@@ -17,6 +18,7 @@ import os
 import shutil
 import subprocess
 import time
+import typing
 import zipfile
 from dataclasses import is_dataclass, astuple
 from datetime import datetime, date
@@ -354,6 +356,25 @@ def add_params(*params):
         return f
 
     return decorator
+
+
+def parse_required_dc_fields_from_dict(dataclazz, obj: dict):
+    """Parse required values of a dataclass from a given dict."""
+    populated = {}
+    class_fields = dataclasses.fields(dataclazz)
+
+    for field in class_fields:
+        field_types = typing.get_args(field.type)
+        value = obj.get(field.name)
+
+        # required
+        if not (len(field_types) > 1 and field_types[-1] is not None):
+            if value is None:
+                raise ValueError(f'Missing required field for {field.name}')
+
+        populated[field.name] = value
+
+    return populated
 
 
 class Ndjson(list):

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -166,8 +166,8 @@ class TestThreatMappings(BaseRuleTest):
     def test_duplicated_tactics(self):
         """Check that a tactic is only defined once."""
         for rule in self.all_rules:
-            threat_mapping = rule.contents.data.threat
-            tactics = [t.tactic.name for t in threat_mapping or []]
+            threat_mapping = rule.contents.data.threat or []
+            tactics = [t.tactic.name for t in threat_mapping]
             duplicates = sorted(set(t for t in tactics if tactics.count(t) > 1))
 
             if duplicates:
@@ -389,7 +389,7 @@ class TestRuleMetadata(BaseRuleTest):
                 deprecated_rules[rule.id] = rule
                 err_msg = f'{self.rule_str(rule)} cannot be deprecated if it has not been version locked. ' \
                           f'Convert to `development` or delete the rule file instead'
-                self.assertIn(rule.id, versions, err_msg)
+                self.assertIn(rule.id, list(versions), err_msg)
 
                 rule_path = rule.path.relative_to(get_path('rules'))
                 err_msg = f'{self.rule_str(rule)} deprecated rules should be stored in ' \


### PR DESCRIPTION
## Issues


## Summary
WIP: non validated rule loading. This approach allows deprecated rules to drift from valid schemas and still load as a rule object.

This would resolve the failure in #1396, which is preventing it from merging

### Problems
- failing
- painfully slow