### PR TITLE
[Rule Tuning] Volume Shadow Copy Deletion or Resized via VssAdmin

### DIFF
--- a/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
@@ -1,19 +1,19 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2021/10/04"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies use of vssadmin.exe for shadow copy deletion on endpoints. This commonly occurs in tandem with ransomware or
-other destructive attacks.
+Identifies use of vssadmin.exe for shadow copy deletion or resizing on endpoints. This commonly occurs in tandem with
+ransomware or other destructive attacks.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
-name = "Volume Shadow Copy Deletion via VssAdmin"
+name = "Volume Shadow Copy Deleted or Resized via VssAdmin"
 risk_score = 73
 rule_id = "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921"
 severity = "high"
@@ -22,22 +22,21 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start", "process_started") and
-  (process.name : "vssadmin.exe" or process.pe.original_file_name == "VSSADMIN.EXE") and
-  process.args : "delete" and process.args : "shadows"
+process where event.type in ("start", "process_started") and event.action == "start" 
+  and (process.name : "vssadmin.exe" or process.pe.original_file_name == "VSSADMIN.EXE") and
+  process.args in ("delete", "resize") and process.args : "shadows*"
 '''
 
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-id = "T1490"
 reference = "https://attack.mitre.org/techniques/T1490/"
 name = "Inhibit System Recovery"
+id = "T1490"
 
 
 [rule.threat.tactic]
-id = "TA0040"
 reference = "https://attack.mitre.org/tactics/TA0040/"
 name = "Impact"
-
+id = "TA0040"

--- a/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
@@ -40,3 +40,4 @@ id = "T1490"
 reference = "https://attack.mitre.org/tactics/TA0040/"
 name = "Impact"
 id = "TA0040"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
Closes #1523

## Summary
This rule adds volume shadow copy resizing as a technique to hinder ransomware recovery.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? Yes
