### PR TITLE
Linux Shell Evasion Rule Tuning

### DIFF
--- a/rules/linux/execution_apt_binary.toml
+++ b/rules/linux/execution_apt_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog" and process.name == "sensible-pager" and process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and process.parent.name in ("apt", "apt-get")
+process where event.type == "start" and process.name == "sensible-pager" and 
+  process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and 
+  process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog"
 '''
 
 

--- a/rules/linux/execution_apt_binary.toml
+++ b/rules/linux/execution_apt_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/24"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,10 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m 
-  [process where process.name : ("apt", "apt-get") and process.args : "changelog"] 
-  [process where process.name : "sensible-pager" and process.args : ("/bin/sh", "/bin/bash") and 
-   process.parent.name : ("apt", "apt-get")]
+process where event.type == "start" and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog" and process.name == "sensible-pager" and process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and process.parent.name in ("apt", "apt-get")
 '''
 
 

--- a/rules/linux/execution_apt_binary.toml
+++ b/rules/linux/execution_apt_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name == "sensible-pager" and process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog"
+process where event.type == "start" and process.name == "sensible-pager" and 
+  process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and 
+  process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog"
 '''
 
 

--- a/rules/linux/execution_apt_binary.toml
+++ b/rules/linux/execution_apt_binary.toml
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name == "sensible-pager" and 
-  process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and 
-  process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog"
+process where event.type == "start" and process.name == "sensible-pager" and process.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog"
 '''
 
 

--- a/rules/linux/execution_awk_binary_shell.toml
+++ b/rules/linux/execution_awk_binary_shell.toml
@@ -24,8 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("sh", "bash", "dash") and
-  process.parent.name in ("nawk", "mawk", "awk", "gawk") and process.parent.args : "BEGIN {system(*)}"
+process where event.type == "start" and process.name in ("sh", "bash", "dash") and process.parent.name in ("nawk", "mawk", "awk", "gawk") and process.parent.args : "BEGIN {system(*)}"
 '''
 
 

--- a/rules/linux/execution_awk_binary_shell.toml
+++ b/rules/linux/execution_awk_binary_shell.toml
@@ -24,7 +24,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.parent.name in ("nawk", "mawk", "awk", "gawk") and process.parent.args : "BEGIN {system(*)}" and process.name in ("sh", "bash", "dash")
+process where event.type == "start" and process.name in ("sh", "bash", "dash") and
+  process.parent.name in ("nawk", "mawk", "awk", "gawk") and process.parent.args : "BEGIN {system(*)}"
 '''
 
 

--- a/rules/linux/execution_awk_binary_shell.toml
+++ b/rules/linux/execution_awk_binary_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/24"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m 
-  [process where process.name : ("nawk", "mawk", "awk", "gawk") and process.args : "BEGIN {system(*)}"] 
-  [process where process.parent.name : ("nawk", "mawk", "awk", "gawk") and process.name : ("sh", "bash")]
+process where event.type == "start" and process.parent.name in ("nawk", "mawk", "awk", "gawk") and process.parent.args : "BEGIN {system(*)}" and process.name in ("sh", "bash", "dash")
 '''
 
 

--- a/rules/linux/execution_awk_binary_shell.toml
+++ b/rules/linux/execution_awk_binary_shell.toml
@@ -24,7 +24,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("sh", "bash", "dash") and process.parent.name in ("nawk", "mawk", "awk", "gawk") and process.parent.args : "BEGIN {system(*)}"
+process where event.type == "start" and process.name in ("sh", "bash", "dash") and 
+  process.parent.name in ("nawk", "mawk", "awk", "gawk") and process.parent.args : "BEGIN {system(*)}"
 '''
 
 

--- a/rules/linux/execution_busybox_binary.toml
+++ b/rules/linux/execution_busybox_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/15"
 maturity = "production"
-updated_date = "2022/03/15"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name : "busybox" and process.args_count == 2 and process.args : ("/bin/sh", "/bin/ash", "sh", "ash")
+process where event.type == "start" and process.name == "busybox" and process.args_count == 2 and process.args in ("/bin/sh", "/bin/ash", "sh", "ash")
 '''
 
 

--- a/rules/linux/execution_c89_c99_binary.toml
+++ b/rules/linux/execution_c89_c99_binary.toml
@@ -25,7 +25,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("sh", "dash", "bash") and process.parent.name == "gcc" and process.parent.args == "-wrapper" and process.parent.args in ("-std=c99", "-std=c89") and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") 
+process where event.type == "start" and process.name in ("sh", "dash", "bash") and 
+  process.parent.name in ("c89","c99") and process.parent.args == "-wrapper" and 
+  process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") 
 '''
 
 

--- a/rules/linux/execution_c89_c99_binary.toml
+++ b/rules/linux/execution_c89_c99_binary.toml
@@ -25,7 +25,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.parent.name == "gcc" and process.parent.args in ("-std=c99", "-std=c89") and process.parent.args == "-wrapper" and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") and process.name in ("sh", "dash", "bash")
+process where event.type == "start" and process.name in ("sh", "dash", "bash") and 
+  process.parent.name == "gcc" and 
+  process.parent.args == "-wrapper" and process.parent.args in ("-std=c99", "-std=c89") and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") 
 '''
 
 

--- a/rules/linux/execution_c89_c99_binary.toml
+++ b/rules/linux/execution_c89_c99_binary.toml
@@ -25,9 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("sh", "dash", "bash") and 
-  process.parent.name == "gcc" and 
-  process.parent.args == "-wrapper" and process.parent.args in ("-std=c99", "-std=c89") and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") 
+process where event.type == "start" and process.name in ("sh", "dash", "bash") and process.parent.name == "gcc" and process.parent.args == "-wrapper" and process.parent.args in ("-std=c99", "-std=c89") and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") 
 '''
 
 

--- a/rules/linux/execution_c89_c99_binary.toml
+++ b/rules/linux/execution_c89_c99_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/15"
 maturity = "production"
-updated_date = "2022/03/15"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -25,9 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where process.name :("c89","c99") and process.args == "-wrapper" and process.args : ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s")]
-[process where process.parent.name : ("bash", "sh", "dash")]
+process where event.type == "start" and process.parent.name == "gcc" and process.parent.args in ("-std=c99", "-std=c89") and process.parent.args == "-wrapper" and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") and process.name in ("sh", "dash", "bash")
 '''
 
 

--- a/rules/linux/execution_cpulimit_binary.toml
+++ b/rules/linux/execution_cpulimit_binary.toml
@@ -26,7 +26,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.parent.name == "cpulimit" and process.parent.args == "-f" and process.parent.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and process.name : ("bash", "sh", "dash")
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
+  process.parent.name == "cpulimit" and process.parent.args == "-f" and process.parent.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") 
 '''
 
 

--- a/rules/linux/execution_cpulimit_binary.toml
+++ b/rules/linux/execution_cpulimit_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/17"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -26,9 +26,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where event.type == "start" and process.name == "cpulimit" and process.args == "-f" and process.args : ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash")]
-[process where process.parent.name == "cpulimit" and process.name : ("bash", "sh", "dash")]
+process where event.type == "start" and process.parent.name == "cpulimit" and process.parent.args == "-f" and process.parent.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") and process.name : ("bash", "sh", "dash")
 '''
 
 

--- a/rules/linux/execution_cpulimit_binary.toml
+++ b/rules/linux/execution_cpulimit_binary.toml
@@ -26,7 +26,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh", "dash") and process.parent.name == "cpulimit" and process.parent.args == "-f" and process.parent.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") 
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
+  process.parent.name == "cpulimit" and process.parent.args == "-f" and 
+  process.parent.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") 
 '''
 
 

--- a/rules/linux/execution_cpulimit_binary.toml
+++ b/rules/linux/execution_cpulimit_binary.toml
@@ -26,8 +26,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
-  process.parent.name == "cpulimit" and process.parent.args == "-f" and process.parent.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") 
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and process.parent.name == "cpulimit" and process.parent.args == "-f" and process.parent.args in ("/bin/sh", "/bin/bash", "/bin/dash", "sh", "bash", "dash") 
 '''
 
 

--- a/rules/linux/execution_crash_binary.toml
+++ b/rules/linux/execution_crash_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/21"
 maturity = "production"
-updated_date = "2022/03/21"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -25,9 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where event.type == "start" and process.name == "crash" and process.args : "-h"]
-[process where process.parent.name == "crash" and process.name : "sh"]
+process where event.type == "start" and process.parent.name == "crash" and process.parent.args == "-h" and process.name == "sh"
 '''
 
 

--- a/rules/linux/execution_expect_binary.toml
+++ b/rules/linux/execution_expect_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args in ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact","spawn bash;interact", "spawn dash;interact") and process.name : ("bash", "sh", "dash")
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
+  process.parent.name == "expect" and process.parent.args == "-c" and 
+  process.parent.args in ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact", "spawn bash;interact", "spawn dash;interact") 
 '''
 
 

--- a/rules/linux/execution_expect_binary.toml
+++ b/rules/linux/execution_expect_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/07"
 maturity = "development"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m 
-[process where process.name == "expect" and process.args : "-c" and process.args : ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact","spawn bash;interact", "spawn dash;interact")] 
-[process where process.parent.name == "expect" and process.name : ("bash", "sh", "dash")]
+process where event.type == "start" and process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args in ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact","spawn bash;interact", "spawn dash;interact") and process.name : ("bash", "sh", "dash")
 '''
 
 

--- a/rules/linux/execution_expect_binary.toml
+++ b/rules/linux/execution_expect_binary.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2022/03/07"
-maturity = "development"
+maturity = "production"
 updated_date = "2022/03/24"
 
 [rule]

--- a/rules/linux/execution_expect_binary.toml
+++ b/rules/linux/execution_expect_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh", "dash") and process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args in ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact", "spawn bash;interact", "spawn dash;interact") 
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
+  process.parent.name == "expect" and process.parent.args == "-c" and 
+  process.parent.args in ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact", "spawn bash;interact", "spawn dash;interact") 
 '''
 
 

--- a/rules/linux/execution_expect_binary.toml
+++ b/rules/linux/execution_expect_binary.toml
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
-  process.parent.name == "expect" and process.parent.args == "-c" and 
-  process.parent.args in ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact", "spawn bash;interact", "spawn dash;interact") 
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args in ("spawn /bin/sh;interact", "spawn /bin/bash;interact", "spawn /bin/dash;interact", "spawn sh;interact", "spawn bash;interact", "spawn dash;interact") 
 '''
 
 

--- a/rules/linux/execution_find_binary.toml
+++ b/rules/linux/execution_find_binary.toml
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh") and 
-  process.parent.name == "find" and process.parent.args == "-exec" and process.parent.args == ";" and 
-  process.parent.args in ("/bin/bash", "/bin/sh", "bash", "sh")
+process where event.type == "start" and process.name in ("bash", "sh") and process.parent.name == "find" and process.parent.args == "-exec" and process.parent.args == ";" and process.parent.args in ("/bin/bash", "/bin/sh", "bash", "sh")
 '''
 
 

--- a/rules/linux/execution_find_binary.toml
+++ b/rules/linux/execution_find_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh") and process.parent.name == "find" and process.parent.args == "-exec" and process.parent.args == ";" and process.parent.args in ("/bin/bash", "/bin/sh", "bash", "sh")
+process where event.type == "start" and process.name in ("bash", "sh") and 
+  process.parent.name == "find" and process.parent.args == "-exec" and 
+  process.parent.args == ";" and process.parent.args in ("/bin/bash", "/bin/sh", "bash", "sh")
 '''
 
 

--- a/rules/linux/execution_find_binary.toml
+++ b/rules/linux/execution_find_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/28"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where process.name == "find" and process.args : "-exec" and process.args : ("/bin/bash", "/bin/sh", "bash", "sh") and process.args : ";"]
-[process where process.parent.name == "find" and process.name : ("bash", "sh")]
+process where event.type == "start" and process.parent.name == "find" and process.parent.args == "-exec" and process.parent.args in ("/bin/bash", "/bin/sh", "bash", "sh") and process.parent.args == ";" and process.name : ("bash", "sh")
 '''
 
 

--- a/rules/linux/execution_find_binary.toml
+++ b/rules/linux/execution_find_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.parent.name == "find" and process.parent.args == "-exec" and process.parent.args in ("/bin/bash", "/bin/sh", "bash", "sh") and process.parent.args == ";" and process.name : ("bash", "sh")
+process where event.type == "start" and process.name in ("bash", "sh") and 
+  process.parent.name == "find" and process.parent.args == "-exec" and process.parent.args == ";" and 
+  process.parent.args in ("/bin/bash", "/bin/sh", "bash", "sh")
 '''
 
 

--- a/rules/linux/execution_gcc_binary.toml
+++ b/rules/linux/execution_gcc_binary.toml
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("sh", "dash", "bash")  and
-  process.parent.name == "gcc" and process.parent.args == "-wrapper" and 
-  process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s")
+process where event.type == "start" and process.name in ("sh", "dash", "bash")  and process.parent.name == "gcc" and process.parent.args == "-wrapper" and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s")
 '''
 
 

--- a/rules/linux/execution_gcc_binary.toml
+++ b/rules/linux/execution_gcc_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/09"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where process.name == "gcc" and process.args == "-wrapper" and process.args : ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s")]
-[process where process.parent.name == "gcc" and process.name : ("bash", "sh", "dash")]
+process where event.type == "start" and process.parent.name == "gcc" and process.parent.args == "-wrapper" and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") and process.name in ("sh", "dash", "bash") and not process.parent.args in ("-std=c99", "-std=c89")
 '''
 
 

--- a/rules/linux/execution_gcc_binary.toml
+++ b/rules/linux/execution_gcc_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("sh", "dash", "bash")  and process.parent.name == "gcc" and process.parent.args == "-wrapper" and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s")
+process where event.type == "start" and process.name in ("sh", "dash", "bash")  and 
+  process.parent.name == "gcc" and process.parent.args == "-wrapper" and 
+  process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s")
 '''
 
 

--- a/rules/linux/execution_gcc_binary.toml
+++ b/rules/linux/execution_gcc_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.parent.name == "gcc" and process.parent.args == "-wrapper" and process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s") and process.name in ("sh", "dash", "bash") and not process.parent.args in ("-std=c99", "-std=c89")
+process where event.type == "start" and process.name in ("sh", "dash", "bash")  and
+  process.parent.name == "gcc" and process.parent.args == "-wrapper" and 
+  process.parent.args in ("sh,-s", "bash,-s", "dash,-s", "/bin/sh,-s", "/bin/bash,-s", "/bin/dash,-s")
 '''
 
 

--- a/rules/linux/execution_mysql_binary.toml
+++ b/rules/linux/execution_mysql_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh", "dash") and process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : ("\\!*sh", "\\!*bash", "\\!*dash", "\\!*/bin/sh", "\\!*/bin/bash", "\\!*/bin/dash") 
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
+  process.parent.name == "mysql" and process.parent.args == "-e" and 
+  process.parent.args : ("\\!*sh", "\\!*bash", "\\!*dash", "\\!*/bin/sh", "\\!*/bin/bash", "\\!*/bin/dash") 
 '''
 
 

--- a/rules/linux/execution_mysql_binary.toml
+++ b/rules/linux/execution_mysql_binary.toml
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
-  process.parent.name == "mysql" and process.parent.args == "-e" and 
-  process.parent.args : ("\\!*sh", "\\!*bash", "\\!*dash", "\\!*/bin/sh", "\\!*/bin/bash", "\\!*/bin/dash") 
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : ("\\!*sh", "\\!*bash", "\\!*dash", "\\!*/bin/sh", "\\!*/bin/bash", "\\!*/bin/dash") 
 '''
 
 

--- a/rules/linux/execution_mysql_binary.toml
+++ b/rules/linux/execution_mysql_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : ("\\!*sh", "\\!*bash", "\\!*dash", "\\!*/bin/sh", "\\!*/bin/bash", "\\!*/bin/dash") and process.name in ("bash", "sh", "dash")
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
+  process.parent.name == "mysql" and process.parent.args == "-e" and 
+  process.parent.args : ("\\!*sh", "\\!*bash", "\\!*dash", "\\!*/bin/sh", "\\!*/bin/bash", "\\!*/bin/dash") 
 '''
 
 

--- a/rules/linux/execution_mysql_binary.toml
+++ b/rules/linux/execution_mysql_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/09"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where process.name == "mysql" and process.args == "-e" and process.args : ("\\!*sh", "\\!*bash", "\\!*dash", "\\!*/bin/sh", "\\!*/bin/bash", "\\!*/bin/dash")]
-[process where process.parent.name == "mysql" and process.name : ("bash", "sh", "dash")]
+process where event.type == "start" and process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : ("\\!*sh", "\\!*bash", "\\!*dash", "\\!*/bin/sh", "\\!*/bin/bash", "\\!*/bin/dash") and process.name in ("bash", "sh", "dash")
 '''
 
 

--- a/rules/linux/execution_nice_binary.toml
+++ b/rules/linux/execution_nice_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/07"
 maturity = "development"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where event.type == "start" and process.name == "nice" and process.args : ("/bin/bash", "/bin/sh", "/bin/dash", "sh", "bash", "dash")]
-[process where process.name : ("bash", "sh", "dash")]
+sequence with maxspan=30s
+[process where event.type == "start" and process.name == "nice" and process.args in ("/bin/bash", "/bin/sh", "/bin/dash", "sh", "bash", "dash")] by process.entity_id
+[process where process.name in ("bash", "sh", "dash")] by process.parent.entity_id
 '''
 
 

--- a/rules/linux/execution_nice_binary.toml
+++ b/rules/linux/execution_nice_binary.toml
@@ -24,9 +24,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence with maxspan=30s
-[process where event.type == "start" and process.name == "nice" and process.args in ("/bin/bash", "/bin/sh", "/bin/dash", "sh", "bash", "dash")] by process.entity_id
-[process where process.name in ("bash", "sh", "dash")] by process.parent.entity_id
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and
+  process.parent.name == "nice" and process.parent.args in ("/bin/bash", "/bin/sh", "/bin/dash", "sh", "bash", "dash")
 '''
 
 

--- a/rules/linux/execution_nice_binary.toml
+++ b/rules/linux/execution_nice_binary.toml
@@ -24,8 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh", "dash") and
-  process.parent.name == "nice" and process.parent.args in ("/bin/bash", "/bin/sh", "/bin/dash", "sh", "bash", "dash")
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and process.parent.name == "nice" and process.parent.args in ("/bin/bash", "/bin/sh", "/bin/dash", "sh", "bash", "dash")
 '''
 
 

--- a/rules/linux/execution_nice_binary.toml
+++ b/rules/linux/execution_nice_binary.toml
@@ -24,7 +24,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name in ("bash", "sh", "dash") and process.parent.name == "nice" and process.parent.args in ("/bin/bash", "/bin/sh", "/bin/dash", "sh", "bash", "dash")
+process where event.type == "start" and process.name in ("bash", "sh", "dash") and 
+  process.parent.name == "nice" and process.parent.args in ("/bin/bash", "/bin/sh", "/bin/dash", "sh", "bash", "dash")
 '''
 
 

--- a/rules/linux/execution_perl_tty_shell.toml
+++ b/rules/linux/execution_perl_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/16"
 maturity = "production"
-updated_date = "2021/03/24"
+updated_date = "2021/03/03"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ interactive tty after obtaining initial access to a host.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
-language = "eql"
+language = "kuery"
 license = "Elastic License v2"
 name = "Interactive Terminal Spawned via Perl"
 risk_score = 73
@@ -19,12 +19,11 @@ rule_id = "05e5a668-7b51-4a67-93ab-e9af405c9ef3"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "eql"
+type = "query"
 
 query = '''
-sequence with maxspan=30s 
-[process where event.type == "start" and process.name == "perl" and process.args == "-e"] by process.entity_id
-[process where event.type == "start" and process.name in ("dash", "bash", "sh")] by process.parent.entity_id
+event.category:process and event.type:(start or process_started) and process.name:perl and
+  process.args:("exec \"/bin/sh\";" or "exec \"/bin/dash\";" or "exec \"/bin/bash\";")
 '''
 
 
@@ -40,4 +39,3 @@ reference = "https://attack.mitre.org/techniques/T1059/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
-

--- a/rules/linux/execution_perl_tty_shell.toml
+++ b/rules/linux/execution_perl_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/16"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ interactive tty after obtaining initial access to a host.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Interactive Terminal Spawned via Perl"
 risk_score = 73
@@ -19,11 +19,12 @@ rule_id = "05e5a668-7b51-4a67-93ab-e9af405c9ef3"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:perl and
-  process.args:("exec \"/bin/sh\";" or "exec \"/bin/dash\";" or "exec \"/bin/bash\";")
+sequence with maxspan=30s 
+[process where event.type == "start" and process.name == "perl" and process.args == "-e"] by process.entity_id
+[process where event.type == "start" and process.name in ("dash", "bash", "sh")] by process.parent.entity_id
 '''
 
 

--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/15"
 maturity = "production"
-updated_date = "2021/03/24"
+updated_date = "2021/03/03"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ interactive tty after obtaining initial access to a host.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
-language = "eql"
+language = "kuery"
 license = "Elastic License v2"
 name = "Interactive Terminal Spawned via Python"
 risk_score = 73
@@ -19,10 +19,13 @@ rule_id = "d76b02ef-fc95-4001-9297-01cb7412232f"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "eql"
+type = "query"
 
 query = '''
-process where event.type == "start" and process.parent.name : "python*" and process.parent.args == "-c" and process.name in ("bash", "dash", "sh")
+event.category:process and event.type:(start or process_started) and process.name:python and
+  process.args:("import pty; pty.spawn(\"/bin/sh\")" or
+                "import pty; pty.spawn(\"/bin/dash\")" or
+                "import pty; pty.spawn(\"/bin/bash\")")
 '''
 
 
@@ -38,4 +41,3 @@ reference = "https://attack.mitre.org/techniques/T1059/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
-

--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -11,7 +11,7 @@ interactive tty after obtaining initial access to a host.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Interactive Terminal Spawned via Python"
 risk_score = 73
@@ -19,7 +19,7 @@ rule_id = "d76b02ef-fc95-4001-9297-01cb7412232f"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
 process where event.type == "start" and process.parent.name : "python*" and process.parent.args == "-c" and process.name in ("bash", "dash", "sh")

--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/15"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2021/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -22,10 +22,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and event.type:(start or process_started) and process.name:python and
-  process.args:("import pty; pty.spawn(\"/bin/sh\")" or
-                "import pty; pty.spawn(\"/bin/dash\")" or
-                "import pty; pty.spawn(\"/bin/bash\")")
+process where event.type == "start" and process.parent.name : "python*" and process.parent.args == "-c" and process.name in ("bash", "dash", "sh")
 '''
 
 

--- a/rules/linux/execution_ssh_binary.toml
+++ b/rules/linux/execution_ssh_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name : ("bash", "sh", "dash") and process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args in ("ProxyCommand=;sh 0<&2 1>&2", "ProxyCommand=;bash 0<&2 1>&2", "ProxyCommand=;dash 0<&2 1>&2", "ProxyCommand=;/bin/sh 0<&2 1>&2", "ProxyCommand=;/bin/bash 0<&2 1>&2", "ProxyCommand=;/bin/dash 0<&2 1>&2")
+process where event.type == "start" and process.name : ("bash", "sh", "dash") and 
+  process.parent.name == "ssh" and process.parent.args == "-o" and 
+  process.parent.args in ("ProxyCommand=;sh 0<&2 1>&2", "ProxyCommand=;bash 0<&2 1>&2", "ProxyCommand=;dash 0<&2 1>&2", "ProxyCommand=;/bin/sh 0<&2 1>&2", "ProxyCommand=;/bin/bash 0<&2 1>&2", "ProxyCommand=;/bin/dash 0<&2 1>&2")
 '''
 
 

--- a/rules/linux/execution_ssh_binary.toml
+++ b/rules/linux/execution_ssh_binary.toml
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name : ("bash", "sh", "dash") and
-  process.parent.name == "ssh" and process.parent.args == "-o" and 
-  process.parent.args in ("ProxyCommand=;sh 0<&2 1>&2", "ProxyCommand=;bash 0<&2 1>&2", "ProxyCommand=;dash 0<&2 1>&2", "ProxyCommand=;/bin/sh 0<&2 1>&2", "ProxyCommand=;/bin/bash 0<&2 1>&2", "ProxyCommand=;/bin/dash 0<&2 1>&2")
+process where event.type == "start" and process.name : ("bash", "sh", "dash") and process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args in ("ProxyCommand=;sh 0<&2 1>&2", "ProxyCommand=;bash 0<&2 1>&2", "ProxyCommand=;dash 0<&2 1>&2", "ProxyCommand=;/bin/sh 0<&2 1>&2", "ProxyCommand=;/bin/bash 0<&2 1>&2", "ProxyCommand=;/bin/dash 0<&2 1>&2")
 '''
 
 

--- a/rules/linux/execution_ssh_binary.toml
+++ b/rules/linux/execution_ssh_binary.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args in ("ProxyCommand=;sh 0<&2 1>&2", "ProxyCommand=;bash 0<&2 1>&2", "ProxyCommand=;dash 0<&2 1>&2", "ProxyCommand=;/bin/sh 0<&2 1>&2", "ProxyCommand=;/bin/bash 0<&2 1>&2", "ProxyCommand=;/bin/dash 0<&2 1>&2") and process.name : ("bash", "sh", "dash")
+process where event.type == "start" and process.name : ("bash", "sh", "dash") and
+  process.parent.name == "ssh" and process.parent.args == "-o" and 
+  process.parent.args in ("ProxyCommand=;sh 0<&2 1>&2", "ProxyCommand=;bash 0<&2 1>&2", "ProxyCommand=;dash 0<&2 1>&2", "ProxyCommand=;/bin/sh 0<&2 1>&2", "ProxyCommand=;/bin/bash 0<&2 1>&2", "ProxyCommand=;/bin/dash 0<&2 1>&2")
 '''
 
 

--- a/rules/linux/execution_ssh_binary.toml
+++ b/rules/linux/execution_ssh_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/10"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id, process.pid with maxspan=1m
-[process where process.name == "ssh" and process.args == "-o" and process.args : ("ProxyCommand=;sh*", "ProxyCommand=;bash*", "ProxyCommand=;dash*", "ProxyCommand=;/bin/sh*", "ProxyCommand=;/bin/bash*", "ProxyCommand=;/bin/dash*")]
-[process where process.parent.name == "ssh" and process.name : ("bash", "sh", "dash")]
+process where process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args in ("ProxyCommand=;sh 0<&2 1>&2", "ProxyCommand=;bash 0<&2 1>&2", "ProxyCommand=;dash 0<&2 1>&2", "ProxyCommand=;/bin/sh 0<&2 1>&2", "ProxyCommand=;/bin/bash 0<&2 1>&2", "ProxyCommand=;/bin/dash 0<&2 1>&2") and process.name : ("bash", "sh", "dash")
 '''
 
 

--- a/rules/linux/execution_vi_binary.toml
+++ b/rules/linux/execution_vi_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/03"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/24"
 
 [rule]
 author = ["Elastic"]
@@ -24,9 +24,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence by host.id,process.pid with maxspan=1m
-[process where process.name == "vi" and process.args : "-c" and process.args : (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh")]
-[process where process.parent.name == "vi" and process.name : ("bash", "sh")]
+process where process.parent.name == "vi" and process.parent.args == "-c" and process.parent.args in (":!/bin/bash", ":!/bin/sh", ":!bash", ":!sh") and process.name : ("bash", "sh")
 '''
 
 


### PR DESCRIPTION
## Summary

Tuning these shell evasion rules to increase accuracy and performance by taking multi match selections from ":" to "in", taking single match selection from ":" to "==" and by removing sequencing where possible and using entity_id to sequence where necessary. Each of these rules has been tested and validated to ensure they work as expected. 

