### PR TITLE
Expand timestamp override tests

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -295,9 +295,14 @@ class EQLRuleData(QueryRuleData):
             return self.convert_time_span(lookback)
 
     @cached_property
+    def is_sequence(self) -> bool:
+        """Checks if the current rule is a sequence-based rule."""
+        return eql.utils.get_query_type(self.ast) == 'sequence'
+
+    @cached_property
     def max_span(self) -> Optional[int]:
         """Maxspan value for sequence rules if defined."""
-        if eql.utils.get_query_type(self.ast) == 'sequence' and hasattr(self.ast.first, 'max_span'):
+        if self.is_sequence and hasattr(self.ast.first, 'max_span'):
             return self.ast.first.max_span.as_milliseconds() if self.ast.first.max_span else None
 
     @cached_property

--- a/rules/cross-platform/credential_access_cookies_chromium_browsers_debugging.toml
+++ b/rules/cross-platform/credential_access_cookies_chromium_browsers_debugging.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,10 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Potential Cookies Theft via Browser Debugging"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://github.com/defaultnamehere/cookie_crimes",
     "https://embracethered.com/blog/posts/2020/cookie-crimes-on-mirosoft-edge/",

--- a/rules/cross-platform/defense_evasion_deleting_websvr_access_logs.toml
+++ b/rules/cross-platform/defense_evasion_deleting_websvr_access_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "winlogbeat-*", "logs-endpoint.events.*", "logs-windows.
 language = "eql"
 license = "Elastic License v2"
 name = "WebServer Access Logs Deleted"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "665e7a4f-c58e-4fc6-bc83-87a7572670ac"
 severity = "medium"

--- a/rules/cross-platform/defense_evasion_timestomp_touch.toml
+++ b/rules/cross-platform/defense_evasion_timestomp_touch.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2021/03/09"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Timestomping using Touch Command"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "b0046934-486e-462f-9487-0d4cf9e429c6"
 severity = "medium"

--- a/rules/cross-platform/discovery_security_software_grep.toml
+++ b/rules/cross-platform/discovery_security_software_grep.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/20"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["logs-endpoint.events.*", "auditbeat-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Security Software Discovery via Grep"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "870aecc0-cea4-4110-af3f-e02e9b373655"
 severity = "medium"
@@ -78,3 +82,4 @@ reference = "https://attack.mitre.org/techniques/T1518/001/"
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/cross-platform/discovery_virtual_machine_fingerprinting_grep.toml
+++ b/rules/cross-platform/discovery_virtual_machine_fingerprinting_grep.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/09/29"
 maturity = "production"
-updated_date = "2021/09/29"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -21,6 +21,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Virtual Machine Fingerprinting via Grep"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://objective-see.com/blog/blog_0x4F.html"]
 risk_score = 47
 rule_id = "c85eb82c-d2c8-485c-a36f-534f914b7663"
@@ -49,3 +53,4 @@ reference = "https://attack.mitre.org/techniques/T1082/"
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/cross-platform/execution_python_script_in_cmdline.toml
+++ b/rules/cross-platform/execution_python_script_in_cmdline.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/13"
 maturity = "development"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Python Script Execution via Command Line"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "ee9f08dc-cf80-4124-94ae-08c405f059ae"
 severity = "medium"

--- a/rules/cross-platform/execution_revershell_via_shell_cmd.toml
+++ b/rules/cross-platform/execution_revershell_via_shell_cmd.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/07"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Reverse Shell Activity via Terminal"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Reverse%20Shell%20Cheatsheet.md",
     "https://github.com/WangYihang/Reverse-Shell-Manager",

--- a/rules/cross-platform/execution_suspicious_jar_child_process.toml
+++ b/rules/cross-platform/execution_suspicious_jar_child_process.toml
@@ -1,23 +1,27 @@
 [metadata]
 creation_date = "2021/01/19"
 maturity = "production"
-updated_date = "2021/12/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies suspicious child processes of the Java interpreter process. This may indicate an attempt to execute a malicious
-JAR file or an exploitation attempt via a JAVA specific vulnerability.
+Identifies suspicious child processes of the Java interpreter process. This may indicate an attempt to execute a
+malicious JAR file or an exploitation attempt via a JAVA specific vulnerability.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious JAVA Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
-"https://www.lunasec.io/docs/blog/log4j-zero-day/",
-"https://github.com/christophetd/log4shell-vulnerable-app",
-"https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
+    "https://www.lunasec.io/docs/blog/log4j-zero-day/",
+    "https://github.com/christophetd/log4shell-vulnerable-app",
+    "https://www.blackhat.com/docs/us-16/materials/us-16-Munoz-A-Journey-From-JNDI-LDAP-Manipulation-To-RCE.pdf",
 ]
 risk_score = 47
 rule_id = "8acb7614-1d92-4359-bfcf-478b6d9de150"

--- a/rules/cross-platform/execution_suspicious_java_netcon_childproc.toml
+++ b/rules/cross-platform/execution_suspicious_java_netcon_childproc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/12/10"
 maturity = "production"
-updated_date = "2021/12/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,6 @@ risk_score = 73
 rule_id = "c3f5e1d8-910e-43b4-8d44-d748e498ca86"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "macOS", "Threat Detection", "Execution"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/07"
 maturity = "production"
-updated_date = "2021/10/27"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,10 @@ license = "Elastic License v2"
 name = "Hosts File Modified"
 note = """## Config
 
-For Windows systems using Auditbeat, this rule requires adding `C:/Windows/System32/drivers/etc` as an additional path in the 'file_integrity' module of auditbeat.yml."""
+For Windows systems using Auditbeat, this rule requires adding `C:/Windows/System32/drivers/etc` as an additional path in the 'file_integrity' module of auditbeat.yml.
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://www.elastic.co/guide/en/beats/auditbeat/current/auditbeat-reference-yml.html"]
 risk_score = 47
 rule_id = "9c260313-c811-4ec8-ab89-8f6530e0246c"

--- a/rules/integrations/okta/credential_access_mfa_push_brute_force.toml
+++ b/rules/integrations/okta/credential_access_mfa_push_brute_force.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/01/05"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 integration = "okta"
 
 [rule]
@@ -23,7 +23,6 @@ risk_score = 73
 rule_id = "97a8e584-fd3b-421f-9b9d-9c9d9e57e9d7"
 severity = "high"
 tags = ["Elastic", "Identity", "Okta", "Continuous Monitoring", "SecOps", "Identity and Access"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/command_and_control_tunneling_via_earthworm.toml
+++ b/rules/linux/command_and_control_tunneling_via_earthworm.toml
@@ -1,22 +1,27 @@
 [metadata]
 creation_date = "2021/04/12"
 maturity = "production"
-updated_date = "2021/04/12"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
 Identifies the execution of the EarthWorm tunneler. Adversaries may tunnel network communications to and from a victim
-system within a separate protocol to avoid detection and network filtering, or to enable access to otherwise unreachable systems.
+system within a separate protocol to avoid detection and network filtering, or to enable access to otherwise unreachable
+systems.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Protocol Tunneling via EarthWorm"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "http://rootkiter.com/EarthWorm/",
-    "https://decoded.avast.io/luigicamastra/apt-group-targeting-governmental-agencies-in-east-asia/"
+    "https://decoded.avast.io/luigicamastra/apt-group-targeting-governmental-agencies-in-east-asia/",
 ]
 risk_score = 47
 rule_id = "9f1c4ca3-44b5-481d-ba42-32dc215a2769"
@@ -38,7 +43,9 @@ id = "T1572"
 name = "Protocol Tunneling"
 reference = "https://attack.mitre.org/techniques/T1572/"
 
+
 [rule.threat.tactic]
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/linux/credential_access_ssh_backdoor_log.toml
+++ b/rules/linux/credential_access_ssh_backdoor_log.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential OpenSSH Backdoor Logging Activity"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://github.com/eset/malware-ioc/tree/master/sshdoor",
     "https://www.welivesecurity.com/wp-content/uploads/2021/01/ESET_Kobalos.pdf",

--- a/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
+++ b/rules/linux/defense_evasion_deletion_of_bash_command_line_history.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/05/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Tampering of Bash Command-Line History"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "7bcbb3ac-e533-41ad-a612-d6c3bf666aba"
 severity = "medium"

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2020/04/29"
 maturity = "production"
-updated_date = "2021/03/03"
 min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -24,6 +24,10 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Creation of Hidden Files and Directories"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "b9666521-4742-49ce-9ddc-b8e84c35acae"
 severity = "medium"

--- a/rules/linux/defense_evasion_log_files_deleted.toml
+++ b/rules/linux/defense_evasion_log_files_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "System Log File Deletion"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.fireeye.com/blog/threat-research/2020/11/live-off-the-land-an-overview-of-unc1945.html",
 ]

--- a/rules/linux/execution_apt_binary.toml
+++ b/rules/linux/execution_apt_binary.toml
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "8fed8450-847e-43bd-874c-3bbf0cd425f3"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_apt_binary.toml
+++ b/rules/linux/execution_apt_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/24"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,6 @@ risk_score = 47
 rule_id = "8fed8450-847e-43bd-874c-3bbf0cd425f3"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_awk_binary_shell.toml
+++ b/rules/linux/execution_awk_binary_shell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/24"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,6 @@ risk_score = 47
 rule_id = "10754992-28c7-4472-be5b-f3770fd04f2d"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_awk_binary_shell.toml
+++ b/rules/linux/execution_awk_binary_shell.toml
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "10754992-28c7-4472-be5b-f3770fd04f2d"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_c89_c99_binary.toml
+++ b/rules/linux/execution_c89_c99_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/15"
 maturity = "production"
-updated_date = "2022/03/15"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,6 @@ risk_score = 47
 rule_id = "1859ce38-6a50-422b-a5e8-636e231ea0cd"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_c89_c99_binary.toml
+++ b/rules/linux/execution_c89_c99_binary.toml
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "1859ce38-6a50-422b-a5e8-636e231ea0cd"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_cpulimit_binary.toml
+++ b/rules/linux/execution_cpulimit_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/17"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -22,7 +22,6 @@ risk_score = 47
 rule_id = "0968cfbd-40f0-4b1c-b7b1-a60736c7b241"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_cpulimit_binary.toml
+++ b/rules/linux/execution_cpulimit_binary.toml
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "0968cfbd-40f0-4b1c-b7b1-a60736c7b241"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_crash_binary.toml
+++ b/rules/linux/execution_crash_binary.toml
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "ee619805-54d7-4c56-ba6f-7717282ddd73"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_crash_binary.toml
+++ b/rules/linux/execution_crash_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/21"
 maturity = "production"
-updated_date = "2022/03/21"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,6 @@ risk_score = 47
 rule_id = "ee619805-54d7-4c56-ba6f-7717282ddd73"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_expect_binary.toml
+++ b/rules/linux/execution_expect_binary.toml
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "fd3fc25e-7c7c-4613-8209-97942ac609f6"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_expect_binary.toml
+++ b/rules/linux/execution_expect_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/07"
 maturity = "development"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,6 @@ risk_score = 47
 rule_id = "fd3fc25e-7c7c-4613-8209-97942ac609f6"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_find_binary.toml
+++ b/rules/linux/execution_find_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/28"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,6 @@ risk_score = 47
 rule_id = "6f683345-bb10-47a7-86a7-71e9c24fb358"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_find_binary.toml
+++ b/rules/linux/execution_find_binary.toml
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "6f683345-bb10-47a7-86a7-71e9c24fb358"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_gcc_binary.toml
+++ b/rules/linux/execution_gcc_binary.toml
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "da986d2c-ffbf-4fd6-af96-a88dbf68f386"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_gcc_binary.toml
+++ b/rules/linux/execution_gcc_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/09"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,6 @@ risk_score = 47
 rule_id = "da986d2c-ffbf-4fd6-af96-a88dbf68f386"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_mysql_binary.toml
+++ b/rules/linux/execution_mysql_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/09"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,6 @@ risk_score = 47
 rule_id = "83b2c6e5-e0b2-42d7-8542-8f3af86a1acb"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_mysql_binary.toml
+++ b/rules/linux/execution_mysql_binary.toml
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "83b2c6e5-e0b2-42d7-8542-8f3af86a1acb"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_nice_binary.toml
+++ b/rules/linux/execution_nice_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/07"
 maturity = "development"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,6 @@ risk_score = 47
 rule_id = "22755f7f-1e1e-4528-a75f-bb3f4026d1b9"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_nice_binary.toml
+++ b/rules/linux/execution_nice_binary.toml
@@ -22,6 +22,7 @@ risk_score = 47
 rule_id = "22755f7f-1e1e-4528-a75f-bb3f4026d1b9"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_ssh_binary.toml
+++ b/rules/linux/execution_ssh_binary.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/10"
 maturity = "production"
-updated_date = "2022/03/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,6 @@ risk_score = 47
 rule_id = "97da359b-2b61-4a40-b2e4-8fc48cf7a294"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/execution_ssh_binary.toml
+++ b/rules/linux/execution_ssh_binary.toml
@@ -21,6 +21,7 @@ risk_score = 47
 rule_id = "97da359b-2b61-4a40-b2e4-8fc48cf7a294"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "GTFOBins"]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/persistence_kde_autostart_modification.toml
+++ b/rules/linux/persistence_kde_autostart_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/06"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via KDE AutoStart Script or Desktop File Modification"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://userbase.kde.org/System_Settings/Autostart",
     "https://www.amnesty.org/en/latest/research/2020/09/german-made-finspy-spyware-found-in-egypt-and-mac-and-linux-versions-revealed/",

--- a/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
+++ b/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Access of Stored Browser Credentials"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://securelist.com/calisto-trojan-for-macos/86543/"]
 risk_score = 73
 rule_id = "20457e4f-d1de-4b92-ae69-142e27a4342a"

--- a/rules/macos/credential_access_credentials_keychains.toml
+++ b/rules/macos/credential_access_credentials_keychains.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Access to Keychain Credentials Directories"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://objective-see.com/blog/blog_0x25.html",
     "https://securelist.com/calisto-trojan-for-macos/86543/",
@@ -68,3 +72,4 @@ reference = "https://attack.mitre.org/techniques/T1555/001/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/macos/credential_access_dumping_keychain_security.toml
+++ b/rules/macos/credential_access_dumping_keychain_security.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Dumping of Keychain Content via Security Command"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://ss64.com/osx/security.html"]
 risk_score = 73
 rule_id = "565d6ca5-75ba-4c82-9b13-add25353471c"

--- a/rules/macos/credential_access_keychain_pwd_retrieval_security_cmd.toml
+++ b/rules/macos/credential_access_keychain_pwd_retrieval_security_cmd.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/06"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Keychain Password Retrieval via Command Line"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.netmeister.org/blog/keychain-passwords.html",
     "https://github.com/priyankchheda/chrome_password_grabber/blob/master/chrome.py",
@@ -48,6 +52,7 @@ id = "T1555.001"
 name = "Keychain"
 reference = "https://attack.mitre.org/techniques/T1555/001/"
 
+
 [[rule.threat.technique]]
 id = "T1555"
 name = "Credentials from Password Stores"
@@ -58,7 +63,9 @@ name = "Credentials from Web Browsers"
 reference = "https://attack.mitre.org/techniques/T1555/003/"
 
 
+
 [rule.threat.tactic]
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
+++ b/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/16"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Prompt for Credentials with OSASCRIPT"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://github.com/EmpireProject/EmPyre/blob/master/lib/modules/collection/osx/prompt.py",
     "https://ss64.com/osx/osascript.html",

--- a/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
+++ b/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Attempt to Remove File Quarantine Attribute"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.trendmicro.com/en_us/research/20/k/new-macos-backdoor-connected-to-oceanlotus-surfaces.html",
     "https://ss64.com/osx/xattr.html",

--- a/rules/macos/defense_evasion_privacy_controls_tcc_database_modification.toml
+++ b/rules/macos/defense_evasion_privacy_controls_tcc_database_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/23"
 maturity = "production"
-updated_date = "2021/08/25"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privacy Control Bypass via TCCDB Modification"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://applehelpwriter.com/2016/08/29/discovering-how-dropbox-hacks-your-mac/",
     "https://github.com/bp88/JSS-Scripts/blob/master/TCC.db%20Modifier.sh",

--- a/rules/macos/defense_evasion_privilege_escalation_privacy_pref_sshd_fulldiskaccess.toml
+++ b/rules/macos/defense_evasion_privilege_escalation_privacy_pref_sshd_fulldiskaccess.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/11"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privacy Control Bypass via Localhost Secure Copy"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://blog.trendmicro.com/trendlabs-security-intelligence/xcsset-mac-malware-infects-xcode-projects-performs-uxss-attack-on-safari-other-browsers-leverages-zero-day-exploits/",
 ]

--- a/rules/macos/discovery_users_domain_built_in_commands.toml
+++ b/rules/macos/discovery_users_domain_built_in_commands.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/12"
 maturity = "production"
-updated_date = "2022/03/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Enumeration of Users or Groups via Built-in Commands"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "6e9b351e-a531-4bdc-b73e-7034d6eed7ff"
 severity = "low"
@@ -51,3 +55,4 @@ reference = "https://attack.mitre.org/techniques/T1087/"
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/macos/execution_installer_spawned_network_event.toml
+++ b/rules/macos/execution_installer_spawned_network_event.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/02/23"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -28,7 +28,6 @@ risk_score = 47
 rule_id = "99239e7d-b0d4-46e3-8609-acafcf99f68c"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Execution"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/macos/lateral_movement_mounting_smb_share.toml
+++ b/rules/macos/lateral_movement_mounting_smb_share.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Attempt to Mount SMB Share via Command Line"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://www.freebsd.org/cgi/man.cgi?mount_smbfs", "https://ss64.com/osx/mount.html"]
 risk_score = 21
 rule_id = "661545b4-1a90-4f45-85ce-2ebd7c6a15d0"

--- a/rules/macos/lateral_movement_vpn_connection_attempt.toml
+++ b/rules/macos/lateral_movement_vpn_connection_attempt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/25"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Virtual Private Network Connection Attempt"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://github.com/rapid7/metasploit-framework/blob/master/modules/post/osx/manage/vpn.rb",
     "https://www.unix.com/man-page/osx/8/networksetup/",

--- a/rules/macos/persistence_creation_hidden_login_item_osascript.toml
+++ b/rules/macos/persistence_creation_hidden_login_item_osascript.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/05"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation of Hidden Login Item via Apple Script"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "f24bcae1-8980-4b30-b5dd-f851b055c9e7"
 severity = "medium"

--- a/rules/macos/persistence_emond_rules_file_creation.toml
+++ b/rules/macos/persistence_emond_rules_file_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/11"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Emond Rules Creation or Modification"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://www.xorrior.com/emond-persistence/"]
 risk_score = 47
 rule_id = "a6bf4dd4-743e-4da8-8c03-3ebd753a6c90"

--- a/rules/macos/persistence_evasion_hidden_launch_agent_deamon_creation.toml
+++ b/rules/macos/persistence_evasion_hidden_launch_agent_deamon_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/05"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation of Hidden Launch Agent or Daemon"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html",
 ]

--- a/rules/macos/persistence_login_logout_hooks_defaults.toml
+++ b/rules/macos/persistence_login_logout_hooks_defaults.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/07"
 maturity = "production"
-updated_date = "2021/03/09"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Login or Logout Hook"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.virusbulletin.com/uploads/pdf/conference_slides/2014/Wardle-VB2014.pdf",
     "https://www.manpagez.com/man/1/defaults/",
@@ -50,3 +54,4 @@ reference = "https://attack.mitre.org/techniques/T1037/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/macos/persistence_modification_sublime_app_plugin_or_script.toml
+++ b/rules/macos/persistence_modification_sublime_app_plugin_or_script.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Sublime Plugin or Application Script Modification"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://posts.specterops.io/persistent-jxa-66e1c3cd1cf5"]
 risk_score = 21
 rule_id = "88817a33-60d3-411f-ba79-7c905d865b2a"

--- a/rules/macos/persistence_screensaver_engine_unexpected_child_process.toml
+++ b/rules/macos/persistence_screensaver_engine_unexpected_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/05"
 maturity = "production"
-updated_date = "2021/10/05"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,11 @@ note = """## Triage and analysis
 as a download of a payload from a server.
 - Review the installed and activated screensaver on the host. Triage the screensaver (.saver) file that was triggered to
 identify whether the file is malicious or not.
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
 references = [
     "https://posts.specterops.io/saving-your-access-d562bf5bf90b",
@@ -42,9 +47,9 @@ process where event.type == "start" and process.parent.name == "ScreenSaverEngin
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1546/"
-name = "Event Triggered Execution"
 id = "T1546"
+name = "Event Triggered Execution"
+reference = "https://attack.mitre.org/techniques/T1546/"
 
 
 [rule.threat.tactic]

--- a/rules/macos/persistence_screensaver_plist_file_modification.toml
+++ b/rules/macos/persistence_screensaver_plist_file_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/05"
 maturity = "production"
-updated_date = "2021/10/05"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,12 @@ note = """## Triage and analysis
 
 - Analyze the plist file modification event to identify whether the change was expected or not
 - Investigate the process that modified the plist file for malicious code or other suspicious behavior
-- Identify if any suspicious or known malicious screensaver (.saver) files were recently written to or modified on the host"""
+- Identify if any suspicious or known malicious screensaver (.saver) files were recently written to or modified on the host
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://posts.specterops.io/saving-your-access-d562bf5bf90b",
     "https://github.com/D00MFist/PersistentJXA",
@@ -52,9 +57,9 @@ file where event.type != "deletion" and
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1546/"
-name = "Event Triggered Execution"
 id = "T1546"
+name = "Event Triggered Execution"
+reference = "https://attack.mitre.org/techniques/T1546/"
 
 
 [rule.threat.tactic]

--- a/rules/macos/privilege_escalation_applescript_with_admin_privs.toml
+++ b/rules/macos/privilege_escalation_applescript_with_admin_privs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/27"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Apple Scripting Execution with Administrator Privileges"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://discussions.apple.com/thread/2266150"]
 risk_score = 47
 rule_id = "827f8d8f-4117-4ae4-b551-f56d54b9da6b"

--- a/rules/windows/collection_email_powershell_exchange_mailbox.toml
+++ b/rules/windows/collection_email_powershell_exchange_mailbox.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/15"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Exporting Exchange Mailbox via PowerShell"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.volexity.com/blog/2020/12/14/dark-halo-leverages-solarwinds-compromise-to-breach-organizations/",
     "https://docs.microsoft.com/en-us/powershell/module/exchange/new-mailboxexportrequest?view=exchange-ps",
@@ -35,19 +39,19 @@ process where event.type in ("start", "process_started") and
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
+id = "T1005"
+name = "Data from Local System"
+reference = "https://attack.mitre.org/techniques/T1005/"
+
+[[rule.threat.technique]]
 id = "T1114"
 name = "Email Collection"
 reference = "https://attack.mitre.org/techniques/T1114/"
+[[rule.threat.technique.subtechnique]]
+id = "T1114.002"
+name = "Remote Email Collection"
+reference = "https://attack.mitre.org/techniques/T1114/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1114.002"
-  name = "Remote Email Collection"
-  reference = "https://attack.mitre.org/techniques/T1114/002/"
-
-[[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1005/"
-id = "T1005"
-name = "Data from Local System"
 
 
 [rule.threat.tactic]

--- a/rules/windows/collection_winrar_encryption.toml
+++ b/rules/windows/collection_winrar_encryption.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Encrypting Files with WinRar or 7z"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://www.welivesecurity.com/2020/12/02/turla-crutch-keeping-back-door-open/"]
 risk_score = 47
 rule_id = "45d273fb-1dca-457d-9855-bcb302180c21"
@@ -43,11 +47,11 @@ framework = "MITRE ATT&CK"
 id = "T1560"
 name = "Archive Collected Data"
 reference = "https://attack.mitre.org/techniques/T1560/"
+[[rule.threat.technique.subtechnique]]
+id = "T1560.001"
+name = "Archive via Utility"
+reference = "https://attack.mitre.org/techniques/T1560/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1560.001"
-  name = "Archive via Utility"
-  reference = "https://attack.mitre.org/techniques/T1560/001/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/command_and_control_encrypted_channel_freesslcert.toml
+++ b/rules/windows/command_and_control_encrypted_channel_freesslcert.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Connection to Commonly Abused Free SSL Certificate Providers"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "e3cf38fa-d5b8-46cc-87f9-4a7513e4281d"
 severity = "low"

--- a/rules/windows/command_and_control_port_forwarding_added_registry.toml
+++ b/rules/windows/command_and_control_port_forwarding_added_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Port Forwarding Rule Addition"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.fireeye.com/blog/threat-research/2019/01/bypassing-network-restrictions-through-rdp-tunneling.html",
 ]

--- a/rules/windows/command_and_control_rdp_tunnel_plink.toml
+++ b/rules/windows/command_and_control_rdp_tunnel_plink.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/14"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Remote Desktop Tunneling Detected"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://blog.netspi.com/how-to-access-rdp-over-a-reverse-ssh-tunnel/"]
 risk_score = 73
 rule_id = "76fd43b7-3480-4dd9-8ad7-8bd36bfad92f"
@@ -36,6 +40,7 @@ framework = "MITRE ATT&CK"
 id = "T1572"
 name = "Protocol Tunneling"
 reference = "https://attack.mitre.org/techniques/T1572/"
+
 
 [rule.threat.tactic]
 id = "TA0011"

--- a/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
+++ b/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote File Download via Desktopimgdownldr Utility"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://labs.sentinelone.com/living-off-windows-land-a-new-native-file-downldr/"]
 risk_score = 47
 rule_id = "15c0b7a7-9c34-4869-b25b-fa6518414899"
@@ -33,12 +37,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1105"
-reference = "https://attack.mitre.org/techniques/T1105/"
 name = "Ingress Tool Transfer"
+reference = "https://attack.mitre.org/techniques/T1105/"
 
 
 [rule.threat.tactic]
 id = "TA0011"
-reference = "https://attack.mitre.org/tactics/TA0011/"
 name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
 

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,12 @@ name = "Remote File Download via MpCmdRun"
 note = """## Triage and analysis
 
 ### Investigating Remote File Download via MpCmdRun
-Verify details such as the parent process, URL reputation, and downloaded file details. Additionally, `MpCmdRun` logs this information in the Appdata Temp folder in `MpCmdRun.log`."""
+Verify details such as the parent process, URL reputation, and downloaded file details. Additionally, `MpCmdRun` logs this information in the Appdata Temp folder in `MpCmdRun.log`.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://twitter.com/mohammadaskar2/status/1301263551638761477",
     "https://www.bleepingcomputer.com/news/microsoft/microsoft-defender-can-ironically-be-used-to-download-malware/",
@@ -37,12 +42,12 @@ process where event.type == "start" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1105"
-reference = "https://attack.mitre.org/techniques/T1105/"
 name = "Ingress Tool Transfer"
+reference = "https://attack.mitre.org/techniques/T1105/"
 
 
 [rule.threat.tactic]
 id = "TA0011"
-reference = "https://attack.mitre.org/tactics/TA0011/"
 name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
 

--- a/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
+++ b/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/02"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote File Copy via TeamViewer"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://blog.menasec.net/2019/11/hunting-for-suspicious-use-of.html"]
 risk_score = 47
 rule_id = "b25a7df2-120a-4db2-bd3f-3e4b86b24bee"
@@ -29,9 +33,8 @@ file where event.type == "creation" and process.name : "TeamViewer.exe" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1105"
-reference = "https://attack.mitre.org/techniques/T1105/"
 name = "Ingress Tool Transfer"
-
+reference = "https://attack.mitre.org/techniques/T1105/"
 
 [[rule.threat.technique]]
 id = "T1219"
@@ -41,6 +44,6 @@ reference = "https://attack.mitre.org/techniques/T1219/"
 
 [rule.threat.tactic]
 id = "TA0011"
-reference = "https://attack.mitre.org/tactics/TA0011/"
 name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
 

--- a/rules/windows/credential_access_cmdline_dump_tool.toml
+++ b/rules/windows/credential_access_cmdline_dump_tool.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/07/20"
 min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Credential Access via Windows Utilities"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://lolbas-project.github.io/"]
 risk_score = 73
 rule_id = "00140285-b827-4aee-aa09-8113f58a08f3"
@@ -45,16 +49,17 @@ framework = "MITRE ATT&CK"
 id = "T1003"
 name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.001"
+name = "LSASS Memory"
+reference = "https://attack.mitre.org/techniques/T1003/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "LSASS Memory"
-  id = "T1003.001"
-  reference = "https://attack.mitre.org/techniques/T1003/001/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.003"
+name = "NTDS"
+reference = "https://attack.mitre.org/techniques/T1003/003/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "NTDS"
-  id = "T1003.003"
-  reference = "https://attack.mitre.org/techniques/T1003/003/"
+
 
 [rule.threat.tactic]
 id = "TA0006"

--- a/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
+++ b/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
@@ -1,10 +1,10 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/07/22"
+updated_date = "2022/03/31"
 
 [rule]
-author = ["Elastic","Austin Songer"]
+author = ["Elastic", "Austin Songer"]
 description = """
 Identifies a copy operation of the Active Directory Domain Database (ntds.dit) or Security Account Manager (SAM) files.
 Those files contain sensitive information including hashed domain and/or local credentials.
@@ -15,6 +15,10 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "NTDS or SAM Database File Copied"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://thedfirreport.com/2020/11/23/pysa-mespinoza-ransomware/",
     "https://github.com/redcanaryco/atomic-red-team/blob/master/atomics/T1003.002/T1003.002.md#atomic-test-3---esentutlexe-sam-copy",
@@ -44,13 +48,15 @@ framework = "MITRE ATT&CK"
 id = "T1003"
 name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.002"
+name = "Security Account Manager"
+reference = "https://attack.mitre.org/techniques/T1003/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "Security Account Manager"
-  id = "T1003.002"
-  reference = "https://attack.mitre.org/techniques/T1003/002/"
+
 
 [rule.threat.tactic]
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_credential_dumping_msbuild.toml
+++ b/rules/windows/credential_access_credential_dumping_msbuild.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/credential_access_dcsync_replication_rights.toml
+++ b/rules/windows/credential_access_dcsync_replication_rights.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/08"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -82,6 +82,9 @@ Audit Policies >
 DS Access > 
 Audit Directory Service Changes (Success,Failure)
 ```
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+
 """
 references = [
     "https://threathunterplaybook.com/notebooks/windows/06_credential_access/WIN-180815210510.html",

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,12 @@ license = "Elastic License v2"
 name = "Creation or Modification of Domain Backup DPAPI private key"
 note = """## Triage and analysis
 
-Domain DPAPI Backup keys are stored on domain controllers and can be dumped remotely with tools such as Mimikatz. The resulting .pvk private key can be used to decrypt ANY domain user masterkeys, which then can be used to decrypt any secrets protected by those keys."""
+Domain DPAPI Backup keys are stored on domain controllers and can be dumped remotely with tools such as Mimikatz. The resulting .pvk private key can be used to decrypt ANY domain user masterkeys, which then can be used to decrypt any secrets protected by those keys.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.dsinternals.com/en/retrieving-dpapi-backup-keys-from-active-directory/",
     "https://www.harmj0y.net/blog/redteaming/operational-guidance-for-offensive-user-dpapi-abuse/",
@@ -37,21 +42,22 @@ file where event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_ca
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1552"
-reference = "https://attack.mitre.org/techniques/T1552/"
 name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
 [[rule.threat.technique.subtechnique]]
 id = "T1552.004"
-reference = "https://attack.mitre.org/techniques/T1552/004/"
 name = "Private Keys"
+reference = "https://attack.mitre.org/techniques/T1552/004/"
+
+
 [[rule.threat.technique]]
 id = "T1555"
 name = "Credentials from Password Stores"
 reference = "https://attack.mitre.org/techniques/T1555/"
 
 
-
 [rule.threat.tactic]
 id = "TA0006"
-reference = "https://attack.mitre.org/tactics/TA0006/"
 name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
 

--- a/rules/windows/credential_access_dump_registry_hives.toml
+++ b/rules/windows/credential_access_dump_registry_hives.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Credential Acquisition via Registry Hive Dumping"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://medium.com/threatpunter/detecting-attempts-to-steal-passwords-from-the-registry-7512674487f8",
 ]
@@ -35,16 +39,17 @@ framework = "MITRE ATT&CK"
 id = "T1003"
 name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.002"
+name = "Security Account Manager"
+reference = "https://attack.mitre.org/techniques/T1003/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "Security Account Manager"
-  id = "T1003.002"
-  reference = "https://attack.mitre.org/techniques/T1003/002/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.004"
+name = "LSA Secrets"
+reference = "https://attack.mitre.org/techniques/T1003/004/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "LSA Secrets"
-  id = "T1003.004"
-  reference = "https://attack.mitre.org/techniques/T1003/004/"
+
 
 [rule.threat.tactic]
 id = "TA0006"

--- a/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
+++ b/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Microsoft IIS Service Account Password Dumped"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://blog.netspi.com/decrypting-iis-passwords-to-break-out-of-the-dmz-part-1/"]
 risk_score = 73
 rule_id = "0564fb9d-90b9-4234-a411-82a546dc1343"

--- a/rules/windows/credential_access_iis_connectionstrings_dumping.toml
+++ b/rules/windows/credential_access_iis_connectionstrings_dumping.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Microsoft IIS Connection Strings Decryption"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://blog.netspi.com/decrypting-iis-passwords-to-break-out-of-the-dmz-part-1/",
     "https://symantec-enterprise-blogs.security.com/blogs/threat-intelligence/greenbug-espionage-telco-south-asia",

--- a/rules/windows/credential_access_kerberoasting_unusual_process.toml
+++ b/rules/windows/credential_access_kerberoasting_unusual_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2022/02/16"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Kerberos Traffic from Unusual Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "897dc6b5-b39f-432a-8d75-d3730d50c782"
 severity = "medium"

--- a/rules/windows/credential_access_lsass_memdump_file_created.toml
+++ b/rules/windows/credential_access_lsass_memdump_file_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "LSASS Memory Dump Creation"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://github.com/outflanknl/Dumpert", "https://github.com/hoangprod/AndrewSpecial"]
 risk_score = 73
 rule_id = "f2f46686-6f3c-4724-bd7d-24e31c70f98f"
@@ -32,16 +36,17 @@ file where file.name : ("lsass*.dmp", "dumpert.dmp", "Andrew.dmp", "SQLDmpr*.mdm
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1003"
-reference = "https://attack.mitre.org/techniques/T1003/"
 name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.001"
+name = "LSASS Memory"
+reference = "https://attack.mitre.org/techniques/T1003/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "LSASS Memory"
-  id = "T1003.001"
-  reference = "https://attack.mitre.org/techniques/T1003/001/"
+
 
 [rule.threat.tactic]
 id = "TA0006"
-reference = "https://attack.mitre.org/tactics/TA0006/"
 name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
 

--- a/rules/windows/credential_access_lsass_memdump_handle_access.toml
+++ b/rules/windows/credential_access_lsass_memdump_handle_access.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/16"
 maturity = "production"
-updated_date = "2022/02/16"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -64,6 +64,9 @@ Audit Handle Manipulation (Success,Failure)
 ```
 
 Also, this event generates only if the object’s [SACL](https://docs.microsoft.com/en-us/windows/win32/secauthz/access-control-lists) has the required ACE to handle the use of specific access rights.
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+
 """
 references = [
     "https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4656",

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Mimikatz Memssp Log File Detected"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "ebb200e8-adf0-43f8-a0bb-4ee5b5d852c6"
 severity = "high"
@@ -27,12 +31,12 @@ file where file.name : "mimilsa.log" and process.name : "lsass.exe"
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1003"
-reference = "https://attack.mitre.org/techniques/T1003/"
 name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
 
 
 [rule.threat.tactic]
 id = "TA0006"
-reference = "https://attack.mitre.org/tactics/TA0006/"
 name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
 

--- a/rules/windows/credential_access_mimikatz_powershell_module.toml
+++ b/rules/windows/credential_access_mimikatz_powershell_module.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/07"
 maturity = "development"
-updated_date = "2021/09/09"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -53,6 +53,11 @@ used the machine. These users should have their password reset.
 this capability.
 - This [resource](https://adsecurity.org/?page_id=1821) provided by ADSecurity should be used as required reading for
 detecting/preventing and understanding the different Mimikatz components.
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
 references = ["https://attack.mitre.org/software/S0002/"]
 risk_score = 99
@@ -67,19 +72,22 @@ process where event.type in ("start", "process_started") and process.name : ("cm
 and process.args : ("*DumpCreds", "*Mimikatz*")
 '''
 
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1003"
 name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.001"
+name = "LSASS Memory"
+reference = "https://attack.mitre.org/techniques/T1003/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "LSASS Memory"
-  id = "T1003.001"
-  reference = "https://attack.mitre.org/techniques/T1003/001/"
+
 
 [rule.threat.tactic]
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_mod_wdigest_security_provider.toml
+++ b/rules/windows/credential_access_mod_wdigest_security_provider.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/19"
 maturity = "production"
-updated_date = "2022/02/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Modification of WDigest Security Provider"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.csoonline.com/article/3438824/how-to-detect-and-halt-credential-theft-via-windows-wdigest.html",
     "https://www.praetorian.com/blog/mitigating-mimikatz-wdigest-cleartext-credential-theft?edition=2019",

--- a/rules/windows/credential_access_potential_lsa_memdump_via_mirrordump.toml
+++ b/rules/windows/credential_access_potential_lsa_memdump_via_mirrordump.toml
@@ -1,20 +1,23 @@
 [metadata]
 creation_date = "2021/09/27"
 maturity = "production"
-updated_date = "2021/09/27"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies suspicious access to an LSASS handle via DuplicateHandle from an unknown call trace module. 
-This may indicate an attempt to bypass the NtOpenProcess API to evade detection and dump LSASS memory
-for credential access.
+Identifies suspicious access to an LSASS handle via DuplicateHandle from an unknown call trace module. This may indicate
+an attempt to bypass the NtOpenProcess API to evade detection and dump LSASS memory for credential access.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Credential Access via DuplicateHandle in LSASS"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://github.com/CCob/MirrorDump"]
 risk_score = 47
 rule_id = "02a4576a-7480-4284-9327-548a806b5e48"
@@ -40,13 +43,15 @@ framework = "MITRE ATT&CK"
 id = "T1003"
 name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.001"
+name = "LSASS Memory"
+reference = "https://attack.mitre.org/techniques/T1003/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "LSASS Memory"
-  id = "T1003.001"
-  reference = "https://attack.mitre.org/techniques/T1003/001/"
+
 
 [rule.threat.tactic]
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_remote_sam_secretsdump.toml
+++ b/rules/windows/credential_access_remote_sam_secretsdump.toml
@@ -3,7 +3,7 @@ creation_date = "2022/03/01"
 maturity = "production"
 min_stack_comments = "The field `file.Ext.header_bytes` was not introduced until 7.15"
 min_stack_version = "7.15.0"
-updated_date = "2022/03/01"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,6 @@ risk_score = 73
 rule_id = "850d901a-2a3c-46c6-8b22-55398a01aad8"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement", "Credential Access"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/credential_access_saved_creds_vaultcmd.toml
+++ b/rules/windows/credential_access_saved_creds_vaultcmd.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Searching for Saved Credentials via VaultCmd"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://medium.com/threatpunter/detecting-adversary-tradecraft-with-image-load-event-logging-and-eql-8de93338c16",
     "https://rastamouse.me/blog/rdp-jump-boxes/",
@@ -39,6 +43,7 @@ framework = "MITRE ATT&CK"
 id = "T1003"
 name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+
 [[rule.threat.technique]]
 id = "T1555"
 name = "Credentials from Password Stores"
@@ -47,6 +52,7 @@ reference = "https://attack.mitre.org/techniques/T1555/"
 id = "T1555.004"
 name = "Windows Credential Manager"
 reference = "https://attack.mitre.org/techniques/T1555/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/credential_access_suspicious_comsvcs_imageload.toml
+++ b/rules/windows/credential_access_suspicious_comsvcs_imageload.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2021/10/17"
-updated_date = "2022/02/16"
+updated_date = "2022/03/31"
 maturity = "production"
 
 
@@ -25,7 +25,6 @@ risk_score = 73
 rule_id = "c5c9f591-d111-4cf8-baec-c26a39bc31ef"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/credential_access_suspicious_lsass_access_memdump.toml
+++ b/rules/windows/credential_access_suspicious_lsass_access_memdump.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/07"
 maturity = "production"
-updated_date = "2022/02/16"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,13 @@ index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Credential Access via LSASS Memory Dump"
-references = ["https://www.ired.team/offensive-security/credential-access-and-credential-dumping/dump-credentials-from-lsass-process-without-mimikatz"]
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
+references = [
+    "https://www.ired.team/offensive-security/credential-access-and-credential-dumping/dump-credentials-from-lsass-process-without-mimikatz",
+]
 risk_score = 73
 rule_id = "9960432d-9b26-409f-972b-839a959e79e2"
 severity = "high"
@@ -40,13 +46,15 @@ framework = "MITRE ATT&CK"
 id = "T1003"
 name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.001"
+name = "LSASS Memory"
+reference = "https://attack.mitre.org/techniques/T1003/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "LSASS Memory"
-  id = "T1003.001"
-  reference = "https://attack.mitre.org/techniques/T1003/001/"
+
 
 [rule.threat.tactic]
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
+++ b/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/16"
 maturity = "production"
-updated_date = "2022/02/16"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -51,7 +51,6 @@ risk_score = 47
 rule_id = "47e22836-4a16-4b35-beee-98f6c4ee9bf2"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement", "Credential Access"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/credential_access_symbolic_link_to_shadow_copy_created.toml
+++ b/rules/windows/credential_access_symbolic_link_to_shadow_copy_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/12/25"
 maturity = "production"
-updated_date = "2022/03/18"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -64,6 +64,9 @@ Audit Handle Manipulation (Success,Failure)
 
 This event will only trigger if symbolic links are created from a new process spawning for cmd.exe or powershell.exe with the correct arguments.
 Direct access to a shell and calling symbolic link creation tools will not generate an event.
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+
 """
 references = [
     "https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mklink",

--- a/rules/windows/credential_access_via_snapshot_lsass_clone_creation.toml
+++ b/rules/windows/credential_access_via_snapshot_lsass_clone_creation.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2021/11/27"
-updated_date = "2021/11/27"
+updated_date = "2022/03/31"
 maturity = "production"
 
 
@@ -17,7 +17,10 @@ license = "Elastic License v2"
 name = "Potential LSASS Clone Creation via PssCaptureSnapShot"
 note = """## Config
 
-This is meant to run only on datasources using Windows security event 4688 that captures the process clone creation."""
+This is meant to run only on datasources using Windows security event 4688 that captures the process clone creation.
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
 "https://www.matteomalvica.com/blog/2019/12/02/win-defender-atp-cred-bypass/",
 "https://medium.com/@Achilles8284/the-birth-of-a-process-part-2-97c6fb9c42a2"

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Adding Hidden File Attribute via Attrib"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "4630d948-40d4-4cef-ac69-4002e29bc3db"
 severity = "low"
@@ -28,24 +32,24 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1564"
-reference = "https://attack.mitre.org/techniques/T1564/"
 name = "Hide Artifacts"
+reference = "https://attack.mitre.org/techniques/T1564/"
 [[rule.threat.technique.subtechnique]]
 id = "T1564.001"
-reference = "https://attack.mitre.org/techniques/T1564/001/"
 name = "Hidden Files and Directories"
+reference = "https://attack.mitre.org/techniques/T1564/001/"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 

--- a/rules/windows/defense_evasion_amsienable_key_mod.toml
+++ b/rules/windows/defense_evasion_amsienable_key_mod.toml
@@ -1,20 +1,24 @@
 [metadata]
 creation_date = "2021/06/01"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when JScript tries to query the AmsiEnable registry key from the HKEY_USERS registry hive before initializing Antimalware
-Scan Interface (AMSI). If this key is set to 0, AMSI is not enabled for the JScript process. An adversary can modify
-this key to disable AMSI protections.
+Identifies when JScript tries to query the AmsiEnable registry key from the HKEY_USERS registry hive before initializing
+Antimalware Scan Interface (AMSI). If this key is set to 0, AMSI is not enabled for the JScript process. An adversary
+can modify this key to disable AMSI protections.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Modification of AmsiEnable Registry Key"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://hackinparis.com/data/slides/2019/talks/HIP2019-Dominic_Chell-Cracking_The_Perimeter_With_Sharpshooter.pdf",
     "https://docs.microsoft.com/en-us/windows/win32/amsi/antimalware-scan-interface-portal",

--- a/rules/windows/defense_evasion_clearing_windows_console_history.toml
+++ b/rules/windows/defense_evasion_clearing_windows_console_history.toml
@@ -1,19 +1,23 @@
 [metadata]
 creation_date = "2021/11/22"
 maturity = "production"
-updated_date = "2021/11/24"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Austin Songer"]
 description = """
-Identifies when a user attempts to clear console history. An adversary may clear the command history of a compromised account to conceal
-the actions undertaken during an intrusion.
+Identifies when a user attempts to clear console history. An adversary may clear the command history of a compromised
+account to conceal the actions undertaken during an intrusion.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Clearing Windows Console History"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://stefanos.cloud/blog/kb/how-to-clear-the-powershell-command-history/",
     "https://www.shellhacks.com/clear-history-powershell/",
@@ -34,19 +38,22 @@ process where event.action == "start" and
      (process.args : "*Set-PSReadlineOption*" and process.args : "*SaveNothing*"))
 '''
 
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
 name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+[[rule.threat.technique.subtechnique]]
+id = "T1070.003"
+name = "Clear Command History"
+reference = "https://attack.mitre.org/techniques/T1070/003/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1070.003"
-  name = "Clear Command History"
-  reference = "https://attack.mitre.org/techniques/T1070/003/"
+
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Clearing Windows Event Logs"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "d331bbe2-6db4-4941-80a5-8270db72eb61"
 severity = "low"
@@ -35,15 +39,15 @@ framework = "MITRE ATT&CK"
 id = "T1070"
 name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+[[rule.threat.technique.subtechnique]]
+id = "T1070.001"
+name = "Clear Windows Event Logs"
+reference = "https://attack.mitre.org/techniques/T1070/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1070.001"
-  name = "Clear Windows Event Logs"
-  reference = "https://attack.mitre.org/techniques/T1070/001/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_code_injection_conhost.toml
+++ b/rules/windows/defense_evasion_code_injection_conhost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/31"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Process from Conhost"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://modexp.wordpress.com/2018/09/12/process-injection-user-data/",
     "https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Defense%20Evasion/evasion_codeinj_odzhan_conhost_sysmon_10_1.evtx",
@@ -33,12 +37,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1055"
-reference = "https://attack.mitre.org/techniques/T1055/"
 name = "Process Injection"
+reference = "https://attack.mitre.org/techniques/T1055/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_create_mod_root_certificate.toml
+++ b/rules/windows/defense_evasion_create_mod_root_certificate.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/02/01"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation or Modification of Root Certificate"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://posts.specterops.io/code-signing-certificate-cloning-attacks-and-defenses-6f98657fc6ec",
     "https://www.ired.team/offensive-security/persistence/t1130-install-root-certificate",

--- a/rules/windows/defense_evasion_defender_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_defender_disabled_via_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/23"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,12 @@ license = "Elastic License v2"
 name = "Windows Defender Disabled via Registry Modification"
 note = """## Triage and analysis
 
-Detections should be investigated to identify if the hosts and users are authorized to use this tool. As this rule detects post-exploitation process activity, investigations into this should be prioritized."""
+Detections should be investigated to identify if the hosts and users are authorized to use this tool. As this rule detects post-exploitation process activity, investigations into this should be prioritized.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://thedfirreport.com/2020/12/13/defender-control/"]
 risk_score = 21
 rule_id = "2ffa1f1e-b6db-47fa-994b-1512743847eb"
@@ -47,14 +52,14 @@ id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
 [[rule.threat.technique.subtechnique]]
-id = "T1562.006"
-name = "Indicator Blocking"
-reference = "https://attack.mitre.org/techniques/T1562/006/"
-
-[[rule.threat.technique.subtechnique]]
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.006"
+name = "Indicator Blocking"
+reference = "https://attack.mitre.org/techniques/T1562/006/"
 
 
 

--- a/rules/windows/defense_evasion_defender_exclusion_via_powershell.toml
+++ b/rules/windows/defense_evasion_defender_exclusion_via_powershell.toml
@@ -1,12 +1,13 @@
 [metadata]
 creation_date = "2021/07/20"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies modifications to the Windows Defender configuration settings using PowerShell to add exclusions at the folder directory or process level.
+Identifies modifications to the Windows Defender configuration settings using PowerShell to add exclusions at the folder
+directory or process level.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
@@ -45,8 +46,15 @@ potentially isolate further activity.
 - If further analysis showed malicious intent was behind the Defender exclusions, administrators should remove
 the exclusion and ensure antimalware capability has not been disabled or deleted.
 - Exclusion lists for antimalware capabilities should always be routinely monitored for review.
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
-references = ["https://www.bitdefender.com/files/News/CaseStudies/study/400/Bitdefender-PR-Whitepaper-MosaicLoader-creat5540-en-EN.pdf"]
+references = [
+    "https://www.bitdefender.com/files/News/CaseStudies/study/400/Bitdefender-PR-Whitepaper-MosaicLoader-creat5540-en-EN.pdf",
+]
 risk_score = 47
 rule_id = "2c17e5d7-08b9-43b2-b58a-0270d65ac85b"
 severity = "medium"
@@ -69,14 +77,14 @@ id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
 [[rule.threat.technique.subtechnique]]
-id = "T1562.006"
-name = "Indicator Blocking"
-reference = "https://attack.mitre.org/techniques/T1562/006/"
-
-[[rule.threat.technique.subtechnique]]
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.006"
+name = "Indicator Blocking"
+reference = "https://attack.mitre.org/techniques/T1562/006/"
 
 
 
@@ -96,7 +104,9 @@ name = "PowerShell"
 reference = "https://attack.mitre.org/techniques/T1059/001/"
 
 
+
 [rule.threat.tactic]
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
+++ b/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Delete Volume USN Journal with Fsutil"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "f675872f-6d85-40a3-b502-c0d2ef101e92"
 severity = "low"
@@ -32,17 +36,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
-reference = "https://attack.mitre.org/techniques/T1070/"
 name = "Indicator Removal on Host"
+reference = "https://attack.mitre.org/techniques/T1070/"
 [[rule.threat.technique.subtechnique]]
 id = "T1070.004"
-reference = "https://attack.mitre.org/techniques/T1070/004/"
 name = "File Deletion"
+reference = "https://attack.mitre.org/techniques/T1070/004/"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
+++ b/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
@@ -1,19 +1,23 @@
 [metadata]
 creation_date = "2022/01/31"
 maturity = "production"
-updated_date = "2022/01/31"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies attempts to disable PowerShell Script Block Logging via registry modification. Attackers may disable
-this logging to conceal their activities in the host and evade detection.
+Identifies attempts to disable PowerShell Script Block Logging via registry modification. Attackers may disable this
+logging to conceal their activities in the host and evade detection.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "PowerShell Script Block Logging Disabled"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://admx.help/?Category=Windows_10_2016&Policy=Microsoft.Policies.PowerShell::EnableScriptBlockLogging",
 ]
@@ -34,20 +38,19 @@ registry where event.type == "change" and
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
-
 [[rule.threat.technique]]
 id = "T1562"
-reference = "https://attack.mitre.org/techniques/T1562/"
 name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+[[rule.threat.technique.subtechnique]]
+id = "T1562.002"
+name = "Disable Windows Event Logging"
+reference = "https://attack.mitre.org/techniques/T1562/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1562.002"
-  name = "Disable Windows Event Logging"
-  reference = "https://attack.mitre.org/techniques/T1562/002/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Disable Windows Firewall Rules via Netsh"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "4b438734-3793-4fda-bd42-ceeada0be8f9"
 severity = "medium"
@@ -33,17 +37,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1562"
-reference = "https://attack.mitre.org/techniques/T1562/"
 name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
 [[rule.threat.technique.subtechnique]]
 id = "T1562.004"
-reference = "https://attack.mitre.org/techniques/T1562/004/"
 name = "Disable or Modify System Firewall"
+reference = "https://attack.mitre.org/techniques/T1562/004/"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_disabling_windows_defender_powershell.toml
+++ b/rules/windows/defense_evasion_disabling_windows_defender_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/07"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -12,6 +12,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Disabling Windows Defender Security Settings via PowerShell"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/defender/set-mppreference?view=windowsserver2019-ps",
 ]
@@ -33,16 +37,17 @@ process where event.type == "start" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1562"
-reference = "https://attack.mitre.org/techniques/T1562/"
 name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
 [[rule.threat.technique.subtechnique]]
 id = "T1562.001"
-reference = "https://attack.mitre.org/techniques/T1562/001/"
 name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_disabling_windows_logs.toml
+++ b/rules/windows/defense_evasion_disabling_windows_logs.toml
@@ -1,13 +1,12 @@
 [metadata]
 creation_date = "2021/05/06"
 maturity = "production"
-updated_date = "2021/09/23"
-
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Ivan Ninichuck", "Austin Songer"]
 description = """
-Identifies attempts to disable EventLog via the logman Windows utility, PowerShell, or auditpol. This is often done by 
+Identifies attempts to disable EventLog via the logman Windows utility, PowerShell, or auditpol. This is often done by
 attackers in an attempt to evade detection on a system.
 """
 from = "now-9m"
@@ -15,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Disable Windows Event and Security Logs Using Built-in Tools"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/logman"]
 risk_score = 21
 rule_id = "4de76544-f0e5-486a-8f84-eae0b6063cdc"
@@ -36,20 +39,22 @@ process where event.type in ("start", "process_started") and
   ((process.name:"auditpol.exe" or process.pe.original_file_name == "AUDITPOL.EXE") and process.args : "/success:disable")
 '''
 
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1070"
 name = "Indicator Removal on Host"
 reference = "https://attack.mitre.org/techniques/T1070/"
+[[rule.threat.technique.subtechnique]]
+id = "T1070.001"
+name = "Clear Windows Event Logs"
+reference = "https://attack.mitre.org/techniques/T1070/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1070.001"
-  name = "Clear Windows Event Logs"
-  reference = "https://attack.mitre.org/techniques/T1070/001/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_dns_over_https_enabled.toml
+++ b/rules/windows/defense_evasion_dns_over_https_enabled.toml
@@ -1,19 +1,24 @@
 [metadata]
 creation_date = "2021/07/22"
 maturity = "production"
-updated_date = "2021/10/15"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Austin Songer"]
-description = """Identifies when a user enables DNS-over-HTTPS. This can be used to hide internet activity or
-the process of exfiltrating data. With this enabled, an organization will lose visibility into data such as query type,
-response, and originating IP, which are used to determine bad actors."""
-
+description = """
+Identifies when a user enables DNS-over-HTTPS. This can be used to hide internet activity or the process of exfiltrating
+data. With this enabled, an organization will lose visibility into data such as query type, response, and originating
+IP, which are used to determine bad actors.
+"""
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "DNS-over-HTTPS Enabled via Registry"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.tenforums.com/tutorials/151318-how-enable-disable-dns-over-https-doh-microsoft-edge.html",
     "https://chromeenterprise.google/policies/?policy=DnsOverHttpsMode",
@@ -35,12 +40,14 @@ registry where event.type in ("creation", "change") and
   registry.data.strings : "1")
 '''
 
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
+
 
 [rule.threat.tactic]
 id = "TA0005"

--- a/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
+++ b/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious .NET Code Compilation"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "201200f1-a99b-43fb-88ed-f65a45c4972c"
 severity = "medium"
@@ -31,11 +35,11 @@ framework = "MITRE ATT&CK"
 id = "T1027"
 name = "Obfuscated Files or Information"
 reference = "https://attack.mitre.org/techniques/T1027/"
+[[rule.threat.technique.subtechnique]]
+id = "T1027.004"
+name = "Compile After Delivery"
+reference = "https://attack.mitre.org/techniques/T1027/004/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1027.004"
-  name = "Compile After Delivery"
-  reference = "https://attack.mitre.org/techniques/T1027/004/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
+++ b/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote Desktop Enabled in Windows Firewall"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "074464f9-f30d-4029-8c03-0ed237fffec7"
 severity = "medium"
@@ -37,8 +41,9 @@ name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
 [[rule.threat.technique.subtechnique]]
 id = "T1562.004"
-reference = "https://attack.mitre.org/techniques/T1562/004/"
 name = "Disable or Modify System Firewall"
+reference = "https://attack.mitre.org/techniques/T1562/004/"
+
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_enable_network_discovery_with_netsh.toml
+++ b/rules/windows/defense_evasion_enable_network_discovery_with_netsh.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2021/07/07"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies use of the netsh.exe program to enable host discovery via the network. Attackers can use this command-line tool to
-weaken the host firewall settings.
+Identifies use of the netsh.exe program to enable host discovery via the network. Attackers can use this command-line
+tool to weaken the host firewall settings.
 """
 false_positives = ["Host Windows Firewall planned system administration changes."]
 from = "now-9m"
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Enable Host Network Discovery via Netsh"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "8b4f0816-6a65-4630-86a6-c21c179c0d09"
 severity = "medium"
@@ -37,12 +41,13 @@ name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
 [[rule.threat.technique.subtechnique]]
 id = "T1562.004"
-reference = "https://attack.mitre.org/techniques/T1562/004/"
 name = "Disable or Modify System Firewall"
+reference = "https://attack.mitre.org/techniques/T1562/004/"
 
 
 
 [rule.threat.tactic]
-reference = "https://attack.mitre.org/tactics/TA0005/"
 id = "TA0005"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_execution_control_panel_suspicious_args.toml
+++ b/rules/windows/defense_evasion_execution_control_panel_suspicious_args.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/09/08"
 maturity = "production"
-updated_date = "2021/09/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Control Panel Process with Unusual Arguments"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://www.joesandbox.com/analysis/476188/1/html"]
 risk_score = 73
 rule_id = "416697ae-e468-4093-a93d-59661fa619ec"
@@ -45,18 +49,18 @@ process where event.type in ("start", "process_started") and
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1218/"
-name = "Signed Binary Proxy Execution"
 id = "T1218"
+name = "Signed Binary Proxy Execution"
+reference = "https://attack.mitre.org/techniques/T1218/"
 [[rule.threat.technique.subtechnique]]
-reference = "https://attack.mitre.org/techniques/T1218/002/"
-name = "Control Panel"
 id = "T1218.002"
+name = "Control Panel"
+reference = "https://attack.mitre.org/techniques/T1218/002/"
 
 
 
 [rule.threat.tactic]
-reference = "https://attack.mitre.org/tactics/TA0005/"
-name = "Defense Evasion"
 id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
+++ b/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "ImageLoad via Windows Update Auto Update Client"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://dtm.uk/wuauclt/"]
 risk_score = 47
 rule_id = "edf8ee23-5ea7-4123-ba19-56b41e424ae3"

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by an Office Application"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://blog.talosintelligence.com/2020/02/building-bypass-with-msbuild.html"]
 risk_score = 73
 rule_id = "c5dc3223-13a2-44a2-946c-e9dc0aa0449c"
@@ -46,23 +50,24 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1127"
-reference = "https://attack.mitre.org/techniques/T1127/"
 name = "Trusted Developer Utilities Proxy Execution"
+reference = "https://attack.mitre.org/techniques/T1127/"
+[[rule.threat.technique.subtechnique]]
+id = "T1127.001"
+name = "MSBuild"
+reference = "https://attack.mitre.org/techniques/T1127/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1127.001"
-  name = "MSBuild"
-  reference = "https://attack.mitre.org/techniques/T1127/001/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by a Script Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2"
 severity = "low"
@@ -33,24 +37,24 @@ process where event.type == "start" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1127"
-reference = "https://attack.mitre.org/techniques/T1127/"
 name = "Trusted Developer Utilities Proxy Execution"
+reference = "https://attack.mitre.org/techniques/T1127/"
+[[rule.threat.technique.subtechnique]]
+id = "T1127.001"
+name = "MSBuild"
+reference = "https://attack.mitre.org/techniques/T1127/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1127.001"
-  name = "MSBuild"
-  reference = "https://attack.mitre.org/techniques/T1127/001/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by a System Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae3"
 severity = "medium"
@@ -33,24 +37,24 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1127"
-reference = "https://attack.mitre.org/techniques/T1127/"
 name = "Trusted Developer Utilities Proxy Execution"
+reference = "https://attack.mitre.org/techniques/T1127/"
+[[rule.threat.technique.subtechnique]]
+id = "T1127.001"
+name = "MSBuild"
+reference = "https://attack.mitre.org/techniques/T1127/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1127.001"
-  name = "MSBuild"
-  reference = "https://attack.mitre.org/techniques/T1127/001/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Using an Alternate Name"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae4"
 severity = "low"
@@ -33,17 +37,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1036"
-reference = "https://attack.mitre.org/techniques/T1036/"
 name = "Masquerading"
+reference = "https://attack.mitre.org/techniques/T1036/"
+[[rule.threat.technique.subtechnique]]
+id = "T1036.003"
+name = "Rename System Utilities"
+reference = "https://attack.mitre.org/techniques/T1036/003/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1036.003"
-  name = "Rename System Utilities"
-  reference = "https://attack.mitre.org/techniques/T1036/003/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started an Unusual Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://blog.talosintelligence.com/2020/02/building-bypass-with-msbuild.html"]
 risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae6"
@@ -39,17 +43,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1027"
-reference = "https://attack.mitre.org/techniques/T1027/"
 name = "Obfuscated Files or Information"
+reference = "https://attack.mitre.org/techniques/T1027/"
 [[rule.threat.technique.subtechnique]]
 id = "T1027.004"
-reference = "https://attack.mitre.org/techniques/T1027/004/"
 name = "Compile After Delivery"
+reference = "https://attack.mitre.org/techniques/T1027/004/"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
+++ b/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential DLL SideLoading via Trusted Microsoft Programs"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "1160dcdb-0a0a-4a79-91d8-9b84616edebd"
 severity = "high"
@@ -40,11 +44,12 @@ process where event.type == "start" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1036"
-reference = "https://attack.mitre.org/techniques/T1036/"
 name = "Masquerading"
+reference = "https://attack.mitre.org/techniques/T1036/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_execution_windefend_unusual_path.toml
+++ b/rules/windows/defense_evasion_execution_windefend_unusual_path.toml
@@ -1,14 +1,14 @@
 [metadata]
 creation_date = "2021/07/07"
 maturity = "production"
-updated_date = "2021/09/22"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Dennis Perto"]
 description = """
-Identifies a Windows trusted program that is known to be vulnerable to DLL Search Order Hijacking
-starting after being renamed or from a non-standard path. This is uncommon behavior and may indicate an attempt to evade
-defenses via side-loading a malicious DLL within the memory space of one of those processes.
+Identifies a Windows trusted program that is known to be vulnerable to DLL Search Order Hijacking starting after being
+renamed or from a non-standard path. This is uncommon behavior and may indicate an attempt to evade defenses via
+side-loading a malicious DLL within the memory space of one of those processes.
 """
 false_positives = ["Microsoft Antimalware Service Executable installed on non default installation path."]
 from = "now-9m"
@@ -16,6 +16,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential DLL Side-Loading via Microsoft Antimalware Service Executable"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://news.sophos.com/en-us/2021/07/04/independence-day-revil-uses-supply-chain-exploit-to-attack-hundreds-of-businesses/",
 ]
@@ -50,7 +54,9 @@ name = "DLL Side-Loading"
 reference = "https://attack.mitre.org/techniques/T1574/002/"
 
 
+
 [rule.threat.tactic]
+id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-id = "TA0005"
+

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2021/01/19"
 maturity = "production"
-updated_date = "2021/09/23"
 min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Executable File Creation with Multiple Extensions"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "8b2b3a62-a598-4293-bc14-3d5fa22bb98f"
 severity = "medium"
@@ -47,19 +51,18 @@ reference = "https://attack.mitre.org/techniques/T1036/004/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1204"
 name = "User Execution"
 reference = "https://attack.mitre.org/techniques/T1204/"
+[[rule.threat.technique.subtechnique]]
+id = "T1204.002"
+name = "Malicious File"
+reference = "https://attack.mitre.org/techniques/T1204/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1204.002"
-  name = "Malicious File"
-  reference = "https://attack.mitre.org/techniques/T1204/002/"
+
 
 [rule.threat.tactic]
 id = "TA0002"

--- a/rules/windows/defense_evasion_iis_httplogging_disabled.toml
+++ b/rules/windows/defense_evasion_iis_httplogging_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/04/14"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "IIS HTTP Logging Disabled"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "ebf1adea-ccf2-4943-8b96-7ab11ca173a5"
 severity = "high"
@@ -34,17 +38,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1562"
-reference = "https://attack.mitre.org/techniques/T1562/"
 name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+[[rule.threat.technique.subtechnique]]
+id = "T1562.002"
+name = "Disable Windows Event Logging"
+reference = "https://attack.mitre.org/techniques/T1562/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1562.002"
-  name = "Disable Windows Event Logging"
-  reference = "https://attack.mitre.org/techniques/T1562/002/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
+++ b/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/24"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Endpoint Security Parent Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "b41a13c6-ba45-4bab-a534-df53d0cfed6a"
 severity = "medium"

--- a/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
+++ b/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/01"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Renamed AutoIt Scripts Interpreter"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "2e1e835d-01e5-48ca-b9fc-7a61f7f11902"
 severity = "medium"
@@ -33,11 +37,11 @@ framework = "MITRE ATT&CK"
 id = "T1036"
 name = "Masquerading"
 reference = "https://attack.mitre.org/techniques/T1036/"
+[[rule.threat.technique.subtechnique]]
+id = "T1036.003"
+name = "Rename System Utilities"
+reference = "https://attack.mitre.org/techniques/T1036/003/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1036.003"
-  name = "Rename System Utilities"
-  reference = "https://attack.mitre.org/techniques/T1036/003/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
+++ b/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/24"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious WerFault Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.hexacorn.com/blog/2019/09/19/silentprocessexit-quick-look-under-the-hood/",
     "https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Persistence/persistence_SilentProcessExit_ImageHijack_sysmon_13_1.evtx",
@@ -50,11 +54,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1036"
-reference = "https://attack.mitre.org/techniques/T1036/"
 name = "Masquerading"
+reference = "https://attack.mitre.org/techniques/T1036/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_masquerading_trusted_directory.toml
+++ b/rules/windows/defense_evasion_masquerading_trusted_directory.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Program Files Directory Masquerading"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14"
 severity = "medium"
@@ -35,11 +39,11 @@ framework = "MITRE ATT&CK"
 id = "T1036"
 name = "Masquerading"
 reference = "https://attack.mitre.org/techniques/T1036/"
+[[rule.threat.technique.subtechnique]]
+id = "T1036.005"
+name = "Match Legitimate Name or Location"
+reference = "https://attack.mitre.org/techniques/T1036/005/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1036.005"
-  name = "Match Legitimate Name or Location"
-  reference = "https://attack.mitre.org/techniques/T1036/005/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/defense_evasion_microsoft_defender_tampering.toml
+++ b/rules/windows/defense_evasion_microsoft_defender_tampering.toml
@@ -1,20 +1,24 @@
 [metadata]
 creation_date = "2021/10/18"
 maturity = "production"
-updated_date = "2022/03/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Austin Songer"]
 description = """
-Identifies when one or more features on Microsoft Defender are disabled. Adversaries may disable or tamper with Microsoft
-Defender features to evade detection and conceal malicious behavior.
+Identifies when one or more features on Microsoft Defender are disabled. Adversaries may disable or tamper with
+Microsoft Defender features to evade detection and conceal malicious behavior.
 """
 false_positives = ["Legitimate Windows Defender configuration changes"]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"] 
+index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Windows Defender Tampering"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://thedfirreport.com/2021/10/18/icedid-to-xinglocker-ransomware-in-24-hours/",
     "https://www.tenforums.com/tutorials/32236-enable-disable-microsoft-defender-pua-protection-windows-10-a.html",
@@ -64,6 +68,7 @@ registry where event.type in ("creation", "change") and
   registry.data.strings : ("1", "0x00000001"))
 '''
 
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -71,7 +76,9 @@ id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
 
+
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
+++ b/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/01/12"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -57,6 +57,11 @@ positives (B-TPs), as this configuration can put the user and the domain at risk
 - Reset the registry key value.
 - Isolate the host if malicious code was executed and reset the involved account's passwords.
 - Explore using GPOs to manage security settings for Microsoft Office macros.
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
 risk_score = 47
 rule_id = "feeed87c-5e95-4339-aef1-47fd79bcfbe3"
@@ -78,30 +83,31 @@ registry where event.type == "change" and
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
-
 [[rule.threat.technique]]
 id = "T1112"
 name = "Modify Registry"
 reference = "https://attack.mitre.org/techniques/T1112/"
 
+
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1204"
 name = "User Execution"
 reference = "https://attack.mitre.org/techniques/T1204/"
+[[rule.threat.technique.subtechnique]]
+id = "T1204.002"
+name = "Malicious File"
+reference = "https://attack.mitre.org/techniques/T1204/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1204.002"
-  name = "Malicious File"
-  reference = "https://attack.mitre.org/techniques/T1204/002/"
+
 
 [rule.threat.tactic]
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/defense_evasion_powershell_windows_firewall_disabled.toml
+++ b/rules/windows/defense_evasion_powershell_windows_firewall_disabled.toml
@@ -1,8 +1,7 @@
 [metadata]
 creation_date = "2021/10/15"
 maturity = "production"
-updated_date = "2022/02/16"
-
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Austin Songer"]
@@ -22,6 +21,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Windows Firewall Disabled via PowerShell"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://docs.microsoft.com/en-us/powershell/module/netsecurity/set-netfirewallprofile?view=windowsserver2019-ps",
     "https://www.tutorialspoint.com/how-to-get-windows-firewall-profile-settings-using-powershell",
@@ -43,17 +46,19 @@ process where event.action == "start" and
   (process.args : "*-All*" or process.args : ("*Public*", "*Domain*", "*Private*"))
 '''
 
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
+[[rule.threat.technique.subtechnique]]
+id = "T1562.004"
+name = "Disable or Modify System Firewall"
+reference = "https://attack.mitre.org/techniques/T1562/004/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1562.004"
-  reference = "https://attack.mitre.org/techniques/T1562/004/"
-  name = "Disable or Modify System Firewall"
+
 
 [rule.threat.tactic]
 id = "TA0005"

--- a/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
+++ b/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Scheduled Tasks AT Command Enabled"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-scheduledjob"]
 risk_score = 47
 rule_id = "9aa0e1f6-52ce-42e1-abb3-09657cee2698"

--- a/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
+++ b/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,12 @@ license = "Elastic License v2"
 name = "Potential Secure File Deletion via SDelete Utility"
 note = """## Triage and analysis
 
-Verify process details such as command line and hash to confirm this activity legitimacy."""
+Verify process details such as command line and hash to confirm this activity legitimacy.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "5aee924b-6ceb-4633-980e-1bde8cdb40c5"
 severity = "low"

--- a/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "SolarWinds Process Disabling Services via Registry"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html",
 ]

--- a/rules/windows/defense_evasion_suspicious_certutil_commands.toml
+++ b/rules/windows/defense_evasion_suspicious_certutil_commands.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/10/15"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
 description = """
-Identifies suspicious commands being used with certutil.exe. CertUtil is a native Windows component which is part of 
-Certificate Services. CertUtil is often abused by attackers to live off the land for stealthier command and control or 
+Identifies suspicious commands being used with certutil.exe. CertUtil is a native Windows component which is part of
+Certificate Services. CertUtil is often abused by attackers to live off the land for stealthier command and control or
 data exfiltration.
 """
 from = "now-9m"
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious CertUtil Commands"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://twitter.com/Moriarty_Meng/status/984380793383370752",
     "https://twitter.com/egre55/status/1087685529016193025",
@@ -39,12 +43,12 @@ process where event.type == "start" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1140"
-reference = "https://attack.mitre.org/techniques/T1140/"
 name = "Deobfuscate/Decode Files or Information"
+reference = "https://attack.mitre.org/techniques/T1140/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_suspicious_execution_from_mounted_device.toml
+++ b/rules/windows/defense_evasion_suspicious_execution_from_mounted_device.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/05/28"
 maturity = "production"
-updated_date = "2021/05/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Execution from a Mounted Device"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.microsoft.com/security/blog/2021/05/27/new-sophisticated-email-based-attack-from-nobelium/",
     "https://www.volexity.com/blog/2021/05/27/suspected-apt29-operation-launches-election-fraud-themed-phishing-campaigns/",
@@ -37,44 +41,45 @@ process where event.type == "start" and process.executable : "C:\\*" and
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1218/"
 id = "T1218"
 name = "Signed Binary Proxy Execution"
+reference = "https://attack.mitre.org/techniques/T1218/"
 [[rule.threat.technique.subtechnique]]
-reference = "https://attack.mitre.org/techniques/T1218/011/"
-id = "T1218.011"
-name = "Rundll32"
-
-[[rule.threat.technique.subtechnique]]
-reference = "https://attack.mitre.org/techniques/T1218/005/"
 id = "T1218.005"
 name = "Mshta"
+reference = "https://attack.mitre.org/techniques/T1218/005/"
 
 [[rule.threat.technique.subtechnique]]
-reference = "https://attack.mitre.org/techniques/T1218/010/"
 id = "T1218.010"
 name = "Regsvr32"
+reference = "https://attack.mitre.org/techniques/T1218/010/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1218.011"
+name = "Rundll32"
+reference = "https://attack.mitre.org/techniques/T1218/011/"
 
 
 
 [rule.threat.tactic]
-reference = "https://attack.mitre.org/tactics/TA0005/"
 id = "TA0005"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1059/"
 id = "T1059"
 name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
 [[rule.threat.technique.subtechnique]]
-reference = "https://attack.mitre.org/techniques/T1059/001/"
 id = "T1059.001"
 name = "PowerShell"
+reference = "https://attack.mitre.org/techniques/T1059/001/"
 
 
 
 [rule.threat.tactic]
-reference = "https://attack.mitre.org/tactics/TA0002/"
 id = "TA0002"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
+++ b/rules/windows/defense_evasion_suspicious_managedcode_host_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 73
 rule_id = "acf738b5-b5b2-4acc-bad9-1e18ee234f40"
 severity = "high"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_suspicious_process_access_direct_syscall.toml
+++ b/rules/windows/defense_evasion_suspicious_process_access_direct_syscall.toml
@@ -1,23 +1,27 @@
 [metadata]
 creation_date = "2021/10/11"
 maturity = "production"
-updated_date = "2021/10/11"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies suspicious process access events from an unknown memory region. Endpoint security solutions usually hook userland
-Windows APIs in order to decide if the code that is being executed is malicious or not. It's possible to bypass hooked
-functions by writing malicious functions that call syscalls directly.
+Identifies suspicious process access events from an unknown memory region. Endpoint security solutions usually hook
+userland Windows APIs in order to decide if the code that is being executed is malicious or not. It's possible to bypass
+hooked functions by writing malicious functions that call syscalls directly.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Process Access via Direct System Call"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://twitter.com/SBousseaden/status/1278013896440324096",
-    "https://www.ired.team/offensive-security/defense-evasion/using-syscalls-directly-from-visual-studio-to-bypass-avs-edrs"
+    "https://www.ired.team/offensive-security/defense-evasion/using-syscalls-directly-from-visual-studio-to-bypass-avs-edrs",
 ]
 risk_score = 73
 rule_id = "2dd480be-1263-4d9c-8672-172928f6789a"
@@ -47,3 +51,4 @@ reference = "https://attack.mitre.org/techniques/T1055/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_suspicious_process_creation_calltrace.toml
+++ b/rules/windows/defense_evasion_suspicious_process_creation_calltrace.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/24"
 maturity = "production"
-updated_date = "2021/10/24"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,6 @@ risk_score = 43
 rule_id = "3ed032b2-45d8-4406-bc79-7ad1eabb2c72"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
+++ b/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/09/03"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Zoom Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "97aba1ef-6034-4bd3-8c1a-1e0996b27afa"
 severity = "medium"

--- a/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
+++ b/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Executable File Creation by a System Critical Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "e94262f2-c1e9-4d3f-a907-aeab16712e1a"
 severity = "high"
@@ -40,11 +44,12 @@ file where event.type != "deletion" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1211"
-reference = "https://attack.mitre.org/techniques/T1211/"
 name = "Exploitation for Defense Evasion"
+reference = "https://attack.mitre.org/techniques/T1211/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_unusual_ads_file_creation.toml
+++ b/rules/windows/defense_evasion_unusual_ads_file_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/21"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual File Creation - Alternate Data Stream"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "71bccb61-e19b-452f-b104-79a60e546a95"
 severity = "medium"

--- a/rules/windows/defense_evasion_unusual_dir_ads.toml
+++ b/rules/windows/defense_evasion_unusual_dir_ads.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Process Execution Path - Alternate Data Stream"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "4bd1c1af-79d4-4d37-9efa-6e0240640242"
 severity = "medium"
@@ -39,7 +43,9 @@ name = "NTFS File Attributes"
 reference = "https://attack.mitre.org/techniques/T1564/004/"
 
 
+
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_unusual_network_connection_via_dllhost.toml
+++ b/rules/windows/defense_evasion_unusual_network_connection_via_dllhost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/05/28"
 maturity = "production"
-updated_date = "2021/05/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,6 @@ risk_score = 47
 rule_id = "c7894234-7814-44c2-92a9-f7d851ea246a"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
+++ b/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/19"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Child Process from a System Virtual Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "de9bd7e0-49e9-4e92-a64d-53ade2e66af1"
 severity = "high"
@@ -29,11 +33,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1055"
-reference = "https://attack.mitre.org/techniques/T1055/"
 name = "Process Injection"
+reference = "https://attack.mitre.org/techniques/T1055/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Evasion via Filter Manager"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "06dceabf-adca-48af-ac79-ffdf4c3b1e9a"
 severity = "medium"
@@ -39,8 +43,9 @@ name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
 
 
+
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 

--- a/rules/windows/defense_evasion_whitespace_padding_in_command_line.toml
+++ b/rules/windows/defense_evasion_whitespace_padding_in_command_line.toml
@@ -1,16 +1,16 @@
 [metadata]
 creation_date = "2021/07/30"
 maturity = "production"
-updated_date = "2021/12/06"
 min_stack_comments = "EQL regex had a bug when dealing with wildcard fields that was fixed in 7.16 (elastic/elasticsearch/issues/78391)"
 min_stack_version = "7.16.0"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies process execution events where the command line value contains a long sequence of whitespace characters or 
-multiple occurrences of contiguous whitespace. Attackers may attempt to evade signature-based detections by padding 
-their malicious command with unnecessary whitespace characters. These observations should be investigated for malicious 
+Identifies process execution events where the command line value contains a long sequence of whitespace characters or
+multiple occurrences of contiguous whitespace. Attackers may attempt to evade signature-based detections by padding
+their malicious command with unnecessary whitespace characters. These observations should be investigated for malicious
 behavior.
 """
 from = "now-9m"
@@ -21,7 +21,12 @@ name = "Whitespace Padding in Process Command Line"
 note = """## Triage and analysis
 
 - Analyze the command line of the process in question for evidence of malicious code execution.
-- Review the ancestor and child processes spawned by the process in question for indicators of further malicious code execution."""
+- Review the ancestor and child processes spawned by the process in question for indicators of further malicious code execution.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://twitter.com/JohnLaTwC/status/1419251082736201737"]
 risk_score = 47
 rule_id = "e0dacebe-4311-4d50-9387-b17e89c2e7fd"
@@ -38,10 +43,12 @@ process where event.type in ("start", "process_started") and
   process.command_line regex ".*(.*[ ]{5,}[^ ]*){3,}.*"
 '''
 
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_workfolders_control_execution.toml
+++ b/rules/windows/defense_evasion_workfolders_control_execution.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/03/02"
 maturity = "production"
-updated_date = "2022/03/02"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -41,6 +41,11 @@ behavior.
 - If no lateral movement was identified during investigation, take the effected host offline if possible and remove the control.exe binary as well as any additional artifacts identified during investigation.
 - Review integrating Windows Information Protection (WIP) to enforce data protection by encrypting the data on PCs using Work Folders.
 - Confirm with user whether this was expected or not and reset their password.
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
 references = [
     "https://docs.microsoft.com/en-us/windows-server/storage/work-folders/work-folders-overview",

--- a/rules/windows/discovery_adfind_command_activity.toml
+++ b/rules/windows/discovery_adfind_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -50,6 +50,11 @@ isolation, so reviewing previous logs/activity from impacted machines can be ver
 post-compromise behavior.
 - It's important to understand that `AdFind` is an Active Directory enumeration tool and can be used for malicious or legitimate
 purposes, so understanding the intent behind the activity will help determine the appropropriate response.
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
 references = [
     "http://www.joeware.net/freetools/tools/adfind/",
@@ -82,6 +87,11 @@ process where event.type in ("start", "process_started") and
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
+id = "T1018"
+name = "Remote System Discovery"
+reference = "https://attack.mitre.org/techniques/T1018/"
+
+[[rule.threat.technique]]
 id = "T1069"
 name = "Permission Groups Discovery"
 reference = "https://attack.mitre.org/techniques/T1069/"
@@ -105,12 +115,6 @@ reference = "https://attack.mitre.org/techniques/T1087/002/"
 id = "T1482"
 name = "Domain Trust Discovery"
 reference = "https://attack.mitre.org/techniques/T1482/"
-
-
-[[rule.threat.technique]]
-id = "T1018"
-name = "Remote System Discovery"
-reference = "https://attack.mitre.org/techniques/T1018/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/discovery_admin_recon.toml
+++ b/rules/windows/discovery_admin_recon.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Enumeration of Administrator Accounts"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "871ea072-1b71-4def-b016-6278b505138d"
 severity = "low"
@@ -43,11 +47,11 @@ framework = "MITRE ATT&CK"
 id = "T1069"
 name = "Permission Groups Discovery"
 reference = "https://attack.mitre.org/techniques/T1069/"
+[[rule.threat.technique.subtechnique]]
+id = "T1069.002"
+name = "Domain Groups"
+reference = "https://attack.mitre.org/techniques/T1069/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1069.002"
-  name = "Domain Groups"
-  reference = "https://attack.mitre.org/techniques/T1069/002/"
 
 [[rule.threat.technique]]
 id = "T1087"

--- a/rules/windows/discovery_file_dir_discovery.toml
+++ b/rules/windows/discovery_file_dir_discovery.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,6 @@ risk_score = 21
 rule_id = "7b08314d-47a0-4b71-ae4e-16544176924f"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/18"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Net command via SYSTEM account"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "2856446a-34e6-435b-9fb5-f8f040bfa7ed"
 severity = "low"
@@ -34,11 +38,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1033"
-reference = "https://attack.mitre.org/techniques/T1033/"
 name = "System Owner/User Discovery"
+reference = "https://attack.mitre.org/techniques/T1033/"
 
 
 [rule.threat.tactic]
 id = "TA0007"
-reference = "https://attack.mitre.org/tactics/TA0007/"
 name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/windows/discovery_net_view.toml
+++ b/rules/windows/discovery_net_view.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Windows Network Enumeration"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "7b8bfc26-81d2-435e-965c-d722ee397ef1"
 severity = "medium"

--- a/rules/windows/discovery_peripheral_device.toml
+++ b/rules/windows/discovery_peripheral_device.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Peripheral Device Discovery"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "0c7ca5c2-728d-4ad9-b1c5-bbba83ecb1f4"
 severity = "low"

--- a/rules/windows/discovery_privileged_localgroup_membership.toml
+++ b/rules/windows/discovery_privileged_localgroup_membership.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/15"
 maturity = "production"
-updated_date = "2022/02/16"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,9 @@ note = """## Config
 
 This will require Windows security event 4799 by enabling audit success for the Windows Account Management category and
 the Security Group Management subcategory.
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+
 """
 risk_score = 43
 rule_id = "291a0de9-937a-4189-94c0-3e847c8b13e4"

--- a/rules/windows/discovery_remote_system_discovery_commands_windows.toml
+++ b/rules/windows/discovery_remote_system_discovery_commands_windows.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote System Discovery Commands"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "0635c542-1b96-4335-9b47-126582d2c19a"
 severity = "low"

--- a/rules/windows/discovery_security_software_wmic.toml
+++ b/rules/windows/discovery_security_software_wmic.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Security Software Discovery using WMIC"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "6ea55c81-e2ba-42f2-a134-bccf857ba922"
 severity = "medium"
@@ -34,11 +38,11 @@ framework = "MITRE ATT&CK"
 id = "T1518"
 name = "Software Discovery"
 reference = "https://attack.mitre.org/techniques/T1518/"
+[[rule.threat.technique.subtechnique]]
+id = "T1518.001"
+name = "Security Software Discovery"
+reference = "https://attack.mitre.org/techniques/T1518/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1518.001"
-  name = "Security Software Discovery"
-  reference = "https://attack.mitre.org/techniques/T1518/001/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Whoami Process Activity"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "ef862985-3f13-4262-a686-5f357bbb9bc2"
 severity = "low"
@@ -36,12 +40,12 @@ process where event.type in ("start", "process_started") and process.name : "who
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1033"
-reference = "https://attack.mitre.org/techniques/T1033/"
 name = "System Owner/User Discovery"
+reference = "https://attack.mitre.org/techniques/T1033/"
 
 
 [rule.threat.tactic]
 id = "TA0007"
-reference = "https://attack.mitre.org/tactics/TA0007/"
 name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
 

--- a/rules/windows/execution_apt_solarwinds_backdoor_child_cmd_powershell.toml
+++ b/rules/windows/execution_apt_solarwinds_backdoor_child_cmd_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Command Execution via SolarWinds Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html",
     "https://github.com/fireeye/sunburst_countermeasures/blob/main/rules/SUNBURST/hxioc/SOLARWINDS%20SUSPICIOUS%20FILEWRITES%20(METHODOLOGY).ioc",

--- a/rules/windows/execution_apt_solarwinds_backdoor_unusual_child_processes.toml
+++ b/rules/windows/execution_apt_solarwinds_backdoor_unusual_child_processes.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious SolarWinds Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html",
     "https://github.com/fireeye/sunburst_countermeasures/blob/main/rules/SUNBURST/hxioc/SOLARWINDS%20SUSPICIOUS%20CHILD%20PROCESSES%20(METHODOLOGY).ioc",

--- a/rules/windows/execution_com_object_xwizard.toml
+++ b/rules/windows/execution_com_object_xwizard.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/20"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Execution of COM object via Xwizard"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://lolbas-project.github.io/lolbas/Binaries/Xwizard/",
     "http://www.hexacorn.com/blog/2017/07/31/the-wizard-of-x-oppa-plugx-style/",

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Svchost spawning Cmd"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "fd7a6052-58fa-4397-93c3-4795249ccfa2"
 severity = "low"
@@ -29,11 +33,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-reference = "https://attack.mitre.org/techniques/T1059/"
 name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/21"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Parent Process for cmd.exe"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "3b47900d-e793-49e8-968f-c90dc3526aa1"
 severity = "medium"
@@ -52,12 +56,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-reference = "https://attack.mitre.org/techniques/T1059/"
 name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
 

--- a/rules/windows/execution_command_shell_via_rundll32.toml
+++ b/rules/windows/execution_command_shell_via_rundll32.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -12,6 +12,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Command Shell Activity Started via RunDLL32"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "9ccf3ce0-0057-440a-91f5-870c6ad39093"
 severity = "low"
@@ -46,3 +50,4 @@ reference = "https://attack.mitre.org/techniques/T1059/001/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/execution_enumeration_via_wmiprvse.toml
+++ b/rules/windows/execution_enumeration_via_wmiprvse.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/19"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Enumeration Command Spawned via WMIPrvSE"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "770e0c4d-b998-41e5-a62e-c7901fd7f470"
 severity = "low"
@@ -64,29 +68,26 @@ reference = "https://attack.mitre.org/techniques/T1047/"
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-id = "T1518"
-name = "Software Discovery"
-reference = "https://attack.mitre.org/techniques/T1518/"
-
+id = "T1018"
+name = "Remote System Discovery"
+reference = "https://attack.mitre.org/techniques/T1018/"
 
 [[rule.threat.technique]]
 id = "T1087"
 name = "Account Discovery"
 reference = "https://attack.mitre.org/techniques/T1087/"
 
-
 [[rule.threat.technique]]
-id = "T1018"
-name = "Remote System Discovery"
-reference = "https://attack.mitre.org/techniques/T1018/"
+id = "T1518"
+name = "Software Discovery"
+reference = "https://attack.mitre.org/techniques/T1518/"
 
 
 [rule.threat.tactic]
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+

--- a/rules/windows/execution_from_unusual_directory.toml
+++ b/rules/windows/execution_from_unusual_directory.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/30"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Process Execution from an Unusual Directory"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "ebfe1448-7fac-4d59-acea-181bd89b1f7f"
 severity = "medium"

--- a/rules/windows/execution_from_unusual_path_cmdline.toml
+++ b/rules/windows/execution_from_unusual_path_cmdline.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/30"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,12 @@ license = "Elastic License v2"
 name = "Execution from Unusual Directory - Command Line"
 note = """## Triage and analysis
 
-This is related to the `Process Execution from an Unusual Directory rule`."""
+This is related to the `Process Execution from an Unusual Directory rule`.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "cff92c41-2225-4763-b4ce-6f71e5bda5e6"
 severity = "medium"

--- a/rules/windows/execution_shared_modules_local_sxs_dll.toml
+++ b/rules/windows/execution_shared_modules_local_sxs_dll.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,12 @@ license = "Elastic License v2"
 name = "Execution via local SxS Shared Module"
 note = """## Triage and analysis
 
-The SxS DotLocal folder is a legitimate feature that can be abused to hijack standard modules loading order by forcing an executable on the same application.exe.local folder to load a malicious DLL module from the same directory."""
+The SxS DotLocal folder is a legitimate feature that can be abused to hijack standard modules loading order by forcing an executable on the same application.exe.local folder to load a malicious DLL module from the same directory.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-redirection"]
 risk_score = 47
 rule_id = "a3ea12f3-0d4e-4667-8b44-4230c63f3c75"

--- a/rules/windows/execution_suspicious_cmd_wmi.toml
+++ b/rules/windows/execution_suspicious_cmd_wmi.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Cmd Execution via WMI"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "12f07955-1674-44f7-86b5-c35da0a6f41a"
 severity = "medium"

--- a/rules/windows/execution_suspicious_image_load_wmi_ms_office.toml
+++ b/rules/windows/execution_suspicious_image_load_wmi_ms_office.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious WMI Image Load from MS Office"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://medium.com/threatpunter/detecting-adversary-tradecraft-with-image-load-event-logging-and-eql-8de93338c16",
 ]

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/30"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious PDF Reader Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "53a26770-9cbd-40c5-8b57-61d01a325e14"
 severity = "low"
@@ -42,12 +46,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1204"
-reference = "https://attack.mitre.org/techniques/T1204/"
 name = "User Execution"
+reference = "https://attack.mitre.org/techniques/T1204/"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
 

--- a/rules/windows/execution_suspicious_powershell_imgload.toml
+++ b/rules/windows/execution_suspicious_powershell_imgload.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/07/20"
 min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious PowerShell Engine ImageLoad"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "852c1f19-68e8-43a6-9dce-340771fe1be3"
 severity = "medium"

--- a/rules/windows/execution_suspicious_psexesvc.toml
+++ b/rules/windows/execution_suspicious_psexesvc.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Process Execution via Renamed PsExec Executable"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "e2f9fdf5-8076-45ad-9427-41e0e03dc9c2"
 severity = "medium"

--- a/rules/windows/execution_suspicious_short_program_name.toml
+++ b/rules/windows/execution_suspicious_short_program_name.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Execution - Short Program Name"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "17c7f6a5-5bc9-4e1f-92bf-13632d24384d"
 severity = "medium"

--- a/rules/windows/execution_via_compiled_html_file.toml
+++ b/rules/windows/execution_via_compiled_html_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Process Activity via Compiled HTML File"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "e3343ab9-4245-4715-b344-e11c56b0a47f"
 severity = "medium"
@@ -42,30 +46,28 @@ framework = "MITRE ATT&CK"
 id = "T1204"
 name = "User Execution"
 reference = "https://attack.mitre.org/techniques/T1204/"
+[[rule.threat.technique.subtechnique]]
+id = "T1204.002"
+name = "Malicious File"
+reference = "https://attack.mitre.org/techniques/T1204/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1204.002"
-  name = "Malicious File"
-  reference = "https://attack.mitre.org/techniques/T1204/002/"
 
 
 [rule.threat.tactic]
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1218"
 name = "Signed Binary Proxy Execution"
 reference = "https://attack.mitre.org/techniques/T1218/"
+[[rule.threat.technique.subtechnique]]
+id = "T1218.001"
+name = "Compiled HTML File"
+reference = "https://attack.mitre.org/techniques/T1218/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1218.001"
-  name = "Compiled HTML File"
-  reference = "https://attack.mitre.org/techniques/T1218/001/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/execution_via_hidden_shell_conhost.toml
+++ b/rules/windows/execution_via_hidden_shell_conhost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Conhost Spawned By Suspicious Parent Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.fireeye.com/blog/threat-research/2017/08/monitoring-windows-console-activity-part-one.html",
 ]
@@ -37,11 +41,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-reference = "https://attack.mitre.org/techniques/T1059/"
 name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Execution via MSSQL xp_cmdshell Stored Procedure"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "4ed493fc-d637-4a36-80ff-ac84937e5461"
 severity = "high"
@@ -31,12 +35,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-reference = "https://attack.mitre.org/techniques/T1059/"
 name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
 

--- a/rules/windows/impact_backup_file_deletion.toml
+++ b/rules/windows/impact_backup_file_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/01"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -54,6 +54,11 @@ not from the backup suite. Exceptions can be added for specific accounts and exe
 - Initiate the incident response process based on the outcome of the triage.
 - Reset the password of the involved accounts.
 - Perform data recovery locally or restore the backups from replicated copies (Cloud, other servers, etc.).
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
 references = ["https://www.advintel.io/post/backup-removal-solutions-from-conti-ransomware-with-love"]
 risk_score = 47
@@ -82,14 +87,14 @@ file where event.type == "deletion" and
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1490"
+name = "Inhibit System Recovery"
+reference = "https://attack.mitre.org/techniques/T1490/"
 
-  [[rule.threat.technique]]
-  id = "T1490"
-  name = "Inhibit System Recovery"
-  reference = "https://attack.mitre.org/techniques/T1490/"
 
-  [rule.threat.tactic]
-  id = "TA0040"
-  name = "Impact"
-  reference = "https://attack.mitre.org/tactics/TA0040/"
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
 

--- a/rules/windows/impact_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/impact_deleting_backup_catalogs_with_wbadmin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Deleting Backup Catalogs with Wbadmin"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "581add16-df76-42bb-af8e-c979bfb39a59"
 severity = "low"

--- a/rules/windows/impact_modification_of_boot_config.toml
+++ b/rules/windows/impact_modification_of_boot_config.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/16"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Modification of Boot Configuration"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "69c251fb-a5d6-4035-b5ec-40438bd829ff"
 severity = "low"

--- a/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2022/02/04"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Volume Shadow Copy Deleted or Resized via VssAdmin"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921"
 severity = "high"
@@ -31,13 +35,13 @@ process where event.type in ("start", "process_started")
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1490/"
-name = "Inhibit System Recovery"
 id = "T1490"
+name = "Inhibit System Recovery"
+reference = "https://attack.mitre.org/techniques/T1490/"
 
 
 [rule.threat.tactic]
-reference = "https://attack.mitre.org/tactics/TA0040/"
-name = "Impact"
 id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
 

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_powershell.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_powershell.toml
@@ -1,19 +1,23 @@
 [metadata]
 creation_date = "2021/07/19"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
 description = """
-Identifies the use of the Win32_ShadowCopy class and related cmdlets to achieve shadow copy deletion. This commonly occurs
-in tandem with ransomware or other destructive attacks.
+Identifies the use of the Win32_ShadowCopy class and related cmdlets to achieve shadow copy deletion. This commonly
+occurs in tandem with ransomware or other destructive attacks.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Volume Shadow Copy Deletion via PowerShell"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://docs.microsoft.com/en-us/previous-versions/windows/desktop/vsswmi/win32-shadowcopy",
     "https://powershell.one/wmi/root/cimv2/win32_shadowcopy",
@@ -39,13 +43,12 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1490"
-reference = "https://attack.mitre.org/techniques/T1490/"
 name = "Inhibit System Recovery"
-
+reference = "https://attack.mitre.org/techniques/T1490/"
 
 
 [rule.threat.tactic]
 id = "TA0040"
-reference = "https://attack.mitre.org/tactics/TA0040/"
 name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
 

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_wmic.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Volume Shadow Copy Deletion via WMIC"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "dc9c1f74-dac3-48e3-b47f-eb79db358f57"
 severity = "high"

--- a/rules/windows/initial_access_script_executing_powershell.toml
+++ b/rules/windows/initial_access_script_executing_powershell.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Windows Script Executing PowerShell"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc"
 severity = "low"
@@ -31,17 +35,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1566"
-reference = "https://attack.mitre.org/techniques/T1566/"
 name = "Phishing"
+reference = "https://attack.mitre.org/techniques/T1566/"
 [[rule.threat.technique.subtechnique]]
 id = "T1566.001"
-reference = "https://attack.mitre.org/techniques/T1566/001/"
 name = "Spearphishing Attachment"
+reference = "https://attack.mitre.org/techniques/T1566/001/"
 
 
 
 [rule.threat.tactic]
 id = "TA0001"
-reference = "https://attack.mitre.org/tactics/TA0001/"
 name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
 

--- a/rules/windows/initial_access_suspicious_ms_exchange_files.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_files.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/04"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -32,6 +32,11 @@ Positive hits can be checked against the established Microsoft [baselines](https
 Microsoft highly recommends that the best course of action is patching, but this may not protect already compromised systems
 from existing intrusions. Other tools for detecting and mitigating can be found within their Exchange support
 [repository](https://github.com/microsoft/CSS-Exchange/tree/main/Security)
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
 references = [
     "https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers",

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/04"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -20,6 +20,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Exchange Server UM Spawning Suspicious Processes"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers",
     "https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities",

--- a/rules/windows/initial_access_suspicious_ms_exchange_worker_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_worker_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/03/08"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Exchange Worker Spawning Suspicious Processes"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers",
     "https://www.volexity.com/blog/2021/03/02/active-exploitation-of-microsoft-exchange-zero-day-vulnerabilities",

--- a/rules/windows/initial_access_suspicious_ms_office_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_office_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious MS Office Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "a624863f-a70d-417f-a7d2-7a404638d47f"
 severity = "medium"

--- a/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious MS Outlook Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "32f4675e-6c49-4ace-80f9-97c9259dca2e"
 severity = "low"
@@ -39,17 +43,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1566"
-reference = "https://attack.mitre.org/techniques/T1566/"
 name = "Phishing"
+reference = "https://attack.mitre.org/techniques/T1566/"
 [[rule.threat.technique.subtechnique]]
 id = "T1566.001"
-reference = "https://attack.mitre.org/techniques/T1566/001/"
 name = "Spearphishing Attachment"
+reference = "https://attack.mitre.org/techniques/T1566/001/"
 
 
 
 [rule.threat.tactic]
 id = "TA0001"
-reference = "https://attack.mitre.org/tactics/TA0001/"
 name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
 

--- a/rules/windows/initial_access_unusual_dns_service_children.toml
+++ b/rules/windows/initial_access_unusual_dns_service_children.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -28,7 +28,12 @@ Detection alerts from this rule indicate potential suspicious child processes sp
 - Any suspicious or abnormal child process spawned from dns.exe should be reviewed and investigated with care. It's impossible to predict what an adversary may deploy as the follow-on process after the exploit, but built-in discovery/enumeration utilities should be top of mind (whoami.exe, netstat.exe, systeminfo.exe, tasklist.exe).
 - Built-in Windows programs that contain capabilities used to download and execute additional payloads should also be considered. This is not an exhaustive list, but ideal candidates to start out would be: mshta.exe, powershell.exe, regsvr32.exe, rundll32.exe, wscript.exe, wmic.exe.
 - If the DoS exploit is successful and DNS Server service crashes, be mindful of potential child processes related to werfault.exe occurring.
-- Any subsequent activity following the child process spawned related to execution/network activity should be thoroughly reviewed from the endpoint."""
+- Any subsequent activity following the child process spawned related to execution/network activity should be thoroughly reviewed from the endpoint.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://research.checkpoint.com/2020/resolving-your-way-into-domain-admin-exploiting-a-17-year-old-bug-in-windows-dns-servers/",
     "https://msrc-blog.microsoft.com/2020/07/14/july-2020-security-update-cve-2020-1350-vulnerability-in-windows-domain-name-system-dns-server/",
@@ -51,12 +56,12 @@ process where event.type == "start" and process.parent.name : "dns.exe" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1133"
-reference = "https://attack.mitre.org/techniques/T1133/"
 name = "External Remote Services"
+reference = "https://attack.mitre.org/techniques/T1133/"
 
 
 [rule.threat.tactic]
 id = "TA0001"
-reference = "https://attack.mitre.org/tactics/TA0001/"
 name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
 

--- a/rules/windows/initial_access_unusual_dns_service_file_writes.toml
+++ b/rules/windows/initial_access_unusual_dns_service_file_writes.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/16"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,12 @@ note = """## Triage and analysis
 ### Investigating Unusual File Write
 Detection alerts from this rule indicate potential unusual/abnormal file writes from the DNS Server service process (`dns.exe`) after exploitation from CVE-2020-1350 (SigRed) has occurred. Here are some possible avenues of investigation:
 - Post-exploitation, adversaries may write additional files or payloads to the system as additional discovery/exploitation/persistence mechanisms.
-- Any suspicious or abnormal files written from `dns.exe` should be reviewed and investigated with care."""
+- Any suspicious or abnormal files written from `dns.exe` should be reviewed and investigated with care.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://research.checkpoint.com/2020/resolving-your-way-into-domain-admin-exploiting-a-17-year-old-bug-in-windows-dns-servers/",
     "https://msrc-blog.microsoft.com/2020/07/14/july-2020-security-update-cve-2020-1350-vulnerability-in-windows-domain-name-system-dns-server/",
@@ -41,12 +46,12 @@ file where process.name : "dns.exe" and event.type in ("creation", "deletion", "
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1133"
-reference = "https://attack.mitre.org/techniques/T1133/"
 name = "External Remote Services"
+reference = "https://attack.mitre.org/techniques/T1133/"
 
 
 [rule.threat.tactic]
 id = "TA0001"
-reference = "https://attack.mitre.org/tactics/TA0001/"
 name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
 

--- a/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
+++ b/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/29"
 maturity = "production"
-updated_date = "2021/03/11"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Explorer Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "9a5b4e31-6cde-4295-9ff7-6be1b8567e1b"
 severity = "medium"
@@ -60,3 +64,4 @@ reference = "https://attack.mitre.org/techniques/T1566/002/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/windows/lateral_movement_evasion_rdp_shadowing.toml
+++ b/rules/windows/lateral_movement_evasion_rdp_shadowing.toml
@@ -1,23 +1,28 @@
 [metadata]
 creation_date = "2021/04/12"
 maturity = "production"
-updated_date = "2021/04/12"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
 Identifies the modification of the Remote Desktop Protocol (RDP) Shadow registry or the execution of processes
-indicative of an active RDP shadowing session. An adversary may abuse the RDP Shadowing feature to spy on or control other users active
-RDP sessions.
+indicative of an active RDP shadowing session. An adversary may abuse the RDP Shadowing feature to spy on or control
+other users active RDP sessions.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Remote Desktop Shadowing Activity"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
-"https://bitsadm.in/blog/spying-on-users-using-rdp-shadowing",
-"https://swarm.ptsecurity.com/remote-desktop-services-shadowing/"]
+    "https://bitsadm.in/blog/spying-on-users-using-rdp-shadowing",
+    "https://swarm.ptsecurity.com/remote-desktop-services-shadowing/",
+]
 risk_score = 73
 rule_id = "c57f8579-e2a5-4804-847f-f2732edc5156"
 severity = "high"
@@ -52,3 +57,4 @@ reference = "https://attack.mitre.org/techniques/T1021/"
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
+

--- a/rules/windows/lateral_movement_execution_from_tsclient_mup.toml
+++ b/rules/windows/lateral_movement_execution_from_tsclient_mup.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/11"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Execution via TSClient Mountpoint"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://posts.specterops.io/revisiting-remote-desktop-lateral-movement-8fb905cb46c3"]
 risk_score = 73
 rule_id = "4fe9d835-40e1-452d-8230-17c147cafad8"

--- a/rules/windows/lateral_movement_mount_hidden_or_webdav_share_net.toml
+++ b/rules/windows/lateral_movement_mount_hidden_or_webdav_share_net.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/02"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Mounting Hidden or WebDav Remote Shares"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "c4210e1c-64f2-4f48-b67e-b5a8ffe3aa14"
 severity = "medium"

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/25"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "RDP Enabled via Registry"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "58aa72ca-d968-4f34-b9f7-bea51d75eb50"
 severity = "medium"
@@ -35,11 +39,11 @@ framework = "MITRE ATT&CK"
 id = "T1021"
 name = "Remote Services"
 reference = "https://attack.mitre.org/techniques/T1021/"
+[[rule.threat.technique.subtechnique]]
+id = "T1021.001"
+name = "Remote Desktop Protocol"
+reference = "https://attack.mitre.org/techniques/T1021/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1021.001"
-  name = "Remote Desktop Protocol"
-  reference = "https://attack.mitre.org/techniques/T1021/001/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
+++ b/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/04"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote File Copy to a Hidden Share"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "fa01341d-6662-426b-9d0c-6d81e33c8a9d"
 severity = "medium"

--- a/rules/windows/lateral_movement_service_control_spawned_script_int.toml
+++ b/rules/windows/lateral_movement_service_control_spawned_script_int.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "logs-system.*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Service Control Spawned via Script Interpreter"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "e8571d5f-bea1-46c2-9f56-998de2d3ed95"
 severity = "low"
@@ -46,3 +50,4 @@ reference = "https://attack.mitre.org/techniques/T1021/"
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
+

--- a/rules/windows/lateral_movement_suspicious_rdp_client_imageload.toml
+++ b/rules/windows/lateral_movement_suspicious_rdp_client_imageload.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious RDP ActiveX Client Loaded"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://posts.specterops.io/revisiting-remote-desktop-lateral-movement-8fb905cb46c3"]
 risk_score = 47
 rule_id = "71c5cb27-eca5-4151-bb47-64bc3f883270"

--- a/rules/windows/lateral_movement_via_startup_folder_rdp_smb.toml
+++ b/rules/windows/lateral_movement_via_startup_folder_rdp_smb.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Lateral Movement via Startup Folder"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://www.mdsec.co.uk/2017/06/rdpinception/"]
 risk_score = 73
 rule_id = "25224a80-5a4a-4b8a-991e-6ab390465c4f"

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Adobe Hijack Persistence"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "2bf78aa2-9c56-48de-b139-f169bf99cf86"
 severity = "low"
@@ -30,17 +34,17 @@ file where event.type == "creation" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1574"
-reference = "https://attack.mitre.org/techniques/T1574/"
 name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
 [[rule.threat.technique.subtechnique]]
 id = "T1574.010"
-reference = "https://attack.mitre.org/techniques/T1574/010/"
 name = "Services File Permissions Weakness"
+reference = "https://attack.mitre.org/techniques/T1574/010/"
 
 
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 

--- a/rules/windows/persistence_appcertdlls_registry.toml
+++ b/rules/windows/persistence_appcertdlls_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Registry Persistence via AppCert DLL"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "513f0ffd-b317-4b9c-9494-92ce861f22c7"
 severity = "medium"

--- a/rules/windows/persistence_appinitdlls_registry.toml
+++ b/rules/windows/persistence_appinitdlls_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Registry Persistence via AppInit DLL"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "d0e159cf-73e9-40d1-a9ed-077e3158a855"
 severity = "medium"

--- a/rules/windows/persistence_evasion_hidden_local_account_creation.toml
+++ b/rules/windows/persistence_evasion_hidden_local_account_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation of a Hidden Local User Account"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://blog.menasec.net/2019/02/threat-hunting-6-hiding-in-plain-sights_8.html",
     "https://github.com/CyberMonitor/APT_CyberCriminal_Campagin_Collections/tree/master/2020/2020.12.15.Lazarus_Campaign",
@@ -37,11 +41,11 @@ framework = "MITRE ATT&CK"
 id = "T1136"
 name = "Create Account"
 reference = "https://attack.mitre.org/techniques/T1136/"
+[[rule.threat.technique.subtechnique]]
+id = "T1136.001"
+name = "Local Account"
+reference = "https://attack.mitre.org/techniques/T1136/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1136.001"
-  name = "Local Account"
-  reference = "https://attack.mitre.org/techniques/T1136/001/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_gpo_schtask_service_creation.toml
+++ b/rules/windows/persistence_gpo_schtask_service_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/13"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation or Modification of a new GPO Scheduled Task or Service"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "c0429aa8-9974-42da-bfb6-53a0a515a145"
 severity = "low"
@@ -34,17 +38,17 @@ file where event.type != "deletion" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1053"
-reference = "https://attack.mitre.org/techniques/T1053/"
 name = "Scheduled Task/Job"
+reference = "https://attack.mitre.org/techniques/T1053/"
+[[rule.threat.technique.subtechnique]]
+id = "T1053.005"
+name = "Scheduled Task"
+reference = "https://attack.mitre.org/techniques/T1053/005/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1053.005"
-  name = "Scheduled Task"
-  reference = "https://attack.mitre.org/techniques/T1053/005/"
 
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 

--- a/rules/windows/persistence_local_scheduled_job_creation.toml
+++ b/rules/windows/persistence_local_scheduled_job_creation.toml
@@ -1,17 +1,24 @@
 [metadata]
 creation_date = "2021/03/15"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
-description = "A job can be used to schedule programs or scripts to be executed at a specified date and time. Adversaries may abuse task scheduling functionality to facilitate initial or recurring execution of malicious code."
+description = """
+A job can be used to schedule programs or scripts to be executed at a specified date and time. Adversaries may abuse
+task scheduling functionality to facilitate initial or recurring execution of malicious code.
+"""
 false_positives = ["Legitimate scheduled jobs may be created during installation of new software."]
 from = "now-9m"
 index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Scheduled Job Creation"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "1327384f-00f3-44d5-9a8c-2373ba071e92"
 severity = "medium"
@@ -31,14 +38,15 @@ framework = "MITRE ATT&CK"
 id = "T1053"
 name = "Scheduled Task/Job"
 reference = "https://attack.mitre.org/techniques/T1053/"
+[[rule.threat.technique.subtechnique]]
+id = "T1053.005"
+name = "Scheduled Task"
+reference = "https://attack.mitre.org/techniques/T1053/005/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1053.005"
-  name = "Scheduled Task"
-  reference = "https://attack.mitre.org/techniques/T1053/005/"
 
 
 [rule.threat.tactic]
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/windows/persistence_local_scheduled_task_creation.toml
+++ b/rules/windows/persistence_local_scheduled_task_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,6 @@ risk_score = 21
 rule_id = "afcce5ad-65de-4ed2-8516-5e093d3ac99a"
 severity = "low"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/persistence_ms_office_addins_file.toml
+++ b/rules/windows/persistence_ms_office_addins_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/16"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Microsoft Office AddIns"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://labs.mwrinfosecurity.com/blog/add-in-opportunities-for-office-persistence/"]
 risk_score = 73
 rule_id = "f44fa4b6-524c-4e87-8d9e-a32599e4fb7c"

--- a/rules/windows/persistence_ms_outlook_vba_template.toml
+++ b/rules/windows/persistence_ms_outlook_vba_template.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -12,6 +12,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Microsoft Outlook VBA"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.mdsec.co.uk/2020/11/a-fresh-outlook-on-mail-based-persistence/",
     "https://www.linkedin.com/pulse/outlook-backdoor-using-vba-samir-b-/",

--- a/rules/windows/persistence_powershell_exch_mailbox_activesync_add_device.toml
+++ b/rules/windows/persistence_powershell_exch_mailbox_activesync_add_device.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/15"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "New ActiveSyncAllowedDeviceID Added via PowerShell"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.volexity.com/blog/2020/12/14/dark-halo-leverages-solarwinds-compromise-to-breach-organizations/",
     "https://docs.microsoft.com/en-us/powershell/module/exchange/set-casmailbox?view=exchange-ps",
@@ -38,11 +42,11 @@ framework = "MITRE ATT&CK"
 id = "T1098"
 name = "Account Manipulation"
 reference = "https://attack.mitre.org/techniques/T1098/"
+[[rule.threat.technique.subtechnique]]
+id = "T1098.002"
+name = "Exchange Email Delegate Permissions"
+reference = "https://attack.mitre.org/techniques/T1098/002/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1098.002"
-  name = "Exchange Email Delegate Permissions"
-  reference = "https://attack.mitre.org/techniques/T1098/002/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Modification of Accessibility Binaries"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://www.elastic.co/blog/practical-security-engineering-stateful-detection"]
 risk_score = 73
 rule_id = "7405ddf1-6c8e-41ce-818f-48bea6bcaed8"

--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/18"
 maturity = "production"
-updated_date = "2022/01/24"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -24,7 +24,6 @@ risk_score = 47
 rule_id = "2820c9c2-bcd7-4d6e-9eba-faf3891ba450"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
+++ b/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/24"
 maturity = "production"
-updated_date = "2022/02/24"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -78,6 +78,9 @@ Audit Policies >
 DS Access > 
 Audit Directory Service Changes (Success)
 ```
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+
 """
 references = [
     "https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dsheuristics_bad",

--- a/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
+++ b/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Shortcut File Written or Modified for Persistence"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "440e2db4-bc7f-4c96-a068-65b78da59bde"
 severity = "medium"

--- a/rules/windows/persistence_startup_folder_scripts.toml
+++ b/rules/windows/persistence_startup_folder_scripts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistent Scripts in the Startup Directory"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "f7c4dc5a-a58d-491d-9f14-9b66507121c0"
 severity = "medium"

--- a/rules/windows/persistence_suspicious_image_load_scheduled_task_ms_office.toml
+++ b/rules/windows/persistence_suspicious_image_load_scheduled_task_ms_office.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Image Load (taskschd.dll) from MS Office"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://medium.com/threatpunter/detecting-adversary-tradecraft-with-image-load-event-logging-and-eql-8de93338c16",
     "https://www.clearskysec.com/wp-content/uploads/2020/10/Operation-Quicksand.pdf",

--- a/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
+++ b/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/19"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -12,6 +12,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Execution via Scheduled Task"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "5d1d6907-0747-4d5d-9b24-e4a18853dc0a"
 severity = "medium"
@@ -62,11 +66,11 @@ framework = "MITRE ATT&CK"
 id = "T1053"
 name = "Scheduled Task/Job"
 reference = "https://attack.mitre.org/techniques/T1053/"
+[[rule.threat.technique.subtechnique]]
+id = "T1053.005"
+name = "Scheduled Task"
+reference = "https://attack.mitre.org/techniques/T1053/005/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1053.005"
-  name = "Scheduled Task"
-  reference = "https://attack.mitre.org/techniques/T1053/005/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "System Shells via Services"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "0022d47d-39c7-4f69-a232-4fe9dc7a3acd"
 severity = "medium"
@@ -35,16 +39,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1543"
-reference = "https://attack.mitre.org/techniques/T1543/"
 name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
 [[rule.threat.technique.subtechnique]]
 id = "T1543.003"
-reference = "https://attack.mitre.org/techniques/T1543/003/"
 name = "Windows Service"
+reference = "https://attack.mitre.org/techniques/T1543/003/"
 
 
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
+++ b/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/09"
 maturity = "production"
-updated_date = "2022/03/16"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Skoetting"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "User Added to Privileged Group in Active Directory"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/plan/security-best-practices/appendix-b--privileged-accounts-and-groups-in-active-directory",
 ]
@@ -42,12 +46,12 @@ iam where event.action == "added-member-to-group" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1098"
-reference = "https://attack.mitre.org/techniques/T1098/"
 name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
 
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "User Account Creation"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "1aa9181a-492b-4c01-8b16-fa0735786b2b"
 severity = "low"
@@ -33,17 +37,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1136"
-reference = "https://attack.mitre.org/techniques/T1136/"
 name = "Create Account"
+reference = "https://attack.mitre.org/techniques/T1136/"
+[[rule.threat.technique.subtechnique]]
+id = "T1136.001"
+name = "Local Account"
+reference = "https://attack.mitre.org/techniques/T1136/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1136.001"
-  name = "Local Account"
-  reference = "https://attack.mitre.org/techniques/T1136/001/"
 
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 

--- a/rules/windows/persistence_via_application_shimming.toml
+++ b/rules/windows/persistence_via_application_shimming.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Application Shimming via Sdbinst"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "fd4a992d-6130-4802-9ff8-829b89ae801f"
 severity = "low"
@@ -31,34 +35,34 @@ process where event.type in ("start", "process_started") and process.name : "sdb
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1546"
-reference = "https://attack.mitre.org/techniques/T1546/"
 name = "Event Triggered Execution"
+reference = "https://attack.mitre.org/techniques/T1546/"
 [[rule.threat.technique.subtechnique]]
 id = "T1546.011"
-reference = "https://attack.mitre.org/techniques/T1546/011/"
 name = "Application Shimming"
+reference = "https://attack.mitre.org/techniques/T1546/011/"
 
 
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1546"
-reference = "https://attack.mitre.org/techniques/T1546/"
 name = "Event Triggered Execution"
+reference = "https://attack.mitre.org/techniques/T1546/"
 [[rule.threat.technique.subtechnique]]
 id = "T1546.011"
-reference = "https://attack.mitre.org/techniques/T1546/011/"
 name = "Application Shimming"
+reference = "https://attack.mitre.org/techniques/T1546/011/"
 
 
 
 [rule.threat.tactic]
 id = "TA0004"
-reference = "https://attack.mitre.org/tactics/TA0004/"
 name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
 

--- a/rules/windows/persistence_via_bits_job_notify_command.toml
+++ b/rules/windows/persistence_via_bits_job_notify_command.toml
@@ -1,24 +1,29 @@
 [metadata]
 creation_date = "2021/12/04"
 maturity = "production"
-updated_date = "2021/12/04"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
 An adversary can use the Background Intelligent Transfer Service (BITS) SetNotifyCmdLine method to execute a program
-that runs after a job finishes transferring data or after a job enters a specified state in order to persist on a system.
+that runs after a job finishes transferring data or after a job enters a specified state in order to persist on a
+system.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via BITS Job Notify Cmdline"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
-"https://pentestlab.blog/2019/10/30/persistence-bits-jobs/",
-"https://docs.microsoft.com/en-us/windows/win32/api/bits1_5/nf-bits1_5-ibackgroundcopyjob2-setnotifycmdline",
-"https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/bitsadmin-setnotifycmdline",
-"https://www.elastic.co/blog/hunting-for-persistence-using-elastic-security-part-2"
+    "https://pentestlab.blog/2019/10/30/persistence-bits-jobs/",
+    "https://docs.microsoft.com/en-us/windows/win32/api/bits1_5/nf-bits1_5-ibackgroundcopyjob2-setnotifycmdline",
+    "https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/bitsadmin-setnotifycmdline",
+    "https://www.elastic.co/blog/hunting-for-persistence-using-elastic-security-part-2",
 ]
 risk_score = 47
 rule_id = "c3b915e0-22f3-4bf7-991d-b643513c722f"
@@ -50,3 +55,4 @@ reference = "https://attack.mitre.org/techniques/T1197/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/windows/persistence_via_hidden_run_key_valuename.toml
+++ b/rules/windows/persistence_via_hidden_run_key_valuename.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/15"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Hidden Run Key Detected"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://github.com/outflanknl/SharpHide",
     "https://github.com/ewhitehats/InvisiblePersistence/blob/master/InvisibleRegValues_Whitepaper.pdf",

--- a/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
+++ b/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/18"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Installation of Security Support Provider"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "e86da94d-e54b-4fb5-b96c-cecff87e8787"
 severity = "medium"

--- a/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
+++ b/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via TelemetryController Scheduled Task Hijack"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.trustedsec.com/blog/abusing-windows-telemetry-for-persistence/?utm_content=131234033&utm_medium=social&utm_source=twitter&hss_channel=tw-403811306",
 ]
@@ -40,17 +44,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1053"
-reference = "https://attack.mitre.org/techniques/T1053/"
 name = "Scheduled Task/Job"
+reference = "https://attack.mitre.org/techniques/T1053/"
+[[rule.threat.technique.subtechnique]]
+id = "T1053.005"
+name = "Scheduled Task"
+reference = "https://attack.mitre.org/techniques/T1053/005/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1053.005"
-  name = "Scheduled Task"
-  reference = "https://attack.mitre.org/techniques/T1053/005/"
 
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 

--- a/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
+++ b/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/17"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Update Orchestrator Service Hijack"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://github.com/irsl/CVE-2020-1313"]
 risk_score = 73
 rule_id = "265db8f5-fc73-4d0d-b434-6483b56372e2"

--- a/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
+++ b/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/04"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via WMI Event Subscription"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "9b6813a1-daf1-457e-b0e6-0bb4e55b8a4c"
 severity = "low"
@@ -36,11 +40,11 @@ framework = "MITRE ATT&CK"
 id = "T1546"
 name = "Event Triggered Execution"
 reference = "https://attack.mitre.org/techniques/T1546/"
+[[rule.threat.technique.subtechnique]]
+id = "T1546.003"
+name = "Windows Management Instrumentation Event Subscription"
+reference = "https://attack.mitre.org/techniques/T1546/003/"
 
-  [[rule.threat.technique.subtechnique]]
-  id = "T1546.003"
-  name = "Windows Management Instrumentation Event Subscription"
-  reference = "https://attack.mitre.org/techniques/T1546/003/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/persistence_webshell_detection.toml
+++ b/rules/windows/persistence_webshell_detection.toml
@@ -1,16 +1,15 @@
 [metadata]
 creation_date = "2021/08/24"
 maturity = "production"
-updated_date = "2021/10/17"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
-description = """
-Identifies suspicious commands executed via a web server, which may suggest a vulnerability and remote shell access.
-"""
+description = "Identifies suspicious commands executed via a web server, which may suggest a vulnerability and remote shell access."
 false_positives = [
     """
-    Security audits, maintenance, and network administrative scripts may trigger this alert when run under web processes.
+    Security audits, maintenance, and network administrative scripts may trigger this alert when run under web
+    processes.
     """,
 ]
 from = "now-9m"
@@ -20,8 +19,15 @@ license = "Elastic License v2"
 name = "Webshell Detection: Script Process Child of Common Web Processes"
 note = """## Triage and analysis
 
-Detections should be investigated to identify if the activity corresponds to legitimate activity. As this rule detects post-exploitation process activity, investigations into this should be prioritized."""
-references = ["https://www.microsoft.com/security/blog/2020/02/04/ghost-in-the-shell-investigating-web-shell-attacks/"]
+Detections should be investigated to identify if the activity corresponds to legitimate activity. As this rule detects post-exploitation process activity, investigations into this should be prioritized.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
+references = [
+    "https://www.microsoft.com/security/blog/2020/02/04/ghost-in-the-shell-investigating-web-shell-attacks/",
+]
 risk_score = 73
 rule_id = "2917d495-59bd-4250-b395-c29409b76086"
 severity = "high"
@@ -48,6 +54,7 @@ name = "Web Shell"
 reference = "https://attack.mitre.org/techniques/T1505/003/"
 
 
+
 [rule.threat.tactic]
 id = "TA0003"
 name = "Persistence"
@@ -64,3 +71,4 @@ reference = "https://attack.mitre.org/techniques/T1190/"
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
+

--- a/rules/windows/privilege_escalation_disable_uac_registry.toml
+++ b/rules/windows/privilege_escalation_disable_uac_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/20"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Disabling User Account Control via Registry Modification"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.greyhathacker.net/?p=796",
     "https://docs.microsoft.com/en-us/windows/security/identity-protection/user-account-control/user-account-control-group-policy-and-registry-key-settings",

--- a/rules/windows/privilege_escalation_installertakeover.toml
+++ b/rules/windows/privilege_escalation_installertakeover.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/11/25"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -42,10 +42,13 @@ to the location to escalate privileges. An attacker is able to still take over a
 
 - Immediate response steps should be taken to validate, investigate, and potentially contain the activity to prevent
 further post-compromise behavior.
+
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
-references = [
-    "https://github.com/klinix5/InstallerFileTakeOver"
-]
+references = ["https://github.com/klinix5/InstallerFileTakeOver"]
 risk_score = 73
 rule_id = "58c6d58b-a0d3-412d-b3b8-0981a9400607"
 severity = "high"
@@ -71,13 +74,14 @@ process where event.type == "start" and
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1068"
+name = "Exploitation for Privilege Escalation"
+reference = "https://attack.mitre.org/techniques/T1068/"
 
-  [[rule.threat.technique]]
-  id = "T1068"
-  reference = "https://attack.mitre.org/techniques/T1068/"
-  name = "Exploitation for Privilege Escalation"  
-  
-  [rule.threat.tactic]
-  id = "TA0004"
-  reference = "https://attack.mitre.org/tactics/TA0004/"
-  name = "Privilege Escalation"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/windows/privilege_escalation_named_pipe_impersonation.toml
+++ b/rules/windows/privilege_escalation_named_pipe_impersonation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/23"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Privilege Escalation via Named Pipe Impersonation"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://www.ired.team/offensive-security/privilege-escalation/windows-namedpipes-privilege-escalation",
 ]

--- a/rules/windows/privilege_escalation_persistence_phantom_dll.toml
+++ b/rules/windows/privilege_escalation_persistence_phantom_dll.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/07"
 maturity = "production"
-updated_date = "2021/05/27"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious DLL Loaded for Persistence or Privilege Escalation"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://itm4n.github.io/windows-dll-hijacking-clarified/",
     "http://remoteawesomethoughts.blogspot.com/2019/05/windows-10-task-schedulerservice.html",

--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious PrintSpooler Service Executable File Creation"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://voidsec.com/cve-2020-1337-printdemon-is-dead-long-live-printdemon/",
     "https://www.thezdi.com/blog/2020/7/8/cve-2020-1300-remote-code-execution-through-microsoft-windows-cab-files",
@@ -37,12 +41,12 @@ file where event.type != "deletion" and process.name : "spoolsv.exe" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1068"
-reference = "https://attack.mitre.org/techniques/T1068/"
 name = "Exploitation for Privilege Escalation"
+reference = "https://attack.mitre.org/techniques/T1068/"
 
 
 [rule.threat.tactic]
 id = "TA0004"
-reference = "https://attack.mitre.org/tactics/TA0004/"
 name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
 

--- a/rules/windows/privilege_escalation_printspooler_suspicious_file_deletion.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_file_deletion.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/06"
 maturity = "production"
-updated_date = "2021/07/06"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Print Spooler File Deletion"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527",
     "https://github.com/afwu/PrintNightmare",
@@ -42,11 +46,12 @@ file where event.type : "deletion" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1068"
-reference = "https://attack.mitre.org/techniques/T1068/"
 name = "Exploitation for Privilege Escalation"
+reference = "https://attack.mitre.org/techniques/T1068/"
 
 
 [rule.threat.tactic]
 id = "TA0004"
-reference = "https://attack.mitre.org/tactics/TA0004/"
 name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/14"
 maturity = "production"
-updated_date = "2021/05/10"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,12 @@ license = "Elastic License v2"
 name = "Suspicious PrintSpooler SPL File Created"
 note = """## Threat intel
 
-Refer to CVEs, CVE-2020-1048 and CVE-2020-1337 for further information on the vulnerability and exploit. Verify that the relevant system is patched."""
+Refer to CVEs, CVE-2020-1048 and CVE-2020-1337 for further information on the vulnerability and exploit. Verify that the relevant system is patched.
+
+## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://safebreach.com/Post/How-we-bypassed-CVE-2020-1048-Patch-and-got-CVE-2020-1337"]
 risk_score = 73
 rule_id = "a7ccae7b-9d2c-44b2-a061-98e5946971fa"
@@ -42,11 +47,12 @@ file where event.type != "deletion" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1068"
-reference = "https://attack.mitre.org/techniques/T1068/"
 name = "Exploitation for Privilege Escalation"
+reference = "https://attack.mitre.org/techniques/T1068/"
 
 
 [rule.threat.tactic]
 id = "TA0004"
-reference = "https://attack.mitre.org/tactics/TA0004/"
 name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
+++ b/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
@@ -1,20 +1,24 @@
 [metadata]
 creation_date = "2021/12/12"
 maturity = "production"
-updated_date = "2021/12/12"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
 description = """
 Identifies a suspicious computer account name rename event, which may indicate an attempt to exploit CVE-2021-42278 to
-elevate privileges from a standard domain user to a user with domain admin privileges. CVE-2021-42278 is a security vulnerability
-that allows potential attackers to impersonate a domain controller via samAccountName attribute spoofing.
+elevate privileges from a standard domain user to a user with domain admin privileges. CVE-2021-42278 is a security
+vulnerability that allows potential attackers to impersonate a domain controller via samAccountName attribute spoofing.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privileged Escalation via SamAccountName Spoofing"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://support.microsoft.com/en-us/topic/kb5008102-active-directory-security-accounts-manager-hardening-changes-cve-2021-42278-5975b463-4c95-45e1-831a-d120004e258e",
     "https://cloudbrothers.info/en/exploit-kerberos-samaccountname-spoofing/",
@@ -39,30 +43,30 @@ iam where event.action == "renamed-user-account" and
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1078/"
-name = "Valid Accounts"
 id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
 [[rule.threat.technique.subtechnique]]
-reference = "https://attack.mitre.org/techniques/T1078/002/"
-name = "Domain Accounts"
 id = "T1078.002"
+name = "Domain Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/002/"
 
 
 
 [rule.threat.tactic]
-reference = "https://attack.mitre.org/tactics/TA0004/"
-name = "Privilege Escalation"
 id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1098/"
-name = "Account Manipulation"
 id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
 
 
 [rule.threat.tactic]
-reference = "https://attack.mitre.org/tactics/TA0003/"
-name = "Persistence"
 id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 

--- a/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/28"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass Attempt with IEditionUpgradeManager Elevated COM Interface"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://github.com/hfiref0x/UACME"]
 risk_score = 73
 rule_id = "b90cdde7-7e0d-4359-8bf0-2c112ce2008a"

--- a/rules/windows/privilege_escalation_uac_bypass_com_ieinstal.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_ieinstal.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/03"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass Attempt via Elevated COM Internet Explorer Add-On Installer"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://swapcontext.blogspot.com/2020/11/uac-bypasses-from-comautoapprovallist.html"]
 risk_score = 47
 rule_id = "fc7c0fa4-8f03-4b3e-8336-c5feab0be022"

--- a/rules/windows/privilege_escalation_uac_bypass_com_interface_icmluautil.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_interface_icmluautil.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/19"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass via ICMLuaUtil Elevated COM Interface"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "68d56fdc-7ffa-4419-8e95-81641bd6f845"
 severity = "high"

--- a/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/08/18"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass via DiskCleanup Scheduled Task Hijack"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "1dcc51f6-ba26-49e7-9ef4-2655abb2361e"
 severity = "medium"
@@ -47,3 +51,4 @@ reference = "https://attack.mitre.org/techniques/T1548/002/"
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/windows/privilege_escalation_uac_bypass_dll_sideloading.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_dll_sideloading.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/27"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass Attempt via Privileged IFileOperation COM Interface"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://github.com/hfiref0x/UACME"]
 risk_score = 73
 rule_id = "5a14d01d-7ac8-4545-914c-b687c2cf66b3"

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/17"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Bypass UAC via Event Viewer"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 73
 rule_id = "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62"
 severity = "high"
@@ -36,17 +40,17 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1548"
-reference = "https://attack.mitre.org/techniques/T1548/"
 name = "Abuse Elevation Control Mechanism"
+reference = "https://attack.mitre.org/techniques/T1548/"
 [[rule.threat.technique.subtechnique]]
 id = "T1548.002"
-reference = "https://attack.mitre.org/techniques/T1548/002/"
 name = "Bypass User Account Control"
+reference = "https://attack.mitre.org/techniques/T1548/002/"
 
 
 
 [rule.threat.tactic]
 id = "TA0004"
-reference = "https://attack.mitre.org/tactics/TA0004/"
 name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
 

--- a/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/26"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass Attempt via Windows Directory Masquerading"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://medium.com/tenable-techblog/uac-bypass-by-mocking-trusted-directories-24a96675f6e"]
 risk_score = 73
 rule_id = "290aca65-e94d-403b-ba0f-62f320e63f51"

--- a/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/14"
 maturity = "production"
-updated_date = "2021/08/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass via Windows Firewall Snap-In Hijack"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://github.com/AzAgarampur/byeintegrity-uac"]
 risk_score = 47
 rule_id = "1178ae09-5aff-460a-9f2f-455cd0ac4d8e"

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/08/25"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Parent-Child Relationship"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://github.com/sbousseaden/Slides/blob/master/Hunting%20MindMaps/PNG/Windows%20Processes%20TH.map.png",
     "https://www.andreafortuna.org/2017/06/15/standard-windows-processes-a-brief-reference/",

--- a/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
+++ b/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/06"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,8 +11,8 @@ escalation vulnerabilities related to the Printing Service on Windows.
 """
 false_positives = [
     """
-    Install or update of a legitimate printing driver. Verify the printer driver file metadata such as manufacturer and signature
-    information.
+    Install or update of a legitimate printing driver. Verify the printer driver file metadata such as manufacturer and
+    signature information.
     """,
 ]
 from = "now-9m"
@@ -20,6 +20,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Print Spooler Child Process"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-34527",
     "https://github.com/afwu/PrintNightmare",
@@ -50,12 +54,13 @@ process where event.type == "start" and
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-reference = "https://attack.mitre.org/techniques/T1068/"
-name = "Exploitation for Privilege Escalation"
 id = "T1068"
+name = "Exploitation for Privilege Escalation"
+reference = "https://attack.mitre.org/techniques/T1068/"
 
 
 [rule.threat.tactic]
-reference = "https://attack.mitre.org/tactics/TA0004/"
-name = "Privilege Escalation"
 id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/windows/privilege_escalation_unusual_svchost_childproc_childless.toml
+++ b/rules/windows/privilege_escalation_unusual_svchost_childproc_childless.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2021/03/08"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Service Host Child Process - Childless Service"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 47
 rule_id = "6a8ab9cc-4023-4d17-b5df-1a3e16882ce7"
 severity = "medium"

--- a/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
+++ b/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/13"
 maturity = "production"
-updated_date = "2021/10/13"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,9 @@ note = """## Config
 
 Named Pipe Creation Events need to be enabled within the Sysmon configuration by including the following settings:
 `condition equal "contains" and keyword equal "pipe"`
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+
 """
 references = [
     "https://itm4n.github.io/printspoofer-abusing-impersonate-privileges/",

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,9 +18,9 @@ class BaseRuleTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         rc = RuleCollection.default()
-        cls.all_rules = rc
+        cls.all_rules = rc.rules
         cls.rule_lookup = rc.id_map
-        cls.production_rules = cls.all_rules.filter(production_filter)
+        cls.production_rules = rc.filter(production_filter)
         cls.deprecated_rules: DeprecatedCollection = rc.deprecated
 
     @staticmethod

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -505,7 +505,7 @@ class TestRuleTiming(BaseRuleTest):
                 'errors': [],
                 'msg': 'cannot have the `timestamp_override` set to `event.ingested` because it uses a sequence'
             },
-            'lt_82_eql_': {
+            'lt_82_eql': {
                 'errors': [],
                 'msg': 'should have the `timestamp_override` set to `event.ingested`'
             },
@@ -522,10 +522,10 @@ class TestRuleTiming(BaseRuleTest):
             }
         }
 
-        pipeline_config = ''.join('If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions '
-                                  '<8.2, events will not define `event.ingested` and default fallback for EQL rules '
-                                  'was not added until 8.2, so you will need to add a custom pipeline to populate '
-                                  '`event.ingested` to @timestamp for this rule to work.'.splitlines())
+        pipeline_config = ('If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions '
+                           '<8.2, events will not define `event.ingested` and default fallback for EQL rules '
+                           'was not added until 8.2, so you will need to add a custom pipeline to populate '
+                           '`event.ingested` to @timestamp for this rule to work.')
 
         for rule in self.all_rules:
             if rule.contents.data.type not in ('eql', 'query'):

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -10,16 +10,16 @@ import warnings
 from collections import defaultdict
 from pathlib import Path
 
-import eql
-
 import kql
+
 from detection_rules import attack
-from detection_rules.version_lock import default_version_lock
+from detection_rules.beats import parse_beats_from_index
 from detection_rules.rule import QueryRuleData
 from detection_rules.rule_loader import FILE_PATTERN
 from detection_rules.schemas import definitions
 from detection_rules.semver import Version
 from detection_rules.utils import get_path, load_etc_dump
+from detection_rules.version_lock import default_version_lock
 from rta import get_ttp_names
 from .base import BaseRuleTest
 
@@ -489,28 +489,84 @@ class TestRuleTiming(BaseRuleTest):
     """Test rule timing and timestamps."""
 
     def test_event_override(self):
-        """Test that rules have defined an timestamp_override if needed."""
-        missing = []
+        """Test that timestamp_override is properly applied to rules."""
+        # kql: always require (fallback to @timestamp enabled)
+        # eql:
+        #   sequences: never
+        #   min_stack_version < 8.2: only where event.ingested defined (no beats) or add config to update pipeline
+        #   min_stack_version >= 8.2: any - fallback to @timestamp enabled https://github.com/elastic/kibana/pull/127989
+
+        errors = {
+            'query': {
+                'errors': [],
+                'msg': 'should have the `timestamp_override` set to `event.ingested`'
+            },
+            'eql_sq': {
+                'errors': [],
+                'msg': 'cannot have the `timestamp_override` set to `event.ingested` because it uses a sequence'
+            },
+            'lt_82_eql_': {
+                'errors': [],
+                'msg': 'should have the `timestamp_override` set to `event.ingested`'
+            },
+            'lt_82_eql_beats': {
+                'errors': [],
+                'msg': ('eql rules include beats indexes, which do not add the `event.ingested` field and there is no '
+                        'default fallback to @timestamp for EQL rules <8.2, or add a config entry to add it in '
+                        'a custom pipeline')
+            },
+            'gte_82_eql': {
+                'errors': [],
+                'msg': ('should have the `timestamp_override` set to `event.ingested` - default fallback to '
+                        '@timestamp was added in 8.2')
+            }
+        }
+
+        pipeline_config = ('If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, '
+                           'events will not define `event.ingested` and default fallback for EQL rules was not added '
+                           'until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to '
+                           '@timestamp for this rule to work.')
 
         for rule in self.all_rules:
-            required = False
-
+            if rule.contents.data.type not in ('eql', 'query'):
+                continue
             if isinstance(rule.contents.data, QueryRuleData) and 'endgame-*' in rule.contents.data.index:
                 continue
 
+            has_event_ingested = rule.contents.data.timestamp_override == 'event.ingested'
+            indexes = rule.contents.data.get('index', [])
+            beats_indexes = parse_beats_from_index(indexes)
+            min_stack_is_less_than_82 = Version(rule.contents.metadata.min_stack_version or '7.13') < (8, 2)
+            config = rule.contents.data.get('note') or ''
+            rule_str = self.rule_str(rule, trailer=None)
+
             if rule.contents.data.type == 'query':
-                required = True
-            elif rule.contents.data.type == 'eql' and \
-                    eql.utils.get_query_type(rule.contents.data.ast) != 'sequence':
-                required = True
+                if not has_event_ingested:
+                    errors['query']['errors'].append(rule_str)
+            # eql rules depends
+            elif rule.contents.data.type == 'eql':
+                if rule.contents.data.is_sequence:
+                    if has_event_ingested:
+                        errors['eql_sq']['errors'].append(rule_str)
+                else:
+                    if min_stack_is_less_than_82:
+                        if not beats_indexes and not has_event_ingested:
+                            errors['lt_82_eql']['errors'].append(rule_str)
+                        elif beats_indexes and has_event_ingested and pipeline_config not in config:
+                            errors['lt_82_eql_beats']['errors'].append(rule_str)
+                    else:
+                        if not has_event_ingested:
+                            errors['gte_82_eql']['errors'].append(rule_str)
 
-            if required and rule.contents.data.timestamp_override != 'event.ingested':
-                missing.append(rule)
-
-        if missing:
-            rules_str = '\n '.join(self.rule_str(r, trailer=None) for r in missing)
-            err_msg = f'The following rules should have the `timestamp_override` set to `event.ingested`\n {rules_str}'
-            self.fail(err_msg)
+        if any([v['errors'] for k, v in errors.items()]):
+            err_strings = ['errors with `timestamp_override = "event.ingested"`']
+            for _, errors_by_type in errors.items():
+                type_errors = errors_by_type['errors']
+                if not type_errors:
+                    continue
+                err_strings.append(f'({len(type_errors)}) {errors_by_type["msg"]}')
+                err_strings.extend([f'  - {e}' for e in type_errors])
+            self.fail('\n'.join(err_strings))
 
     def test_required_lookback(self):
         """Ensure endpoint rules have the proper lookback time."""

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -511,9 +511,9 @@ class TestRuleTiming(BaseRuleTest):
             },
             'lt_82_eql_beats': {
                 'errors': [],
-                'msg': ('eql rules include beats indexes, which do not add the `event.ingested` field and there is no '
-                        'default fallback to @timestamp for EQL rules <8.2, or add a config entry to add it in '
-                        'a custom pipeline')
+                'msg': ('eql rules include beats indexes. Non-elastic-agent indexes do not add the `event.ingested` '
+                        'field and there is no default fallback to @timestamp for EQL rules <8.2, so the override '
+                        'should be removed or a config entry included to manually add it in a custom pipeline')
             },
             'gte_82_eql': {
                 'errors': [],
@@ -522,10 +522,10 @@ class TestRuleTiming(BaseRuleTest):
             }
         }
 
-        pipeline_config = ('If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, '
-                           'events will not define `event.ingested` and default fallback for EQL rules was not added '
-                           'until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to '
-                           '@timestamp for this rule to work.')
+        pipeline_config = ''.join('If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions '
+                                  '<8.2, events will not define `event.ingested` and default fallback for EQL rules '
+                                  'was not added until 8.2, so you will need to add a custom pipeline to populate '
+                                  '`event.ingested` to @timestamp for this rule to work.'.splitlines())
 
         for rule in self.all_rules:
             if rule.contents.data.type not in ('eql', 'query'):


### PR DESCRIPTION
## Issues


## Summary
Adds tests for the usage of the `timestamp_override` field to:
* kql rules always require (fallback to @timestamp enabled)
*eql:
    * sequences: never allow
    * rules with min_stack_version < 8.2: only where event.ingested defined (no beats) or add config to update pipeline
    * rules with min_stack_version >= 8.2: any - fallback to @timestamp enabled https://github.com/elastic/kibana/pull/127989

This also updated rules which were out of bounds of these tests