### PR TITLE
[New Rule] PowerShell Script Block Logging Disabled

### DIFF
--- a/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
+++ b/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
@@ -6,8 +6,7 @@ updated_date = "2022/01/31"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the disable of PowerShell Script Block Logging. Attackers can disable the logging of PowerShell Scripts to
-conceal their activities in the host.
+Identifies attempt to disable PowerShell Script Block Logging via registry modification. Attackers may disable the logging of PowerShell Scripts to conceal their activities in the host.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]

--- a/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
+++ b/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
@@ -1,0 +1,53 @@
+[metadata]
+creation_date = "2022/01/31"
+maturity = "production"
+updated_date = "2022/01/31"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies the disable of PowerShell Script Block Logging. Attackers can disable the logging of PowerShell Scripts to
+conceal their activities in the host.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "PowerShell Script Block Logging Disabled"
+references = [
+    "https://admx.help/?Category=Windows_10_2016&Policy=Microsoft.Policies.PowerShell::EnableScriptBlockLogging",
+]
+risk_score = 47
+rule_id = "818e23e6-2094-4f0e-8c01-22d30f3506c6"
+severity = "medium"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+registry where event.type : "change" and
+    registry.path : 
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\\EnableScriptBlockLogging"
+    and registry.data.strings : ("0", "0x00000000")
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+reference = "https://attack.mitre.org/techniques/T1562/"
+name = "Impair Defenses"
+
+  [[rule.threat.technique.subtechnique]]
+  id = "T1562.002"
+  name = "Disable Windows Event Logging"
+  reference = "https://attack.mitre.org/techniques/T1562/002/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+name = "Defense Evasion"
+

--- a/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
+++ b/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
@@ -6,8 +6,8 @@ updated_date = "2022/01/31"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies attempt to disable PowerShell Script Block Logging via registry modification. Attackers may disable the
-logging of PowerShell Scripts to conceal their activities in the host.
+Identifies attempts to disable PowerShell Script Block Logging via registry modification. Attackers may disable
+this logging to conceal their activities in the host and evade detection.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
@@ -25,7 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where event.type : "change" and
+registry where event.type == "change" and
     registry.path : 
         "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\\EnableScriptBlockLogging"
     and registry.data.strings : ("0", "0x00000000")

--- a/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
+++ b/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
@@ -6,7 +6,8 @@ updated_date = "2022/01/31"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies attempt to disable PowerShell Script Block Logging via registry modification. Attackers may disable the logging of PowerShell Scripts to conceal their activities in the host.
+Identifies attempt to disable PowerShell Script Block Logging via registry modification. Attackers may disable the
+logging of PowerShell Scripts to conceal their activities in the host.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]


### PR DESCRIPTION
## Issues

Resolves #1748 

## Summary

Identifies the disable of PowerShell Script Block Logging. Attackers can disable the logging of PowerShell Scripts to
conceal their activities in the host.

The rule works for both sysmon and Elastic Endpoint Security