### PR TITLE
Update the marshmallow dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,8 @@ PyYAML~=5.3
 eql==0.9.9
 elasticsearch~=7.9
 XlsxWriter~=1.3.6
-marshmallow~=3.12.2
-marshmallow-dataclass[union]~=8.4
+marshmallow~=3.13.0
+marshmallow-dataclass[union]~=8.5.3
 
 # test deps
 pyflakes==2.2.0


### PR DESCRIPTION
## Issues
Related to a [community slack conversation](https://elasticstack.slack.com/archives/C016E72DWDS/p1631095572080100)


## Summary
Our dependencies are in a compatible combination, but there's possible incompatible mixes of marshmallow and marshmallow-dataclass. This updates them to the most recent valid configuration.

Before merging this, we should confirm nothing breaks for `marshmallow-jsonschema` and `marshmallow-union` dependencies and run commands that use them to make sure they function like normal.