### PR TITLE
[Rule Deprecation] Deprecate PrintNightmare Rules

### DIFF
--- a/rules/_deprecated/privilege_escalation_printspooler_malicious_driver_file_changes.toml
+++ b/rules/_deprecated/privilege_escalation_printspooler_malicious_driver_file_changes.toml
@@ -1,7 +1,8 @@
 [metadata]
 creation_date = "2021/07/06"
-maturity = "production"
-updated_date = "2021/07/06"
+deprecation_date = "2022/03/16"
+maturity = "deprecated"
+updated_date = "2022/03/16"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/privilege_escalation_printspooler_malicious_registry_modification.toml
+++ b/rules/_deprecated/privilege_escalation_printspooler_malicious_registry_modification.toml
@@ -1,7 +1,8 @@
 [metadata]
 creation_date = "2021/07/06"
-maturity = "production"
-updated_date = "2022/02/14"
+deprecation_date = "2022/03/16"
+maturity = "deprecated"
+updated_date = "2022/03/16"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Summary

This PR deprecates two rules related to PrintNightmare, which are not effective anymore because they look for certain DLL names, which is a variable that the attacker controls.

After discussing with Samir possible tunings, we concluded that adding other DLL names to these rules will not make them stronger.

Rules Deprecated:

- Potential PrintNightmare File Modification
- Potential PrintNightmare Exploit Registry Modification