### PR TITLE
[Rule Tuning] Add EQL optional field syntax

### DIFF
--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/18"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/04/04"
 
 [rule]
 author = ["Elastic"]
@@ -27,8 +27,8 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and 
-  (process.Ext.token.integrity_level_name : "System" or
-  winlog.event_data.IntegrityLevel : "System") and
+  (?process.Ext.token.integrity_level_name : "System" or
+  ?winlog.event_data.IntegrityLevel : "System") and
   process.name : "whoami.exe" or
   (process.name : "net1.exe" and not process.parent.name : "net.exe")
 '''

--- a/rules/windows/discovery_net_command_system_account.toml
+++ b/rules/windows/discovery_net_command_system_account.toml
@@ -1,6 +1,8 @@
 [metadata]
 creation_date = "2020/03/18"
 maturity = "production"
+min_stack_comments = "EQL optional fields syntax was not introduced until 7.16"
+min_stack_version = "7.16.0"
 updated_date = "2022/04/04"
 
 [rule]

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -1,6 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
+min_stack_comments = "EQL optional fields syntax was not introduced until 7.16"
+min_stack_version = "7.16.0"
 updated_date = "2022/04/04"
 
 [rule]

--- a/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_register_server_program_connecting_to_the_internet.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2022/02/14"
+updated_date = "2022/04/04"
 
 [rule]
 author = ["Elastic"]
@@ -32,7 +32,7 @@ sequence by process.entity_id
   [process where event.type == "start" and
    process.name : ("regsvr32.exe", "RegAsm.exe", "RegSvcs.exe") and
    not (
-         (process.Ext.token.integrity_level_name : "System" or winlog.event_data.IntegrityLevel : "System") and
+         (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System") and
          (process.parent.name : "msiexec.exe" or process.parent.executable : ("C:\\Program Files (x86)\\*.exe", "C:\\Program Files\\*.exe"))
        )
    ]

--- a/rules/windows/persistence_local_scheduled_task_creation.toml
+++ b/rules/windows/persistence_local_scheduled_task_creation.toml
@@ -1,6 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
+min_stack_comments = "EQL optional fields syntax was not introduced until 7.16"
+min_stack_version = "7.16.0"
 updated_date = "2022/04/04"
 
 [rule]

--- a/rules/windows/persistence_local_scheduled_task_creation.toml
+++ b/rules/windows/persistence_local_scheduled_task_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/04/04"
 
 [rule]
 author = ["Elastic"]
@@ -34,7 +34,7 @@ sequence with maxspan=1m
     (process.name : "schtasks.exe" or process.pe.original_file_name == "schtasks.exe") and
     process.args : ("/create", "-create") and process.args : ("/RU", "/SC", "/TN", "/TR", "/F", "/XML") and
     /* exclude SYSTEM Integrity Level - look for task creations by non-SYSTEM user */
-    not (process.Ext.token.integrity_level_name : "System" or winlog.event_data.IntegrityLevel : "System")
+    not (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System")
   ] by process.parent.entity_id
 '''
 

--- a/rules/windows/privilege_escalation_installertakeover.toml
+++ b/rules/windows/privilege_escalation_installertakeover.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/11/25"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/04/04"
 
 [rule]
 author = ["Elastic"]
@@ -60,8 +60,8 @@ query = '''
 /* This rule is compatible with both Sysmon and Elastic Endpoint */
 
 process where event.type == "start" and 
-    (process.Ext.token.integrity_level_name : "System" or
-    winlog.event_data.IntegrityLevel : "System") and
+    (?process.Ext.token.integrity_level_name : "System" or
+    ?winlog.event_data.IntegrityLevel : "System") and
     (
       (process.name : "elevation_service.exe" and 
        not process.pe.original_file_name == "elevation_service.exe") or

--- a/rules/windows/privilege_escalation_installertakeover.toml
+++ b/rules/windows/privilege_escalation_installertakeover.toml
@@ -1,6 +1,8 @@
 [metadata]
 creation_date = "2021/11/25"
 maturity = "production"
+min_stack_comments = "EQL optional fields syntax was not introduced until 7.16"
+min_stack_version = "7.16.0"
 updated_date = "2022/04/04"
 
 [rule]

--- a/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
+++ b/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
@@ -1,6 +1,8 @@
 [metadata]
 creation_date = "2021/07/06"
 maturity = "production"
+min_stack_comments = "EQL optional fields syntax was not introduced until 7.16"
+min_stack_version = "7.16.0"
 updated_date = "2022/04/04"
 
 [rule]

--- a/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
+++ b/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/06"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/04/04"
 
 [rule]
 author = ["Elastic"]
@@ -38,8 +38,8 @@ type = "eql"
 query = '''
 process where event.type == "start" and
  process.parent.name : "spoolsv.exe" and
- (process.Ext.token.integrity_level_name : "System" or
- winlog.event_data.IntegrityLevel : "System") and
+ (?process.Ext.token.integrity_level_name : "System" or
+ ?winlog.event_data.IntegrityLevel : "System") and
 
  /* exclusions for FP control below */
  not process.name : ("splwow64.exe", "PDFCreator.exe", "acrodist.exe", "spoolsv.exe", "msiexec.exe", "route.exe", "WerFault.exe") and


### PR DESCRIPTION
## Issues

Related to https://github.com/elastic/sdh-security-team/issues/339

## Summary

Adds EQL Optional field syntax to rules that use specific fields across different data sources, which was causing schema errors.