### PR TITLE
[Rule Tuning] O365 Excessive Single Sign-On Logon Errors

### DIFF
--- a/rules/integrations/o365/credential_access_user_excessive_sso_logon_errors.toml
+++ b/rules/integrations/o365/credential_access_user_excessive_sso_logon_errors.toml
@@ -32,7 +32,7 @@ type = "threshold"
 
 
 query = '''
-event.dataset:o365.audit and event.provider:AzureActiveDirectory and event.category:web and o365.audit.LogonError:"SsoArtifactInvalidOrExpired"
+event.dataset:o365.audit and event.provider:AzureActiveDirectory and event.category:authentication and o365.audit.LogonError:"SsoArtifactInvalidOrExpired"
 '''
 
 

--- a/rules/integrations/o365/credential_access_user_excessive_sso_logon_errors.toml
+++ b/rules/integrations/o365/credential_access_user_excessive_sso_logon_errors.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/05/17"
 maturity = "production"
-updated_date = "2021/10/11"
+updated_date = "2021/12/30"
 integration = "o365"
 
 [rule]


### PR DESCRIPTION
The original rule had the event.category as "web" the correct value is "authentication".

![SsoArtifactInvalidOrExpired](https://user-images.githubusercontent.com/22669390/147789568-64f2f679-e59c-43bc-ab3b-4bd490397151.png)