### PR TITLE
[bug] Current stack version in deprecation lock missing parens

### DIFF
--- a/detection_rules/version_lock.py
+++ b/detection_rules/version_lock.py
@@ -146,7 +146,7 @@ class VersionLock:
             if rule.id in newly_deprecated:
                 current_deprecated_lock[rule.id] = {
                     "rule_name": rule.name,
-                    "stack_version": current_stack_version,
+                    "stack_version": current_stack_version(),
                     "deprecation_date": rule.contents.metadata['deprecation_date']
                 }
 


### PR DESCRIPTION
## Issues
None

## Summary
Issue found when locking versions. The function was not being properly called, leading to `null` values
