### PR TITLE
[Deprecate Rule] Threat Intel Filebeat Module (v7.x) Indicator Match

### DIFF
--- a/rules/_deprecated/threat_intel_filebeat7x.toml
+++ b/rules/_deprecated/threat_intel_filebeat7x.toml
@@ -1,12 +1,14 @@
 [metadata]
 creation_date = "2021/04/21"
-maturity = "production"
-updated_date = "2021/10/29"
+deprecation_date = "2022/01/12"
+maturity = "deprecated"
+updated_date = "2022/01/12"
 
 [rule]
 author = ["Elastic"]
 description = """
-This rule is triggered when indicators from the Threat Intel Filebeat module (v7.x) has a match against local file or network observations.
+This rule is triggered when indicators from the Threat Intel Filebeat module (v7.x) has a match against local file or
+network observations.
 """
 from = "now-65m"
 index = ["auditbeat-*", "endgame-*", "filebeat-*", "logs-*", "packetbeat-*", "winlogbeat-*"]
@@ -56,31 +58,30 @@ device such as a firewall or proxy appliance to prevent any outbound activity fr
 - Another example of a response with a malicious file hash match would involve validating if the file was properly quarantined,
 review current running processes looking for any abnormal activity, and investigating for any other follow-up actions such as persistence or lateral movement
 """
-references = [ "https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-threatintel.html"]
+references = ["https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-threatintel.html"]
 risk_score = 99
 rule_id = "dc672cb7-d5df-4d1f-a6d7-0841b1caafb9"
 severity = "critical"
 tags = ["Elastic", "Windows", "Elastic Endgame", "Network", "Continuous Monitoring", "SecOps", "Monitoring"]
+threat_index = ["filebeat-*"]
+threat_indicator_path = "threatintel.indicator"
+threat_language = "kuery"
+threat_query = """
+@timestamp >= "now-30d" and event.module:threatintel and (threatintel.indicator.file.hash.*:* or
+threatintel.indicator.file.pe.imphash:* or threatintel.indicator.ip:* or threatintel.indicator.registry.path:* or
+threatintel.indicator.url.full:*)
+"""
 timeline_id = "495ad7a7-316e-4544-8a0f-9c098daee76e"
 timeline_title = "Generic Threat Match Timeline"
 type = "threat_match"
 
-threat_index = [ "filebeat-*"]
-threat_indicator_path = "threatintel.indicator"
-threat_language = "kuery"
-
-threat_query = '''
-@timestamp >= "now-30d" and event.module:threatintel and
-  (threatintel.indicator.file.hash.*:* or threatintel.indicator.file.pe.imphash:* or threatintel.indicator.ip:* or
-     threatintel.indicator.registry.path:* or threatintel.indicator.url.full:*)
-'''
-
-query = """
+query = '''
 file.hash.*:* or file.pe.imphash:* or source.ip:* or destination.ip:* or url.full:* or registry.path:*
-"""
+'''
 
 
 [[rule.threat_filters]]
+
 [rule.threat_filters."$state"]
 store = "appState"
 [rule.threat_filters.meta]
@@ -92,8 +93,8 @@ key = "event.module"
 query = "threatintel"
 [rule.threat_filters.query.match_phrase]
 "event.module" = "threatintel"
-
 [[rule.threat_filters]]
+
 [rule.threat_filters."$state"]
 store = "appState"
 [rule.threat_filters.meta]
@@ -105,8 +106,8 @@ key = "event.category"
 query = "threat"
 [rule.threat_filters.query.match_phrase]
 "event.category" = "threat"
-
 [[rule.threat_filters]]
+
 [rule.threat_filters."$state"]
 store = "appState"
 [rule.threat_filters.meta]
@@ -118,8 +119,8 @@ key = "event.kind"
 query = "enrichment"
 [rule.threat_filters.query.match_phrase]
 "event.kind" = "enrichment"
-
 [[rule.threat_filters]]
+
 [rule.threat_filters."$state"]
 store = "appState"
 [rule.threat_filters.meta]
@@ -131,51 +132,60 @@ key = "event.type"
 query = "indicator"
 [rule.threat_filters.query.match_phrase]
 "event.type" = "indicator"
-
 [[rule.threat_mapping]]
+
 [[rule.threat_mapping.entries]]
+value = "threatintel.indicator.file.hash.md5"
 field = "file.hash.md5"
 type = "mapping"
-value = "threatintel.indicator.file.hash.md5"
 
 [[rule.threat_mapping]]
+
 [[rule.threat_mapping.entries]]
+value = "threatintel.indicator.file.hash.sha1"
 field = "file.hash.sha1"
 type = "mapping"
-value = "threatintel.indicator.file.hash.sha1"
 
 [[rule.threat_mapping]]
+
 [[rule.threat_mapping.entries]]
+value = "threatintel.indicator.file.hash.sha256"
 field = "file.hash.sha256"
 type = "mapping"
-value = "threatintel.indicator.file.hash.sha256"
 
 [[rule.threat_mapping]]
+
 [[rule.threat_mapping.entries]]
+value = "threatintel.indicator.file.pe.imphash"
 field = "file.pe.imphash"
 type = "mapping"
-value = "threatintel.indicator.file.pe.imphash"
 
 [[rule.threat_mapping]]
+
 [[rule.threat_mapping.entries]]
+value = "threatintel.indicator.ip"
 field = "source.ip"
 type = "mapping"
-value = "threatintel.indicator.ip"
 
 [[rule.threat_mapping]]
+
 [[rule.threat_mapping.entries]]
+value = "threatintel.indicator.ip"
 field = "destination.ip"
 type = "mapping"
-value = "threatintel.indicator.ip"
 
 [[rule.threat_mapping]]
+
 [[rule.threat_mapping.entries]]
+value = "threatintel.indicator.url.full"
 field = "url.full"
 type = "mapping"
-value = "threatintel.indicator.url.full"
 
 [[rule.threat_mapping]]
+
 [[rule.threat_mapping.entries]]
+value = "threatintel.indicator.registry.path"
 field = "registry.path"
 type = "mapping"
-value = "threatintel.indicator.registry.path"
+
+


### PR DESCRIPTION
## Issues
resolves #1697 

## Summary
This deprecates this rule, which is compatible with 7.x only.

This should only deprecate as of 8.0 and should not be backported beyond that