### PR TITLE
Revert "[Rule Tuning] Interactive Terminal Spawned via Python - Python3 and bypasses fix"

### DIFF
--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/15"
 maturity = "production"
-updated_date = "2021/12/06"
+updated_date = "2021/03/03"
 
 [rule]
 author = ["Elastic"]
@@ -10,8 +10,8 @@ Identifies when a terminal (tty) is spawned via Python. Attackers may upgrade a 
 interactive tty after obtaining initial access to a host.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
-language = "eql"
+index = ["auditbeat-*", "logs-endpoint.events.*"]
+language = "kuery"
 license = "Elastic License v2"
 name = "Interactive Terminal Spawned via Python"
 risk_score = 73
@@ -19,40 +19,23 @@ rule_id = "d76b02ef-fc95-4001-9297-01cb7412232f"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "eql"
+type = "query"
 
 query = '''
-sequence with maxspan=20s
-  [process where event.type in ("start", "process_started") and process.name : "python*"] by process.entity_id
-  [process where event.type in ("start", "process_started") and 
-   process.executable : (
-      "/bin/bash",
-      "/bin/sh",
-      "/bin/dash",
-      "/bin/csh",
-      "/bin/zsh",
-      "/bin/ksh",
-      "/bin/tcsh",
-      "/bin/fish",
-      "/bin/ash",
-      "/bin/bsh"
-   )
-  ] by process.parent.entity_id
+event.category:process and event.type:(start or process_started) and process.name:python and
+  process.args:("import pty; pty.spawn(\"/bin/sh\")" or
+                "import pty; pty.spawn(\"/bin/dash\")" or
+                "import pty; pty.spawn(\"/bin/bash\")")
 '''
 
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
-
 [[rule.threat.technique]]
 id = "T1059"
 name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1059.006"
-  name = "Python"
-  reference = "https://attack.mitre.org/techniques/T1059/006/"
 
 [rule.threat.tactic]
 id = "TA0002"


### PR DESCRIPTION
## Issue
related to #1730 

## Description

Rolls back changes to rule due to a bug (8.0) where existing rules change rule `type`. We can explore adding these changes back in after a fix is implemented.

If the change is needed urgently before that, we can deprecate this rule and create a new one with the changes