### PR TITLE
Add an explicit indicator path for prebuilt IM rule

### DIFF
--- a/rules/cross-platform/threat_intel_module_match.toml
+++ b/rules/cross-platform/threat_intel_module_match.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/04/21"
 maturity = "production"
-updated_date = "2021/10/29"
+updated_date = "2021/11/10"
 
 [rule]
 author = ["Elastic"]
@@ -66,7 +66,7 @@ timeline_title = "Generic Threat Match Timeline"
 type = "threat_match"
 
 threat_index = [ "filebeat-*"]
-threat_indicator_path = ""
+threat_indicator_path = "threatintel.indicator"
 threat_language = "kuery"
 
 threat_query = '''


### PR DESCRIPTION
## Summary
While this was [implicitly](https://github.com/elastic/security-team/issues/2174) `threatintel.indicator` in 7.15 due to our defaulting logic within kibana, the default is now changing (to`threat.indicator`) and we need to preserve this rule's behavior.

NB that this requires https://github.com/elastic/kibana/pull/116583 in order to affect existing rules on upgrade.

## Issues
* https://github.com/elastic/security-team/issues/2174
* https://github.com/elastic/security-team/issues/2175


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
