### PR TITLE
[Rule Tuning] AWS RDS Instance/Cluster Deletion

### DIFF
--- a/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
@@ -1,19 +1,19 @@
 [metadata]
 creation_date = "2020/05/21"
 maturity = "production"
-updated_date = "2021/07/20"
+updated_date = "2022/04/07"
 integration = "aws"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the deletion of an Amazon Relational Database Service (RDS) Aurora database cluster or global database
-cluster.
+Identifies the deletion of an Amazon Relational Database Service (RDS) Aurora database cluster, global database
+cluster, or database instance.
 """
 false_positives = [
     """
-    Clusters may be deleted by a system administrator. Verify whether the user identity, user agent, and/or hostname
-    should be making changes in your environment. Cluster deletions by unfamiliar users or hosts should be
+    Clusters or instances may be deleted by a system administrator. Verify whether the user identity, user agent, and/or hostname
+    should be making changes in your environment. Cluster or instance deletions by unfamiliar users or hosts should be
     investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-aws*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
-name = "AWS RDS Cluster Deletion"
+name = "AWS RDS Instance/Cluster Deletion"
 note = """## Config
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
@@ -31,6 +31,9 @@ references = [
     "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBCluster.html",
     "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/delete-global-cluster.html",
     "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteGlobalCluster.html",
+    "https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/delete-db-instance.html",
+    "https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBInstance.html"
+
 ]
 risk_score = 47
 rule_id = "9055ece6-2689-4224-a0e0-b04881e1f8ad"
@@ -40,7 +43,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:rds.amazonaws.com and event.action:(DeleteDBCluster or DeleteGlobalCluster) and event.outcome:success
+event.dataset:aws.cloudtrail and event.provider:rds.amazonaws.com and event.action:(DeleteDBCluster or DeleteGlobalCluster or DeleteDBInstance) 
+and event.outcome:success
 '''
 
 

--- a/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-aws*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
-name = "AWS RDS Instance/Cluster Deletion"
+name = "AWS Deletion of RDS Instance or Cluster"
 note = """## Config
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""


### PR DESCRIPTION
## Issues
Related to https://github.com/elastic/detection-rules/issues/1873 

## Summary
I've added to this rule to improve our coverage. Currently we detect the creation and stopping of both AWS RDS clusters and instances. But we only detect for the deletion of clusters, not instances. This adds the deletion of RDS instances to the detection.


## Proof of Success
![image](https://user-images.githubusercontent.com/59296946/162272281-ceb330c7-3575-4de7-ba8b-158ff3c4d022.png)

