### PR TITLE
expect shell evasion threat

### DIFF
--- a/rules/linux/defense_evasion_expect_binary.toml
+++ b/rules/linux/defense_evasion_expect_binary.toml
@@ -24,9 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id,process.pid with maxspan=1m
-[process where process.name == "expect" and process.args : "-c" and process.args : ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn sh;interact","spawn bash;interact")]
-[process where process.parent.name == "expect" and process.name : ("bash", "sh")]
+sequence by host.id, process.pid with maxspan=1m 
+[process where process.name == "expect" and process.args : "-c" and process.args : ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact","spawn bash;interact", "spawn dash;interact")] 
+[process where process.parent.name == "expect" and process.name : ("bash", "sh", "dash")]
 '''
 
 

--- a/rules/linux/defense_evasion_expect_binary.toml
+++ b/rules/linux/defense_evasion_expect_binary.toml
@@ -1,0 +1,74 @@
+[metadata]
+creation_date = "2022/03/07"
+maturity = "development"
+updated_date = "2022/03/07"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies Linux binary expect abuse to break out from restricted environments by spawning an interactive system shell
+This activity is not standard use with this binary for a user or system administrator and could potentially indicate
+malicious actor attempting to improve the capabilities or stability of their access.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Linux Restricted Shell Breakout via the expect command"
+references = ["https://gtfobins.github.io/gtfobins/expect/"]
+risk_score = 47
+rule_id = "fd3fc25e-7c7c-4613-8209-97942ac609f6"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion", "GTFOBins"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+sequence by host.id,process.pid with maxspan=1m
+[process where process.name == "expect" and process.args : "-c" and process.args : ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn sh;interact","spawn bash;interact")]
+[process where process.parent.name == "expect" and process.name : ("bash", "sh")]
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1548"
+name = "Abuse Elevation Control Mechanism"
+reference = "https://attack.mitre.org/techniques/T1548/"
+[[rule.threat.technique.subtechnique]]
+id = "T1548.004"
+name = "Elevated Execution with Prompt"
+reference = "https://attack.mitre.org/techniques/T1548/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/linux/defense_evasion_expect_binary.toml
+++ b/rules/linux/defense_evasion_expect_binary.toml
@@ -49,13 +49,6 @@ name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
-
-[rule.threat.tactic]
-id = "TA0002"
-name = "Execution"
-reference = "https://attack.mitre.org/tactics/TA0002/"
-[[rule.threat]]
-framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
 name = "Command and Scripting Interpreter"


### PR DESCRIPTION
## Issues
https://github.com/elastic/detection-rules/issues/1816

## Summary
expect, a common IOC, the Unix binary can be abused to breakout out of restricted shells or environments by spawning an interactive system shell. This activity is not standard use with this binary for a user or system administrator. It indicates a potentially malicious actor attempting to improve the capabilities or stability of their access.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
