### PR TITLE
[Bug] Fix AttributeError in RuleCollection dupe check

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -525,7 +525,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
 class TOMLRule:
     contents: TOMLRuleContents = field(hash=True)
     path: Optional[Path] = None
-    gh_pr: Any = field(hash=False, compare=False, default=None, repr=None)
+    gh_pr: Any = field(hash=False, compare=False, default=None, repr=False)
 
     @property
     def id(self):

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -203,7 +203,7 @@ class RuleCollection(BaseCollection):
 
         assert not self.frozen, f"Unable to add rule {rule.name} {rule.id} to a frozen collection"
         assert rule.id not in id_map, \
-            f"Rule ID {rule.id} for {rule.name} collides with rule {id_map.get(rule.id).get('name')}"
+            f"Rule ID {rule.id} for {rule.name} collides with rule {id_map.get(rule.id).name}"
 
         if rule.path is not None:
             rule_path = rule.path.resolve()


### PR DESCRIPTION
## Issues
Fixes bug found in #1743 

## Summary
```
 f"Rule ID {rule.id} for {rule.name} collides with rule {id_map.get(rule.id).get('name')}"
AttributeError: 'TOMLRule' object has no attribute 'get'
```