### PR TITLE
[Rule Tuning] Sysmon Compatibility - Replace user.id for Integrity fields

### DIFF
--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/05/26"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -32,7 +32,7 @@ sequence by process.entity_id
   [process where event.type == "start" and
    process.name : ("regsvr32.exe", "RegAsm.exe", "RegSvcs.exe") and
    not (
-         user.id == "S-1-5-18" and
+         (process.Ext.token.integrity_level_name : "System" or winlog.event_data.IntegrityLevel : "System") and
          (process.parent.name : "msiexec.exe" or process.parent.executable : ("C:\\Program Files (x86)\\*.exe", "C:\\Program Files\\*.exe"))
        )
    ]

--- a/rules/windows/persistence_local_scheduled_task_creation.toml
+++ b/rules/windows/persistence_local_scheduled_task_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -31,8 +31,9 @@ sequence with maxspan=1m
   [process where event.type == "start" and
     (process.name : "schtasks.exe" or process.pe.original_file_name == "schtasks.exe") and
     process.args : ("/create", "-create") and process.args : ("/RU", "/SC", "/TN", "/TR", "/F", "/XML") and
-    /* exclude SYSTEM SIDs - look for task creations by non-SYSTEM user */
-    not user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20")] by process.parent.entity_id
+    /* exclude SYSTEM Integrity Level - look for task creations by non-SYSTEM user */
+    not (process.Ext.token.integrity_level_name : "System" or winlog.event_data.IntegrityLevel : "System")
+  ] by process.parent.entity_id
 '''
 
 

--- a/rules/windows/privilege_escalation_installertakeover.toml
+++ b/rules/windows/privilege_escalation_installertakeover.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/11/25"
 maturity = "production"
-updated_date = "2021/11/25"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -57,7 +57,8 @@ query = '''
 /* This rule is compatible with both Sysmon and Elastic Endpoint */
 
 process where event.type == "start" and 
-    user.id : "S-1-5-18" and
+    (process.Ext.token.integrity_level_name : "System" or
+    winlog.event_data.IntegrityLevel : "System") and
     (
       (process.name : "elevation_service.exe" and 
        not process.pe.original_file_name == "elevation_service.exe") or

--- a/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
+++ b/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/06"
 maturity = "production"
-updated_date = "2021/07/21"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -33,7 +33,9 @@ type = "eql"
 
 query = '''
 process where event.type == "start" and
- process.parent.name : "spoolsv.exe" and user.id : "S-1-5-18" and
+ process.parent.name : "spoolsv.exe" and
+ (process.Ext.token.integrity_level_name : "System" or
+ winlog.event_data.IntegrityLevel : "System") and
 
  /* exclusions for FP control below */
  not process.name : ("splwow64.exe", "PDFCreator.exe", "acrodist.exe", "spoolsv.exe", "msiexec.exe", "route.exe", "WerFault.exe") and


### PR DESCRIPTION
## Issues

Related to #1770 

## Summary

Replace the usage of user.id (checking if the process is run by SYSTEM) for integrity level fields (process.Ext.token.integrity_level_name & winlog.event_data.IntegrityLevel)