### PR TITLE
[Rule tuning] Azure Active Directory High Risk Sign-in

### DIFF
--- a/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin.toml
+++ b/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin.toml
@@ -34,7 +34,7 @@ type = "query"
 
 query = '''
 event.dataset:azure.signinlogs and
-  azure.signinlogs.properties.risk_level_during_signin:high and
+  (azure.signinlogs.properties.risk_level_during_signin:high or azure.signinlogs.properties.risk_level_aggregated:high) and
   event.outcome:(success or Success)
 '''
 

--- a/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin.toml
+++ b/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/04"
 maturity = "production"
-updated_date = "2021/07/20"
+updated_date = "2021/08/30"
 integration = "azure"
 
 [rule]


### PR DESCRIPTION
There can be a risk_level_during_signin:low but have a risk_level_aggregated:high which is also just as concerning and must be alerted on.

An example is a password spray attack and have a successful login. Which makes me consider a new rule for interesting risk event types

azure.signinlogs.properties.riskEventTypes_v2: unfamiliarFeatures, passwordSpray

<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

## Summary
This PR is to add additional detection logic to catch other high risk user activity. The current rule does not account for aggregated risk activity such as a password spray attack where the sign in risk is low but the aggregated risk is high.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? I hope so
