### PR TITLE
[Rule Tuning] Net command via SYSTEM account

### DIFF
--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,8 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and 
-  user.id in ("S-1-5-18", "S-1-5-19", "S-1-5-20") and
+  (process.Ext.token.integrity_level_name : "System" or
+  winlog.event_data.IntegrityLevel : "System") and
   process.name : "whoami.exe" or
   (process.name : "net1.exe" and not process.parent.name : "net.exe")
 '''


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/sdh-security-team/issues/300

Changes the rule logic to use `winlog.event_data.IntegrityLevel` and `process.Ext.token.integrity_level_name` instead of `user.id`, as the field is always populated with `S-1-5-18`, even on regular user processes with Low/Medium/High integrity.

![image](https://user-images.githubusercontent.com/26856693/153518159-7367a782-9096-42c6-947c-4fd19f2b90ad.png)