### PR TITLE
[New Rule] SeEnableDelegationPrivilege assigned to User

### DIFF
--- a/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
+++ b/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
@@ -1,0 +1,66 @@
+[metadata]
+creation_date = "2022/01/27"
+maturity = "production"
+updated_date = "2022/01/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies the assignment of the SeEnableDelegationPrivilege right to a user. Attackers can abuse the right to write to
+a GPO to assign this privilege to an account; If they have privileges over any user in the domain, they can set
+msDS-AllowedToDelegateTo to any service they want to compromise.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "SeEnableDelegationPrivilege assigned to User"
+note = """## Config
+
+The 'Audit Directory Service Changes' logging policy must be configured for (Success, Failure).
+Steps to implement the logging policy with Advanced Audit Configuration:
+
+```
+Computer Configuration >
+Windows Settings >
+Security Settings >
+Advanced Audit Policy Configuration >
+Audit Policies >
+Policy Change >
+Audit Authorization Policy Change (Success,Failure)
+```
+"""
+references = [
+    "https://www.harmj0y.net/blog/activedirectory/the-most-dangerous-user-right-you-probably-have-never-heard-of",
+    "https://github.com/SigmaHQ/sigma/blob/master/rules/windows/builtin/security/win_alert_active_directory_user_control.yml",
+    "https://github.com/atc-project/atomic-threat-coverage/blob/master/Atomic_Threat_Coverage/Logging_Policies/LP_0105_windows_audit_authorization_policy_change.md",
+]
+risk_score = 73
+rule_id = "f494c678-3c33-43aa-b169-bb3d5198c41d"
+severity = "high"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+event.code:4704 and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+


### PR DESCRIPTION
## Issues

Resolves #1736 

## Summary

Identifies the assignment of the SeEnableDelegationPrivilege right to a user. Attackers can abuse the right to write to
a GPO to assign this privilege to an account; If they have privileges over any user in the domain, they can set
msDS-AllowedToDelegateTo to any service they want to compromise.