### PR TITLE
[Rule Tuning] Potential Process Injection via PowerShell

### DIFF
--- a/rules/windows/defense_evasion_posh_process_injection.toml
+++ b/rules/windows/defense_evasion_posh_process_injection.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/14"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/15"
 
 [rule]
 author = ["Elastic"]
@@ -83,7 +83,7 @@ event.category:process and
    (VirtualAlloc or VirtualAllocEx or VirtualProtect or LdrLoadDll or LoadLibrary or LoadLibraryA or
       LoadLibraryEx or GetProcAddress or OpenProcess or OpenProcessToken or AdjustTokenPrivileges) and
    (WriteProcessMemory or CreateRemoteThread or NtCreateThreadEx or CreateThread or QueueUserAPC or
-      SuspendThread or ResumeThread)
+      SuspendThread or ResumeThread or GetDelegateForFunctionPointer)
   )
 '''
 


### PR DESCRIPTION
## Summary

Adds GetDelegateForFunctionPointer function to second part of the query, making this detection efficient to detect some kinds of powershell loaders, examples:

* https://www.virustotal.com/gui/file/df38ec7ba3b397d66296fabd731e1f594df5afbdeda166fa6f499c0ae221ebb9
* https://www.virustotal.com/gui/file/2821056c9092ad3f2b4f273449353773204b7f2f23e0e6b39c2d20884eba8533