### PR TITLE
[Rule Tuning] Switch "Roshal Archive (RAR) or PowerShell File Downloaded from the Internet" to use KQL

### DIFF
--- a/rules/network/command_and_control_download_rar_powershell_from_internet.toml
+++ b/rules/network/command_and_control_download_rar_powershell_from_internet.toml
@@ -19,7 +19,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["auditbeat-*", "filebeat-*", "packetbeat-*", "logs-endpoint.events.*"]
-language = "lucene"
+language = "kuery"
 license = "Elastic License v2"
 name = "Roshal Archive (RAR) or PowerShell File Downloaded from the Internet"
 note = """## Threat intel

--- a/rules/network/command_and_control_download_rar_powershell_from_internet.toml
+++ b/rules/network/command_and_control_download_rar_powershell_from_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/02"
 maturity = "production"
-updated_date = "2021/05/27"
+updated_date = "2021/12/06"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues

Resolves #1471 

## Summary

Switch the query language from Lucene to KQL to solve "Can only use regexp queries on keyword and text fields - not on [destination.ip] which is of type [ip]" bug