### PR TITLE
[Rule Tuning] Update PowerShell script_block queries to avoid partial matches

### DIFF
--- a/rules/windows/collection_posh_audio_capture.toml
+++ b/rules/windows/collection_posh_audio_capture.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/19"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/02"
 
 [rule]
 author = ["Elastic"]
@@ -72,7 +72,7 @@ type = "query"
 query = '''
 event.category:process and 
   powershell.file.script_block_text : (
-    Get-MicrophoneAudio or (waveInGetNumDevs and mciSendStringA)
+    "Get-MicrophoneAudio" or (waveInGetNumDevs and mciSendStringA)
   )
 '''
 

--- a/rules/windows/collection_posh_keylogger.toml
+++ b/rules/windows/collection_posh_keylogger.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/15"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/02"
 
 [rule]
 author = ["Elastic"]
@@ -75,8 +75,11 @@ type = "query"
 query = '''
 event.category:process and 
   ( 
-   powershell.file.script_block_text : (GetAsyncKeyState or NtUserGetAsyncKeyState or GetKeyboardState or Get-Keystrokes) or 
-   powershell.file.script_block_text : ((SetWindowsHookA or SetWindowsHookW or SetWindowsHookEx or SetWindowsHookExA or NtUserSetWindowsHookEx) and (GetForegroundWindow or GetWindowTextA or GetWindowTextW or WM_KEYBOARD_LL))
+   powershell.file.script_block_text : (GetAsyncKeyState or NtUserGetAsyncKeyState or GetKeyboardState or "Get-Keystrokes") or 
+   powershell.file.script_block_text : (
+        (SetWindowsHookA or SetWindowsHookW or SetWindowsHookEx or SetWindowsHookExA or NtUserSetWindowsHookEx) and
+        (GetForegroundWindow or GetWindowTextA or GetWindowTextW or "WM_KEYBOARD_LL")
+   )
    )
 '''
 

--- a/rules/windows/collection_posh_screen_grabber.toml
+++ b/rules/windows/collection_posh_screen_grabber.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/19"
 maturity = "production"
-updated_date = "2022/02/16"
+updated_date = "2022/03/02"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ query = '''
 event.category:process and 
   powershell.file.script_block_text : (
     CopyFromScreen and
-    (System.Drawing.Bitmap or Drawing.Bitmap)
+    ("System.Drawing.Bitmap" or "Drawing.Bitmap")
   )
 '''
 

--- a/rules/windows/defense_evasion_posh_compressed.toml
+++ b/rules/windows/defense_evasion_posh_compressed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/19"
 maturity = "production"
-updated_date = "2022/02/16"
+updated_date = "2022/03/02"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,12 @@ type = "query"
 query = '''
 event.category:process and 
   powershell.file.script_block_text : (
-    (System.IO.Compression.DeflateStream or System.IO.Compression.GzipStream or IO.Compression.DeflateStream or IO.Compression.GzipStream) and
+    (
+      "System.IO.Compression.DeflateStream" or
+      "System.IO.Compression.GzipStream" or
+      "IO.Compression.DeflateStream" or
+      "IO.Compression.GzipStream"
+    ) and
     FromBase64String
   )
 '''

--- a/rules/windows/execution_posh_psreflect.toml
+++ b/rules/windows/execution_posh_psreflect.toml
@@ -81,7 +81,7 @@ query = '''
 event.category:process and 
   powershell.file.script_block_text:(
     "New-InMemoryModule" or
-    Add-Win32Type or
+    "Add-Win32Type" or
     psenum or
     DefineDynamicAssembly or
     DefineDynamicModule or

--- a/rules/windows/execution_posh_psreflect.toml
+++ b/rules/windows/execution_posh_psreflect.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/15"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/02"
 
 [rule]
 author = ["Elastic"]
@@ -80,15 +80,15 @@ type = "query"
 query = '''
 event.category:process and 
   powershell.file.script_block_text:(
-    New-InMemoryModule or
+    "New-InMemoryModule" or
     Add-Win32Type or
     psenum or
     DefineDynamicAssembly or
     DefineDynamicModule or
-    Reflection.TypeAttributes or
-    Reflection.Emit.OpCodes or
-    Reflection.Emit.CustomAttributeBuilder or
-    Runtime.InteropServices.DllImportAttribute
+    "Reflection.TypeAttributes" or
+    "Reflection.Emit.OpCodes" or
+    "Reflection.Emit.CustomAttributeBuilder" or
+    "Runtime.InteropServices.DllImportAttribute"
   )
 '''
 


### PR DESCRIPTION
## Summary

Update PowerShell queries to avoid partial matches (which are causing FPs) due to field type change (wildcard)