### PR TITLE
[Rule Tuning] Change Rules to use Source.ip instead of source.address

### DIFF
--- a/rules/windows/lateral_movement_dcom_hta.toml
+++ b/rules/windows/lateral_movement_dcom_hta.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -29,7 +29,7 @@ sequence with maxspan=1m
   ] by host.id, process.entity_id
   [network where event.type == "start" and process.name : "mshta.exe" and 
      network.direction : ("incoming", "ingress") and network.transport == "tcp" and
-     source.port > 49151 and destination.port > 49151 and not source.address in ("127.0.0.1", "::1")
+     source.port > 49151 and destination.port > 49151 and not source.ip in ("127.0.0.1", "::1")
   ] by host.id, process.entity_id
 '''
 

--- a/rules/windows/lateral_movement_dcom_hta.toml
+++ b/rules/windows/lateral_movement_dcom_hta.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -29,7 +29,7 @@ sequence with maxspan=1m
   ] by host.id, process.entity_id
   [network where event.type == "start" and process.name : "mshta.exe" and 
      network.direction : ("incoming", "ingress") and network.transport == "tcp" and
-     source.port > 49151 and destination.port > 49151 and not source.ip in ("127.0.0.1", "::1")
+     source.port > 49151 and destination.port > 49151 and source.ip != "127.0.0.1" and source.ip != "::1"
   ] by host.id, process.entity_id
 '''
 

--- a/rules/windows/lateral_movement_dcom_mmc20.toml
+++ b/rules/windows/lateral_movement_dcom_mmc20.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -24,8 +24,8 @@ type = "eql"
 
 query = '''
 sequence by host.id with maxspan=1m
- [network where event.type == "start" and process.name : "mmc.exe" and
-  source.port >= 49152 and destination.port >= 49152 and source.ip not in ("127.0.0.1", "::1") and
+ [network where event.type == "start" and process.name : "mmc.exe" and source.port >= 49152 and
+ destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
   network.direction : ("incoming", "ingress") and network.transport == "tcp"
  ] by process.entity_id
  [process where event.type in ("start", "process_started") and process.parent.name : "mmc.exe"

--- a/rules/windows/lateral_movement_dcom_mmc20.toml
+++ b/rules/windows/lateral_movement_dcom_mmc20.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=1m
  [network where event.type == "start" and process.name : "mmc.exe" and
-  source.port >= 49152 and destination.port >= 49152 and source.address not in ("127.0.0.1", "::1") and
+  source.port >= 49152 and destination.port >= 49152 and source.ip not in ("127.0.0.1", "::1") and
   network.direction : ("incoming", "ingress") and network.transport == "tcp"
  ] by process.entity_id
  [process where event.type in ("start", "process_started") and process.parent.name : "mmc.exe"

--- a/rules/windows/lateral_movement_dcom_shellwindow_shellbrowserwindow.toml
+++ b/rules/windows/lateral_movement_dcom_shellwindow_shellbrowserwindow.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ query = '''
 sequence by host.id with maxspan=5s
  [network where event.type == "start" and process.name : "explorer.exe" and
   network.direction : ("incoming", "ingress") and network.transport == "tcp" and
-  source.port > 49151 and destination.port > 49151 and not source.ip in ("127.0.0.1", "::1")
+  source.port > 49151 and destination.port > 49151 source.ip != "127.0.0.1" and source.ip != "::1"
  ] by process.entity_id
  [process where event.type in ("start", "process_started") and
   process.parent.name : "explorer.exe"

--- a/rules/windows/lateral_movement_dcom_shellwindow_shellbrowserwindow.toml
+++ b/rules/windows/lateral_movement_dcom_shellwindow_shellbrowserwindow.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/06"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ query = '''
 sequence by host.id with maxspan=5s
  [network where event.type == "start" and process.name : "explorer.exe" and
   network.direction : ("incoming", "ingress") and network.transport == "tcp" and
-  source.port > 49151 and destination.port > 49151 and not source.address in ("127.0.0.1", "::1")
+  source.port > 49151 and destination.port > 49151 and not source.ip in ("127.0.0.1", "::1")
  ] by process.entity_id
  [process where event.type in ("start", "process_started") and
   process.parent.name : "explorer.exe"

--- a/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
+++ b/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/10"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -23,8 +23,8 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=30s
   [network where event.type == "start" and process.pid == 4 and destination.port == 445 and
-   network.direction : ("incoming", "ingress") and network.transport == "tcp" and
-   source.address != "127.0.0.1" and source.address != "::1"
+   network.direction : ("incoming", "ingress") and
+   network.transport == "tcp" and not source.ip in ("127.0.0.1", "::1")
   ] by process.entity_id
   /* add more executable extensions here if they are not noisy in your environment */
   [file where event.type in ("creation", "change") and process.pid == 4 and file.extension : ("exe", "dll", "bat", "cmd")] by process.entity_id

--- a/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
+++ b/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/10"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -24,7 +24,7 @@ query = '''
 sequence by host.id with maxspan=30s
   [network where event.type == "start" and process.pid == 4 and destination.port == 445 and
    network.direction : ("incoming", "ingress") and
-   network.transport == "tcp" and not source.ip in ("127.0.0.1", "::1")
+   network.transport == "tcp" and source.ip != "127.0.0.1" and source.ip != "::1"
   ] by process.entity_id
   /* add more executable extensions here if they are not noisy in your environment */
   [file where event.type in ("creation", "change") and process.pid == 4 and file.extension : ("exe", "dll", "bat", "cmd")] by process.entity_id

--- a/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
+++ b/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -29,7 +29,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=30s
    [network where process.pid == 4 and network.direction : ("incoming", "ingress") and
-    destination.port in (5985, 5986) and network.protocol == "http" and not source.address in ("::1", "127.0.0.1")
+    destination.port in (5985, 5986) and network.protocol == "http" and not source.ip in ("::1", "127.0.0.1")
    ]
    [process where event.type == "start" and process.parent.name : "winrshost.exe" and not process.name : "conhost.exe"]
 '''

--- a/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
+++ b/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -29,7 +29,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=30s
    [network where process.pid == 4 and network.direction : ("incoming", "ingress") and
-    destination.port in (5985, 5986) and network.protocol == "http" and not source.ip in ("::1", "127.0.0.1")
+    destination.port in (5985, 5986) and network.protocol == "http" and source.ip != "127.0.0.1" and source.ip != "::1"
    ]
    [process where event.type == "start" and process.parent.name : "winrshost.exe" and not process.name : "conhost.exe"]
 '''

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -26,8 +26,7 @@ sequence by host.id with maxspan = 2s
  /* Accepted Incoming RPC connection by Winmgmt service */
 
   [network where process.name : "svchost.exe" and network.direction : ("incoming", "ingress") and
-   source.address != "127.0.0.1" and source.address != "::1" and 
-   source.port >= 49152 and destination.port >= 49152
+   not source.ip in ("127.0.0.1", "::1") and source.port >= 49152 and destination.port >= 49152
   ]
 
   /* Excluding Common FPs Nessus and SCCM */

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ sequence by host.id with maxspan = 2s
  /* Accepted Incoming RPC connection by Winmgmt service */
 
   [network where process.name : "svchost.exe" and network.direction : ("incoming", "ingress") and
-   not source.ip in ("127.0.0.1", "::1") and source.port >= 49152 and destination.port >= 49152
+   source.ip != "127.0.0.1" and source.ip != "::1" and source.port >= 49152 and destination.port >= 49152
   ]
 
   /* Excluding Common FPs Nessus and SCCM */

--- a/rules/windows/lateral_movement_powershell_remoting_target.toml
+++ b/rules/windows/lateral_movement_powershell_remoting_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -32,7 +32,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan = 30s
    [network where network.direction : ("incoming", "ingress") and destination.port in (5985, 5986) and
-    network.protocol == "http" and not source.ip in ("127.0.0.1", "::1")
+    network.protocol == "http" and source.ip != "127.0.0.1" and source.ip != "::1"
    ]
    [process where event.type == "start" and process.parent.name : "wsmprovhost.exe" and not process.name : "conhost.exe"]
 '''

--- a/rules/windows/lateral_movement_powershell_remoting_target.toml
+++ b/rules/windows/lateral_movement_powershell_remoting_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -32,7 +32,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan = 30s
    [network where network.direction : ("incoming", "ingress") and destination.port in (5985, 5986) and
-    network.protocol == "http" and source.address != "127.0.0.1" and source.address != "::1"
+    network.protocol == "http" and not source.ip in ("127.0.0.1", "::1")
    ]
    [process where event.type == "start" and process.parent.name : "wsmprovhost.exe" and not process.name : "conhost.exe"]
 '''

--- a/rules/windows/lateral_movement_rdp_sharprdp_target.toml
+++ b/rules/windows/lateral_movement_rdp_sharprdp_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/11"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -30,7 +30,7 @@ query = '''
 sequence by host.id with maxspan=1m
   [network where event.type == "start" and process.name : "svchost.exe" and destination.port == 3389 and 
    network.direction : ("incoming", "ingress") and network.transport == "tcp" and
-   source.address != "127.0.0.1" and source.address != "::1"
+   not source.ip in ("127.0.0.1", "::1")
   ]
 
   [registry where process.name : "explorer.exe" and 

--- a/rules/windows/lateral_movement_rdp_sharprdp_target.toml
+++ b/rules/windows/lateral_movement_rdp_sharprdp_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/11"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -30,7 +30,7 @@ query = '''
 sequence by host.id with maxspan=1m
   [network where event.type == "start" and process.name : "svchost.exe" and destination.port == 3389 and 
    network.direction : ("incoming", "ingress") and network.transport == "tcp" and
-   not source.ip in ("127.0.0.1", "::1")
+   source.ip != "127.0.0.1" and source.ip != "::1"
   ]
 
   [registry where process.name : "explorer.exe" and 

--- a/rules/windows/lateral_movement_remote_services.toml
+++ b/rules/windows/lateral_movement_remote_services.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/16"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -24,7 +24,7 @@ query = '''
 sequence with maxspan=1s
    [network where process.name : "services.exe" and
       network.direction : ("incoming", "ingress") and network.transport == "tcp" and 
-      source.port >= 49152 and destination.port >= 49152 and source.address not in ("127.0.0.1", "::1")
+      source.port >= 49152 and destination.port >= 49152 and source.ip not in ("127.0.0.1", "::1")
    ] by host.id, process.entity_id
 
    [process where event.type in ("start", "process_started") and process.parent.name : "services.exe" and 

--- a/rules/windows/lateral_movement_remote_services.toml
+++ b/rules/windows/lateral_movement_remote_services.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/16"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -24,7 +24,7 @@ query = '''
 sequence with maxspan=1s
    [network where process.name : "services.exe" and
       network.direction : ("incoming", "ingress") and network.transport == "tcp" and 
-      source.port >= 49152 and destination.port >= 49152 and source.ip not in ("127.0.0.1", "::1")
+      source.port >= 49152 and destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1"
    ] by host.id, process.entity_id
 
    [process where event.type in ("start", "process_started") and process.parent.name : "services.exe" and 

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2022/01/11"
+updated_date = "2022/01/13"
 
 [rule]
 author = ["Elastic"]
@@ -58,7 +58,7 @@ query = '''
 sequence by host.id, process.entity_id with maxspan = 1m
    [network where process.name : "svchost.exe" and
    network.direction : ("incoming", "ingress") and source.port >= 49152 and destination.port >= 49152 and
-   not source.ip in ("127.0.0.1", "::1")
+   source.ip != "127.0.0.1" and source.ip != "::1"
    ]
    [registry where registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions"]
 '''

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/20"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -58,7 +58,7 @@ query = '''
 sequence by host.id, process.entity_id with maxspan = 1m
    [network where process.name : "svchost.exe" and
    network.direction : ("incoming", "ingress") and source.port >= 49152 and destination.port >= 49152 and
-   source.address != "127.0.0.1" and source.address != "::1"
+   not source.ip in ("127.0.0.1", "::1")
    ]
    [registry where registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions"]
 '''


### PR DESCRIPTION
## Issues

Resolves #1689 

## Summary

Change the query of 10 rules to be compatible with sysmon, that doesn't currently populate the source.address field.

Tested with the Remote Scheduled Task Creation rule:

![image](https://user-images.githubusercontent.com/26856693/149313708-92f29337-2ed2-4733-a45c-7acb3bedffeb.png)

PS: Tried/Tested with `not source.ip in ("127.0.0.1", "::1")`, raises a error.