### PR TITLE
[Rule Tuning] Add system index to Windows Event Logs Cleared

### DIFF
--- a/rules/windows/defense_evasion_clearing_windows_security_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_security_logs.toml
@@ -10,7 +10,7 @@ Identifies attempts to clear Windows event log stores. This is often done by att
 or destroy forensic evidence on a system.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Windows Event Logs Cleared"


### PR DESCRIPTION
## Issues
None

## Summary
Since elastic agent v7.11, Windows event logs are now collected via the system integration, so this adds the necessary index.