### PR TITLE
Add Jamf Connect exception for macOS users enumeration rule

### DIFF
--- a/rules/macos/discovery_users_domain_built_in_commands.toml
+++ b/rules/macos/discovery_users_domain_built_in_commands.toml
@@ -24,6 +24,7 @@ process where event.type in ("start", "process_started") and
     "/Applications/ZoomPresence.app/Contents/MacOS/ZoomPresence",
      "/Applications/Sourcetree.app/Contents/MacOS/Sourcetree",
      "/Library/Application Support/JAMF/Jamf.app/Contents/MacOS/JamfDaemon.app/Contents/MacOS/JamfDaemon",
+     "/Applications/Jamf Connect.app/Contents/MacOS/Jamf Connect",
      "/usr/local/jamf/bin/jamf"
     ) and 
   process.name : ("ldapsearch", "dsmemberutil") or

--- a/rules/macos/discovery_users_domain_built_in_commands.toml
+++ b/rules/macos/discovery_users_domain_built_in_commands.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/12"
 maturity = "production"
-updated_date = "2021/03/16"
+updated_date = "2022/03/28"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Summary
Jamf Connect uses ldapsearch to synchronize user passwords. This rule generates tons of false positives when Jamf Connect is deployed.

