### PR TITLE
[eql2kql] fix wildcard bug

### DIFF
--- a/kql/eql2kql.py
+++ b/kql/eql2kql.py
@@ -8,7 +8,7 @@ from eql import DepthFirstWalker
 
 from .ast import (
     Value, String, OrValues, Field, Expression, FieldRange, FieldComparison,
-    NotExpr, AndExpr, OrExpr, Exists
+    NotExpr, AndExpr, OrExpr, Exists, Wildcard
 )
 
 
@@ -66,8 +66,16 @@ class Eql2Kql(DepthFirstWalker):
     def _walk_function_call(self, tree):  # type: (eql.ast.FunctionCall) -> KqlNode
         if tree.name in ("wildcard", "cidrMatch"):
             if isinstance(tree.arguments[0], Field):
-                return FieldComparison(tree.arguments[0], OrValues(tree.arguments[1:]))
-
+                if tree.name == "wildcard" :
+                    args = []
+                    for arg in tree.arguments[1:] :
+                        if '*' in arg.value or '?' in arg.value :
+                            args.append(Wildcard(arg.value))
+                        else :
+                            args.append(arg)
+                    return FieldComparison(tree.arguments[0], OrValues(args))
+                else :
+                    return FieldComparison(tree.arguments[0], OrValues(tree.arguments[1:]))
         raise eql.errors.EqlCompileError("Unable to convert `{}`".format(tree))
 
     def _walk_literal(self, tree):


### PR DESCRIPTION
**Describe the bug**

When i try to convert  a query that contain a wildcard value from eql to kql using this   [eql2kql](https://github.com/elastic/detection-rules/blob/main/kql/eql2kql.py) script.
wildcard value in the kql query  generated  will be quoted so it gonna be treated as string.
for example if we take the eql query
``` eql
authentication where user.name : "user-*"
```
it will generate
```
event.category:authentication and user.name:"user-*"
```
instead of
```
event.category:authentication and user.name: user-*
```
to make it more clear , if we use the kql2dsl script for the quoted example we gonna get
```
{'bool': {
	'filter': [
		{'match': {'event.category': 'authentication'}},
		{'match': {'user.name': 'user-*'}}]
	}
}
```
the match query treat the value as string .
and for the unquoted :
```
{'bool': {
	'filter': [
		{'match': {'event.category': 'authentication'}},
		{'query_string': {'fields': ['user.name'], 'query': 'user-*'}}]
	}
}
```
**Solution**

To remediate this problem we need just to change the node type from String to Wildcard
