### PR TITLE
Bump min_stack_version in version.lock for specific rules

### DIFF
--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -592,7 +592,7 @@
     "version": 5
   },
   "3115bd2c-0baa-4df0-80ea-45e474b5ef93": {
-    "min_stack_version": "7.14.0",
+    "min_stack_version": "7.15.0",
     "rule_name": "Agent Spoofing - Mismatched Agent ID",
     "sha256": "64619f9caffb2d5207658b5ddb16c86462b4c19c8567280b74c5191166c42a25",
     "version": 1
@@ -884,7 +884,7 @@
     "version": 1
   },
   "493834ca-f861-414c-8602-150d5505b777": {
-    "min_stack_version": "7.14.0",
+    "min_stack_version": "7.15.0",
     "rule_name": "Agent Spoofing - Multiple Hosts Using Same Agent",
     "sha256": "f8e4481e5c38326daea5818415a4f06be1da64247686974940283c6b7a31f81f",
     "version": 1


### PR DESCRIPTION
## Issues
None
related to #1613 

## Summary
Bumps the min_stack_version within the version.lock for 2 specific rules which were targeted for 7.15+

Should merge _after_ #1613