### PR TITLE
gcc shell evasion threat

### DIFF
--- a/rules/linux/defense_evasion_gcc_binary.toml
+++ b/rules/linux/defense_evasion_gcc_binary.toml
@@ -1,0 +1,50 @@
+[metadata]
+creation_date = "2022/03/09"
+maturity = "production"
+updated_date = "2022/03/09"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies Linux binary gcc abuse to break out from restricted environments by spawning an interactive system shell.This
+activity is not standard use with this binary for a user or system administrator and could potentially indicate
+malicious actor attempting to improve the capabilities or stability of their access.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Linux Restricted Shell Breakout via the gcc command"
+references = ["https://gtfobins.github.io/gtfobins/gcc/"]
+risk_score = 47
+rule_id = "da986d2c-ffbf-4fd6-af96-a88dbf68f386"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion", "GTFOBins"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+sequence by host.id, process.pid with maxspan=1m
+[process where process.name == "gcc" and process.args == "-wrapper" and process.args : ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s")]
+[process where process.parent.name == "gcc" and process.name : ("bash", "sh", "dash")]
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1548"
+name = "Abuse Elevation Control Mechanism"
+reference = "https://attack.mitre.org/techniques/T1548/"
+[[rule.threat.technique.subtechnique]]
+id = "T1548.004"
+name = "Elevated Execution with Prompt"
+reference = "https://attack.mitre.org/techniques/T1548/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+


### PR DESCRIPTION
## Issues
https://github.com/elastic/detection-rules/issues/1821

## Summary
gcc, an IOC, the Unix binary can be abused to breakout out of restricted shells or environments by spawning an interactive system shell. This activity is not standard use with this binary for a user or system administrator. It indicates a potentially malicious actor attempting to improve the capabilities or stability of their access.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
