### PR TITLE
[Rule Tuning] O365 Exchange Suspicious Mailbox Right Delegation

### DIFF
--- a/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
+++ b/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/05/17"
 maturity = "production"
-updated_date = "2021/01/31"
+updated_date = "2022/01/31"
 integration = "o365"
 
 [rule]

--- a/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
+++ b/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/05/17"
 maturity = "production"
-updated_date = "2021/10/11"
+updated_date = "2021/01/31"
 integration = "o365"
 
 [rule]
@@ -28,7 +28,8 @@ type = "query"
 
 query = '''
 event.dataset:o365.audit and event.provider:Exchange and event.action:Add-MailboxPermission and 
-o365.audit.Parameters.AccessRights:(FullAccess or SendAs or SendOnBehalf) and event.outcome:success
+o365.audit.Parameters.AccessRights:(FullAccess or SendAs or SendOnBehalf) and event.outcome:success and
+not user.id : "NT AUTHORITY\SYSTEM (Microsoft.Exchange.Servicehost)"
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary

Exclude the "NT AUTHORITY\SYSTEM (Microsoft.Exchange.Servicehost)" user.id. The rule is triggered by a legitimate task executed by this account, that is related to eDiscovery.

More information can be found here: https://community.spiceworks.com/topic/2233033-high-severity-alert-nt-authority-system