### PR TITLE
[Rule Tuning] Sysmon Registry-based Rules Review & Fixes

### DIFF
--- a/rules/windows/command_and_control_port_forwarding_added_registry.toml
+++ b/rules/windows/command_and_control_port_forwarding_added_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where registry.path : "HKLM\\SYSTEM\\ControlSet*\\Services\\PortProxy\\v4tov4\\*"
+registry where registry.path : "HKLM\\SYSTEM\\*ControlSet*\\Services\\PortProxy\\v4tov4\\*"
 '''
 
 

--- a/rules/windows/defense_evasion_defender_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_defender_disabled_via_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/23"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -27,10 +27,16 @@ type = "eql"
 
 query = '''
 registry where event.type in ("creation", "change") and
-  ((registry.path:"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\DisableAntiSpyware" and
-     registry.data.strings:"1") or
-  (registry.path:"HKLM\\System\\ControlSet*\\Services\\WinDefend\\Start" and
-     registry.data.strings in ("3", "4")))
+  (
+    (
+      registry.path:"HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\DisableAntiSpyware" and
+      registry.data.strings: ("1", "0x00000001")
+   ) or
+   (
+      registry.path:"HKLM\\System\\*ControlSet*\\Services\\WinDefend\\Start" and
+      registry.data.strings in ("3", "4", "0x00000003", "0x00000004")
+   )
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
+++ b/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies registry write modifications to hide an encoded portable executable. 
 defense evasion by avoiding the storing of malicious content directly on disk.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Encoded Executable Stored in the Registry"

--- a/rules/windows/defense_evasion_microsoft_defender_tampering.toml
+++ b/rules/windows/defense_evasion_microsoft_defender_tampering.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/18"
 maturity = "production"
-updated_date = "2021/12/31"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -35,33 +35,33 @@ type = "eql"
 query = '''
 registry where event.type in ("creation", "change") and
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\PUAProtection" and
-  registry.data.strings : "0") or
+  registry.data.strings : ("0", "0x00000000")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender Security Center\\App and Browser protection\\DisallowExploitProtectionOverride" and
-  registry.data.strings : "1") or
+  registry.data.strings : ("1", "0x00000001")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\DisableAntiSpyware" and
-  registry.data.strings : "1") or
+  registry.data.strings : ("1", "0x00000001")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Features\\TamperProtection" and
-  registry.data.strings : "0") or
+  registry.data.strings : ("0", "0x00000000")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableRealtimeMonitoring" and
-  registry.data.strings : "1") or
+  registry.data.strings : ("1", "0x00000001")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIntrusionPreventionSystem" and
-  registry.data.strings : "1") or
+  registry.data.strings : ("1", "0x00000001")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableScriptScanning" and
-  registry.data.strings : "1") or
+  registry.data.strings : ("1", "0x00000001")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\Controlled Folder Access\\EnableControlledFolderAccess" and
-  registry.data.strings : "0") or
+  registry.data.strings : ("0", "0x00000000")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIOAVProtection" and
-  registry.data.strings : "1") or
+  registry.data.strings : ("1", "0x00000001")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Reporting\\DisableEnhancedNotifications" and
-  registry.data.strings : "1") or
+  registry.data.strings : ("1", "0x00000001")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\DisableBlockAtFirstSeen" and
-  registry.data.strings : "1") or
+  registry.data.strings : ("1", "0x00000001")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SpynetReporting" and
-  registry.data.strings : "0") or
+  registry.data.strings : ("0", "0x00000000")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SubmitSamplesConsent" and
-  registry.data.strings : "0") or
+  registry.data.strings : ("0", "0x00000000")) or
   (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableBehaviorMonitoring" and
-  registry.data.strings : "1")
+  registry.data.strings : ("1", "0x00000001"))
 '''
 
 [[rule.threat]]

--- a/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
+++ b/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,8 @@ type = "eql"
 
 query = '''
 registry where 
- registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt" and registry.data.strings == "1"
+ registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt" and 
+ registry.data.strings : ("1", "0x00000001")
 '''
 
 

--- a/rules/windows/defense_evasion_sip_provider_mod.toml
+++ b/rules/windows/defense_evasion_sip_provider_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_sip_provider_mod.toml
+++ b/rules/windows/defense_evasion_sip_provider_mod.toml
@@ -11,7 +11,7 @@ Windows cryptographic system to validate file signatures on the system. This may
 validation checks or inject code into critical processes.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "SIP Provider Modification"

--- a/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -25,15 +25,16 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where registry.path : "HKLM\\SYSTEM\\*ControlSet*\\Services\\*\\Start" and registry.data.strings == "4" and
- process.name : (
-     "SolarWinds.BusinessLayerHost*.exe", 
-     "ConfigurationWizard*.exe", 
-     "NetflowDatabaseMaintenance*.exe", 
-     "NetFlowService*.exe", 
-     "SolarWinds.Administration*.exe", 
-     "SolarWinds.Collector.Service*.exe" , 
-     "SolarwindsDiagnostics*.exe")
+registry where registry.path : "HKLM\\SYSTEM\\*ControlSet*\\Services\\*\\Start" and
+  registry.data.strings : ("4", "0x00000004") and
+  process.name : (
+      "SolarWinds.BusinessLayerHost*.exe", 
+      "ConfigurationWizard*.exe", 
+      "NetflowDatabaseMaintenance*.exe", 
+      "NetFlowService*.exe", 
+      "SolarWinds.Administration*.exe", 
+      "SolarWinds.Collector.Service*.exe" , 
+      "SolarwindsDiagnostics*.exe")
 '''
 
 

--- a/rules/windows/lateral_movement_defense_evasion_lanman_nullsessionpipe_modification.toml
+++ b/rules/windows/lateral_movement_defense_evasion_lanman_nullsessionpipe_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/22"
 maturity = "production"
-updated_date = "2021/03/22"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies NullSessionPipe registry modifications that specify which pipes can b
 be indicative of adversary lateral movement preparation by making the added pipe available to everyone.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "NullSessionPipe Registry Modification"

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -22,10 +22,10 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where
-registry.path : "HKLM\\SYSTEM\\ControlSet*\\Control\\Terminal Server\\fDenyTSConnections" and
-registry.data.strings == "0" and not (process.name : "svchost.exe" and user.domain == "NT AUTHORITY") and
-not process.executable : "C:\\Windows\\System32\\SystemPropertiesRemote.exe"
+registry where event.type in ("creation", "change") and
+  registry.path : "HKLM\\SYSTEM\\*ControlSet*\\Control\\Terminal Server\\fDenyTSConnections" and
+  registry.data.strings : ("0", "0x00000000") and not (process.name : "svchost.exe" and user.domain == "NT AUTHORITY") and
+  not process.executable : "C:\\Windows\\System32\\SystemPropertiesRemote.exe"
 '''
 
 

--- a/rules/windows/lateral_movement_rdp_sharprdp_target.toml
+++ b/rules/windows/lateral_movement_rdp_sharprdp_target.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/11"
 maturity = "production"
-updated_date = "2022/01/13"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies potential behavior of SharpRDP, which is a tool that can be used to p
 against a remote target via Remote Desktop Protocol (RDP) for the purposes of lateral movement.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential SharpRDP Behavior"

--- a/rules/windows/persistence_appcertdlls_registry.toml
+++ b/rules/windows/persistence_appcertdlls_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -24,7 +24,7 @@ type = "eql"
 query = '''
 registry where
 /* uncomment once stable length(bytes_written_string) > 0 and */
-  registry.path : "HKLM\\SYSTEM\\ControlSet*\\Control\\Session Manager\\AppCertDLLs\\*"
+  registry.path : "HKLM\\SYSTEM\\*ControlSet*\\Control\\Session Manager\\AppCertDLLs\\*"
 '''
 
 

--- a/rules/windows/persistence_evasion_registry_ifeo_injection.toml
+++ b/rules/windows/persistence_evasion_registry_ifeo_injection.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/07/20"
+updated_date = "2022/02/14"
 min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
 
@@ -12,7 +12,7 @@ The Debugger and SilentProcessExit registry keys can allow an adversary to inter
 different process to be executed. This functionality can be abused by an adversary to establish persistence.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Image File Execution Options Injection"

--- a/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
+++ b/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/15"
 maturity = "production"
-updated_date = "2021/09/10"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies suspicious startup shell folder modifications to change the default S
 detections monitoring file creation in the Windows Startup folder.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Startup Shell Folder Modification"

--- a/rules/windows/persistence_registry_uncommon.toml
+++ b/rules/windows/persistence_registry_uncommon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Detects changes to registry persistence keys that are uncommonly used or modifie
 an indication of an adversary's attempt to persist in a stealthy manner.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Uncommon Registry Persistence Change"

--- a/rules/windows/persistence_run_key_and_startup_broad.toml
+++ b/rules/windows/persistence_run_key_and_startup_broad.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/04/07"
+updated_date = "2022/02/14"
 
 
 [rule]
@@ -11,7 +11,7 @@ Identifies run key or startup key registry modifications. In order to survive re
 attackers will modify run keys within the registry or leverage startup folder items as a form of persistence.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Startup or Run Key Registry Modification"

--- a/rules/windows/persistence_services_registry.toml
+++ b/rules/windows/persistence_services_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/04/07"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ could be an indication of an adversary attempting to stealthily persist through 
 modification of an existing service.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Persistence via Services Registry"

--- a/rules/windows/persistence_suspicious_com_hijack_registry.toml
+++ b/rules/windows/persistence_suspicious_com_hijack_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/09/22"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies Component Object Model (COM) hijacking via registry modification. Adv
 executing malicious content triggered by hijacked references to COM objects.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Component Object Model Hijacking"

--- a/rules/windows/persistence_suspicious_service_created_registry.toml
+++ b/rules/windows/persistence_suspicious_service_created_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies the creation of a suspicious ImagePath value. This could be an indica
 stealthily persist or escalate privileges through abnormal service creation.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious ImagePath Service Creation"

--- a/rules/windows/persistence_time_provider_mod.toml
+++ b/rules/windows/persistence_time_provider_mod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ abuse this architecture to establish persistence, specifically by registering an
 provider.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Persistence via Time Provider Modification"

--- a/rules/windows/persistence_via_hidden_run_key_valuename.toml
+++ b/rules/windows/persistence_via_hidden_run_key_valuename.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -28,10 +28,12 @@ type = "eql"
 query = '''
 /* Registry Path ends with backslash */
 registry where /* length(registry.data.strings) > 0 and */
- registry.path : ("HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\", 
+ registry.path : ("HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
+                  "HKU\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
                   "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\", 
                   "HKLM\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run\\", 
-                  "HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\", 
+                  "HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\",
+                  "HKU\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\",
                   "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\")
 '''
 

--- a/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
+++ b/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -23,8 +23,8 @@ type = "eql"
 
 query = '''
 registry where
-   registry.path : ("HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\Security Packages*", 
-                    "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\OSConfig\\Security Packages*") and
+   registry.path : ("HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\Security Packages*", 
+                    "HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\OSConfig\\Security Packages*") and
    not process.executable : ("C:\\Windows\\System32\\msiexec.exe", "C:\\Windows\\SysWOW64\\msiexec.exe")
 '''
 

--- a/rules/windows/persistence_via_wmi_stdregprov_run_services.toml
+++ b/rules/windows/persistence_via_wmi_stdregprov_run_services.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/15"
 maturity = "production"
-updated_date = "2021/03/15"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies use of the Windows Management Instrumentation StdRegProv (registry pr
 registry locations for persistence.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via WMI Standard Registry Provider"

--- a/rules/windows/privilege_escalation_disable_uac_registry.toml
+++ b/rules/windows/privilege_escalation_disable_uac_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/20"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -36,7 +36,7 @@ registry where event.type == "change" and
       "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\ConsentPromptBehaviorAdmin",
       "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\PromptOnSecureDesktop"
     ) and
-  registry.data.strings : "0"
+  registry.data.strings : ("0", "0x00000000")
 '''
 
 

--- a/rules/windows/privilege_escalation_port_monitor_print_pocessor_abuse.toml
+++ b/rules/windows/privilege_escalation_port_monitor_print_pocessor_abuse.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ processors to run malicious DLLs during system boot that will be executed as SYS
 persistence, if permissions allow writing a fully-qualified pathname for that DLL.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Port Monitor or Print Processor Registration Abuse"
@@ -26,7 +26,7 @@ type = "eql"
 query = '''
 registry where event.type in ("creation", "change") and
   registry.path : ("HKLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Monitors\\*",
-    "HLLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Environments\\Windows*\\Print Processors\\*") and
+    "HKLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Environments\\Windows*\\Print Processors\\*") and
   registry.data.strings : "*.dll" and
   /* exclude SYSTEM SID - look for changes by non-SYSTEM user */
   not user.id : "S-1-5-18"

--- a/rules/windows/privilege_escalation_printspooler_malicious_registry_modification.toml
+++ b/rules/windows/privilege_escalation_printspooler_malicious_registry_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/06"
 maturity = "production"
-updated_date = "2021/07/06"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Detects attempts to exploit privilege escalation vulnerabilities related to the 
 information refer to CVE-2021-34527 and verify that the impacted system is investigated.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential PrintNightmare Exploit Registry Modification"

--- a/rules/windows/privilege_escalation_printspooler_registry_copyfiles.toml
+++ b/rules/windows/privilege_escalation_printspooler_registry_copyfiles.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/26"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ Exploitation involves chaining multiple primitives to load an arbitrary DLL into
 SYSTEM.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Print Spooler Point and Print DLL"

--- a/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
+++ b/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/26"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/02/14"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies a privilege escalation attempt via a rogue Windows directory (Windir)
 primitive that is often combined with other vulnerabilities to elevate privileges.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Privilege Escalation via Windir Environment Variable"


### PR DESCRIPTION
## Summary

Resolves #1766
Resolves #1761 

Changes:

* Drops support for sysmon in registry-based rules that look for values other than QWORD & DWORD (Integration Issue, will update once the issue is open)
* Add HKU version of HKEY_USER keys in supported rules
* Fix minor syntax errors and lack of wildcards to be compatible with both sysmon and endpoint