### PR TITLE
[Bug] Community label: use getMembershipForUser

### DIFF
--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -18,7 +18,7 @@ jobs:
           github-token: ${{ secrets.READ_ORG_TOKEN }}
           result-encoding: string
           script: |
-            const result = await github.orgs.getMembershipForAuthenticatedUser({
+            const result = await github.orgs.getMembershipForUser({
                        org: "elastic",
                        username: context.payload.sender.login
                     })


### PR DESCRIPTION
# Issues
None

## Summary
Use getMembershipForUser to determine the proper org membership status
