### PR TITLE
[Rule Tuning] Whitespace Padding in Process Command Line - Limit Indexes

### DIFF
--- a/rules/windows/defense_evasion_whitespace_padding_in_command_line.toml
+++ b/rules/windows/defense_evasion_whitespace_padding_in_command_line.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/30"
 maturity = "production"
-updated_date = "2021/07/30"
+updated_date = "2021/12/06"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ their malicious command with unnecessary whitespace characters. These observatio
 behavior.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Whitespace Padding in Process Command Line"


### PR DESCRIPTION
## Summary

As the first of a two-part fix to #1641, we will limit the index that this rule runs on versions prior to 7.16 to logs-endpoint.events
