### PR TITLE
[New Rule] Potential Shadow Credentials added to AD Object

### DIFF
--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -52,7 +52,7 @@ references = [
 risk_score = 73
 rule_id = "f494c678-3c33-43aa-b169-bb3d5198c41d"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Active Directory"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/01/26"
 maturity = "production"
-updated_date = "2022/01/26"
+updated_date = "2022/01/31"
 
 [rule]
 author = ["Elastic"]
@@ -57,7 +57,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code:"5136" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink"
+event.action:"Directory Service Changes" and event.code:"5136" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink"
 '''
 
 

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -1,0 +1,76 @@
+[metadata]
+creation_date = "2022/01/26"
+maturity = "production"
+updated_date = "2022/01/26"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identify the modification of the msDS-KeyCredentialLink attribute in a Active Directory Computer or User Object.
+Attackers can abuse contol over the object and create a key pair, append to raw public key in the attribute, and obtain
+persistent and stealthy access to the target object (can be a user or a computer).
+"""
+false_positives = [
+    """
+    Modifications in the msDS-KeyCredentialLink attribute can be done legitimately by the Azure AD Connect
+    synchronization account or the ADFS service account. These accounts can be added as Exceptions.
+    """,
+]
+from = "now-9m"
+index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Potential Shadow Credentials added to AD Object"
+note = """## Config
+
+The 'Audit Directory Service Changes' logging policy must be configured for (Success, Failure).
+Steps to implement the logging policy with Advanced Audit Configuration:
+
+```
+Computer Configuration > 
+Policies > 
+Windows Settings > 
+Security Settings > 
+Advanced Audit Policies Configuration > 
+Audit Policies > 
+DS Access > 
+Audit Directory Service Changes (Success,Failure)
+```
+
+The above policy does not cover User objects, so we need to set up an AuditRule using https://github.com/OTRF/Set-AuditRule.
+As this specifies the msDS-KeyCredentialLink Attribute GUID, it is expected to be low noise.
+
+```
+Set-AuditRule -AdObjectPath 'AD:\\CN=Users,DC=Domain,DC=com' -WellKnownSidType WorldSid -Rights WriteProperty -InheritanceFlags Children -AttributeGUID 5b47d60f-6090-40b2-9f37-2a4de88f3063 -AuditFlags Success
+```
+"""
+references = [
+    "https://posts.specterops.io/shadow-credentials-abusing-key-trust-account-mapping-for-takeover-8ee1a53566ab",
+    "https://www.thehacker.recipes/ad/movement/kerberos/shadow-credentials",
+    "https://github.com/OTRF/Set-AuditRule",
+]
+risk_score = 73
+rule_id = "f494c678-3c33-43aa-b169-bb3d5198c41d"
+severity = "high"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+event.code:"5136" and winlog.event_data.AttributeLDAPDisplayName : "msDS-KeyCredentialLink"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+name = "Modify Authentication Process"
+id = "T1556"
+reference = "https://attack.mitre.org/techniques/T1556/"
+
+
+[rule.threat.tactic]
+name = "Credential Access"
+id = "TA0006"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -6,9 +6,9 @@ updated_date = "2022/01/26"
 [rule]
 author = ["Elastic"]
 description = """
-Identify the modification of the msDS-KeyCredentialLink attribute in a Active Directory Computer or User Object.
-Attackers can abuse contol over the object and create a key pair, append to raw public key in the attribute, and obtain
-persistent and stealthy access to the target object (can be a user or a computer).
+Identify the modification of the msDS-KeyCredentialLink attribute in an Active Directory Computer or User Object.
+Attackers can abuse control over the object and create a key pair, append to raw public key in the attribute, and obtain
+persistent and stealthy access to the target user or computer object.
 """
 false_positives = [
     """
@@ -57,7 +57,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code:"5136" and winlog.event_data.AttributeLDAPDisplayName : "msDS-KeyCredentialLink"
+event.code:"5136" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink"
 '''
 
 

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -50,7 +50,7 @@ references = [
     "https://github.com/OTRF/Set-AuditRule",
 ]
 risk_score = 73
-rule_id = "f494c678-3c33-43aa-b169-bb3d5198c41d"
+rule_id = "79f97b31-480e-4e63-a7f4-ede42bf2c6de"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Active Directory"]
 timestamp_override = "event.ingested"


### PR DESCRIPTION
## Issues

Resolves #1728 

## Summary

Identify the modification of the msDS-KeyCredentialLink attribute in a Active Directory Computer or User Object.
Attackers can abuse contol over the object and create a key pair, append to raw public key in the attribute, and obtain
persistent and stealthy access to the target object (can be a user or a computer).