### PR TITLE
crash shell evasion threat

### DIFF
--- a/rules/linux/execution_crash_binary.toml
+++ b/rules/linux/execution_crash_binary.toml
@@ -1,0 +1,51 @@
+[metadata]
+creation_date = "2022/03/21"
+maturity = "production"
+updated_date = "2022/03/21"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies Linux binary crash abuse to break out from restricted environments by spawning an interactive system
+shell.The crash utility helps to analyze Linux crash dump data or a live system and the activity of spawing a shell is
+not a standard use of this binary by a user or system administrator. It indicates a potentially malicious actor
+attempting to improve the capabilities or stability of their access.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Linux Restricted Shell Breakout via crash Shell evasion"
+references = ["https://gtfobins.github.io/gtfobins/crash/"]
+risk_score = 47
+rule_id = "ee619805-54d7-4c56-ba6f-7717282ddd73"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+sequence by host.id, process.pid with maxspan=1m
+[process where event.type == "start" and process.name == "crash" and process.args : "-h"]
+[process where process.parent.name == "crash" and process.name : "sh"]
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+


### PR DESCRIPTION
## Issues
https://github.com/elastic/detection-rules/issues/1859

## Summary
crash an IOC, the Unix binary can be abused to breakout out of restricted shells or environments by spawning an interactive system shell. This activity is not standard use with this binary for a user or system administrator. It indicates a potentially malicious actor attempting to improve the capabilities or stability of their access.

The way the process tree works is: crash > sh > less > sh > whatever shell you invoked (sh, dash, bash). We cannot currently sequence that far down the process tree by PIDm but crash invoking sh is good enough for our purposes here since crash spawning sh isn't a standard use of the crash binary.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
