### PR TITLE
[Rule Tuning] Fix query and change severity of the "O365 Exchange Suspicious Mailbox Right Delegation" rule

### DIFF
--- a/etc/non-ecs-schema.json
+++ b/etc/non-ecs-schema.json
@@ -23,7 +23,8 @@
     "powershell.file.script_block_text": "text"
   },
   "filebeat-*": {
-    "o365.audit.NewValue": "keyword"
+    "o365.audit.NewValue": "keyword",
+    "o365audit.Parameters.AccessRights": "keyword"
   },
   "logs-endpoint.events.*": {
     "process.Ext.token.integrity_level_name": "keyword",

--- a/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
+++ b/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/05/17"
 maturity = "production"
-updated_date = "2021/10/11"
+updated_date = "2022/01/10"
 integration = "o365"
 
 [rule]
@@ -19,16 +19,16 @@ name = "O365 Exchange Suspicious Mailbox Right Delegation"
 note = """## Config
 
 The Microsoft 365 Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
-risk_score = 21
+risk_score = 47
 rule_id = "0ce6487d-8069-4888-9ddd-61b52490cebc"
-severity = "low"
+severity = "medium"
 tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", "Configuration Audit"]
 timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
 event.dataset:o365.audit and event.provider:Exchange and event.action:Add-MailboxPermission and 
-o365.audit.Parameters.AccessRights:(FullAccess or SendAs or SendOnBehalf) and event.outcome:success
+o365audit.Parameters.AccessRights:(FullAccess or SendAs or SendOnBehalf) and event.outcome:success
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary

Fix the query that was pointing to a non-existent field (`o365.audit.Parameters.AccessRights`) to o365audit.Parameters.AccessRights and change the severity of this rule to Medium.

![image](https://user-images.githubusercontent.com/26856693/148851217-630b3815-f218-419a-aaf9-059370ae30b9.png)