### PR TITLE
[Bug] RuleTOMLContents.to_dict serialize with proper schema

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -439,19 +439,8 @@ class TOMLRuleContents(MarshmallowDataclassMixin):
         return data.validate_query(metadata)
 
     def to_dict(self, strip_none_values=True) -> dict:
-        # When marshmallow_dataclass creates a schema for deserialization, it uses typeguard.checktype to select the
-        # appropriate field for union fields. In the case of contents.data, the valid fields are those contained in
-        # AnyRuleData and marshmallow_dataclass will check the list in the order it is defined.
-        #
-        # The final check in the checktype function is an instance check, so if the RuleDataType is inherited from
-        # another RuleDataType in that list, it will incorrectly select the wrong class (ex: QueryRuleData where
-        # ThreatMatchData is expected). This results in an invalid schema and a stripping of fields.
-        #
-        # While we can try to keep AnyRuleData inversely sorted by inheritance, it is more reliable here to dump from
-        # schemas generated directly on the RuleData and RuleMetadata classes explicitly. See issue #1141
-        #
-        # dict_obj = super(TOMLRuleContents, self).to_dict(strip_none_values=strip_none_values)
-
+        # Load schemas directly from the data and metadata classes to avoid schema ambiguity which can
+        # result from union fields which contain classes and related subclasses (AnyRuleData). See issue #1141
         metadata = self.metadata.to_dict(strip_none_values=strip_none_values)
         data = self.data.to_dict(strip_none_values=strip_none_values)
         dict_obj = dict(metadata=metadata, rule=data)


### PR DESCRIPTION
## Issues
resolves #1141 

## Summary
`RuleTOMLContents.to_dict` method dumps data and metadata directly from those objects in order to serialize with the right schema and avoid ambiguous schema generation from a union field (RuleDataType).

See issue for details