### PR TITLE
fix bug in yaml parsing for github workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -56,7 +56,7 @@ jobs:
       max-parallel: 1
       matrix:
         # 7.17 was intentionally skipped because it was added late and was bug fix only
-        target_branch: [7.13, 7.14, 7.15, 7.16, 8.0]
+        target_branch: [7.13, 7.14, 7.15, 7.16, '8.0']
 
     steps:
       - name: Checkout repo

--- a/etc/packages.yml
+++ b/etc/packages.yml
@@ -26,7 +26,7 @@ package:
   registry_data:
     categories: ["security"]
     conditions:
-      kibana.version: "^8.0.1"
+      kibana.version: "^8.1.0"
     description: Prebuilt detection rules for Elastic Security
     format_version: 1.0.0
     icons:


### PR DESCRIPTION
## Issues
None

## Summary
backports fail due to yaml parsing from the matrix for `8.0` being converted to `8`