### PR TITLE
Add min_stack_comments to metadata schema

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -40,6 +40,7 @@ class RuleMeta(MarshmallowDataclassMixin):
     integration: Optional[str]
     maturity: Optional[definitions.Maturity]
     min_stack_version: Optional[definitions.SemVer]
+    min_stack_comments: Optional[str]
     os_type_list: Optional[List[definitions.OSType]]
     query_schema_validation: Optional[bool]
     related_endpoint_rules: Optional[List[str]]

--- a/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
+++ b/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
@@ -5,7 +5,6 @@ updated_date = "2021/07/14"
 min_stack_comments = "The field `event.agent_id_status` was not introduced until 7.14"
 min_stack_version = "7.14.0"
 
-
 [rule]
 author = ["Elastic"]
 description = """Detects events which have a mismatch on the expected event agent ID. The status "agent_id_mismatch"

--- a/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
+++ b/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
@@ -2,7 +2,9 @@
 creation_date = "2021/07/14"
 maturity = "production"
 updated_date = "2021/07/14"
+min_stack_comments = "The field `event.agent_id_status` was not introduced until 7.14"
 min_stack_version = "7.14.0"
+
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/defense_evasion_agent_spoofing_multiple_hosts.toml
+++ b/rules/cross-platform/defense_evasion_agent_spoofing_multiple_hosts.toml
@@ -5,7 +5,6 @@ updated_date = "2021/07/14"
 min_stack_comments = "The field `event.agent_id_status` was not introduced until 7.14"
 min_stack_version = "7.14.0"
 
-
 [rule]
 author = ["Elastic"]
 description = """Detects when multiple hosts are using the same agent ID. This could occur in the event of an agent

--- a/rules/cross-platform/defense_evasion_agent_spoofing_multiple_hosts.toml
+++ b/rules/cross-platform/defense_evasion_agent_spoofing_multiple_hosts.toml
@@ -2,7 +2,9 @@
 creation_date = "2021/07/14"
 maturity = "production"
 updated_date = "2021/07/14"
+min_stack_comments = "The field `event.agent_id_status` was not introduced until 7.14"
 min_stack_version = "7.14.0"
+
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
@@ -3,7 +3,9 @@ creation_date = "2021/06/23"
 maturity = "production"
 updated_date = "2021/07/20"
 integration = "cyberarkpas"
+min_stack_comments = "The integration was not introduced until 7.14"
 min_stack_version = "7.14.0"
+
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
@@ -6,7 +6,6 @@ integration = "cyberarkpas"
 min_stack_comments = "The integration was not introduced until 7.14"
 min_stack_version = "7.14.0"
 
-
 [rule]
 author = ["Elastic"]
 description = """Identifies the occurrence of a CyberArk Privileged Access Security (PAS) error level audit event. The 

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
@@ -3,6 +3,7 @@ creation_date = "2021/06/23"
 maturity = "production"
 updated_date = "2021/07/20"
 integration = "cyberarkpas"
+min_stack_comments = "The integration was not introduced until 7.14"
 min_stack_version = '7.14.0'
 
 [rule]

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/04/29"
 maturity = "production"
 updated_date = "2021/03/03"
+min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
 
 [rule]

--- a/rules/ml/ml_auth_rare_hour_for_a_user_to_logon.toml
+++ b/rules/ml/ml_auth_rare_hour_for_a_user_to_logon.toml
@@ -2,6 +2,7 @@
 creation_date = "2021/06/10"
 maturity = "production"
 updated_date = "2021/06/10"
+min_stack_comments = "ML job introduced in 7.14"
 min_stack_version = "7.14.0"
 
 [rule]

--- a/rules/ml/ml_auth_rare_source_ip_for_a_user.toml
+++ b/rules/ml/ml_auth_rare_source_ip_for_a_user.toml
@@ -2,6 +2,7 @@
 creation_date = "2021/06/10"
 maturity = "production"
 updated_date = "2021/06/10"
+min_stack_comments = "ML job introduced in 7.14"
 min_stack_version = "7.14.0"
 
 [rule]

--- a/rules/ml/ml_auth_rare_user_logon.toml
+++ b/rules/ml/ml_auth_rare_user_logon.toml
@@ -2,6 +2,7 @@
 creation_date = "2021/06/10"
 maturity = "production"
 updated_date = "2021/06/10"
+min_stack_comments = "ML job introduced in 7.14"
 min_stack_version = "7.14.0"
 
 [rule]

--- a/rules/ml/ml_auth_spike_in_failed_logon_events.toml
+++ b/rules/ml/ml_auth_spike_in_failed_logon_events.toml
@@ -2,6 +2,7 @@
 creation_date = "2021/06/10"
 maturity = "production"
 updated_date = "2021/06/10"
+min_stack_comments = "ML job introduced in 7.14"
 min_stack_version = "7.14.0"
 
 [rule]

--- a/rules/ml/ml_auth_spike_in_logon_events.toml
+++ b/rules/ml/ml_auth_spike_in_logon_events.toml
@@ -2,6 +2,7 @@
 creation_date = "2021/06/10"
 maturity = "production"
 updated_date = "2021/06/10"
+min_stack_comments = "ML job introduced in 7.14"
 min_stack_version = "7.14.0"
 
 [rule]

--- a/rules/ml/ml_auth_spike_in_logon_events_from_a_source_ip.toml
+++ b/rules/ml/ml_auth_spike_in_logon_events_from_a_source_ip.toml
@@ -2,6 +2,7 @@
 creation_date = "2021/06/10"
 maturity = "production"
 updated_date = "2021/09/14"
+min_stack_comments = "ML job introduced in 7.14"
 min_stack_version = "7.14.0"
 
 [rule]

--- a/rules/windows/credential_access_cmdline_dump_tool.toml
+++ b/rules/windows/credential_access_cmdline_dump_tool.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/11/24"
 maturity = "production"
 updated_date = "2021/07/20"
+min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
 
 [rule]

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -2,6 +2,7 @@
 creation_date = "2021/01/19"
 maturity = "production"
 updated_date = "2021/09/23"
+min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
 
 [rule]

--- a/rules/windows/execution_suspicious_powershell_imgload.toml
+++ b/rules/windows/execution_suspicious_powershell_imgload.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/11/17"
 maturity = "production"
 updated_date = "2021/07/20"
+min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
 
 [rule]

--- a/rules/windows/persistence_evasion_registry_ifeo_injection.toml
+++ b/rules/windows/persistence_evasion_registry_ifeo_injection.toml
@@ -2,6 +2,7 @@
 creation_date = "2020/11/17"
 maturity = "production"
 updated_date = "2021/07/20"
+min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
 
 [rule]

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -422,6 +422,19 @@ class TestRuleMetadata(BaseRuleTest):
             rule_str = f'{rule_id} - {entry["rule_name"]} ->'
             self.assertIn(rule_id, deprecated_rules, f'{rule_str} is logged in "deprecated_rules.json" but is missing')
 
+    def test_all_min_stack_rules_have_comment(self):
+        failures = []
+
+        for rule in self.all_rules:
+            if rule.contents.metadata.min_stack_version and not rule.contents.metadata.min_stack_comments:
+                failures.append(f'{self.rule_str(rule)} missing `extended.min_stack_comments`. min_stack_version: '
+                                f'{rule.contents.metadata.min_stack_version}')
+
+        if failures:
+            err_msg = '\n'.join(failures)
+            self.fail(f'The following ({len(failures)}) rules have a `min_stack_version` defined but missing comments:'
+                      f'\n{err_msg}')
+
 
 class TestRuleTiming(BaseRuleTest):
     """Test rule timing and timestamps."""

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -427,7 +427,7 @@ class TestRuleMetadata(BaseRuleTest):
 
         for rule in self.all_rules:
             if rule.contents.metadata.min_stack_version and not rule.contents.metadata.min_stack_comments:
-                failures.append(f'{self.rule_str(rule)} missing `extended.min_stack_comments`. min_stack_version: '
+                failures.append(f'{self.rule_str(rule)} missing `metadata.min_stack_comments`. min_stack_version: '
                                 f'{rule.contents.metadata.min_stack_version}')
 
         if failures:


### PR DESCRIPTION
## Issues
None

## Summary
Adds `min_stack_comments` to the metadata schema and adds unit tests which require this field whenever `min_stack_version` is defined.

I also added comments to the existing 15 rules with a min stack version defined.


<details>
<summary>Example error</summary><br>

```
AssertionError: The following (2) rules have a `min_stack_version` defined but missing comments:
b9666521-4742-49ce-9ddc-b8e84c35acae - Creation of Hidden Files and Directories -> missing `extended.min_stack_comments`. min_stack_version: 7.12.0
745b0119-0560-43ba-860a-7235dd8cee8d - Unusual Hour for a User to Logon -> missing `extended.min_stack_comments`. min_stack_version: 7.14.0
```

</details>