### PR TITLE
Add support for eql-wildcard and kql-match_only_text

### DIFF
--- a/detection_rules/ecs.py
+++ b/detection_rules/ecs.py
@@ -173,6 +173,7 @@ def flatten_multi_fields(schema):
 class KqlSchema2Eql(eql.Schema):
     type_mapping = {
         "keyword": eql.types.TypeHint.String,
+        "wildcard": eql.types.TypeHint.String,
         "ip": eql.types.TypeHint.String,
         "float": eql.types.TypeHint.Numeric,
         "double": eql.types.TypeHint.Numeric,

--- a/kql/__init__.py
+++ b/kql/__init__.py
@@ -13,7 +13,7 @@ from .evaluator import FilterGenerator
 from .kql2eql import KqlToEQL
 from .parser import lark_parse, KqlParser
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 __all__ = (
     "ast",
     "from_eql",

--- a/kql/parser.py
+++ b/kql/parser.py
@@ -58,6 +58,7 @@ def elasticsearch_type_family(mapping_type: str) -> str:
         # text search types
         "annotated-text": "text",
         "completion": "text",
+        "match_only_text": "text",
         "search-as_you_type": "text",
 
         # keyword


### PR DESCRIPTION
## Issues
None

## Summary
While refreshing ECS schemas to 1.12.1, there were validation failures due to updates including `wildcard` and `match_only_text` fields.

This adds support for `wildcard` fields to eql schema and `match_only_text` fields to kql for validation.