### PR TITLE
[KQL] Add support for date fields in parser

### DIFF
--- a/kql/__init__.py
+++ b/kql/__init__.py
@@ -13,7 +13,7 @@ from .evaluator import FilterGenerator
 from .kql2eql import KqlToEQL
 from .parser import lark_parse, KqlParser
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 __all__ = (
     "ast",
     "from_eql",

--- a/kql/parser.py
+++ b/kql/parser.py
@@ -224,6 +224,9 @@ class BaseKqlParser(Interpreter):
             elif field_type_family == "ip" and value_type == "keyword":
                 if "::" in python_value or self.ip_regex.match(python_value) is not None:
                     return python_value
+            elif field_type_family == 'date' and value_type in STRING_FIELDS:
+                # this will not validate datemath syntax
+                return python_value
 
             raise self.error(value_tree, "Value doesn't match {field}'s type: {type}",
                              field=field_name, type=field_type)

--- a/tests/kuery/test_parser.py
+++ b/tests/kuery/test_parser.py
@@ -82,3 +82,6 @@ class ParserTests(unittest.TestCase):
     def test_date(self):
         schema = {"@time": "date"}
         self.validate('@time <= now-10d', FieldRange(Field("@time"), "<=", String("now-10d")), schema=schema)
+
+        with self.assertRaises(kql.KqlParseError):
+            kql.parse("@time > 5", schema=schema)

--- a/tests/kuery/test_parser.py
+++ b/tests/kuery/test_parser.py
@@ -8,6 +8,7 @@ import kql
 from kql.ast import (
     Field,
     FieldComparison,
+    FieldRange,
     String,
     Number,
     Exists,
@@ -72,7 +73,12 @@ class ParserTests(unittest.TestCase):
     def test_type_family_success(self):
         kql.parse("abc : 1.2345", schema={"abc": "scaled_float"})
         kql.parse("abc : hello", schema={"abc": "annotated-text"})
+        kql.parse("abc >= now-30d", schema={"abc": "date_nanos"})
 
     def test_type_family_fail(self):
         with self.assertRaises(kql.KqlParseError):
             kql.parse('foo : "hello world"', schema={"foo": "scaled_float"})
+
+    def test_date(self):
+        schema = {"@time": "date"}
+        self.validate('@time <= now-10d', FieldRange(Field("@time"), "<=", String("now-10d")), schema=schema)


### PR DESCRIPTION
## Issues
None
related to problem identified in #1486 

## Summary
The parser was not properly converting date field values. This will allow date fields to be used within a query now such as `@timestamp >= "now-30d"`.