### PR TITLE
[Rule Tuning] Update network.direction

### DIFF
--- a/rules/windows/command_and_control_remote_file_copy_scripts.toml
+++ b/rules/windows/command_and_control_remote_file_copy_scripts.toml
@@ -23,7 +23,7 @@ type = "eql"
 query = '''
 sequence by host.id, process.entity_id
   [network where process.name : ("wscript.exe", "cscript.exe") and network.protocol != "dns" and
-   network.direction == "outgoing" and network.type == "ipv4" and destination.ip != "127.0.0.1"
+   network.direction : ("outgoing", "egress") and network.type == "ipv4" and destination.ip != "127.0.0.1"
   ]
   [file where event.type == "creation" and file.extension : ("exe", "dll")]
 '''

--- a/rules/windows/command_and_control_remote_file_copy_scripts.toml
+++ b/rules/windows/command_and_control_remote_file_copy_scripts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/29"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_kerberoasting_unusual_process.toml
+++ b/rules/windows/credential_access_kerberoasting_unusual_process.toml
@@ -27,7 +27,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-network where event.type == "start" and network.direction == "outgoing" and
+network where event.type == "start" and network.direction : ("outgoing", "egress") and
  destination.port == 88 and source.port >= 49152 and
  process.executable != "C:\\Windows\\System32\\lsass.exe" and destination.address !="127.0.0.1" and destination.address !="::1" and
  /* insert False Positives here */

--- a/rules/windows/credential_access_kerberoasting_unusual_process.toml
+++ b/rules/windows/credential_access_kerberoasting_unusual_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -25,7 +25,7 @@ query = '''
 
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name : "installutil.exe"]
-  [network where process.name : "installutil.exe" and network.direction == "outgoing"]
+  [network where process.name : "installutil.exe" and network.direction : ("outgoing", "egress")]
 '''
 
 

--- a/rules/windows/defense_evasion_masquerading_werfault.toml
+++ b/rules/windows/defense_evasion_masquerading_werfault.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/24"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_masquerading_werfault.toml
+++ b/rules/windows/defense_evasion_masquerading_werfault.toml
@@ -31,7 +31,7 @@ query = '''
 sequence by host.id, process.entity_id with maxspan = 5s
   [process where event.type:"start" and process.name : ("wermgr.exe", "WerFault.exe") and process.args_count == 1]
   [network where process.name : ("wermgr.exe", "WerFault.exe") and network.protocol != "dns" and
-    network.direction == "outgoing" and destination.ip !="::1" and destination.ip !="127.0.0.1"
+    network.direction : ("outgoing", "egress") and destination.ip !="::1" and destination.ip !="127.0.0.1"
   ]
 '''
 

--- a/rules/windows/defense_evasion_msxsl_beacon.toml
+++ b/rules/windows/defense_evasion_msxsl_beacon.toml
@@ -25,7 +25,7 @@ query = '''
 
 sequence by process.entity_id
   [process where event.type in ("start", "process_started") and process.name : "msxsl.exe"]
-  [network where process.name : "msxsl.exe" and network.direction == "outgoing"]
+  [network where process.name : "msxsl.exe" and network.direction : ("outgoing", "egress")]
 '''
 
 

--- a/rules/windows/defense_evasion_msxsl_beacon.toml
+++ b/rules/windows/defense_evasion_msxsl_beacon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "development"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_dcom_hta.toml
+++ b/rules/windows/lateral_movement_dcom_hta.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_dcom_hta.toml
+++ b/rules/windows/lateral_movement_dcom_hta.toml
@@ -28,7 +28,7 @@ sequence with maxspan=1m
      process.name : "mshta.exe" and process.args : "-Embedding"
   ] by host.id, process.entity_id
   [network where event.type == "start" and process.name : "mshta.exe" and 
-     network.direction == "incoming" and network.transport == "tcp" and
+     network.direction : ("incoming", "ingress") and network.transport == "tcp" and
      source.port > 49151 and destination.port > 49151 and not source.address in ("127.0.0.1", "::1")
   ] by host.id, process.entity_id
 '''

--- a/rules/windows/lateral_movement_dcom_mmc20.toml
+++ b/rules/windows/lateral_movement_dcom_mmc20.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_dcom_mmc20.toml
+++ b/rules/windows/lateral_movement_dcom_mmc20.toml
@@ -26,7 +26,7 @@ query = '''
 sequence by host.id with maxspan=1m
  [network where event.type == "start" and process.name : "mmc.exe" and
   source.port >= 49152 and destination.port >= 49152 and source.address not in ("127.0.0.1", "::1") and
-  network.direction == "incoming" and network.transport == "tcp"
+  network.direction : ("incoming", "ingress") and network.transport == "tcp"
  ] by process.entity_id
  [process where event.type in ("start", "process_started") and process.parent.name : "mmc.exe"
  ] by process.parent.entity_id

--- a/rules/windows/lateral_movement_dcom_shellwindow_shellbrowserwindow.toml
+++ b/rules/windows/lateral_movement_dcom_shellwindow_shellbrowserwindow.toml
@@ -25,7 +25,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=5s
  [network where event.type == "start" and process.name : "explorer.exe" and
-  network.direction == "incoming" and network.transport == "tcp" and
+  network.direction : ("incoming", "ingress") and network.transport == "tcp" and
   source.port > 49151 and destination.port > 49151 and not source.address in ("127.0.0.1", "::1")
  ] by process.entity_id
  [process where event.type in ("start", "process_started") and

--- a/rules/windows/lateral_movement_dcom_shellwindow_shellbrowserwindow.toml
+++ b/rules/windows/lateral_movement_dcom_shellwindow_shellbrowserwindow.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
+++ b/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
@@ -23,7 +23,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=30s
   [network where event.type == "start" and process.pid == 4 and destination.port == 445 and
-   network.direction == "incoming" and network.transport == "tcp" and
+   network.direction : ("incoming", "ingress") and network.transport == "tcp" and
    source.address != "127.0.0.1" and source.address != "::1"
   ] by process.entity_id
   /* add more executable extensions here if they are not noisy in your environment */

--- a/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
+++ b/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/10"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
+++ b/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
+++ b/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
@@ -28,7 +28,7 @@ type = "eql"
 
 query = '''
 sequence by host.id with maxspan=30s
-   [network where process.pid == 4 and network.direction == "incoming" and
+   [network where process.pid == 4 and network.direction : ("incoming", "ingress") and
     destination.port in (5985, 5986) and network.protocol == "http" and not source.address in ("::1", "127.0.0.1")
    ]
    [process where event.type == "start" and process.parent.name : "winrshost.exe" and not process.name : "conhost.exe"]

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -25,7 +25,7 @@ sequence by host.id with maxspan = 2s
 
  /* Accepted Incoming RPC connection by Winmgmt service */
 
-  [network where process.name : "svchost.exe" and network.direction == "incoming" and
+  [network where process.name : "svchost.exe" and network.direction : ("incoming", "ingress") and
    source.address != "127.0.0.1" and source.address != "::1" and 
    source.port >= 49152 and destination.port >= 49152
   ]

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_powershell_remoting_target.toml
+++ b/rules/windows/lateral_movement_powershell_remoting_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_powershell_remoting_target.toml
+++ b/rules/windows/lateral_movement_powershell_remoting_target.toml
@@ -31,7 +31,7 @@ type = "eql"
 
 query = '''
 sequence by host.id with maxspan = 30s
-   [network where network.direction == "incoming" and destination.port in (5985, 5986) and
+   [network where network.direction : ("incoming", "ingress") and destination.port in (5985, 5986) and
     network.protocol == "http" and source.address != "127.0.0.1" and source.address != "::1"
    ]
    [process where event.type == "start" and process.parent.name : "wsmprovhost.exe" and not process.name : "conhost.exe"]

--- a/rules/windows/lateral_movement_rdp_sharprdp_target.toml
+++ b/rules/windows/lateral_movement_rdp_sharprdp_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/11"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_rdp_sharprdp_target.toml
+++ b/rules/windows/lateral_movement_rdp_sharprdp_target.toml
@@ -29,7 +29,7 @@ query = '''
 
 sequence by host.id with maxspan=1m
   [network where event.type == "start" and process.name : "svchost.exe" and destination.port == 3389 and 
-   network.direction == "incoming" and network.transport == "tcp" and
+   network.direction : ("incoming", "ingress") and network.transport == "tcp" and
    source.address != "127.0.0.1" and source.address != "::1"
   ]
 

--- a/rules/windows/lateral_movement_remote_services.toml
+++ b/rules/windows/lateral_movement_remote_services.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/16"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/lateral_movement_remote_services.toml
+++ b/rules/windows/lateral_movement_remote_services.toml
@@ -23,7 +23,7 @@ type = "eql"
 query = '''
 sequence with maxspan=1s
    [network where process.name : "services.exe" and
-      network.direction == "incoming" and network.transport == "tcp" and 
+      network.direction : ("incoming", "ingress") and network.transport == "tcp" and 
       source.port >= 49152 and destination.port >= 49152 and source.address not in ("127.0.0.1", "::1")
    ] by host.id, process.entity_id
 

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -57,7 +57,7 @@ query = '''
 
 sequence by host.id, process.entity_id with maxspan = 1m
    [network where process.name : "svchost.exe" and
-   network.direction == "incoming" and source.port >= 49152 and destination.port >= 49152 and
+   network.direction : ("incoming", "ingress") and source.port >= 49152 and destination.port >= 49152 and
    source.address != "127.0.0.1" and source.address != "::1"
    ]
    [registry where registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions"]

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_wpad_exploitation.toml
+++ b/rules/windows/privilege_escalation_wpad_exploitation.toml
@@ -31,7 +31,7 @@ sequence with maxspan=5s
   [network where network.protocol : "dns" and process.name : "svchost.exe" and
      dns.question.name : "wpad" and process.name : "svchost.exe"] by process.entity_id
   [network where process.name : "svchost.exe"
-     and network.direction : "outgoing" and destination.port == 80] by process.entity_id
+     and network.direction : ("outgoing", "egress") and destination.port == 80] by process.entity_id
   [library where event.type : "start" and process.name : "svchost.exe" and
      dll.name : "jscript.dll" and process.name : "svchost.exe"] by process.entity_id
   [process where event.type in ("start", "process_started") and

--- a/rules/windows/privilege_escalation_wpad_exploitation.toml
+++ b/rules/windows/privilege_escalation_wpad_exploitation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "development"
-updated_date = "2021/03/08"
+updated_date = "2021/10/13"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
Starting from 7.16.0, Endpoint will log network.direction with the ingress/egress value, not incoming/outgoing.

This updates the rules that make use of this field to make them compatible with both versions