### PR TITLE
Remove deprecated elasticsearch parameter

### DIFF
--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -391,9 +391,9 @@ def add_client(*client_type, add_to_ctx=True, add_func_arg=True):
                             elasticsearch_client.info():
                         pass
                     else:
-                        elasticsearch_client = get_elasticsearch_client(use_ssl=True, **es_client_args)
+                        elasticsearch_client = get_elasticsearch_client(**es_client_args)
                 except AuthenticationException:
-                    elasticsearch_client = get_elasticsearch_client(use_ssl=True, **es_client_args)
+                    elasticsearch_client = get_elasticsearch_client(**es_client_args)
 
                 if add_func_arg:
                     kwargs['elasticsearch_client'] = elasticsearch_client


### PR DESCRIPTION
## Issues
related to #1911 

## Summary
With the update to elasticsearch module, the `use_ssl` parameter was removed. [REF](https://github.com/elastic/elasticsearch-py/blob/d013e8863667341792c2187cb1b7c677b1fd7862/elasticsearch/_sync/client/utils.py#L187)