### PR TITLE
[Rule Tuning] Bump max_signals on Endgame Promotion Rules

### DIFF
--- a/rules/promotions/endgame_adversary_behavior_detected.toml
+++ b/rules/promotions/endgame_adversary_behavior_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_adversary_behavior_detected.toml
+++ b/rules/promotions/endgame_adversary_behavior_detected.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Adversary Behavior - Detected - Elastic Endgame"
 risk_score = 47
 rule_id = "77a3c3df-8ec4-4da4-b758-878f551dee69"

--- a/rules/promotions/endgame_cred_dumping_detected.toml
+++ b/rules/promotions/endgame_cred_dumping_detected.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Credential Dumping - Detected - Elastic Endgame"
 risk_score = 73
 rule_id = "571afc56-5ed9-465d-a2a9-045f099f6e7e"

--- a/rules/promotions/endgame_cred_dumping_detected.toml
+++ b/rules/promotions/endgame_cred_dumping_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_cred_dumping_prevented.toml
+++ b/rules/promotions/endgame_cred_dumping_prevented.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Credential Dumping - Prevented - Elastic Endgame"
 risk_score = 47
 rule_id = "db8c33a8-03cd-4988-9e2c-d0a4863adb13"

--- a/rules/promotions/endgame_cred_dumping_prevented.toml
+++ b/rules/promotions/endgame_cred_dumping_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_cred_manipulation_detected.toml
+++ b/rules/promotions/endgame_cred_manipulation_detected.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Credential Manipulation - Detected - Elastic Endgame"
 risk_score = 73
 rule_id = "c0be5f31-e180-48ed-aa08-96b36899d48f"

--- a/rules/promotions/endgame_cred_manipulation_detected.toml
+++ b/rules/promotions/endgame_cred_manipulation_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_cred_manipulation_prevented.toml
+++ b/rules/promotions/endgame_cred_manipulation_prevented.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Credential Manipulation - Prevented - Elastic Endgame"
 risk_score = 47
 rule_id = "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa"

--- a/rules/promotions/endgame_cred_manipulation_prevented.toml
+++ b/rules/promotions/endgame_cred_manipulation_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_exploit_detected.toml
+++ b/rules/promotions/endgame_exploit_detected.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Exploit - Detected - Elastic Endgame"
 risk_score = 73
 rule_id = "2003cdc8-8d83-4aa5-b132-1f9a8eb48514"

--- a/rules/promotions/endgame_exploit_detected.toml
+++ b/rules/promotions/endgame_exploit_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_exploit_prevented.toml
+++ b/rules/promotions/endgame_exploit_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_exploit_prevented.toml
+++ b/rules/promotions/endgame_exploit_prevented.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Exploit - Prevented - Elastic Endgame"
 risk_score = 47
 rule_id = "2863ffeb-bf77-44dd-b7a5-93ef94b72036"

--- a/rules/promotions/endgame_malware_detected.toml
+++ b/rules/promotions/endgame_malware_detected.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Malware - Detected - Elastic Endgame"
 risk_score = 99
 rule_id = "0a97b20f-4144-49ea-be32-b540ecc445de"

--- a/rules/promotions/endgame_malware_detected.toml
+++ b/rules/promotions/endgame_malware_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_malware_prevented.toml
+++ b/rules/promotions/endgame_malware_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_malware_prevented.toml
+++ b/rules/promotions/endgame_malware_prevented.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Malware - Prevented - Elastic Endgame"
 risk_score = 73
 rule_id = "3b382770-efbb-44f4-beed-f5e0a051b895"

--- a/rules/promotions/endgame_permission_theft_detected.toml
+++ b/rules/promotions/endgame_permission_theft_detected.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Permission Theft - Detected - Elastic Endgame"
 risk_score = 73
 rule_id = "c3167e1b-f73c-41be-b60b-87f4df707fe3"

--- a/rules/promotions/endgame_permission_theft_detected.toml
+++ b/rules/promotions/endgame_permission_theft_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_permission_theft_prevented.toml
+++ b/rules/promotions/endgame_permission_theft_prevented.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Permission Theft - Prevented - Elastic Endgame"
 risk_score = 47
 rule_id = "453f659e-0429-40b1-bfdb-b6957286e04b"

--- a/rules/promotions/endgame_permission_theft_prevented.toml
+++ b/rules/promotions/endgame_permission_theft_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_process_injection_detected.toml
+++ b/rules/promotions/endgame_process_injection_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_process_injection_detected.toml
+++ b/rules/promotions/endgame_process_injection_detected.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Process Injection - Detected - Elastic Endgame"
 risk_score = 73
 rule_id = "80c52164-c82a-402c-9964-852533d58be1"

--- a/rules/promotions/endgame_process_injection_prevented.toml
+++ b/rules/promotions/endgame_process_injection_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_process_injection_prevented.toml
+++ b/rules/promotions/endgame_process_injection_prevented.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Process Injection - Prevented - Elastic Endgame"
 risk_score = 47
 rule_id = "990838aa-a953-4f3e-b3cb-6ddf7584de9e"

--- a/rules/promotions/endgame_ransomware_detected.toml
+++ b/rules/promotions/endgame_ransomware_detected.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_ransomware_detected.toml
+++ b/rules/promotions/endgame_ransomware_detected.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Ransomware - Detected - Elastic Endgame"
 risk_score = 99
 rule_id = "8cb4f625-7743-4dfb-ae1b-ad92be9df7bd"

--- a/rules/promotions/endgame_ransomware_prevented.toml
+++ b/rules/promotions/endgame_ransomware_prevented.toml
@@ -14,6 +14,7 @@ index = ["endgame-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
+max_signals = 10000
 name = "Ransomware - Prevented - Elastic Endgame"
 risk_score = 73
 rule_id = "e3c5d5cb-41d5-4206-805c-f30561eae3ac"

--- a/rules/promotions/endgame_ransomware_prevented.toml
+++ b/rules/promotions/endgame_ransomware_prevented.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/04"
+updated_date = "2021/12/13"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues

sdh-security-team # 264

## Summary

Update/Add the max_signals field on Endgame Promotion rules to 10000, so the circuit break do not affect the alerts coming from Endgame.