### PR TITLE
vim shell evasion threat

### DIFF
--- a/rules/linux/execution_vi_binary.toml
+++ b/rules/linux/execution_vi_binary.toml
@@ -25,7 +25,6 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id,process.pid with maxspan=1m
 [process where process.name in ("vi", "vim") and process.args == "-c" and process.args in (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh")]
 [process where process.parent.name in ("vi", "vim") and process.name in ("bash", "sh")]
 '''

--- a/rules/linux/execution_vi_binary.toml
+++ b/rules/linux/execution_vi_binary.toml
@@ -27,7 +27,7 @@ type = "eql"
 query = '''
 sequence by host.id,process.pid with maxspan=1m
 [process where process.name in ("vi", "vim") and process.args == "-c" and process.args in (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh")]
-[process where process.parent.name : ("vi", "vim") and process.name : ("bash", "sh")]
+[process where process.parent.name in ("vi", "vim") and process.name in ("bash", "sh")]
 '''
 
 

--- a/rules/linux/execution_vi_binary.toml
+++ b/rules/linux/execution_vi_binary.toml
@@ -26,7 +26,7 @@ type = "eql"
 
 query = '''
 sequence by host.id,process.pid with maxspan=1m
-[process where process.name : ("vi", "vim") and process.args : "-c" and process.args : (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh")]
+[process where process.name in ("vi", "vim") and process.args == "-c" and process.args in (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh")]
 [process where process.parent.name : ("vi", "vim") and process.name : ("bash", "sh")]
 '''
 

--- a/rules/linux/execution_vi_binary.toml
+++ b/rules/linux/execution_vi_binary.toml
@@ -1,14 +1,15 @@
 [metadata]
 creation_date = "2022/03/03"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/22"
 
 [rule]
 author = ["Elastic"]
 description = """
 Identifies Linux binary find abuse to break out from restricted environments by spawning an interactive system shell.
-This activity is not standard use with this binary for a user or system administrator and could potentially indicate
-malicious actor attempting to improve the capabilities or stability of their access."
+The vi/vim is the standard text editor in Linux distribution and the activity of spawning a shell is not a standard use
+of this binary by a user or system administrator and could potentially indicate malicious actor attempting to improve
+the capabilities or stability of their access."
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*"]
@@ -25,8 +26,8 @@ type = "eql"
 
 query = '''
 sequence by host.id,process.pid with maxspan=1m
-[process where process.name == "vi" and process.args : "-c" and process.args : (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh")]
-[process where process.parent.name == "vi" and process.name : ("bash", "sh")]
+[process where process.name : ("vi", "vim") and process.args : "-c" and process.args : (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh")]
+[process where process.parent.name : ("vi", "vim") and process.name : ("bash", "sh")]
 '''
 
 

--- a/rules/linux/execution_vi_binary.toml
+++ b/rules/linux/execution_vi_binary.toml
@@ -25,8 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-[process where process.name in ("vi", "vim") and process.args == "-c" and process.args in (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh")]
-[process where process.parent.name in ("vi", "vim") and process.name in ("bash", "sh")]
+process where event.type == "start" and process.parent.name in ("vi", "vim") and process.parent.args == "-c" and process.parent.args in (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh") and process.name in ("bash", "sh")
 '''
 
 


### PR DESCRIPTION
## Issues
https://github.com/elastic/detection-rules/issues/1864

## Summary
An existing threat identification already exists for vi binary. This issue adds the identification for vim.




## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
