### PR TITLE
[Bug] Add type to deprecated rules in version.lock

### DIFF
--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -135,6 +135,7 @@
   "08d5d7e2-740f-44d8-aeda-e41f4263efaf": {
     "rule_name": "TCP Port 8000 Activity to the Internet",
     "sha256": "d0c6cdede82a9cafacef49dcd6afc1b13383214401be7fbaa3b09ae1fbe9a3fb",
+    "type": "query",
     "version": 8
   },
   "092b068f-84ac-485d-8a55-7dd9e006715f": {
@@ -219,6 +220,7 @@
   "0f616aee-8161-4120-857e-742366f5eeb3": {
     "rule_name": "PowerShell spawning Cmd",
     "sha256": "02b0c2f928a762f61da9b493780d5fe36255c5565093c0d59db3776340a7b2be",
+    "type": "query",
     "version": 8
   },
   "0f93cb9a-1931-48c2-8cd0-f173fd3e5283": {
@@ -267,6 +269,7 @@
   "119c8877-8613-416d-a98a-96b6664ee73a5": {
     "rule_name": "AWS RDS Snapshot Export",
     "sha256": "dc07a6005a4da8eea9b23185abaf24f9db9fbe2271e4c8ddc3f39f020a9ea3d0",
+    "type": "query",
     "version": 2
   },
   "11ea6bec-ebde-4d71-a8e9-784948f8e3e9": {
@@ -284,6 +287,7 @@
   "120559c6-5e24-49f4-9e30-8ffe697df6b9": {
     "rule_name": "User Discovery via Whoami",
     "sha256": "226bffc8f05628ba3e39c84344b42aff68d3c0a8ad10612929d4cb704d902d3e",
+    "type": "query",
     "version": 7
   },
   "125417b8-d3df-479f-8418-12d7e034fee3": {
@@ -314,6 +318,7 @@
   "139c7458-566a-410c-a5cd-f80238d6a5cd": {
     "rule_name": "SQL Traffic to the Internet",
     "sha256": "26fce2242bdb3d7341ec772772151eae5dfe28e3f14a60bbe586e0d5d5842ad7",
+    "type": "query",
     "version": 8
   },
   "141e9b3a-ff37-4756-989d-05d7cbf35b0e": {
@@ -968,6 +973,7 @@
   "3a86e085-094c-412d-97ff-2439731e59cb": {
     "rule_name": "Setgid Bit Set via chmod",
     "sha256": "8a227c09d80f4787ecef3e02690f51fd836b29aafcd6b210d859c4cd51203941",
+    "type": "query",
     "version": 6
   },
   "3ad49c61-7adc-42c1-b788-732eda2f5abf": {
@@ -1130,6 +1136,7 @@
   "47f09343-8d1f-4bb5-8bb0-00c9d18f5010": {
     "rule_name": "Execution via Regsvcs/Regasm",
     "sha256": "fa283dded0764ed89000be343cbbb926c659d742d2cf19d15ad5c5680a096578",
+    "type": "query",
     "version": 7
   },
   "47f76567-d58a-4fed-b32b-21f571e28910": {
@@ -1538,6 +1545,7 @@
   "61c31c14-507f-4627-8c31-072556b89a9c": {
     "rule_name": "Mknod Process Activity",
     "sha256": "9070708b87661e05dc8b0275151d9c928fbf29feacc6b771a10e56eea2ff82ea",
+    "type": "query",
     "version": 7
   },
   "622ecb68-fa81-4601-90b5-f8cd661e4520": {
@@ -1615,11 +1623,13 @@
   "67a9beba-830d-4035-bfe8-40b7e28f8ac4": {
     "rule_name": "SMTP to the Internet",
     "sha256": "38ddd772b9bc49726619cf527ed48d8871a0611ca88d76d03054c6702456d14d",
+    "type": "query",
     "version": 8
   },
   "68113fdc-3105-4cdd-85bb-e643c416ef0b": {
     "rule_name": "Query Registry via reg.exe",
     "sha256": "5752b998b95537fedce81850330b693ee3cb9f030b36bf07dba1da9107bd68d9",
+    "type": "eql",
     "version": 3
   },
   "6839c821-011d-43bd-bd5b-acff00257226": {
@@ -1768,6 +1778,7 @@
   "6f1500bc-62d7-4eb9-8601-7485e87da2f4": {
     "rule_name": "SSH (Secure Shell) to the Internet",
     "sha256": "ccd5c6ae27b2cc637f6bbb39e5d6b025d56dc2c81975d697ada670a54ce65ef5",
+    "type": "query",
     "version": 8
   },
   "6f435062-b7fc-4af9-acea-5b1ead65c5a5": {
@@ -1948,6 +1959,7 @@
   "7a137d76-ce3d-48e2-947d-2747796a78c0": {
     "rule_name": "Network Sniffing via Tcpdump",
     "sha256": "a1d61d8865b525e77420ddd2744a088b6776dae60edb6673253cd1aeba1fd426",
+    "type": "query",
     "version": 7
   },
   "7b08314d-47a0-4b71-ae4e-16544176924f": {
@@ -1983,6 +1995,7 @@
   "7d2c38d7-ede7-4bdf-b140-445906e6c540": {
     "rule_name": "Tor Activity to the Internet",
     "sha256": "a795f581489be91fab79b53ab0afee754fd43c0655cde52c08dd70983c606cb1",
+    "type": "query",
     "version": 8
   },
   "7f370d54-c0eb-4270-ac5a-9a6020585dc6": {
@@ -2012,6 +2025,7 @@
   "81cc58f5-8062-49a2-ba84-5cc4b4d31c40": {
     "rule_name": "Persistence via Kernel Module Modification",
     "sha256": "6d2938fb1e03fb76895197f4565a860e7c346b8cba3ac5bc612938f6af910d86",
+    "type": "query",
     "version": 8
   },
   "81fe9dc6-a2d7-4192-a2d8-eed98afc766a": {
@@ -2078,6 +2092,7 @@
   "87ec6396-9ac4-4706-bcf0-2ebb22002f43": {
     "rule_name": "FTP (File Transfer Protocol) Activity to the Internet",
     "sha256": "b6ea4d4c77b8c1ed584826fd5828493dc1a33eee3546be3a15f540a56a9dc9f7",
+    "type": "query",
     "version": 8
   },
   "88671231-6626-4e1b-abb7-6e361a171fbb": {
@@ -2375,6 +2390,7 @@
   "97f22dab-84e8-409d-955e-dacd1d31670b": {
     "rule_name": "Base64 Encoding/Decoding Activity",
     "sha256": "86fb84d8b0d3b72763c1f25b159b87869dedc4bbea83405c178c095c7f2e66f3",
+    "type": "query",
     "version": 7
   },
   "97fc44d3-8dae-4019-ae83-298c3015600f": {
@@ -2465,6 +2481,7 @@
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1": {
     "rule_name": "Trusted Developer Application Usage",
     "sha256": "01562e377ae2b4b0c607fb9d5776d0d78e0c2452bfd0ec90c08ff9f99499e349",
+    "type": "query",
     "version": 7
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2": {
@@ -2590,6 +2607,7 @@
   "a4ec1382-4557-452b-89ba-e413b22ed4b8": {
     "rule_name": "Network Connection via Mshta",
     "sha256": "233377abf3f67401dc4208d28639241ca34ed38ba30aa4037251b1274fa5bd17",
+    "type": "eql",
     "version": 4
   },
   "a60326d7-dca7-4fb7-93eb-1ca03a1febbd": {
@@ -2637,6 +2655,7 @@
   "a9198571-b135-4a76-b055-e3e5a476fd83": {
     "rule_name": "Hex Encoding/Decoding Activity",
     "sha256": "b6cfa5bf24a78049ee0f873fe01bcc14ef5116a6adf59b8721abeb11ceca01cf",
+    "type": "query",
     "version": 7
   },
   "a989fa1b-9a11-4dd8-a3e9-f0de9c6eb5f2": {
@@ -2756,6 +2775,7 @@
   "ad0e5e75-dd89-4875-8d0a-dfdc1828b5f3": {
     "rule_name": "Proxy Port Activity to the Internet",
     "sha256": "b6ebab2e583cd3bf78d4951f8718ff88b6bbea6dfd4004c586ce00a703ec0a10",
+    "type": "query",
     "version": 8
   },
   "ad3f2807-2b3e-47d7-b282-f84acbbe14be": {
@@ -2812,6 +2832,7 @@
   "b1c14366-f4f8-49a0-bcbb-51d2de8b0bb8": {
     "rule_name": "Potential Persistence via Cron Job",
     "sha256": "0c030fdda99d067a509f80bd3faff91ee4d8414e5074a9ef6cf7bf5fc97fcbed",
+    "type": "query",
     "version": 1
   },
   "b240bfb8-26b7-4e5e-924e-218144a3fa71": {
@@ -3167,6 +3188,7 @@
   "c6474c34-4953-447a-903e-9fcb7b6661aa": {
     "rule_name": "IRC (Internet Relay Chat) Protocol Activity to the Internet",
     "sha256": "dba60ab7ccce534b20532548b6aff6b799d54bacbacf3328fd250e65420a998c",
+    "type": "query",
     "version": 8
   },
   "c749e367-a069-4a73-b1f2-43a3798153ad": {
@@ -3226,6 +3248,7 @@
   "c87fca17-b3a9-4e83-b545-f30746c53920": {
     "rule_name": "Nmap Process Activity",
     "sha256": "85b00c642776304ce2f5d7c1374ad4f666c1669ace49cc43ede47f075674581d",
+    "type": "query",
     "version": 7
   },
   "c88d4bd0-5649-4c52-87ea-9be59dbfbcf2": {
@@ -3288,6 +3311,7 @@
   "cc16f774-59f9-462d-8b98-d27ccd4519ec": {
     "rule_name": "Process Discovery via Tasklist",
     "sha256": "8612fc7b7e41ef8548eb18803ce4a0ca6e178952add06c716bfbf190fa1788f3",
+    "type": "query",
     "version": 6
   },
   "cc2fd2d0-ba3a-4939-b87f-2901764ed036": {
@@ -3323,6 +3347,7 @@
   "cd4d5754-07e1-41d4-b9a5-ef4ea6a0a126": {
     "rule_name": "Socat Process Activity",
     "sha256": "572416fa9eb3b37a9360cbd474d0dccd7844685ad36b022f4a42d3a4525cac25",
+    "type": "query",
     "version": 7
   },
   "cd66a419-9b3f-4f57-8ff8-ac4cd2d5f530": {
@@ -3391,6 +3416,7 @@
   "d2053495-8fe7-4168-b3df-dad844046be3": {
     "rule_name": "PPTP (Point to Point Tunneling Protocol) Activity",
     "sha256": "07e21a98e0a2f05e6d9191ef82577f66f1c1ed1a2f93cd54771faa83ee6ceda6",
+    "type": "query",
     "version": 7
   },
   "d22a85c6-d2ad-4cc4-bf7b-54787473669a": {
@@ -3560,6 +3586,7 @@
   "dc672cb7-d5df-4d1f-a6d7-0841b1caafb9": {
     "rule_name": "Threat Intel Filebeat Module (v7.x) Indicator Match",
     "sha256": "a6db1fdda6906b8d352b2d9c369c0b2e4271c911d0919320c8dd20f053d0e095",
+    "type": "threat_match",
     "version": 4
   },
   "dc9c1f74-dac3-48e3-b47f-eb79db358f57": {
@@ -3758,6 +3785,7 @@
   "e56993d2-759c-4120-984c-9ec9bb940fd5": {
     "rule_name": "RDP (Remote Desktop Protocol) to the Internet",
     "sha256": "e2f1607e4ec15d9f1e4cdfb3c307852c151afef4fa9f42ee068ccd4b335543ed",
+    "type": "query",
     "version": 8
   },
   "e6c1a552-7776-44ad-ae0f-8746cc07773c": {
@@ -3847,6 +3875,7 @@
   "ea0784f0-a4d7-4fea-ae86-4baaf27a6f17": {
     "rule_name": "SSH (Secure Shell) from the Internet",
     "sha256": "a5b483bc27ea95cd71683dd2f631a41276da2ab442b4d14e2e843c1df6519efa",
+    "type": "query",
     "version": 8
   },
   "ea248a02-bc47-4043-8e94-2885b19b2636": {


### PR DESCRIPTION
## Issues
None
related to #1855

## Summary
In #1855 the rule type was added to all entries in the version.lock file, however, deprecated rules were overlooked. This is causing failures in backports to older branches.

This adds the type to those rules

<img width="575" alt="image" src="https://user-images.githubusercontent.com/16747370/160036778-a63534d6-26fc-4596-91f6-2c39e661286f.png">
