### PR TITLE
[Rule Tuning] Whitespace Padding in Process Command Line - Re-add index and add min_stack_version

### DIFF
--- a/rules/windows/defense_evasion_whitespace_padding_in_command_line.toml
+++ b/rules/windows/defense_evasion_whitespace_padding_in_command_line.toml
@@ -2,6 +2,8 @@
 creation_date = "2021/07/30"
 maturity = "production"
 updated_date = "2021/12/06"
+min_stack_comments = "EQL regex had a bug when dealing with wildcard fields that was fixed in 7.16"
+min_stack_version = "7.16.0"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ their malicious command with unnecessary whitespace characters. These observatio
 behavior.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Whitespace Padding in Process Command Line"


### PR DESCRIPTION
## Issues

Resolves #1641 

## Summary

Add the `min_stack_version` to the rule in order to add back indexes that have wildcard fields in 7.16+ stacks, which are not affected by https://github.com/elastic/elasticsearch/issues/78391