### PR TITLE
flock shell evasion threat

### DIFF
--- a/rules/linux/execution_flock_binary.toml
+++ b/rules/linux/execution_flock_binary.toml
@@ -26,7 +26,7 @@ type = "eql"
 
 query = '''
 sequence by host.id, process.pid with maxspan=1m
-[process where event.type == "start" and process.name == "flock" and process.args == "-u" and process.args=="/" and process.args:("/bin/sh","/bin/bash","/bin/dash","sh","bash","dash")]
+[process where event.type == "start" and process.name == "flock" and process.args == "-u" and process.args == "/" and process.args:("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash")]
 [process where process.parent.name : ("bash", "sh", "dash")]
 '''
 

--- a/rules/linux/execution_flock_binary.toml
+++ b/rules/linux/execution_flock_binary.toml
@@ -1,0 +1,51 @@
+[metadata]
+creation_date = "2022/03/22"
+maturity = "production"
+updated_date = "2022/03/22"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies Linux binary flock abuse to break out from restricted environments by spawning an interactive system
+shell.The flock utility allows us to manage advisory file locks in shell scripts or on the command line and the activity
+of spawing a shell is not a standard use of this binary by a user or system administrator. It indicates a potentially
+malicious actor attempting to improve the capabilities or stability of their access.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Linux Restricted Shell Breakout via flock Shell evasion"
+references = ["https://gtfobins.github.io/gtfobins/flock/"]
+risk_score = 47
+rule_id = "f52362cd-baf1-4b6d-84be-064efc826461"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+sequence by host.id, process.pid with maxspan=1m
+[process where event.type == "start" and process.name == "flock" and process.args == "-u" and process.args=="/" and process.args:("/bin/sh","/bin/bash","/bin/dash","sh","bash","dash")]
+[process where process.parent.name : ("bash", "sh", "dash")]
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/linux/execution_flock_binary.toml
+++ b/rules/linux/execution_flock_binary.toml
@@ -25,9 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where event.type == "start" and process.name == "flock" and process.args == "-u" and process.args=="/" and process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash")]
-[process where process.parent.name == "flock" and process.name in ("bash", "dash", "sh")]
+process where event.type == "start" and process.parent.name == "flock" and process.parent.args == "-u" and process.parent.args == "/" and process.parent.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and process.name in ("bash", "dash", "sh")
 '''
 
 

--- a/rules/linux/execution_flock_binary.toml
+++ b/rules/linux/execution_flock_binary.toml
@@ -26,8 +26,8 @@ type = "eql"
 
 query = '''
 sequence by host.id, process.pid with maxspan=1m
-[process where event.type == "start" and process.name == "flock" and process.args == "-u" and process.args == "/" and process.args:("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash")]
-[process where process.parent.name : ("bash", "sh", "dash")]
+[process where event.type == "start" and process.name == "flock" and process.args == "-u" and process.args=="/" and process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash")]
+[process where process.parent.name == "flock" and process.name in ("bash", "dash", "sh")]
 '''
 
 


### PR DESCRIPTION
## Issues
#1862 

## Summary
flock an IOC, the Unix binary can be abused to breakout out of restricted shells or environments by spawning an interactive system shell. This activity is not standard use with this binary for a user or system administrator. It indicates a potentially malicious actor attempting to improve the capabilities or stability of their access.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
