### PR TITLE
[Github Workflows] Only generate navigator files on push to main

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,8 +33,11 @@ jobs:
         python -m detection_rules dev license-check
         
     - name: Build release package
+      env:
+        # only generate the navigator files on push events to main
+        GENERATE_NAVIGATOR_FILES: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} && '--generate-navigator' || ' '"
       run: |
-        python -m detection_rules dev build-release
+        python -m detection_rules dev build-release $GENERATE_NAVIGATOR_FILES
 
     - name: Archive production artifacts for branch builds
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Build release package
       env:
         # only generate the navigator files on push events to main
-        GENERATE_NAVIGATOR_FILES: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} && '--generate-navigator' || ' '"
+        GENERATE_NAVIGATOR_FILES: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && '--generate-navigator' || ' ' }}"
       run: |
         python -m detection_rules dev build-release $GENERATE_NAVIGATOR_FILES
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test: $(VENV) lint pytest
 .PHONY: release
 release: deps
 	@echo "RELEASE: $(app_name)"
-	$(PYTHON) -m detection_rules dev build-release
+	$(PYTHON) -m detection_rules dev build-release --generate-navigator
 	rm -rf dist
 	mkdir dist
 	cp -r releases/*/*.zip dist/

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -67,14 +67,18 @@ def dev_group():
 @click.argument('config-file', type=click.Path(exists=True, dir_okay=False), required=False, default=PACKAGE_FILE)
 @click.option('--update-version-lock', '-u', is_flag=True,
               help='Save version.lock.json file with updated rule versions in the package')
-def build_release(config_file, update_version_lock, release=None, verbose=True):
+@click.option('--generate-navigator', is_flag=True, help='Generate ATT&CK navigator files')
+def build_release(config_file, update_version_lock: bool, generate_navigator: bool, release=None, verbose=True):
     """Assemble all the rules into Kibana-ready release files."""
     config = load_dump(config_file)['package']
+    if generate_navigator:
+        config['generate_navigator'] = True
+
     if release is not None:
         config['release'] = release
 
     if verbose:
-        click.echo('[+] Building package {}'.format(config.get('name')))
+        click.echo(f'[+] Building package {config.get("name")}')
 
     package = Package.from_config(config, verbose=verbose)
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -82,13 +82,15 @@ class Package(object):
 
     def __init__(self, rules: RuleCollection, name: str, release: Optional[bool] = False,
                  min_version: Optional[int] = None, max_version: Optional[int] = None,
-                 registry_data: Optional[dict] = None, verbose: Optional[bool] = True):
+                 registry_data: Optional[dict] = None, verbose: Optional[bool] = True,
+                 generate_navigator: bool = False):
         """Initialize a package."""
         self.name = name
         self.rules = rules
         self.deprecated_rules: DeprecatedCollection = rules.deprecated
         self.release = release
         self.registry_data = registry_data or {}
+        self.generate_navigator = generate_navigator
 
         if min_version is not None:
             self.rules = self.rules.filter(lambda r: min_version <= r.contents.latest_version)
@@ -150,7 +152,8 @@ class Package(object):
         with open(os.path.join(directory, f'{self.name}-changelog-entry.md'), 'w') as f:
             f.write(changelog)
 
-        self.generate_attack_navigator(Path(directory))
+        if self.generate_navigator:
+            self.generate_attack_navigator(Path(directory))
 
         consolidated = json.loads(self.get_consolidated())
         with open(os.path.join(directory, f'{self.name}-consolidated-rules.json'), 'w') as f:


### PR DESCRIPTION
## Issues
None

## Summary
The builds are taking longer after merging #1787 due to the extra time spent archiving all of the navigator files. This updates it to only generate those files on pushes to main.