### PR TITLE
[New Rule] AWS RDS data exfiltration using snapshot share

### DIFF
--- a/etc/non-ecs-schema.json
+++ b/etc/non-ecs-schema.json
@@ -14,7 +14,7 @@
         "AllowedToDelegateTo": "keyword",
         "AttributeLDAPDisplayName": "keyword",
         "AttributeValue": "keyword",
-        "CallerProcessName": "keyword", 
+        "CallerProcessName": "keyword",
         "CallTrace": "keyword",
         "GrantedAccess": "keyword",
         "ObjectDN": "keyword",
@@ -37,7 +37,9 @@
     "o365.audit.NewValue": "keyword",
     "o365audit.Parameters.ForwardTo": "keyword",
     "o365audit.Parameters.ForwardAsAttachmentTo": "keyword",
-    "o365audit.Parameters.RedirectTo": "keyword"
+    "o365audit.Parameters.RedirectTo": "keyword",
+    "aws.cloudtrail.flattened.request_parameters.attributeName": "keyword",
+    "aws.cloudtrail.flattened.request_parameters.valuesToAdd": "keyword"
   },
   "logs-endpoint.events.*": {
     "process.Ext.token.integrity_level_name": "keyword",

--- a/rules/integrations/aws/exfiltration_rds_using_snapshot.toml
+++ b/rules/integrations/aws/exfiltration_rds_using_snapshot.toml
@@ -35,7 +35,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.provider:rds.amazonaws.com and event.action:ModifyDBSnapshotAttribute and
+event.module:aws and event.dataset:aws.cloudtrail and event.provider:rds.amazonaws.com and event.action:ModifyDBSnapshotAttribute and
   aws.cloudtrail.flattened.request_parameters.attributeName:"restore" and
   aws.cloudtrail.flattened.request_parameters.valuesToAdd:*
 '''

--- a/rules/integrations/aws/exfiltration_rds_using_snapshot.toml
+++ b/rules/integrations/aws/exfiltration_rds_using_snapshot.toml
@@ -5,11 +5,9 @@ updated_date = "2022/02/03"
 integration = "aws"
 
 [rule]
-author = ["Elastic", "Stijn Holzhauer"]
+author = ["Stijn Holzhauer"]
 description = """
-This detections monitors for the sharing of a snapshot with another AWS account.
-This could indicate the exfiltration of data using
-a provided mechanism without having to actually access the Database.
+This detections monitors for the sharing of a snapshot with another AWS account. This could indicate the exfiltration of data using a provided mechanism without having to actually access the Database.
 """
 false_positives = [
     """
@@ -37,14 +35,24 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.provider:rds.amazonaws.com and event.action:ModifyDBSnapshotAttribute and aws.cloudtrail.flattened.request_parameters.attributeName:"restore" and aws.cloudtrail.flattened.request_parameters.valuesToAdd:*
+event.provider:rds.amazonaws.com and event.action:ModifyDBSnapshotAttribute and
+  aws.cloudtrail.flattened.request_parameters.attributeName:"restore" and
+  aws.cloudtrail.flattened.request_parameters.valuesToAdd:*
 '''
 
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1578"
+name = "Modify Cloud Compute Infrastructure"
+reference = "https://attack.mitre.org/techniques/T1578/"
+[[rule.threat.technique.subtechnique]]
+id = "T1578.001"
+name = "Create Snapshot"
+reference = "https://attack.mitre.org/techniques/T1578/001/"
 
 [rule.threat.tactic]
-name = "Exfiltration"
-id = "TA0010"
-reference = "https://attack.mitre.org/tactics/TA0010/"
+name = "Defense Evasion"
+id = "TA0005"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/aws/exfiltration_rds_using_snapshot.toml
+++ b/rules/integrations/aws/exfiltration_rds_using_snapshot.toml
@@ -1,0 +1,53 @@
+[metadata]
+creation_date = "2022/02/03"
+maturity = "production"
+updated_date = "2022/02/03"
+integration = "aws"
+
+[rule]
+author = ["Elastic", "Stijn Holzhauer"]
+description = """
+This detections monitors for the sharing of a snapshot with another AWS account.
+This could indicate the exfiltration of data using
+a provided mechanism without having to actually access the Database.
+"""
+false_positives = [
+    """
+    Sharing snapshots with another AWS account could be the architectural setup
+    for data backup in the case of a Disaster; If this is expected you can add an
+    exception on that specific AWS account id.
+    """,
+]
+from = "now-60m"
+index = ["filebeat-*", "logs-aws*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS RDS Snapshot Created and Shared"
+note = """
+## Config
+Cloudtrail has to be parsed according to the Filebeat module of Elastic Agent integration.
+
+## Suggested Investigation
+Verify the account with which the snapshot has been shared.
+"""
+references = ["https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ShareSnapshot.html"]
+risk_score = 21
+rule_id = "b3f1f90b-a0ad-4cd2-8942-60fb4fa96974"
+severity = "medium"
+tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Asset Visibility"]
+timestamp_override = "event.ingested"
+type = "kuery"
+
+query = '''
+event.provider:rds.amazonaws.com and event.action:ModifyDBSnapshotAttribute and aws.cloudtrail.flattened.request_parameters.attributeName:"restore" and aws.cloudtrail.flattened.request_parameters.valuesToAdd:*
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+name = "Exfiltration"
+id = "TA0010"
+reference = "https://attack.mitre.org/tactics/TA0010/"

--- a/rules/integrations/aws/exfiltration_rds_using_snapshot.toml
+++ b/rules/integrations/aws/exfiltration_rds_using_snapshot.toml
@@ -24,12 +24,9 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Snapshot Created and Shared"
-note = """
-## Config
-Cloudtrail has to be parsed according to the Filebeat module of Elastic Agent integration.
+note = """## Config
 
-## Suggested Investigation
-Verify the account with which the snapshot has been shared.
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 """
 references = ["https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ShareSnapshot.html"]
 risk_score = 21
@@ -37,7 +34,7 @@ rule_id = "b3f1f90b-a0ad-4cd2-8942-60fb4fa96974"
 severity = "medium"
 tags = ["Elastic", "Cloud", "AWS", "Continuous Monitoring", "SecOps", "Asset Visibility"]
 timestamp_override = "event.ingested"
-type = "kuery"
+type = "query"
 
 query = '''
 event.provider:rds.amazonaws.com and event.action:ModifyDBSnapshotAttribute and aws.cloudtrail.flattened.request_parameters.attributeName:"restore" and aws.cloudtrail.flattened.request_parameters.valuesToAdd:*


### PR DESCRIPTION
## Issues
Resolves #1752

## Summary
This detections monitors for the sharing of a snapshot with another AWS account.
This could indicate the exfiltration of data using
a provided mechanism without having to actually access the Database.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
