### PR TITLE
1554 update eql schemas to fail validation on text fields

### DIFF
--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -98,6 +98,15 @@ class EQLValidator(QueryValidator):
                 trailer = err_trailer
                 if "Unknown field" in message and beat_types:
                     trailer = f"\nTry adding event.module or event.dataset to specify beats module\n\n{trailer}"
+                elif "Field not recognized" in message:
+                    unrecognized_fields = []
+                    for field in self.unique_fields:
+                        if field in eql_schema.kql_schema:
+                            unrecognized_fields.append(eql_schema.kql_schema[field])
+                    field_types = ', '.join(unrecognized_fields)
+                    query = exc.source.strip()
+                    if unrecognized_fields:
+                        trailer = f"Query `{query}` uses an unsupported elasticsearch eql field_type `{field_types}`"
 
                 raise exc.__class__(exc.error_msg, exc.line, exc.column, exc.source,
                                     len(exc.caret.lstrip()), trailer=trailer) from None

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -67,6 +67,12 @@ class EQLValidator(QueryValidator):
         with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions:
             return eql.parse_query(self.query)
 
+    def text_fields(self, eql_schema: ecs.KqlSchema2Eql) -> List[str]:
+        """Return a list of fields of type text."""
+        from kql.parser import elasticsearch_type_family
+
+        return [f for f in self.unique_fields if elasticsearch_type_family(eql_schema.kql_schema.get(f)) == 'text']
+
     @property
     def unique_fields(self) -> List[str]:
         return list(set(str(f) for f in self.ast if isinstance(f, eql.ast.Field)))
@@ -99,14 +105,10 @@ class EQLValidator(QueryValidator):
                 if "Unknown field" in message and beat_types:
                     trailer = f"\nTry adding event.module or event.dataset to specify beats module\n\n{trailer}"
                 elif "Field not recognized" in message:
-                    unrecognized_fields = []
-                    for field in self.unique_fields:
-                        if field in eql_schema.kql_schema:
-                            unrecognized_fields.append(eql_schema.kql_schema[field])
-                    field_types = ', '.join(unrecognized_fields)
-                    query = exc.source.strip()
-                    if unrecognized_fields:
-                        trailer = f"Query `{query}` uses an unsupported elasticsearch eql field_type `{field_types}`"
+                    text_fields = self.text_fields(eql_schema)
+                    if text_fields:
+                        fields_str = ', '.join(text_fields)
+                        trailer = f"\neql does not support text fields: {fields_str}\n\n{trailer}"
 
                 raise exc.__class__(exc.error_msg, exc.line, exc.column, exc.source,
                                     len(exc.caret.lstrip()), trailer=trailer) from None

--- a/kql/kql2eql.py
+++ b/kql/kql2eql.py
@@ -7,6 +7,8 @@ import eql
 
 from .parser import BaseKqlParser
 
+NOT_SUPPORTED_EQL_FIELDS = ["text"]
+
 
 class KqlToEQL(BaseKqlParser):
 
@@ -51,7 +53,12 @@ class KqlToEQL(BaseKqlParser):
 
         with self.scope(self.visit(field_tree)) as field_name:
             # check the field against the schema
-            self.get_field_type(field_name, field_tree)
+
+            type_mapping = self.get_field_type(field_name, field_tree)
+            if type_mapping in NOT_SUPPORTED_EQL_FIELDS:
+                err_msg = f"{field_name} with field_type {type_mapping} is not supported in eql"
+                raise eql.EqlSemanticError(err_msg, field_tree.line, field_tree.column, self.text)
+
             return self.visit(value_tree)
 
     def or_list_of_values(self, tree):

--- a/kql/kql2eql.py
+++ b/kql/kql2eql.py
@@ -8,7 +8,7 @@ import eql
 from .parser import BaseKqlParser
 
 NOT_SUPPORTED_EQL_FIELDS = ["text"]
-
+#  https://github.com/elastic/eql/issues/17
 
 class KqlToEQL(BaseKqlParser):
 
@@ -56,7 +56,7 @@ class KqlToEQL(BaseKqlParser):
 
             type_mapping = self.get_field_type(field_name, field_tree)
             if type_mapping in NOT_SUPPORTED_EQL_FIELDS:
-                err_msg = f"{field_name} with field_type {type_mapping} is not supported in eql"
+                err_msg = f"{field_name} uses an unsupported elasticsearch eql field_type {type_mapping}"
                 raise eql.EqlSemanticError(err_msg, field_tree.line, field_tree.column, self.text)
 
             return self.visit(value_tree)

--- a/rules/linux/execution_crash_binary.toml
+++ b/rules/linux/execution_crash_binary.toml
@@ -1,0 +1,51 @@
+[metadata]
+creation_date = "2022/03/21"
+maturity = "production"
+updated_date = "2022/03/21"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies Linux binary crash abuse to break out from restricted environments by spawning an interactive system
+shell.The crash utility helps to analyze Linux crash dump data or a live system and the activity of spawing a shell is
+not a standard use of this binary by a user or system administrator. It indicates a potentially malicious actor
+attempting to improve the capabilities or stability of their access.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Linux Restricted Shell Breakout via crash Shell evasion"
+references = ["https://gtfobins.github.io/gtfobins/crash/"]
+risk_score = 47
+rule_id = "ee619805-54d7-4c56-ba6f-7717282ddd73"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+sequence by host.id, process.pid with maxspan=1m
+[process where event.type == "start" and process.name == "crash" and process.args : "-h"]
+[process where process.parent.name == "crash" and process.name : "sh"]
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/tests/kuery/test_kql2eql.py
+++ b/tests/kuery/test_kql2eql.py
@@ -73,12 +73,16 @@ class TestKql2Eql(unittest.TestCase):
         self.validate("top.numF : 1", "top.numF == 1", schema=schema)
         self.validate("top.numF : \"1\"", "top.numF == 1", schema=schema)
         self.validate("top.keyword : 1", "top.keyword == '1'", schema=schema)
-        self.validate("top.text : \"hello\"", "top.text == 'hello'", schema=schema)
         self.validate("top.keyword : \"hello\"", "top.keyword == 'hello'", schema=schema)
-        self.validate("top.text : 1 ", "top.text == '1'", schema=schema)
         self.validate("dest:192.168.255.255", "dest == '192.168.255.255'", schema=schema)
         self.validate("dest:192.168.0.0/16", "cidrMatch(dest, '192.168.0.0/16')", schema=schema)
         self.validate("dest:\"192.168.0.0/16\"", "cidrMatch(dest, '192.168.0.0/16')", schema=schema)
+
+        with self.assertRaises(eql.EqlSemanticError):
+            self.validate("top.text : \"hello\"", "top.text == 'hello'", schema=schema)
+
+        with self.assertRaises(eql.EqlSemanticError):
+            self.validate("top.text : 1 ", "top.text == '1'", schema=schema)
 
         with self.assertRaisesRegex(kql.KqlParseError, r"Value doesn't match top.middle's type: nested"):
             kql.to_eql("top.middle : 1", schema=schema)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -208,6 +208,18 @@ class TestSchemas(unittest.TestCase):
             process where process.name == "cmd.exe"
         """)
 
+        example_text_fields = ['client.as.organization.name.text', 'client.user.full_name.text',
+                               'client.user.name.text', 'destination.as.organization.name.text',
+                               'destination.user.full_name.text', 'destination.user.name.text',
+                               'error.message', 'error.stack_trace.text', 'file.path.text',
+                               'file.target_path.text', 'host.os.full.text', 'host.os.name.text',
+                               'host.user.full_name.text', 'host.user.name.text']
+        for text_field in example_text_fields:
+            with self.assertRaises(eql.parser.EqlSchemaError):
+                build_rule(f"""
+                        any where {text_field} == "some string field"
+                """)
+
         with self.assertRaises(eql.EqlSyntaxError):
             build_rule("""
                     process where process.name == this!is$not#v@lid


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #1554 

## Summary
Adds test cases to ensure `text` fields fail on eql schema validation and conversion from kql to eql.

