### PR TITLE
[Rule Tuning] Add default timestamp condition for threat_query

### DIFF
--- a/rules/cross-platform/threat_intel_module_match.toml
+++ b/rules/cross-platform/threat_intel_module_match.toml
@@ -35,11 +35,11 @@ threat_index = [ "filebeat-*"]
 threat_indicator_path = ""
 threat_language = "kuery"
 
-threat_query = """
-event.module:threatintel and
+threat_query = '''
+@timestamp >= "now-30d" and event.module:threatintel and
   (threatintel.indicator.file.hash.*:* or threatintel.indicator.file.pe.imphash:* or threatintel.indicator.ip:* or
      threatintel.indicator.registry.path:* or threatintel.indicator.url.full:*)
-"""
+'''
 
 query = """
 file.hash.*:* or file.pe.imphash:* or source.ip:* or destination.ip:* or url.full:* or registry.path:*


### PR DESCRIPTION
## Summary

There was the idea to add `@timestamp >= "now-30d"` for all Indicator match rules when we looking for indicators. It should help with the performance of the Indicator match rule.

## Problems
There are problems with tests because they failed after adding `@timestamp` into the query. It say the `@timestamp` value, not a date.
```
kql.errors.KqlParseError: Error at line:1,column:15
Value doesn't match @timestamp's type: date
@timestamp >= "now-30d" and event.module:threatintel and
```

The problem is located in file - `kql/parser.py` -> `get_literal_type` method
```python
    def get_literal_type(literal_value):
        if isinstance(literal_value, bool):
            return "boolean"
        elif isinstance(literal_value, float):
            return "float"
        elif isinstance(literal_value, int):
            return "long"
        elif eql.utils.is_string(literal_value):
            # this will be converted when compared to the field
            return "keyword"
        elif literal_value is None:
            return "null"
        else:
            raise NotImplementedError("Unknown literal type: {}".format(type(literal_value).__name__))
```

You can see in the code above, that it never returns type `date`
Any ideas on how we can change this method to work properly with the `date` type?

Of course, if I add this code, it will help, but looks like that it's far from an ideal solution:
```python
elif literal_value == "now-30d":
            return "date"
```

## Question
Should we do something after merging this PR, to make sure that these changes properly incorporated into Kibana rule?
https://github.com/elastic/kibana/blob/master/x-pack/plugins/security_solution/server/lib/detection_engine/rules/prepackaged_rules/threat_intel_module_match.json