### PR TITLE
[Rule Tuning] Potential Command and Control via Internet Explorer

### DIFF
--- a/rules/windows/command_and_control_iexplore_via_com.toml
+++ b/rules/windows/command_and_control_iexplore_via_com.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/28"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Command and Control"]
 type = "eql"
 
 query = '''
-sequence by host.id, user.id with maxspan = 5s
+sequence by host.id, user.name with maxspan = 5s
   [library where dll.name : "IEProxy.dll" and process.name : ("rundll32.exe", "regsvr32.exe")]
   [process where event.type == "start" and process.parent.name : "iexplore.exe" and process.parent.args : "-Embedding"]
   /* IE started via COM in normal conditions makes few connections, mainly to Microsoft and OCSP related domains, add FPs here */

--- a/rules/windows/command_and_control_iexplore_via_com.toml
+++ b/rules/windows/command_and_control_iexplore_via_com.toml
@@ -2,8 +2,6 @@
 creation_date = "2020/11/28"
 maturity = "production"
 updated_date = "2022/02/14"
-min_stack_comments = "EQL repeated sequences syntax introduced in 7.16"
-min_stack_version = "7.16.0"
 
 [rule]
 author = ["Elastic"]
@@ -42,7 +40,7 @@ sequence by host.id, user.name with maxspan = 5s
     "*.office365.com",
     "*.office.com"
     )
-  ] with runs=5
+  ] /* with runs=5 */
 '''
 
 

--- a/rules/windows/command_and_control_iexplore_via_com.toml
+++ b/rules/windows/command_and_control_iexplore_via_com.toml
@@ -2,6 +2,8 @@
 creation_date = "2020/11/28"
 maturity = "production"
 updated_date = "2022/02/14"
+min_stack_comments = "EQL repeated sequences syntax introduced in 7.16"
+min_stack_version = "7.16.0"
 
 [rule]
 author = ["Elastic"]
@@ -40,7 +42,7 @@ sequence by host.id, user.name with maxspan = 5s
     "*.office365.com",
     "*.office.com"
     )
-  ]
+  ] with runs=5
 '''
 
 


### PR DESCRIPTION
## Issues

Related to #1770 

## Summary

Modifies the sequence to use user.name instead of user.id to not cause FPs.