### PR TITLE
Revert "Lock versions for releases: 7.13,7.14,7.15,7.16,8.0,8.1,8.2"

### DIFF
--- a/etc/deprecated_rules.json
+++ b/etc/deprecated_rules.json
@@ -34,20 +34,10 @@
     "rule_name": "Execution via Regsvcs/Regasm",
     "stack_version": "7.14.0"
   },
-  "5e87f165-45c2-4b80-bfa5-52822552c997": {
-    "deprecation_date": "2022/03/16",
-    "rule_name": "Potential PrintNightmare File Modification",
-    "stack_version": "7.13"
-  },
   "61c31c14-507f-4627-8c31-072556b89a9c": {
     "deprecation_date": "2021/04/15",
     "rule_name": "Mknod Process Activity",
     "stack_version": "7.14.0"
-  },
-  "6506c9fd-229e-4722-8f0f-69be759afd2a": {
-    "deprecation_date": "2022/03/16",
-    "rule_name": "Potential PrintNightmare Exploit Registry Modification",
-    "stack_version": "7.13"
   },
   "67a9beba-830d-4035-bfe8-40b7e28f8ac4": {
     "deprecation_date": "2021/04/15",

--- a/etc/version.lock.json
+++ b/etc/version.lock.json
@@ -8,15 +8,15 @@
   "00140285-b827-4aee-aa09-8113f58a08f3": {
     "min_stack_version": "7.13.0",
     "rule_name": "Potential Credential Access via Windows Utilities",
-    "sha256": "6bd8502bc40bd03620c90d9b566806eabce8546ce2a94ee8b2a6afba2bfd8d9a",
+    "sha256": "cbbb5fe38e0d37cf8fed4293739ecbf327d81a48aeb8aa6d2cb69d0aa362731d",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "0022d47d-39c7-4f69-a232-4fe9dc7a3acd": {
     "rule_name": "System Shells via Services",
-    "sha256": "70a547e0146037d91a87e7bb314d011cf3831d81f98f8aa74b0d4338f2f4b1e9",
+    "sha256": "54fc1dc508daf749ca6a92dfd20fc62e6715527a8aeb14a2c8fcc627d1606105",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "0136b315-b566-482f-866c-1d8e2477ba16": {
     "rule_name": "Microsoft 365 User Restricted from Sending Email",
@@ -26,15 +26,15 @@
   },
   "027ff9ea-85e7-42e3-99d2-bbb7069e02eb": {
     "rule_name": "Potential Cookies Theft via Browser Debugging",
-    "sha256": "d1d8134c952b55fa1b0bee04fa68195ff7ae87787222ae233a9002be2a19f94a",
+    "sha256": "1c44db89d3410a06dc61f99dda258376dd4863095c7c858ad1da33d8c582fc2c",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "02a4576a-7480-4284-9327-548a806b5e48": {
     "rule_name": "Potential Credential Access via DuplicateHandle in LSASS",
-    "sha256": "68c2afebb98ce672775564854f7dfbb1d72f8c30b6c945c86bd7c74421382cb4",
+    "sha256": "dc5c89b6a2667693fbe1a725c957ad2bc11c124768f3a668613ba10a77780f91",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "02ea4563-ec10-4974-b7de-12e65aa4f9b3": {
     "rule_name": "Dumping Account Hashes via Built-In Commands",
@@ -50,9 +50,9 @@
   },
   "035889c4-2686-4583-a7df-67f89c292f2c": {
     "rule_name": "High Number of Process and/or Service Terminations",
-    "sha256": "a1d043e0e5f0a9e74ece3976f76e08b88695789febbe9a2c75a2f2c7b661a351",
+    "sha256": "a5417071894f6d1e07147cb4c4ba4712768327afda352ca1bfbc6237b1834431",
     "type": "threshold",
-    "version": 4
+    "version": 3
   },
   "0415f22a-2336-45fa-ba07-618a5942e22c": {
     "rule_name": "Modification of OpenSSH Binaries",
@@ -68,27 +68,27 @@
   },
   "04c5a96f-19c5-44fd-9571-a0b033f9086f": {
     "rule_name": "Azure AD Global Administrator Role Assigned",
-    "sha256": "6624bd59e3484cbeccc9ba462120dbe3f2687e9197709fb7ad303100c52733c1",
+    "sha256": "7a015cad38d39de1f85abbcd1c66f94779b16769f63b8c6155453e53a2f2fd94",
     "type": "query",
-    "version": 2
+    "version": 1
   },
   "053a0387-f3b5-4ba5-8245-8002cca2bd08": {
     "rule_name": "Potential DLL Side-Loading via Microsoft Antimalware Service Executable",
-    "sha256": "aac08399f02ab0704bc8b64ba045fe7dd1578736d85b8fea2ef0cde8c25958ac",
+    "sha256": "bae7f8ff4ba6ea634982a368fedf0384ba3e9912ae10a1c22dab21a49056cb74",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "0564fb9d-90b9-4234-a411-82a546dc1343": {
     "rule_name": "Microsoft IIS Service Account Password Dumped",
-    "sha256": "81e0cb3eb2e76becdb12a2b8a5551cbd8ebc53eebae7850d5349a26a363177a0",
+    "sha256": "bcda2313ca40b6fb5e29b30a8a4a34392c0e5ec339b88f2b93e391657b5e3dc6",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "05b358de-aa6d-4f6c-89e6-78f74018b43b": {
     "rule_name": "Conhost Spawned By Suspicious Parent Process",
-    "sha256": "aea05dc73b1d06b72db4f0e6bce404d9f254959414d0e3af6dc5eff2175d7d9e",
+    "sha256": "d199c2fe63aef75d00d1404d2da28ece62aafacca1288fad7441a7febb506bc2",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "05e5a668-7b51-4a67-93ab-e9af405c9ef3": {
     "rule_name": "Interactive Terminal Spawned via Perl",
@@ -98,21 +98,21 @@
   },
   "0635c542-1b96-4335-9b47-126582d2c19a": {
     "rule_name": "Remote System Discovery Commands",
-    "sha256": "c122c98b1ce32b6a4b1c6f6cd8e773c9d312bab7e7b32508fa3f5ed205e26d4c",
+    "sha256": "16d8a132a4c14359e8917a15b94a476cff425e291fc3733d15bae53552e8c4b0",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "06dceabf-adca-48af-ac79-ffdf4c3b1e9a": {
     "rule_name": "Potential Evasion via Filter Manager",
-    "sha256": "24081b70d3c6ce13c8bd50d44c705b306d371355afcef70dd1cafd8105c370d1",
+    "sha256": "c481db545277820f57ac0efe04364be82a44271e65b05635d59c07fb0932a535",
     "type": "eql",
-    "version": 9
+    "version": 8
   },
   "074464f9-f30d-4029-8c03-0ed237fffec7": {
-    "rule_name": "Remote Desktop Enabled in Windows Firewall by Netsh",
-    "sha256": "2c90826212589d2f58baa3e279088cf89a517073ca5736395558610b68f3facb",
+    "rule_name": "Remote Desktop Enabled in Windows Firewall",
+    "sha256": "29afef30be0c86eeb8c731c39dbf62b777ed72a65f168c0469f907ed9fd5b801",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "080bc66a-5d56-4d1f-8071-817671716db9": {
     "rule_name": "Suspicious Browser Child Process",
@@ -140,21 +140,15 @@
   },
   "092b068f-84ac-485d-8a55-7dd9e006715f": {
     "rule_name": "Creation of Hidden Launch Agent or Daemon",
-    "sha256": "9dd3814b461fbb4a289ff60e9bc8b793e2cb11bb20225ecab60b3199dddf441e",
+    "sha256": "5863e9461fec288af7418b55eb3a1352d66726c36f3b908c8ae0dd5c4f4a86c5",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "09443c92-46b3-45a4-8f25-383b028b258d": {
     "rule_name": "Process Termination followed by Deletion",
     "sha256": "94e72ce4ad6b954cf01ab7f7a175c472e6936b75e330dec5da7847381fce4224",
     "type": "eql",
     "version": 3
-  },
-  "0968cfbd-40f0-4b1c-b7b1-a60736c7b241": {
-    "rule_name": "Linux Restricted Shell Breakout via cpulimit Shell Evasion",
-    "sha256": "a49a4358e83bf40e29e9dad1bb8afb6700d89cfe5a5b3e29adaa28e1f3c0b244",
-    "type": "eql",
-    "version": 1
   },
   "09d028a5-dcde-409f-8ae0-557cef1b7082": {
     "rule_name": "Azure Frontdoor Web Application Firewall (WAF) Policy Deleted",
@@ -174,17 +168,11 @@
     "type": "machine_learning",
     "version": 5
   },
-  "0b2f3da5-b5ec-47d1-908b-6ebb74814289": {
-    "rule_name": "User account exposed to Kerberoasting",
-    "sha256": "530be151c7380d77b392bb69a3927091b95505dabe5e215d7498dfac9a70be19",
-    "type": "query",
-    "version": 1
-  },
   "0c7ca5c2-728d-4ad9-b1c5-bbba83ecb1f4": {
     "rule_name": "Peripheral Device Discovery",
-    "sha256": "f25cff103d26d356f2e7eb55da5889925ebdbf670af9f4fc8ff2073bc72799dc",
+    "sha256": "499dcd1aa2d62a15f68fa52d95b87511f7f4e14f24ffe83babb3e72e990ff81d",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "0c9a14d9-d65d-486f-9b5b-91e4e6b22bd0": {
     "min_stack_version": "8.0",
@@ -213,9 +201,9 @@
   },
   "0e52157a-8e96-4a95-a6e3-5faae5081a74": {
     "rule_name": "SharePoint Malware File Upload",
-    "sha256": "5afc77de9c885ae65a464091203ad5c5e282658e514751bb85fb54ec09fea3de",
+    "sha256": "48df4cd6be0661df2216bfc2d74a9df628a612d04495422423eed07656ad1a47",
     "type": "query",
-    "version": 2
+    "version": 1
   },
   "0e5acaae-6a64-4bbc-adb8-27649c03f7e1": {
     "rule_name": "GCP Service Account Key Creation",
@@ -238,20 +226,14 @@
   "0f93cb9a-1931-48c2-8cd0-f173fd3e5283": {
     "min_stack_version": "7.14.0",
     "rule_name": "Potential LSASS Memory Dump via PssCaptureSnapShot",
-    "sha256": "7d16ee5358944e8f1ffcc6a1c546c3bf938b26bcce752e118aaa63d1b5ae3633",
+    "sha256": "549215ea3a624085dcc50282089306cd1d82418bedb7612fff262a1adde0d33c",
     "type": "threshold",
-    "version": 3
+    "version": 2
   },
   "0ff84c42-873d-41a2-a4ed-08d74d352d01": {
     "rule_name": "Privilege Escalation via Root Crontab File Modification",
     "sha256": "2149a008d62b8e6a983abd178158948e2c370183a4e070931806ebd07b620ec7",
     "type": "query",
-    "version": 1
-  },
-  "10754992-28c7-4472-be5b-f3770fd04f2d": {
-    "rule_name": "Linux Restricted Shell Breakout via awk Commands",
-    "sha256": "d712972fb7e71daddbd2b5ced9e9845171a1e544e0e981d72fa350f743dec969",
-    "type": "eql",
     "version": 1
   },
   "10a500bb-a28f-418e-ba29-ca4c8d1a9f2f": {
@@ -262,21 +244,21 @@
   },
   "11013227-0301-4a8c-b150-4db924484475": {
     "rule_name": "Abnormally Large DNS Response",
-    "sha256": "72179393e4eaeb676c7ddec38aa17e29cdb602ddbac0b4b4c2727b39bbbd33c4",
+    "sha256": "b1ff9083e41b85fbc22c312e1c5407ff831202a02bf5a4f620a25f4109aa99d6",
     "type": "query",
-    "version": 7
+    "version": 6
   },
   "1160dcdb-0a0a-4a79-91d8-9b84616edebd": {
     "rule_name": "Potential DLL SideLoading via Trusted Microsoft Programs",
-    "sha256": "c6bf0b04d83c6734da31ec49c859872b27c52b8f09ef1738038447cd4a5c95a7",
+    "sha256": "683cd269e40b092fff232c56fb89929f544f1bc09566ef0e03053ce621503fdc",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "1178ae09-5aff-460a-9f2f-455cd0ac4d8e": {
     "rule_name": "UAC Bypass via Windows Firewall Snap-In Hijack",
-    "sha256": "fc2ae1c2e96c70f44fd2103a1cce06b0b4499458add7325e1677415df46f5598",
+    "sha256": "f7a9a22c1a88de514cbe1dae2e20a6e83de0000461b15d949b649704273c9498",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "119c8877-8613-416d-a98a-96b6664ee73a": {
     "rule_name": "AWS RDS Snapshot Export",
@@ -292,9 +274,9 @@
   },
   "11ea6bec-ebde-4d71-a8e9-784948f8e3e9": {
     "rule_name": "Third-party Backup Files Deleted via Unexpected Process",
-    "sha256": "8dc4111ee11147f0444e2f5184ce8e6b6e93638804f7f8a86600299dfb094ecb",
+    "sha256": "6937bd14a24a894d160dfabe3efe0d868b8952a006578c810d3d7b0492c31680",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "12051077-0124-4394-9522-8f4f4db1d674": {
     "rule_name": "AWS Route 53 Domain Transfer Lock Disabled",
@@ -316,15 +298,15 @@
   },
   "12f07955-1674-44f7-86b5-c35da0a6f41a": {
     "rule_name": "Suspicious Cmd Execution via WMI",
-    "sha256": "d4acb2e675bb13e2f7434a310b7de904a02db375f43a3f773ba591d3c3870de8",
+    "sha256": "120221c53163f94f7921394a5239a48a64c87bc263ebcb4fabe661f2813d19a9",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "1327384f-00f3-44d5-9a8c-2373ba071e92": {
     "rule_name": "Persistence via Scheduled Job Creation",
-    "sha256": "2fdb60cdfe201b7d1532e7d87392f0e022255c7c3e2a1ef3fa313e2fa286a9a4",
+    "sha256": "7b02935da719949670e9b9601000c344b1f818124e52ac762cf52c3df244806a",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "138c5dd5-838b-446e-b1ac-c995c7f8108a": {
     "min_stack_version": "7.14.0",
@@ -353,27 +335,27 @@
   },
   "14ed1aa9-ebfd-4cf9-a463-0ac59ec55204": {
     "rule_name": "Potential Persistence via Time Provider Modification",
-    "sha256": "babbc6287d174b837d32ddc45d7233af2a2325136cdd66ffb0cae01ff942611d",
+    "sha256": "16e54b31547c5f1dc1b16ad82368432904753d296f9df8aa69d20c61d4d9b3e1",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "15a8ba77-1c13-4274-88fe-6bd14133861e": {
     "rule_name": "Scheduled Task Execution at Scale via GPO",
-    "sha256": "70660c0b8ec658ef3dee87e50fb1f9043df125fa38e8641a7a6ff9c12bff9157",
+    "sha256": "33fa48cfd6c384e6dcf0a5af2d62090fd89307e136c5ef798efbe745e8324466",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "15c0b7a7-9c34-4869-b25b-fa6518414899": {
     "rule_name": "Remote File Download via Desktopimgdownldr Utility",
-    "sha256": "f732f2de92d1e0677c114480538325ccafbcfa148276ba82298007d6183b8d95",
+    "sha256": "50ec2f5b9815c5cc153531c5a3d35d9393e03eb4c668ffd62c97b1e2efd616ff",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "15dacaa0-5b90-466b-acab-63435a59701a": {
     "rule_name": "Virtual Private Network Connection Attempt",
-    "sha256": "6008fb7584493ce0e46ff236746b8e3f001c7bf8fd0a758ffa6b4253a598c64a",
+    "sha256": "dce41c54cfb048f038e53c478c4df69a51ccb8580b2d1017f26d9c59bab389d3",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "16280f1e-57e6-4242-aa21-bb4d16f13b2f": {
     "rule_name": "Azure Automation Runbook Created or Modified",
@@ -401,9 +383,9 @@
   },
   "16fac1a1-21ee-4ca6-b720-458e3855d046": {
     "rule_name": "Startup/Logon Script added to Group Policy Object",
-    "sha256": "af1ffd24fd0a26c9e8ea2631e0dc2431a63d5292901f4eabdb74a96e7ce20bc5",
+    "sha256": "2efc5fbfcc942c4b9524b11fc28cd6e721a37c7c5c1936c95b9361a2d0a15622",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "1781d055-5c66-4adf-9c59-fc0fa58336a5": {
     "rule_name": "Unusual Windows Username",
@@ -437,9 +419,9 @@
   },
   "17c7f6a5-5bc9-4e1f-92bf-13632d24384d": {
     "rule_name": "Suspicious Execution - Short Program Name",
-    "sha256": "175f6548b5de9b9d17a9a0a1cdab3cc6acaac6de7ed04ce578c3ea023a8d891a",
+    "sha256": "3763b227c0acc1f158a5aafbc971558f823486f26d38ebc8633193bd1110f8d8",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "17e68559-b274-4948-ad0b-f8415bb31126": {
     "rule_name": "Unusual Network Destination Domain Name",
@@ -452,12 +434,6 @@
     "sha256": "545191239ffa25aad0736095596c8b1da4fe02b5853b7d098de97c66a389724f",
     "type": "query",
     "version": 5
-  },
-  "1859ce38-6a50-422b-a5e8-636e231ea0cd": {
-    "rule_name": "Linux Restricted Shell Breakout via c89/c99 Shell evasion",
-    "sha256": "7e7de93079eef0b085e35930659004f7dc4b966ad722932b86b82c762d627e1e",
-    "type": "eql",
-    "version": 1
   },
   "19de8096-e2b0-4bd8-80c9-34a820813fff": {
     "rule_name": "Rare AWS Error Code",
@@ -473,9 +449,9 @@
   },
   "1a6075b0-7479-450e-8fe7-b8b8438ac570": {
     "rule_name": "Execution of COM object via Xwizard",
-    "sha256": "9f3f95028badc6eb4343d13638ad0780a013387a6677d2e415b451e293bece33",
+    "sha256": "4776192663bb176f851e07e413ee7d932ecc34e7ad179253f59c2be526afec0e",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "1aa8fa52-44a7-4dae-b058-f3333b91c8d7": {
     "rule_name": "AWS CloudTrail Log Suspended",
@@ -485,9 +461,9 @@
   },
   "1aa9181a-492b-4c01-8b16-fa0735786b2b": {
     "rule_name": "User Account Creation",
-    "sha256": "ef9723409faac70d85d65a48be677534310d61564e4f1727b2d774522f519b9e",
+    "sha256": "2e6aba11ce3349c0f1b9d4e73146c40479f371af1fc28f299eadcfbcc8673748",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "1b21abcc-4d9f-4b08-a7f5-316f5f94b973": {
     "rule_name": "Connection to Internal Network via Telnet",
@@ -521,9 +497,9 @@
   },
   "1d276579-3380-4095-ad38-e596a01bc64f": {
     "rule_name": "Remote File Download via Script Interpreter",
-    "sha256": "4bc40c8feb45c49d415e8124b65c360096227607352b2ead93c06208f17ec6c9",
+    "sha256": "db68a6ddeb9ff20f43c047dcd1de97515eb952ee0c23b9d232e35a0786a7b71c",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "1d72d014-e2ab-4707-b056-9b96abe7b511": {
     "rule_name": "External IP Lookup from Non-Browser Process",
@@ -533,9 +509,9 @@
   },
   "1dcc51f6-ba26-49e7-9ef4-2655abb2361e": {
     "rule_name": "UAC Bypass via DiskCleanup Scheduled Task Hijack",
-    "sha256": "ed8663447000841656eeb2b4364396acf094b353b6ec07cb28048c63c372c2a3",
+    "sha256": "8b2934c92efde1fe5d402ceab8608bcc234ea06b4959f1fc4244a554402d7fd0",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "1defdd62-cd8d-426e-a246-81a37751bb2b": {
     "rule_name": "Execution of File Written or Modified by PDF Reader",
@@ -575,15 +551,15 @@
   },
   "201200f1-a99b-43fb-88ed-f65a45c4972c": {
     "rule_name": "Suspicious .NET Code Compilation",
-    "sha256": "5a208a45a3c9ddd1f06e0a5cab66e7ae07fc7cbc3aa0543f5241fefc9908a3e2",
+    "sha256": "5e7be99268fbc7605ca567d2dc6d1cb1fd554771d9f92fb62f0d4e00f780a896",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "203ab79b-239b-4aa5-8e54-fc50623ee8e4": {
     "rule_name": "Creation or Modification of Root Certificate",
-    "sha256": "be7ec65d2c7f90cd999aea89e4fdbc01e3b0e56926c2d3e7c6ac23b8daf8afba",
+    "sha256": "530e80dcf00f3d075008dc84df00d8ae307d4cafe4bb16d2f9afe00d7a66e8d6",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "2045567e-b0af-444a-8c0b-0b6e2dae9e13": {
     "rule_name": "AWS Route 53 Domain Transferred to Another Account",
@@ -593,13 +569,7 @@
   },
   "20457e4f-d1de-4b92-ae69-142e27a4342a": {
     "rule_name": "Access of Stored Browser Credentials",
-    "sha256": "ffc126e733d39439f6dbf4169c174fa3d69e58fd8e75c9124c8b2e5a19832d2e",
-    "type": "eql",
-    "version": 2
-  },
-  "208dbe77-01ed-4954-8d44-1e5751cb20de": {
-    "rule_name": "LSASS Memory Dump Handle Access",
-    "sha256": "69e294a09630f9eb4247a56cedb9e0b8e554ec9dbab44a29636131e37fa932cf",
+    "sha256": "70475c97c91896aca0fdd68519bec234ff444f48d2bbbdafb7da5a1da5944868",
     "type": "eql",
     "version": 1
   },
@@ -617,9 +587,9 @@
   },
   "22599847-5d13-48cb-8872-5796fee8692b": {
     "rule_name": "SUNBURST Command and Control Activity",
-    "sha256": "ad1e2ad3f95e7ea0ffcbf17cf87cada0575fbd7c760c4e9d11f68480d67f7740",
+    "sha256": "f653154c491692a6cb83869048a8f92af0b6bd245f2161717df86a6aadd43a15",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "227dc608-e558-43d9-b521-150772250bae": {
     "rule_name": "AWS S3 Bucket Configuration Deletion",
@@ -641,9 +611,9 @@
   },
   "25224a80-5a4a-4b8a-991e-6ab390465c4f": {
     "rule_name": "Lateral Movement via Startup Folder",
-    "sha256": "d530ac665a15face07297369f65e4960527454f70a5d5791eead92fc7a3d5dd0",
+    "sha256": "541c555ba3d9c4e25fdeed71f0c1033b4c3f0ffcfabf9a5ea94828114d63cefc",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "2636aa6c-88b5-4337-9c31-8d0192a8ef45": {
     "rule_name": "Azure Blob Container Access Level Modification",
@@ -653,9 +623,9 @@
   },
   "265db8f5-fc73-4d0d-b434-6483b56372e2": {
     "rule_name": "Persistence via Update Orchestrator Service Hijack",
-    "sha256": "d46cdb1b26cedd1fb2fc7f785592b4facad3b2d931dbf2b66122946f01a21e31",
+    "sha256": "2fde8b5429bcf1a32d15d54f96a2386179c681a0bc3e5eca71ac09eaa51272ad",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "26edba02-6979-4bce-920a-70b080a7be81": {
     "rule_name": "Azure Active Directory High Risk User Sign-in Heuristic",
@@ -677,9 +647,9 @@
   },
   "2772264c-6fb9-4d9d-9014-b416eed21254": {
     "rule_name": "Incoming Execution via PowerShell Remoting",
-    "sha256": "089d0ecdbcb613691dc9e414c064213c63e11df6eac4880f3ee5199aa9072446",
+    "sha256": "25e969879796bbb0d8b68a24c97e5ec6505eced63d6971bc75ee9454d104b3d4",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "2783d84f-5091-4d7d-9319-9fceda8fa71b": {
     "rule_name": "GCP Firewall Rule Modification",
@@ -695,23 +665,15 @@
   },
   "2820c9c2-bcd7-4d6e-9eba-faf3891ba450": {
     "rule_name": "Account Password Reset Remotely",
-    "sha256": "da0025603ed05574a42995a838fa4a59af861dc43897a100c5839f64fc593c2f",
+    "sha256": "5204940ed9faa7c63a7a0085cbc43c3f6873c63e917c5cb5ec3644572c5cf9ca",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "2856446a-34e6-435b-9fb5-f8f040bfa7ed": {
-    "min_stack_version": "7.16.0",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Net command via SYSTEM account",
-        "sha256": "a97a15880fef84d759e6bab118b8f3c882e1cfaa9d51f83415729f840218004a",
-        "version": 10
-      }
-    },
-    "rule_name": "Account Discovery Command via SYSTEM Account",
-    "sha256": "10baf7a22ed410dd6e9322df564f73a88747df6187d923fcbb297e13f8a7e900",
+    "rule_name": "Net command via SYSTEM account",
+    "sha256": "5e35b7ace9af65eee277e440fbb6659768d0caf5ab49a5179222cde8b4410fa1",
     "type": "eql",
-    "version": 11
+    "version": 9
   },
   "2863ffeb-bf77-44dd-b7a5-93ef94b72036": {
     "rule_name": "Exploit - Prevented - Elastic Endgame",
@@ -721,45 +683,45 @@
   },
   "28896382-7d4f-4d50-9b72-67091901fd26": {
     "rule_name": "Suspicious Process from Conhost",
-    "sha256": "49fcf33d915406bad89e37650162857322c5694c4c737f3d6d483354e7093ece",
+    "sha256": "b448efa8a3877578f365cdb010bb962b005c00c8233afaf30bdf8c06784f6dc1",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "29052c19-ff3e-42fd-8363-7be14d7c5469": {
     "rule_name": "AWS Security Group Configuration Change Detection",
-    "sha256": "cb592ba956c6a56693208fd5686ae1c03bb60011a352ae21944ffd7a23fa4336",
+    "sha256": "e612f03f7184fa5ee1e8c62b3508e133ac925898424f7350dd6fa8550331ceb7",
     "type": "query",
-    "version": 4
+    "version": 3
   },
   "290aca65-e94d-403b-ba0f-62f320e63f51": {
     "rule_name": "UAC Bypass Attempt via Windows Directory Masquerading",
-    "sha256": "2a58bf53b9f99f85fa184a7d00f64256623d20f43f4005b9a30cc242d826d6ce",
-    "type": "eql",
-    "version": 5
-  },
-  "2917d495-59bd-4250-b395-c29409b76086": {
-    "rule_name": "Webshell Detection: Script Process Child of Common Web Processes",
-    "sha256": "d2e259962ac2b93ee1362e4906165fc59b3e10e810d2ac53c3f0f32e52295c90",
+    "sha256": "37eb08a6a2e77c04289f41edc70fe76cf6ce25f43d79fad419ffcfaf17ab6ff7",
     "type": "eql",
     "version": 4
   },
-  "291a0de9-937a-4189-94c0-3e847c8b13e4": {
-    "rule_name": "Enumeration of Privileged Local Groups Membership",
-    "sha256": "b7d22fcaf761be065f287bb83583962fdde3b307efe170634cc5476f61649f3f",
+  "2917d495-59bd-4250-b395-c29409b76086": {
+    "rule_name": "Webshell Detection: Script Process Child of Common Web Processes",
+    "sha256": "71c8450638f4fe25ff585483564b55ea9fa82c2e4bf431ada7dd963a5b4c5e22",
     "type": "eql",
     "version": 3
   },
+  "291a0de9-937a-4189-94c0-3e847c8b13e4": {
+    "rule_name": "Enumeration of Privileged Local Groups Membership",
+    "sha256": "10a0ac7664c24449518000fd745408481a284e5530621bcb46bd09274cb30517",
+    "type": "eql",
+    "version": 2
+  },
   "2bf78aa2-9c56-48de-b139-f169bf99cf86": {
     "rule_name": "Adobe Hijack Persistence",
-    "sha256": "510a5d5ea50dae32a5eff7b4f9a53cf51d5b94ca80e913652b80f68d7568d099",
+    "sha256": "b855256f23054ec5025f78c2ec0ddd70e36ef7b16856700f208936300525f544",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "2c17e5d7-08b9-43b2-b58a-0270d65ac85b": {
     "rule_name": "Windows Defender Exclusions Added via PowerShell",
-    "sha256": "904e2f44e3c9d1f0040832d3b18fb43f052cc049a36765156f7f83c051d1caf1",
+    "sha256": "86c10cc273bb5574a224ca30d1328be55d25c8c2b6fb7b02aa04e84f65778038",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "2d8043ed-5bda-4caf-801c-c1feb7410504": {
     "rule_name": "Enumeration of Kernel Modules",
@@ -769,9 +731,9 @@
   },
   "2dd480be-1263-4d9c-8672-172928f6789a": {
     "rule_name": "Suspicious Process Access via Direct System Call",
-    "sha256": "2a81449e1515fb56c82b0a45f0ae80c75614b0ccbc7854c01b59364ca98f9559",
+    "sha256": "c3726db2dfd855db109944def0676bf91e1eba2881adaf2f1f0f76b2ae14e555",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "2de10e77-c144-4e69-afb7-344e7127abd0": {
     "rule_name": "O365 Excessive Single Sign-On Logon Errors",
@@ -781,15 +743,15 @@
   },
   "2e1e835d-01e5-48ca-b9fc-7a61f7f11902": {
     "rule_name": "Renamed AutoIt Scripts Interpreter",
-    "sha256": "ba5f90755135bf439d352a2dfda0a6457b196807dd95e11b1de481359f11d022",
+    "sha256": "2fe8c86abbc5b90c04c50b2d75bc279a82b4ca5b5b9075830ede2cb576e81d8a",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "2e29e96a-b67c-455a-afe4-de6183431d0d": {
     "rule_name": "Potential Process Injection via PowerShell",
-    "sha256": "eaab8260d69faff66f63e9bf739acc6871be99b9c66c13f390e2f5e3b04f7d63",
+    "sha256": "9a94bd09a73f383701fd95cad27beec422c1ffddbfe186463b5fa61733bb2d16",
     "type": "query",
-    "version": 4
+    "version": 3
   },
   "2e580225-2a58-48ef-938b-572933be06fe": {
     "rule_name": "Halfbaked Command and Control Beacon",
@@ -799,9 +761,9 @@
   },
   "2edc8076-291e-41e9-81e4-e3fcbc97ae5e": {
     "rule_name": "Creation of a Hidden Local User Account",
-    "sha256": "f0c358aa5ce1930d3e8307463f794f93731a062290d6be7eef454fc7e6759f35",
+    "sha256": "73d4fb8598a974e4c18b6e713228bdddad082fccbb5b41ead57a9a8a31c0d429",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "2f0bae2d-bf20-4465-be86-1311addebaa3": {
     "rule_name": "GCP Kubernetes Rolebindings Created or Patched",
@@ -811,9 +773,9 @@
   },
   "2f2f4939-0b34-40c2-a0a3-844eb7889f43": {
     "rule_name": "PowerShell Suspicious Script with Audio Capture Capabilities",
-    "sha256": "f8d8792fcd8ecbefccf02a8fa0725cdea1b69cf092d93b6f51a5cec9592de397",
+    "sha256": "d7898ac8939e5614c533f409847a25d00fa7b6de74838a8d8c8c62f4825b7e18",
     "type": "query",
-    "version": 5
+    "version": 4
   },
   "2f8a1226-5720-437d-9c20-e0029deb6194": {
     "rule_name": "Attempt to Disable Syslog Service",
@@ -823,15 +785,15 @@
   },
   "2fba96c0-ade5-4bce-b92f-a5df2509da3f": {
     "rule_name": "Startup Folder Persistence via Unsigned Process",
-    "sha256": "8688f4442a4922c7389a3f775954758dfa304c9cd53815b368df6bd184aea318",
+    "sha256": "88d50c899d049787cadcf825cd76a12de950a6f91cbd75e64461970a259ac97d",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "2ffa1f1e-b6db-47fa-994b-1512743847eb": {
     "rule_name": "Windows Defender Disabled via Registry Modification",
-    "sha256": "26dc5a10698d54e01d3c36e07dd25e3628615f6731e8f0c84899d7d8e84de5d3",
+    "sha256": "96d60aedac6a331445e99ddf32dc6532401ff7ce7eeeaa45b07121449be5e805",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "30562697-9859-4ae0-a8c5-dab45d664170": {
     "rule_name": "GCP Firewall Rule Creation",
@@ -842,9 +804,9 @@
   "3115bd2c-0baa-4df0-80ea-45e474b5ef93": {
     "min_stack_version": "7.15.0",
     "rule_name": "Agent Spoofing - Mismatched Agent ID",
-    "sha256": "d067277b6d08d5e3fe395beecf2eb4a88a5ca6ae5691b52a1d334bae5e23661e",
+    "sha256": "cb10ec3e256bf22234266e706b1f392088ccf60b2e48ea27893d6b4eb27a2e8b",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "31295df3-277b-4c56-a1fb-84e31b4222a9": {
     "rule_name": "Inbound Connection to an Unsecure Elasticsearch Node",
@@ -854,9 +816,9 @@
   },
   "31b4c719-f2b4-41f6-a9bd-fce93c2eaf62": {
     "rule_name": "Bypass UAC via Event Viewer",
-    "sha256": "c6a4927641d1eb10338c2323c4b715e7290427ba2c1c757e5184a711e1f8b0a1",
+    "sha256": "421f583913289f650fdbca557ec44f107d75e90f35328801d816546f8d74b471",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "3202e172-01b1-4738-a932-d024c514ba72": {
     "rule_name": "GCP Pub/Sub Topic Deletion",
@@ -878,15 +840,15 @@
   },
   "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14": {
     "rule_name": "Program Files Directory Masquerading",
-    "sha256": "1b6859e051349833d0808b47b07b5014ffc8e66ecb47ed161ba08ce5df0dd9bf",
+    "sha256": "100633b626385b80ba08306d8456dba05e19987f73a770f60c48334a04297eb2",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "32f4675e-6c49-4ace-80f9-97c9259dca2e": {
     "rule_name": "Suspicious MS Outlook Child Process",
-    "sha256": "d85e57d19e0378c8644514aaf68c5dfa7f02b70d17773d63aaf76346e5255637",
+    "sha256": "cc833cab5c0e547e8cccc3b115f8f6e99921d98eed41251c06cac69498d49119",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "333de828-8190-4cf5-8d7c-7575846f6fe0": {
     "rule_name": "AWS IAM User Addition to Group",
@@ -896,23 +858,15 @@
   },
   "33f306e8-417c-411b-965c-c2812d6d3f4d": {
     "rule_name": "Remote File Download via PowerShell",
-    "sha256": "7306ee785b1176d859665ea223c9740c7ccb006dc20f531389b07da45029573f",
+    "sha256": "0eea43805ecd683b5a20d92763182a589a053f2b3f85e7cd328ff4697555f1a3",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "34fde489-94b0-4500-a76f-b8a157cf9269": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Telnet Port Activity",
-        "sha256": "3dd4a438c915920e6ddb0a5212603af5d94fb8a6b51a32f223d930d7e3becb89",
-        "version": 9
-      }
-    },
     "rule_name": "Telnet Port Activity",
-    "sha256": "b0bdfa73639226fb83eadc0303ad1801e0707743f96a36209aa58228d3bf6a89",
+    "sha256": "3dd4a438c915920e6ddb0a5212603af5d94fb8a6b51a32f223d930d7e3becb89",
     "type": "query",
-    "version": 10
+    "version": 9
   },
   "35330ba2-c859-4c98-8b7f-c19159ea0e58": {
     "rule_name": "Execution via Electron Child Process Node.js Module",
@@ -922,15 +876,15 @@
   },
   "3535c8bb-3bd5-40f4-ae32-b7cd589d5372": {
     "rule_name": "Port Forwarding Rule Addition",
-    "sha256": "711909d4eaff567cd312e657ddf85783df7959700c7e72f0c2ef073c9da1df41",
+    "sha256": "9686d00619c4eda20f8030f22542ba81410c031fa79e8a87712bd72e22b5d96b",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "35df0dd8-092d-4a83-88c1-5151a804f31b": {
     "rule_name": "Unusual Parent-Child Relationship",
-    "sha256": "5859d5a881eb68e584134cc1d2fc316ed5d0035510e0980461ec44f4572a6948",
+    "sha256": "426406e1faa8b58d4d556183c34bdb0f14ecce1c81feafbea403b0802d962ef1",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "35f86980-1fb1-4dff-b311-3be941549c8d": {
     "rule_name": "Network Traffic to Rare Destination Country",
@@ -982,15 +936,15 @@
   },
   "3838e0e3-1850-4850-a411-2e8c5ba40ba8": {
     "rule_name": "Network Connection via Certutil",
-    "sha256": "9a4e0383a2220ac5eabe9f8e3ad9bdb4f9dc39f883852ab9325a0d1eaf5ade26",
+    "sha256": "80cae6ba9f36885936ddc3bfc37d180db9ec37f430b853af1fe21a14311027a0",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "38948d29-3d5d-42e3-8aec-be832aaaf8eb": {
     "rule_name": "Prompt for Credentials with OSASCRIPT",
-    "sha256": "bd79d8b437afbae1a4d585ab89ef30e0f2d80ef4d3307a3722dbfead823ac349",
+    "sha256": "862fe5f0c824fc337577015ea7456a3d5bba2d45e714bb08d08b245b9ce72d84",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "38e5acdd-5f20-4d99-8fe4-f0a1a592077f": {
     "rule_name": "User Added as Owner for Azure Service Principal",
@@ -1006,15 +960,15 @@
   },
   "397945f3-d39a-4e6f-8bcb-9656c2031438": {
     "rule_name": "Persistence via Microsoft Outlook VBA",
-    "sha256": "befc279182fbd32a457ae9627ae90f59b1a2a9a5e33c12066b6412ee7583754b",
+    "sha256": "6de0440b5c9995f4fd4e00b5d7dd242561ace6cc188ef3aff436f59020df155c",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "3a59fc81-99d3-47ea-8cd6-d48d561fca20": {
     "rule_name": "Potential DNS Tunneling via NsLookup",
-    "sha256": "f0866afa0ff0c302726cbac517f57078dc6449aef9accd326db73eaa460774c4",
+    "sha256": "2b74884e710d2b488775647f1a79e3b28390532e537fcabdf72e1595e4b55621",
     "type": "threshold",
-    "version": 4
+    "version": 3
   },
   "3a86e085-094c-412d-97ff-2439731e59cb": {
     "rule_name": "Setgid Bit Set via chmod",
@@ -1042,15 +996,15 @@
   },
   "3b47900d-e793-49e8-968f-c90dc3526aa1": {
     "rule_name": "Unusual Parent Process for cmd.exe",
-    "sha256": "cc5fb7c79b4d4525210f19056a7405a458bf6998dbc99299d69d423137d00584",
+    "sha256": "1c4973f2206952ea9b39bc9d3516f3facd27091bb2c9003d6725f7134d6e19cc",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "3bc6deaa-fbd4-433a-ae21-3e892f95624f": {
     "rule_name": "NTDS or SAM Database File Copied",
-    "sha256": "f3503ed14107c41e7fa5c92e89d8e93113e9056c32e25f5b29337cc7c3d718ed",
+    "sha256": "6190fcbe0b951625445d3995b34ac7d0eb24f491791797d34fdcc52965947e6c",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "3c7e32e6-6104-46d9-a06e-da0f8b5795a0": {
     "rule_name": "Unusual Linux Network Port Activity",
@@ -1072,15 +1026,15 @@
   },
   "3ecbdc9e-e4f2-43fa-8cca-63802125e582": {
     "rule_name": "Privilege Escalation via Named Pipe Impersonation",
-    "sha256": "42081d103e3e0fc244d8e58fbcfb72f60fb5b2e60fac1b1ad77390c8451beb36",
+    "sha256": "3f2d95fdb79cb6ca4c56f1becabbe1d57288b6104b0b40f17398e3fde07651bf",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "3ed032b2-45d8-4406-bc79-7ad1eabb2c72": {
     "rule_name": "Suspicious Process Creation CallTrace",
-    "sha256": "6e0372691f118774060de24fc117cc20e67cf0817806e2e53c698086a22e1954",
+    "sha256": "0f67bb4b3fbdb804594a8f6c72163a50c7a0560738746a8eace419e2b80c81ab",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "3efee4f0-182a-40a8-a835-102c68a4175d": {
     "rule_name": "Potential Password Spraying of Microsoft 365 User Accounts",
@@ -1103,9 +1057,9 @@
   },
   "416697ae-e468-4093-a93d-59661fa619ec": {
     "rule_name": "Control Panel Process with Unusual Arguments",
-    "sha256": "42ae4663f4215c85784c7982dc137384838e9523f06f940f285a75320e74d9f8",
+    "sha256": "24caaad3fea11b7693bad4ee11a32119b0f6804af45f39ac7ded0499c0fa6694",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "41824afb-d68c-4d0e-bfee-474dac1fa56e": {
     "rule_name": "EggShell Backdoor Execution",
@@ -1138,10 +1092,10 @@
     "version": 7
   },
   "440e2db4-bc7f-4c96-a068-65b78da59bde": {
-    "rule_name": "Startup Persistence by a Suspicious Process",
-    "sha256": "f1ff543b747d53d4b2e2b2aa5fda80f1a4d23108b488ea248435bb1a9a7c4345",
+    "rule_name": "Shortcut File Written or Modified for Persistence",
+    "sha256": "944caee6eb6c128e932e1a8b587dbf2a3da7cf3a70751349132eee695e1ad82f",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "445a342e-03fb-42d0-8656-0367eb2dead5": {
     "rule_name": "Unusual Windows Path Activity",
@@ -1163,35 +1117,21 @@
   },
   "45d273fb-1dca-457d-9855-bcb302180c21": {
     "rule_name": "Encrypting Files with WinRar or 7z",
-    "sha256": "3021d788b698bb96799aa0a9f8380152999cb4ba9b3b5a07f3f4aadacc7b2606",
+    "sha256": "afd848d3e14acf0cda06b0eb92b86f3bf86fc362d754c4fa574ee0099f5e779f",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "4630d948-40d4-4cef-ac69-4002e29bc3db": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Adding Hidden File Attribute via Attrib",
-        "sha256": "8b06e2c4389580431725d7ec34eaa01ee257ab1980f1dcb62e9457c7fe3a5383",
-        "version": 9
-      }
-    },
     "rule_name": "Adding Hidden File Attribute via Attrib",
-    "sha256": "9adc15a3acfef979ec710bc2303ef945a4a40f8ccb39a054838b4eaa6a3ac0b9",
+    "sha256": "8b06e2c4389580431725d7ec34eaa01ee257ab1980f1dcb62e9457c7fe3a5383",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "46f804f5-b289-43d6-a881-9387cf594f75": {
     "rule_name": "Unusual Process For a Linux Host",
     "sha256": "5dec41bb8c572f24b5a47b3903e2d4e2fd9bfe5a6a86789f0b50c1c52d956af6",
     "type": "machine_learning",
     "version": 7
-  },
-  "47e22836-4a16-4b35-beee-98f6c4ee9bf2": {
-    "rule_name": "Suspicious Remote Registry Access via SeBackupPrivilege",
-    "sha256": "f6d5f22394af0e7a961260a093dddca1ec0c17447f038d8daeddda7612d0502d",
-    "type": "eql",
-    "version": 1
   },
   "47f09343-8d1f-4bb5-8bb0-00c9d18f5010": {
     "rule_name": "Execution via Regsvcs/Regasm",
@@ -1207,15 +1147,15 @@
   },
   "483c4daf-b0c6-49e0-adf3-0bfa93231d6b": {
     "rule_name": "Microsoft Exchange Server UM Spawning Suspicious Processes",
-    "sha256": "2bb49068fd730f4cfdbf988cd70e015135eb40d0aa149b8636e974c4ff88b8a7",
+    "sha256": "8c07df1d0c0f730e3e3126804f0934ba930fe3aaf3514718b5d17e3873665f4b",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "48d7f54d-c29e-4430-93a9-9db6b5892270": {
     "rule_name": "Unexpected Child Process of macOS Screensaver Engine",
-    "sha256": "d8a4a40ae911a59d2d6d53b9d774feec83f8f135a5b33d7e05d12f96eb057dbb",
+    "sha256": "282abf66ee7d89bd9c9170c0f5d02b637eb154a7dcbe465cd3650a2229bd489e",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "48ec9452-e1fd-4513-a376-10a1a26d2c83": {
     "rule_name": "Potential Persistence via Periodic Tasks",
@@ -1238,15 +1178,15 @@
   },
   "4b438734-3793-4fda-bd42-ceeada0be8f9": {
     "rule_name": "Disable Windows Firewall Rules via Netsh",
-    "sha256": "0182527c3aea40037ee645039520a3345bfdb046ba8fe73ac0e576a699fdefd4",
+    "sha256": "90064df775272d8e2f696fb665bb8e5df6ed2e82abb3a9f450d42b3d0caa61e5",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "4bd1c1af-79d4-4d37-9efa-6e0240640242": {
     "rule_name": "Unusual Process Execution Path - Alternate Data Stream",
-    "sha256": "170c4b4826b714b58e213aba5e0ce18904613c4ca782102bf36a665b4258a3fd",
+    "sha256": "ced0a019b63e9d421f8e75a6d2dd6a581cfd87b9bf4388349f4070700225813d",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "4d50a94f-2844-43fa-8395-6afbd5e1c5ef": {
     "rule_name": "AWS Management Console Brute Force of Root User Identity",
@@ -1262,15 +1202,15 @@
   },
   "4de76544-f0e5-486a-8f84-eae0b6063cdc": {
     "rule_name": "Disable Windows Event and Security Logs Using Built-in Tools",
-    "sha256": "7d0c7d18c1fde527b9d2b1db59f11692c19731d81d4ded5b1474c5157e719ced",
+    "sha256": "c5df84be421d64d3a1261a065649b24397c4d41d7344dd8828b0b1beb84a7d76",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "4ed493fc-d637-4a36-80ff-ac84937e5461": {
     "rule_name": "Execution via MSSQL xp_cmdshell Stored Procedure",
-    "sha256": "2f36549bd55b6f24b1c459a4ade0ee51f29361e90d31b8f42fde98ecab00fc0e",
+    "sha256": "65957d10243835667b29df2c1bf74ef752f91f9ca378cf1382cc41ac5ed81bc6",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "4ed678a9-3a4f-41fb-9fea-f85a6e0a0dff": {
     "rule_name": "Suspicious Script Object Execution",
@@ -1286,21 +1226,21 @@
   },
   "4fe9d835-40e1-452d-8230-17c147cafad8": {
     "rule_name": "Execution via TSClient Mountpoint",
-    "sha256": "61f36263e69c3eef14a1cb48a56aa01eca2883c628a1800960340ba1d1f9d00b",
+    "sha256": "fd6aa0fb6621012cb8e02b57f75725de1c2d778441edb0a01096a2b76f972d53",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "513f0ffd-b317-4b9c-9494-92ce861f22c7": {
     "rule_name": "Registry Persistence via AppCert DLL",
-    "sha256": "3ca220c068f4f9c3b5fc467721f4d53681147e2ea4325031f15090e45ccb9993",
+    "sha256": "e573874c887d52298c8c9a8f0ca2e19769f649bd1b4b36f98aed5a4919ec6c6e",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "514121ce-c7b6-474a-8237-68ff71672379": {
     "rule_name": "Microsoft 365 Exchange DKIM Signing Configuration Disabled",
-    "sha256": "3741ed6a1c231b1f47ca02dbd1bd5609bf58270bbec01faa9a946349eb07d084",
+    "sha256": "7e5f0b340dfbf69334022656802c3cc8dd99a9acd0ca288a87a1cbf73425f305",
     "type": "query",
-    "version": 6
+    "version": 5
   },
   "51859fa0-d86b-4214-bf48-ebb30ed91305": {
     "rule_name": "GCP Logging Sink Deletion",
@@ -1346,9 +1286,9 @@
   },
   "536997f7-ae73-447d-a12d-bff1e8f5f0a0": {
     "rule_name": "AWS EFS File System or Mount Deleted",
-    "sha256": "50fecd5f633def52322813c1945eafd486a657ed308f0a00c4ef1d5437850489",
+    "sha256": "306a95f7b751a3c125d43dd4d56e8bc2df8d9ac55b9a76fef8a1e60ac3ee799c",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "5370d4cd-2bb3-4d71-abf5-1e1d0ff5a2de": {
     "rule_name": "Azure Diagnostic Settings Deletion",
@@ -1358,29 +1298,21 @@
   },
   "53a26770-9cbd-40c5-8b57-61d01a325e14": {
     "rule_name": "Suspicious PDF Reader Child Process",
-    "sha256": "3ed911267cf036188fb9ead85cd39d0a0a023803dfc7684b7c993052141d20ff",
-    "type": "eql",
-    "version": 8
-  },
-  "54902e45-3467-49a4-8abc-529f2c8cfb80": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Uncommon Registry Persistence Change",
-        "sha256": "53219ff8987584e6547f9575812b0376420e95da290d5f3e600c864516a5d0d4",
-        "version": 6
-      }
-    },
-    "rule_name": "Uncommon Registry Persistence Change",
-    "sha256": "eab90afc9e1bee717a0f2d2c8d444c6ea131d22bdee7de0f594f43235e7286bc",
+    "sha256": "28f16475e1b77a83be53387c10dfc3e12a8cb30463ebed52c32e7a3f104093d3",
     "type": "eql",
     "version": 7
   },
+  "54902e45-3467-49a4-8abc-529f2c8cfb80": {
+    "rule_name": "Uncommon Registry Persistence Change",
+    "sha256": "063beeef24d261da01edbbeeaee92572fb436a31d690472418d40c46a6209d50",
+    "type": "eql",
+    "version": 5
+  },
   "54c3d186-0461-4dc3-9b33-2dc5c7473936": {
     "rule_name": "Network Logon Provider Registry Modification",
-    "sha256": "a5518862b6e142e509712bef3ce38b3512bcaec6a6c764bf34405cba00d25086",
+    "sha256": "d7dd9478ea6adaad5568eb2f70c33bc6ce44da0e2a6867f38c5ff48086311669",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "55c2bf58-2a39-4c58-a384-c8b1978153c2": {
     "rule_name": "Windows Service Installed via an Unusual Client",
@@ -1408,21 +1340,21 @@
   },
   "565d6ca5-75ba-4c82-9b13-add25353471c": {
     "rule_name": "Dumping of Keychain Content via Security Command",
-    "sha256": "4bdc0613a8e8085509ab220421528184c30fde624e3ccd0c0ab0b8964f597dd9",
+    "sha256": "902f4fc3cc9b2951b82e74f03c337b150f2584f77ae83e6d2a23ad8b5abb3c45",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "5663b693-0dea-4f2e-8275-f1ae5ff2de8e": {
     "rule_name": "GCP Logging Bucket Deletion",
-    "sha256": "1b9141827a5dee73525bf4bfabca359c75d2441235803082aac3a45bc62f7e6f",
+    "sha256": "b9d492bbf9e35665b2a22d0f90716d61faf78153b20c09c8183e7336b4c1bd65",
     "type": "query",
-    "version": 7
+    "version": 6
   },
   "56f2e9b5-4803-4e44-a0a4-a52dc79d57fe": {
     "rule_name": "PowerShell PSReflect Script",
-    "sha256": "a6ab7a4b6183e85c823652746ea2e25f7f49ac05c1d0dbdc181f9a609672be1c",
+    "sha256": "9c17e951b973ee2ca613cc870ce1e0276513c1acef9546f7f7264e2c71c48a41",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "5700cb81-df44-46aa-a5d7-337798f53eb8": {
     "rule_name": "VNC (Virtual Network Computing) from the Internet",
@@ -1444,21 +1376,21 @@
   },
   "577ec21e-56fe-4065-91d8-45eb8224fe77": {
     "rule_name": "PowerShell MiniDump Script",
-    "sha256": "5d915a9aeca90d9de6c05bd51d0801f4acd7991e9db0e7edd0a36fb22c02e786",
+    "sha256": "105c3f90085d4af397d4adccf7e48445bb28c785e46cd84cefc25720ab8b2b27",
     "type": "query",
-    "version": 6
+    "version": 5
   },
   "581add16-df76-42bb-af8e-c979bfb39a59": {
     "rule_name": "Deleting Backup Catalogs with Wbadmin",
-    "sha256": "ec55c9660d586e674506864e2db38d89f6272a9613a47c361d264d3494ac4e25",
+    "sha256": "868ffb9b45e3d8236b93e72b26814071dc1f1d6f1594fc54b97abc6be9f3d242",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "58aa72ca-d968-4f34-b9f7-bea51d75eb50": {
     "rule_name": "RDP Enabled via Registry",
-    "sha256": "35a31565a9041ceb30cc429bff5ab96fb097062f669b4dc18ef7f94c1e34510c",
+    "sha256": "671a71d6221cf597294f3a2384e29d5a828ffa9b490776ade78495b7180fa810",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "58ac2aa5-6718-427c-a845-5f3ac5af00ba": {
     "rule_name": "Zoom Meeting with no Passcode",
@@ -1473,18 +1405,10 @@
     "version": 4
   },
   "58c6d58b-a0d3-412d-b3b8-0981a9400607": {
-    "min_stack_version": "7.16.0",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Potential Privilege Escalation via InstallerFileTakeOver",
-        "sha256": "4231315b60c3bf0fa71c1adba0830ae312ed1ab1c6bcec7f91b701ecdd5a1aed",
-        "version": 3
-      }
-    },
     "rule_name": "Potential Privilege Escalation via InstallerFileTakeOver",
-    "sha256": "8e8aa226d43b856926204e1cf2ceb2e1a773ac2a396717e953c072206ac2fe4f",
+    "sha256": "c321fa60ddbbe7f3e8b0914a43379c5eacaee6c4c0b9c399fe46481d47c446f2",
     "type": "eql",
-    "version": 4
+    "version": 2
   },
   "5930658c-2107-4afc-91af-e0e55b7f7184": {
     "rule_name": "O365 Email Reported by User as Malware or Phish",
@@ -1506,9 +1430,9 @@
   },
   "5a14d01d-7ac8-4545-914c-b687c2cf66b3": {
     "rule_name": "UAC Bypass Attempt via Privileged IFileOperation COM Interface",
-    "sha256": "3e5d52af7c4dfdbaaef634c12d661be2128611ee551a23e54a7f0f42a32da3e8",
+    "sha256": "c444e8ebabf015f11eca3aad69c7db2c17a53f0ebb7cf413a492bcc22c14252a",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "5ae4e6f8-d1bf-40fa-96ba-e29645e1e4dc": {
     "rule_name": "Remote SSH Login Enabled via systemsetup Command",
@@ -1518,9 +1442,9 @@
   },
   "5aee924b-6ceb-4633-980e-1bde8cdb40c5": {
     "rule_name": "Potential Secure File Deletion via SDelete Utility",
-    "sha256": "fcd101dc07b4064695a8ca86021774beb0652a4896ec15b9e21537b23ea852d6",
+    "sha256": "26c0664d074c41ca13825dbb77b7dd7dba82302a0d5ea7a9842d93e02da18f37",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "5b03c9fb-9945-4d2f-9568-fd690fee3fba": {
     "rule_name": "Virtual Machine Fingerprinting",
@@ -1530,15 +1454,15 @@
   },
   "5bb4a95d-5a08-48eb-80db-4c3a63ec78a8": {
     "rule_name": "Suspicious PrintSpooler Service Executable File Creation",
-    "sha256": "f1950eb7f6f8af4fe72108d6fe0facf987c4b9e54e3c3e2256ac37a091e93c4e",
+    "sha256": "ac6b9792a84324d6359fc162d768843bcf69e9d6a1e60f6a4001a40174a0a17a",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "5beaebc1-cc13-4bfc-9949-776f9e0dc318": {
     "rule_name": "AWS WAF Rule or Rule Group Deletion",
-    "sha256": "c045c86538a685bcfe037412acaa1643be511a3dc15c8c03326e6ceb8cfe0e62",
+    "sha256": "3e550cf60b7bdbefd8793ba92498409e7170c4e56cb1b56abc47eeb6a9f81eaa",
     "type": "query",
-    "version": 8
+    "version": 7
   },
   "5c983105-4681-46c3-9890-0c66d05e776b": {
     "rule_name": "Unusual Linux Process Discovery Activity",
@@ -1554,21 +1478,21 @@
   },
   "5cd8e1f7-0050-4afc-b2df-904e40b2f5ae": {
     "rule_name": "User Added to Privileged Group in Active Directory",
-    "sha256": "356f05e9ebd6e3c5dbc6d04752a5c3c53595f95fd965a983582bdb141b0e5a6c",
+    "sha256": "1c916f85abeafa2fb73df818ab49266806c69dc729e1e2f68e5982972448cd9a",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "5d0265bf-dea9-41a9-92ad-48a8dcd05080": {
     "rule_name": "Persistence via Login or Logout Hook",
-    "sha256": "928d8f1868027c7d42730c081bc9aee7b715081ed77c5ec3ae2da6ea17eadbd3",
+    "sha256": "f0280d78ef564558bec9ff8a9cad7c4ffa23ae2583671463d67d196023c86ad0",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "5d1d6907-0747-4d5d-9b24-e4a18853dc0a": {
     "rule_name": "Suspicious Execution via Scheduled Task",
-    "sha256": "ac910f8ec6f72b2f316ab3cfb7fd27c597892005f07d95045b9acf42a19962d8",
+    "sha256": "39b048716937ceb662422d8e35d3e65524d15b2122f65419c6ee49fff049a570",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "5d9f8cfc-0d03-443e-a167-2b0597ce0965": {
     "rule_name": "Suspicious Automator Workflows Execution",
@@ -1614,9 +1538,9 @@
   },
   "61ac3638-40a3-44b2-855a-985636ca985e": {
     "rule_name": "PowerShell Suspicious Discovery Related Windows API Functions",
-    "sha256": "aedd7e1b3fcd50af628b1c9709e398994b3cfd6f423c0e4b19e3af03cb453f57",
+    "sha256": "2996a4fab8119ba85417d7826967b9135cbefceaa7cb3c8cfcb0183f0d9f92b8",
     "type": "query",
-    "version": 5
+    "version": 4
   },
   "61c31c14-507f-4627-8c31-072556b89a9c": {
     "rule_name": "Mknod Process Activity",
@@ -1624,23 +1548,11 @@
     "type": "query",
     "version": 7
   },
-  "61d29caf-6c15-4d1e-9ccb-7ad12ccc0bc7": {
-    "rule_name": "AdminSDHolder SDProp Exclusion Added",
-    "sha256": "b50f5194aabdcfbce951a9d9fde9396fa41a5dc392a8b4d23f48db9fcbca436b",
-    "type": "eql",
-    "version": 1
-  },
   "622ecb68-fa81-4601-90b5-f8cd661e4520": {
     "rule_name": "Incoming DCOM Lateral Movement via MSHTA",
-    "sha256": "de52074b13baa3ba8ae1a3f2d6678baf22283741d6a40dcaa7aa19bd2356b084",
+    "sha256": "3203c65eec92dee9e1303d21081ea604077f14bd31a3c941ae581c791d450c18",
     "type": "eql",
-    "version": 6
-  },
-  "62a70f6f-3c37-43df-a556-f64fa475fba2": {
-    "rule_name": "Account configured with never Expiring Password",
-    "sha256": "231170e59c7b88093443b9be15147a4f2067521fdb2081c84ca961a107e229f5",
-    "type": "query",
-    "version": 1
+    "version": 5
   },
   "63e65ec3-43b1-45b0-8f2d-45b34291dc44": {
     "rule_name": "Network Connection via Signed Binary",
@@ -1668,21 +1580,21 @@
   },
   "661545b4-1a90-4f45-85ce-2ebd7c6a15d0": {
     "rule_name": "Attempt to Mount SMB Share via Command Line",
-    "sha256": "37a539b9a5de70263630d4718ac3f39c295480c02aeef41cfc1928c27ed89315",
+    "sha256": "22df29a521ec99fa01bf16c417ab71290f62629f00e77a9d9daa68703717e996",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "665e7a4f-c58e-4fc6-bc83-87a7572670ac": {
     "rule_name": "WebServer Access Logs Deleted",
-    "sha256": "61c6683c858823ff29be886b335fa55e32c2de34b90c31b6e2329d406efa9278",
+    "sha256": "9e822f662024fca699b240383c9eebbb725dd9219991cbb412fbc73130137e78",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "66883649-f908-4a5b-a1e0-54090a1d3a32": {
     "rule_name": "Connection to Commonly Abused Web Services",
-    "sha256": "d96aa5b8cc822b8685cde3ef233ed3f96f64628ea7e71117d8ac779f2c959c14",
+    "sha256": "f27800e26f498a07905f3f25d836d4d3234e564f7ff4aacb4e3778b7155475db",
     "type": "eql",
-    "version": 8
+    "version": 7
   },
   "66da12b1-ac83-40eb-814c-07ed1d82b7b9": {
     "rule_name": "Suspicious macOS MS Office Child Process",
@@ -1741,9 +1653,9 @@
   },
   "68921d85-d0dc-48b3-865f-43291ca2c4f2": {
     "rule_name": "Persistence via TelemetryController Scheduled Task Hijack",
-    "sha256": "209c61358a68a5f57e08fcecb5d250d936b555e23e0d9304078362cdf09b67b2",
+    "sha256": "5195503f06d8b358e209d9caebe4d1cfbc94be351590cb60646160fbab60f0a9",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "68994a6c-c7ba-4e82-b476-26a26877adf6": {
     "min_stack_version": "8.0",
@@ -1752,13 +1664,13 @@
         "rule_name": "Google Workspace Admin Role Assigned to a User",
         "sha256": "a9e5fed2c237cba481fd05a38576032d3cddf5a3b67341030a4a77725c478b22",
         "type": "query",
-        "version": 9
+        "version": 7
       }
     },
     "rule_name": "Google Workspace Admin Role Assigned to a User",
     "sha256": "afd34ab4f1d7e038c874333fd83de248c0b54d625f489e74359f3ce4ec9ac71b",
     "type": "query",
-    "version": 10
+    "version": 8
   },
   "689b9d57-e4d5-4357-ad17-9c334609d79a": {
     "rule_name": "Scheduled Task Created by a Windows Script",
@@ -1774,9 +1686,9 @@
   },
   "68d56fdc-7ffa-4419-8e95-81641bd6f845": {
     "rule_name": "UAC Bypass via ICMLuaUtil Elevated COM Interface",
-    "sha256": "4a792f22d9793a8852c22f63e7ab4335f06f0948b4ec6e6db755e070f931e8a4",
+    "sha256": "b5812117895d475376f16cb41ebfb385fdbec5034340b59f60e3dcdf71bc0a6d",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "699e9fdb-b77c-4c01-995c-1c15019b9c43": {
     "min_stack_version": "8.0",
@@ -1787,9 +1699,9 @@
   },
   "69c251fb-a5d6-4035-b5ec-40438bd829ff": {
     "rule_name": "Modification of Boot Configuration",
-    "sha256": "27d3dc7af0fa88b82613be3a319fb70e6003f04d021e352a4076073b1a833af6",
+    "sha256": "22d2bd68a5cc0620132227498ac239156162cfc2774f84b41d0ed7c5733f71fe",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "69c420e8-6c9e-4d28-86c0-8a2be2d1e78c": {
     "rule_name": "AWS IAM Password Recovery Requested",
@@ -1799,15 +1711,15 @@
   },
   "6a8ab9cc-4023-4d17-b5df-1a3e16882ce7": {
     "rule_name": "Unusual Service Host Child Process - Childless Service",
-    "sha256": "40b3b3fbc788dbb827e8599339d234daf485625d36845e5efee9b1db0284db33",
+    "sha256": "79553b3a40acce22ecd91c9946948f0e588df04e533323c192d8e41ded8b499f",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "6aace640-e631-4870-ba8e-5fdda09325db": {
     "rule_name": "Exporting Exchange Mailbox via PowerShell",
-    "sha256": "64d22d71f078b010888d53343adfc825d0dc2e74e9164348bc6c11455058fe02",
+    "sha256": "1ba40e93a9dd9329c966e27d0d95d4f4629eda849b5480dcacf1c03f0fe4a350",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "6b84d470-9036-4cc0-a27c-6d90bbfe81ab": {
     "rule_name": "Sensitive Files Compression",
@@ -1817,15 +1729,15 @@
   },
   "6cd1779c-560f-4b68-a8f1-11009b27fe63": {
     "rule_name": "Microsoft Exchange Server UM Writing Suspicious Files",
-    "sha256": "9a47baed80aaf38c9a8f7e85d4037d396c3a9b38097f0b8e272fffd95dceae7b",
+    "sha256": "578607308f1b76a89e24e98c1a2b553b5455443931198123c558adae551bccf9",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "6d448b96-c922-4adb-b51c-b767f1ea5b76": {
     "rule_name": "Unusual Process For a Windows Host",
-    "sha256": "9acf5cf644f0dd40d86fe207e02999cd5ad7cb60a50cb3c648eb7def01929e9a",
+    "sha256": "cf57ba8d293696a2da6468acbd3af10bfc461d24f0283c80e614ec4266fe3f52",
     "type": "machine_learning",
-    "version": 10
+    "version": 9
   },
   "6e40d56f-5c0e-4ac6-aece-bee96645b172": {
     "rule_name": "Anomalous Process For a Windows Population",
@@ -1841,9 +1753,9 @@
   },
   "6e9b351e-a531-4bdc-b73e-7034d6eed7ff": {
     "rule_name": "Enumeration of Users or Groups via Built-in Commands",
-    "sha256": "b6564f471e4aa0cb13d07712caab5e9f503defbbec1aeedb2daa788a6a53417d",
+    "sha256": "fa4544dbc92b6766522593e44bb10e0036b4824f8d70f381698fc38d56a08aa3",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "6ea41894-66c3-4df7-ad6b-2c5074eb3df8": {
     "rule_name": "Potential Windows Error Manager Masquerading",
@@ -1853,9 +1765,9 @@
   },
   "6ea55c81-e2ba-42f2-a134-bccf857ba922": {
     "rule_name": "Security Software Discovery using WMIC",
-    "sha256": "b9919bdd909607336ad86a5ea0346dd3acf151ca77662498136260cecd305027",
+    "sha256": "b36abb97dfae934d532a0ad8bae5eb1ad848b7862a3fd0e9a35f108c528b905b",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "6ea71ff0-9e95-475b-9506-2580d1ce6154": {
     "rule_name": "DNS Activity to the Internet",
@@ -1876,19 +1788,13 @@
         "rule_name": "Google Workspace Role Modified",
         "sha256": "4776d80c0d1069ed8363242d7b09b4934c3efc58c9db2b87fb5045eda98284e1",
         "type": "query",
-        "version": 9
+        "version": 7
       }
     },
     "rule_name": "Google Workspace Role Modified",
     "sha256": "33a6f2e64d79ebfed4fe0f1b4e5c4a7968b9b4941e11fa0cf720ef3810e38a15",
     "type": "query",
-    "version": 10
-  },
-  "6f683345-bb10-47a7-86a7-71e9c24fb358": {
-    "rule_name": "Linux Restricted Shell Breakout via the find command",
-    "sha256": "7e1c03c53ba1a32b0780b4233a4278668a22939bf80ec896514a0237bbd28eb6",
-    "type": "eql",
-    "version": 1
+    "version": 8
   },
   "7024e2a0-315d-4334-bb1a-441c593e16ab": {
     "rule_name": "AWS CloudTrail Log Deleted",
@@ -1922,15 +1828,15 @@
   },
   "71bccb61-e19b-452f-b104-79a60e546a95": {
     "rule_name": "Unusual File Creation - Alternate Data Stream",
-    "sha256": "a69fad4530cefa62bdc75083a025fa8c6e94d771a95245a080ecd31994e6bf2e",
+    "sha256": "eb2d6bdc651c4d7654fc996bcd8b7238f06ac89c28e7cb8a2e198397e9b3dcc8",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "71c5cb27-eca5-4151-bb47-64bc3f883270": {
     "rule_name": "Suspicious RDP ActiveX Client Loaded",
-    "sha256": "38fe49e47f59a5c88d21d80aec8562353d0a9cb74ab81ba0b00a558095927119",
+    "sha256": "d6f547243894063d94c8152b6485b57855368f0f9288e9d97e4f9e622f1b7e44",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "721999d0-7ab2-44bf-b328-6e63367b9b29": {
     "rule_name": "Microsoft 365 Potential ransomware activity",
@@ -1944,17 +1850,11 @@
     "type": "query",
     "version": 6
   },
-  "72d33577-f155-457d-aad3-379f9b750c97": {
-    "rule_name": "Linux Restricted Shell Breakout via env Shell Evasion",
-    "sha256": "1afd2b836cd82dafad139963d4d003d6088aaa83f45791c64cf7c0d7b66198e6",
-    "type": "eql",
-    "version": 1
-  },
   "7405ddf1-6c8e-41ce-818f-48bea6bcaed8": {
     "rule_name": "Potential Modification of Accessibility Binaries",
-    "sha256": "883643be004c849f235efd3c9beedff038f0c308c0720dce42a6033a8fb16067",
+    "sha256": "ba040e94b982f1b9f417b04f1575ccc06418083b121e165cc9fcfc1013cb291e",
     "type": "eql",
-    "version": 8
+    "version": 7
   },
   "7453e19e-3dbf-4e4e-9ae0-33d6c6ed15e1": {
     "rule_name": "Modification of Environment Variable via Launchctl",
@@ -1989,21 +1889,21 @@
   },
   "76ddb638-abf7-42d5-be22-4a70b0bf7241": {
     "rule_name": "Privilege Escalation via Rogue Named Pipe Impersonation",
-    "sha256": "c49e587f117514667308f02354286753e05f298b84b3fba56709b49bd9570b1f",
+    "sha256": "e2370178900d74daa4cadcb8b42f646efd2ea3f2c73c59f9638366f249e0c5b9",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "76fd43b7-3480-4dd9-8ad7-8bd36bfad92f": {
     "rule_name": "Potential Remote Desktop Tunneling Detected",
-    "sha256": "e268aa25f5482bc6c01b3b15f5015676c76f63d7665d81baa22fbb302bd82167",
+    "sha256": "fcd8c3219898d5276945fcee501c6a589d1e17e99b96a7360a30c6d982f3c614",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "770e0c4d-b998-41e5-a62e-c7901fd7f470": {
     "rule_name": "Enumeration Command Spawned via WMIPrvSE",
-    "sha256": "5300f30cfcc5c187c41d721d3dae57144ef35a521c5f5f42a68cca607bab7536",
+    "sha256": "05939d1b48b1975cfbe6e80623d1c4d942fffa7f68577f3e05f541d61a5eba9b",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "774f5e28-7b75-4a58-b94e-41bf060fdd86": {
     "rule_name": "User Added as Owner for Azure Application",
@@ -2024,13 +1924,13 @@
         "rule_name": "Application Added to Google Workspace Domain",
         "sha256": "43a87b2b542b409c6cfbe267485d8b1ba8e32e9ea553f6180b7d0362c46ea2d9",
         "type": "query",
-        "version": 9
+        "version": 7
       }
     },
     "rule_name": "Application Added to Google Workspace Domain",
     "sha256": "ab5ac05b1f57b0e9a197d51506441eee921132528fde66e99b64021454556e71",
     "type": "query",
-    "version": 10
+    "version": 8
   },
   "7882cebf-6cf1-4de3-9662-213aa13e8b80": {
     "rule_name": "Azure Privilege Identity Management Role Modified",
@@ -2040,9 +1940,9 @@
   },
   "78d3d8d9-b476-451d-a9e0-7a5addd70670": {
     "rule_name": "Spike in AWS Error Messages",
-    "sha256": "fff0babb781222efa28975cac8a64e687dfc4370b983e6c3e9786b024d2a52d4",
+    "sha256": "27c3d706d0b03424992adb2365dfc910ae1a366c39b31f6ef23bd70b93df5233",
     "type": "machine_learning",
-    "version": 9
+    "version": 8
   },
   "792dd7a6-7e00-4a0a-8a9a-a7c24720b5ec": {
     "rule_name": "Azure Key Vault Modified",
@@ -2064,9 +1964,9 @@
   },
   "7b08314d-47a0-4b71-ae4e-16544176924f": {
     "rule_name": "File and Directory Discovery",
-    "sha256": "fb501436e383efcf5e328aebd617b39354e50a49f0f6b3b3ab1107e0e98d4134",
+    "sha256": "565d9e046bb625807c9d552344c5097df14d3f17d12b8c23cc8ef382da27c557",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "7b3da11a-60a2-412e-8aa7-011e1eb9ed47": {
     "rule_name": "AWS ElastiCache Security Group Created",
@@ -2076,15 +1976,15 @@
   },
   "7b8bfc26-81d2-435e-965c-d722ee397ef1": {
     "rule_name": "Windows Network Enumeration",
-    "sha256": "e0b9fe2ce2764508ca2276687829e1de0a3bbfe7ebda22dddb89e17c8081df19",
+    "sha256": "62962d4c50e13c6c3795372fdfa8275aa60f1cba7019c1083b172295130dba0e",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "7bcbb3ac-e533-41ad-a612-d6c3bf666aba": {
     "rule_name": "Tampering of Bash Command-Line History",
-    "sha256": "52cd42c3d4611e694abedca8df138cb0ec2596f60016a1726ddf9b0cd565ada2",
+    "sha256": "f5d97fc723896745fc89eaf2b77608aafa7dab27702ded21ebde4a2756bafe36",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "7ceb2216-47dd-4e64-9433-cddc99727623": {
     "rule_name": "GCP Service Account Creation",
@@ -2118,9 +2018,9 @@
   },
   "818e23e6-2094-4f0e-8c01-22d30f3506c6": {
     "rule_name": "PowerShell Script Block Logging Disabled",
-    "sha256": "4b526ba418a8a67f9378e02adfe4de5aee1b3d1370986fa05d967f8561a3470a",
+    "sha256": "acfba4ee9c92663a86a9a9ea8df686e2efba7ce3491930a45a946285f09ee724",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "81cc58f5-8062-49a2-ba84-5cc4b4d31c40": {
     "rule_name": "Persistence via Kernel Module Modification",
@@ -2130,15 +2030,15 @@
   },
   "81fe9dc6-a2d7-4192-a2d8-eed98afc766a": {
     "rule_name": "PowerShell Suspicious Payload Encoded and Compressed",
-    "sha256": "2d2f233d0eac8f98bb7eaed5cd0e71104341516f9d6b45a7e0895d9ba2353502",
+    "sha256": "24464f1301483fc0c282bda7bcb95105795ae33fc1f9c27ebad8c2633fe03af6",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "827f8d8f-4117-4ae4-b551-f56d54b9da6b": {
     "rule_name": "Apple Scripting Execution with Administrator Privileges",
-    "sha256": "67d8f54def5ff499f3b1bb0ca261c83c5fb1dd3f55d2ecd1bead89a67d371545",
+    "sha256": "f77cf6a6f9ef86b2152b36bf3811485d39bf9c62dcaa02fb0df6c2233cdc8019",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "83a1931d-8136-46fc-b7b9-2db4f639e014": {
     "rule_name": "Azure Kubernetes Pods Deleted",
@@ -2146,25 +2046,12 @@
     "type": "query",
     "version": 3
   },
-  "83b2c6e5-e0b2-42d7-8542-8f3af86a1acb": {
-    "rule_name": "Linux Restricted Shell Breakout via the mysql command",
-    "sha256": "6a7fe2a2002dc6de66039a88c6f06a12e5ca7e45752690720ccd33d86d321194",
-    "type": "eql",
-    "version": 1
-  },
-  "850d901a-2a3c-46c6-8b22-55398a01aad8": {
-    "min_stack_version": "7.15.0",
-    "rule_name": "Potential Remote Credential Access via Registry",
-    "sha256": "5c9f1a93f3b025b4be0f335bb2cae5bfc853b437d7f16355b30cd65eabc4520e",
-    "type": "eql",
-    "version": 1
-  },
   "852c1f19-68e8-43a6-9dce-340771fe1be3": {
     "min_stack_version": "7.13.0",
     "rule_name": "Suspicious PowerShell Engine ImageLoad",
-    "sha256": "82cc2880a87f37799588a44ac43274cc655633a7c57ff138a6bbd29b7e65b254",
+    "sha256": "2d64484c1819eab787cf8dd38ba726a52646aeaac9cc644db872b9cbc99fb254",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "8623535c-1e17-44e1-aa97-7a0699c3037d": {
     "rule_name": "AWS EC2 Network Access Control List Deletion",
@@ -2186,15 +2073,15 @@
   },
   "870aecc0-cea4-4110-af3f-e02e9b373655": {
     "rule_name": "Security Software Discovery via Grep",
-    "sha256": "24c93a54e3558046bd14bf1bda2da780c66b2b4ae6be612adffde0612d389101",
+    "sha256": "b8282c5a925bd40137e5683f4353565a807bc6bfe47b82a52bdacf7e5c32b1ed",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "871ea072-1b71-4def-b016-6278b505138d": {
     "rule_name": "Enumeration of Administrator Accounts",
-    "sha256": "99dc6a0d861583d91f2cfad5c22bff727b1f52ff001b28cacb48b7b09264a1cb",
+    "sha256": "2f6700f791dd256057e4282a89b038cb5296e4c8c37b48776db059141f394a7b",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "87594192-4539-4bc4-8543-23bc3d5bd2b4": {
     "rule_name": "AWS EventBridge Rule Disabled or Deleted",
@@ -2210,33 +2097,27 @@
   },
   "88671231-6626-4e1b-abb7-6e361a171fbb": {
     "rule_name": "Microsoft 365 Global Administrator Role Assigned",
-    "sha256": "5b2d7848cf8058ad890e13ec5f3e44af3cc531a0179d088fdbee5bce0333f0ae",
+    "sha256": "4d10c98c0349b65cb88d0bd42fc5d8cc6a8e2646ec4d27f9fb79db6be9ba03dd",
     "type": "query",
-    "version": 2
+    "version": 1
   },
   "88817a33-60d3-411f-ba79-7c905d865b2a": {
     "rule_name": "Sublime Plugin or Application Script Modification",
-    "sha256": "1df09715f5fb118e20e7f5ec6b69373747948590487d55ea4d610ddd5a86ab65",
-    "type": "eql",
-    "version": 2
-  },
-  "891cb88e-441a-4c3e-be2d-120d99fe7b0d": {
-    "rule_name": "Suspicious WMI Image Load from MS Office",
-    "sha256": "67ab762be07f91d1b75ccffbcfca727b6aeb0d821dee16ed03a6a663bd52ee5b",
-    "type": "eql",
-    "version": 5
-  },
-  "89583d1b-3c2e-4606-8b74-0a9fd2248e88": {
-    "rule_name": "Linux Restricted Shell Breakout via the vi command",
-    "sha256": "4e641b4ff6b6f35846fe1d66fcc4aa611c357f27f064a62f067df3209e95af79",
+    "sha256": "d89a2f8c0e73fe51b3f8dcb1b1fdd398f5b9eb9d4277bf19ec14fd8ebd4f2237",
     "type": "eql",
     "version": 1
   },
+  "891cb88e-441a-4c3e-be2d-120d99fe7b0d": {
+    "rule_name": "Suspicious WMI Image Load from MS Office",
+    "sha256": "e7d2a7b92e920fecc3cd298631d4945b2727effd008ed963b7179303b6f05d58",
+    "type": "eql",
+    "version": 4
+  },
   "897dc6b5-b39f-432a-8d75-d3730d50c782": {
     "rule_name": "Kerberos Traffic from Unusual Process",
-    "sha256": "0bf83bae94f8428bbde22ccd5cb8ada9e697e8f614c366e56ff0123e7ab80231",
+    "sha256": "01a251c96e82a87e563dfaf1263d2a3646c9323638da1fadd54993b0da087d1a",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "89f9a4b0-9f8f-4ee0-8823-c4751a6d6696": {
     "rule_name": "Command Prompt Network Connection",
@@ -2258,9 +2139,9 @@
   },
   "8a1d4831-3ce6-4859-9891-28931fa6101d": {
     "rule_name": "Suspicious Execution from a Mounted Device",
-    "sha256": "f9f14a8051c32e043be75ca358f526845101a7da1f619e9839a00ebf32df14b9",
+    "sha256": "e88541a1a011cfb788e031595a6452d932dfb34adde8fb0adb6a87f91abf9c1e",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "8a5c1e5f-ad63-481e-b53a-ef959230f7f1": {
     "rule_name": "Attempt to Deactivate an Okta Network Zone",
@@ -2270,48 +2151,40 @@
   },
   "8acb7614-1d92-4359-bfcf-478b6d9de150": {
     "rule_name": "Suspicious JAVA Child Process",
-    "sha256": "a578c6ffa3089b0c5c9f2329a0ea4631ba599a350046ee0d17cd7594b6ec253a",
+    "sha256": "9d7875876529960496ced859248197da593afad28edd3ffe08e5d2c0af4119ed",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "8b2b3a62-a598-4293-bc14-3d5fa22bb98f": {
     "min_stack_version": "7.13.0",
     "rule_name": "Executable File Creation with Multiple Extensions",
-    "sha256": "ece6617d0c710bb863cfc4efd2fe61e53bfc9df42a5584c739b063d25a49995a",
-    "type": "eql",
-    "version": 4
-  },
-  "8b4f0816-6a65-4630-86a6-c21c179c0d09": {
-    "rule_name": "Enable Host Network Discovery via Netsh",
-    "sha256": "fdf2016d69e887f99a56af384b5cfe9f354c3b8d6a4c50f5b96d13e1c4936074",
+    "sha256": "49f3873e68cd7416b2933be1ae193783473434d7ed6329f8d313f0a409453d21",
     "type": "eql",
     "version": 3
   },
+  "8b4f0816-6a65-4630-86a6-c21c179c0d09": {
+    "rule_name": "Enable Host Network Discovery via Netsh",
+    "sha256": "ebcb01477dc704bdeee0d1db6985b13879e9151e5552f29028517978eda2b2f0",
+    "type": "eql",
+    "version": 2
+  },
   "8b64d36a-1307-4b2e-a77b-a0027e4d27c8": {
     "rule_name": "Azure Kubernetes Events Deleted",
-    "sha256": "1287f3709369ad7e39723641b691426c67666dc67c11d19db9be42a5106b512c",
+    "sha256": "c425a28b60e23b0d43a2b54d2fc861c42225a3bc7c2ac7f1243f7bb298784bfc",
     "type": "query",
-    "version": 4
+    "version": 3
   },
   "8c1bdde8-4204-45c0-9e0c-c85ca3902488": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "RDP (Remote Desktop Protocol) from the Internet",
-        "sha256": "b6d7ad4ee2f11ab3ed8aa4bcee08a462a4b3aa3790ae27abd86cee6d921e3283",
-        "version": 11
-      }
-    },
     "rule_name": "RDP (Remote Desktop Protocol) from the Internet",
-    "sha256": "e8b7d833a2cad5ad92e04ba43b572eb374e775daa2ec9fa71f72a4b5cad614ee",
+    "sha256": "b6d7ad4ee2f11ab3ed8aa4bcee08a462a4b3aa3790ae27abd86cee6d921e3283",
     "type": "query",
-    "version": 12
+    "version": 11
   },
   "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45": {
     "rule_name": "Unusual Child Process of dns.exe",
-    "sha256": "639a58695ccbcd7ca4a9b58d65eb28c0045ea168aca723d27370331d0dcc6a79",
+    "sha256": "cd28b1f77b37d6e9016c24c3cbbf4d94f8cd152004e883f3986a4d9e88687b3c",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "8c81e506-6e82-4884-9b9a-75d3d252f967": {
     "rule_name": "Potential SharpRDP Behavior",
@@ -2327,9 +2200,9 @@
   },
   "8da41fc9-7735-4b24-9cc6-c78dfc9fc9c9": {
     "rule_name": "Potential Privilege Escalation via PKEXEC",
-    "sha256": "8b35059e3e2c9c1cfabfbd9ae383daa10e26ff3840e20952d4805a3bdb73db8e",
+    "sha256": "7a56ece573a2e7340ff71758fab173b542a2d7063efece0d05078354bc3ac4c9",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "8ddab73b-3d15-4e5d-9413-47f05553c1d7": {
     "rule_name": "Azure Automation Runbook Deleted",
@@ -2355,12 +2228,6 @@
     "type": "query",
     "version": 5
   },
-  "8fed8450-847e-43bd-874c-3bbf0cd425f3": {
-    "rule_name": "Linux Restricted Shell Breakout via  apt/apt-get Changelog Escape",
-    "sha256": "7e88fe635274dd47f23d744bd4b8fb482ab86c8b1b6db9434d64ab40c7edbb62",
-    "type": "eql",
-    "version": 1
-  },
   "90169566-2260-4824-b8e4-8615c3b4ed52": {
     "rule_name": "Hping Process Activity",
     "sha256": "e95b011bb8a3aa490e0c1725dbcb086dcbe8f993b61947c9a5c274bf5de92b83",
@@ -2368,16 +2235,16 @@
     "version": 7
   },
   "9055ece6-2689-4224-a0e0-b04881e1f8ad": {
-    "rule_name": "AWS Deletion of RDS Instance or Cluster",
-    "sha256": "7b5d096d90addc9b02252f9d407fdd13b77181a99c0e5ab42a7b70747921ba46",
+    "rule_name": "AWS RDS Cluster Deletion",
+    "sha256": "814bd87ddb20bb57f1d35ce8e4e8265e2a4915fc68d659aeb8d3fd6adfe68fcb",
     "type": "query",
-    "version": 7
+    "version": 6
   },
   "9092cd6c-650f-4fa3-8a8a-28256c7489c9": {
     "rule_name": "Keychain Password Retrieval via Command Line",
-    "sha256": "e6a46ffeb7518f0f0c6d871a56526257340210b16c109017bd88c457b6707b4d",
+    "sha256": "66c3b0f201fec745d9992dd9e1be815c5a7bf95a2412b6923721ec5aabc6f6cd",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "90e28af7-1d96-4582-bf11-9a1eff21d0e5": {
     "rule_name": "Auditd Login Attempt at Forbidden Time",
@@ -2435,9 +2302,9 @@
   },
   "93b22c0a-06a0-4131-b830-b10d5e166ff4": {
     "rule_name": "Suspicious SolarWinds Child Process",
-    "sha256": "6d382546346f8466280644399f00e615d3e25f460ba094afcc29da63e902a910",
+    "sha256": "23220ce15e2b4d3768918e69f4ac38f910352b9eed00044f55257c99f50c1e29",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "93c1ce76-494c-4f01-8167-35edfb52f7b1": {
     "rule_name": "Encoded Executable Stored in the Registry",
@@ -2452,13 +2319,13 @@
         "rule_name": "Google Workspace Admin Role Deletion",
         "sha256": "3c0f93a51365de485043e4961faba1a74302db6036510abbde8f1b0b60e4de3b",
         "type": "query",
-        "version": 9
+        "version": 7
       }
     },
     "rule_name": "Google Workspace Admin Role Deletion",
     "sha256": "7f3e1672e2c15b1f4386242655493bbd483c0c30d377b65c94cadf17d5dbb100",
     "type": "query",
-    "version": 10
+    "version": 8
   },
   "93f47b6f-5728-4004-ba00-625083b3dcb0": {
     "rule_name": "Modification of Standard Authentication Module or Configuration",
@@ -2468,15 +2335,15 @@
   },
   "954ee7c8-5437-49ae-b2d6-2960883898e9": {
     "rule_name": "Remote Scheduled Task Creation",
-    "sha256": "6160a0f0792097e86209482cea32782afd35428338b00cb36c0fe15245637629",
+    "sha256": "26cfaadd55aa2fc9557f5080015fe75330c144123bae3e90a76582d2114f2690",
     "type": "eql",
-    "version": 8
+    "version": 7
   },
   "959a7353-1129-4aa7-9084-30746b256a70": {
     "rule_name": "PowerShell Suspicious Script with Screenshot Capabilities",
-    "sha256": "fbced4ec00849c83a12529e3b2cb735a03fd08be899628e833a920f1bb042e8a",
+    "sha256": "a9d0adef2ea58481a1500782645964ae1514d39bec94471128be69c318e49ab4",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "96b9f4ea-0e8c-435b-8d53-2096e75fcac5": {
     "rule_name": "Attempt to Create Okta API Token",
@@ -2486,9 +2353,9 @@
   },
   "96e90768-c3b7-4df6-b5d9-6237f8bc36a8": {
     "rule_name": "Access to Keychain Credentials Directories",
-    "sha256": "31f58075d02cfa33ee584ba278c6a69f5194815a84f232236015c2289732e0ff",
+    "sha256": "35502f33157c641cfe6e83113f9301c7c9fbf8b4732eec46a13c0eb77b6df58c",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "97314185-2568-4561-ae81-f3e480e5e695": {
     "rule_name": "Microsoft 365 Exchange Anti-Phish Rule Modification",
@@ -2510,21 +2377,15 @@
   },
   "97a8e584-fd3b-421f-9b9d-9c9d9e57e9d7": {
     "rule_name": "Potential Abuse of Repeated MFA Push Notifications",
-    "sha256": "966905acce285fccf1d3bdaa7a20e880abdc87edb582b4bf914497e078d3a86e",
+    "sha256": "db6fc652133f94ed3b56312ed656e59574f6060596c8663a150999b25c8fb3e9",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "97aba1ef-6034-4bd3-8c1a-1e0996b27afa": {
     "rule_name": "Suspicious Zoom Child Process",
-    "sha256": "b3df2cf5b85f45cfe2549cd032fcdc0ba81feae74704c685664a74f202bd14c9",
+    "sha256": "939b366f86b602d26bc22bbeaed26cfdf9465352e186f0b0034f0c2b0b1d0bae",
     "type": "eql",
-    "version": 6
-  },
-  "97da359b-2b61-4a40-b2e4-8fc48cf7a294": {
-    "rule_name": "Linux Restricted Shell Breakout via the ssh command",
-    "sha256": "835d5b35a441dd1e3abf0c3d4d19ef86039404014b487b05f77cf84e3690073f",
-    "type": "eql",
-    "version": 1
+    "version": 5
   },
   "97f22dab-84e8-409d-955e-dacd1d31670b": {
     "rule_name": "Base64 Encoding/Decoding Activity",
@@ -2533,18 +2394,10 @@
     "version": 7
   },
   "97fc44d3-8dae-4019-ae83-298c3015600f": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Startup or Run Key Registry Modification",
-        "sha256": "1827b7a04db141b503dcbe4bdd0c18468ccc43b937e02c76d1f2e7686d2b17ef",
-        "version": 5
-      }
-    },
     "rule_name": "Startup or Run Key Registry Modification",
-    "sha256": "d7812909f8d6b7f07a49520b790a1a5d653f213f6d542753f78f0d29e06b612c",
+    "sha256": "1827b7a04db141b503dcbe4bdd0c18468ccc43b937e02c76d1f2e7686d2b17ef",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "9890ee61-d061-403d-9bf6-64934c51f638": {
     "rule_name": "GCP IAM Service Account Key Deletion",
@@ -2572,15 +2425,15 @@
   },
   "99239e7d-b0d4-46e3-8609-acafcf99f68c": {
     "rule_name": "macOS Installer Spawns Network Event",
-    "sha256": "cfaf9deaddd648ee2e3181949eb0bfd6054a43b6ff287b70ff4ce50c9bdb8ec4",
+    "sha256": "07c9c8e38e3443ff00955fbdcfd03ed0b67974906d56679ed5f34fa34826a709",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "9960432d-9b26-409f-972b-839a959e79e2": {
     "rule_name": "Potential Credential Access via LSASS Memory Dump",
-    "sha256": "1c43870b1bdc78d2acf56820453508b07eab611dd8a2af96f009411a6c27d2e7",
+    "sha256": "34e37a8d16f99007d21007aa800c2fc54f0de699490e0b9be262f91735376854",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "99dcf974-6587-4f65-9252-d866a3fdfd9c": {
     "min_stack_version": "7.14.0",
@@ -2597,41 +2450,33 @@
   },
   "9a5b4e31-6cde-4295-9ff7-6be1b8567e1b": {
     "rule_name": "Suspicious Explorer Child Process",
-    "sha256": "69ee10a3df9f38002944cae6319b7dc0c72f45e858c467fa56e186c2fc332fb1",
+    "sha256": "c0fb8365df33514e95358c2dff239e8a61b31afbd060ab86ebcd8c00eb20e5fb",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "9aa0e1f6-52ce-42e1-abb3-09657cee2698": {
     "rule_name": "Scheduled Tasks AT Command Enabled",
-    "sha256": "8c64a10859c7d7dda21d039ae70fe9f896bea6d712691f63ac11ff1c6f3cc07a",
+    "sha256": "e42d1f11048885170aa1c334ea460e06ecf2fd17585fbf040805fb33714bb0bf",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "9b6813a1-daf1-457e-b0e6-0bb4e55b8a4c": {
     "rule_name": "Persistence via WMI Event Subscription",
-    "sha256": "1f78348a9f4100c954885e58dd5e9990b2c4046405892b097bbdee110ea96f48",
+    "sha256": "60f3f4ec605f4c52a7cfc278b265651dd12b5b9177a26143a797395fc327d22b",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "9c260313-c811-4ec8-ab89-8f6530e0246c": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Hosts File Modified",
-        "sha256": "3c3588d174cd600f65ee7d3050915a5831b1bd182e27561d3615c7f77973846b",
-        "version": 6
-      }
-    },
     "rule_name": "Hosts File Modified",
-    "sha256": "49a57a69fbfe3f0af1977b95830f2c3bd244cd7fe73ecdb2f7ebbd5c65183d86",
+    "sha256": "3c3588d174cd600f65ee7d3050915a5831b1bd182e27561d3615c7f77973846b",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "9ccf3ce0-0057-440a-91f5-870c6ad39093": {
     "rule_name": "Command Shell Activity Started via RunDLL32",
-    "sha256": "fa31f422b66351e594bf58218cb73ecb52bdabde58ff3ac8d91eb778a63fac31",
+    "sha256": "3672f0f401956a6aa3757faa0cf494a614115fe3a1eeefc8c7f5f61722c7859d",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae1": {
     "rule_name": "Trusted Developer Application Usage",
@@ -2641,33 +2486,33 @@
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae2": {
     "rule_name": "Microsoft Build Engine Started by a Script Process",
-    "sha256": "16b3b95b541ab2bbffc393a414d2706169362e99f8bdfa171a23e2a53361f168",
+    "sha256": "87c20cfb4ea3953543c6011959936c3cdc29ec7b103b20edb95253055c27fde1",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae3": {
     "rule_name": "Microsoft Build Engine Started by a System Process",
-    "sha256": "5667e1f8a9669a7010baee7c5c0539f6a5c16dcf2049c4dec6370b2d45dee29b",
+    "sha256": "f04344278f08e013710f49865b7c6a98732bbe932665e30e5ea30696e19a1057",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae4": {
     "rule_name": "Microsoft Build Engine Using an Alternate Name",
-    "sha256": "fcb79e4901f94a558aaabb86747a1df0891e9184921c4130296382d54389e504",
+    "sha256": "6aa2f902a6c209e4698dff7263b27b1592311dd713e902640ce9f9a2300efeda",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5": {
     "rule_name": "Microsoft Build Engine Loading Windows Credential Libraries",
-    "sha256": "da3737b1f7b999fe289b80a4c54dbe617d9ed24e83ae3d9e7be62a62563b9b08",
+    "sha256": "adee2abc28a974071b6f404a24a10cca641beed6625be5e838bab6cd31f8e9f0",
     "type": "eql",
-    "version": 9
+    "version": 8
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae6": {
     "rule_name": "Microsoft Build Engine Started an Unusual Process",
-    "sha256": "c802c9c37dde668ec390c39ef03aa0593f23f3db6b4de77b57d1915298a60012",
+    "sha256": "a61f532cce3874503bbd1987cc4617a2ad83fd6b289756ccd1b4830bdbf496b7",
     "type": "eql",
-    "version": 9
+    "version": 8
   },
   "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae9": {
     "rule_name": "Process Injection by the Microsoft Build Engine",
@@ -2677,9 +2522,9 @@
   },
   "9d19ece6-c20e-481a-90c5-ccca596537de": {
     "rule_name": "LaunchDaemon Creation or Modification and Immediate Loading",
-    "sha256": "e404dae5c5dcccef855cb68ac7a5d2990bc62e10602ee9ac83a2d44db9744742",
+    "sha256": "85c51be85ab3d5663e311b2549849c31b9da10cb4e8c76762efa8ef23aa601fe",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "9d302377-d226-4e12-b54c-1906b5aec4f6": {
     "rule_name": "Unusual Linux Process Calling the Metadata Service",
@@ -2689,15 +2534,15 @@
   },
   "9f1c4ca3-44b5-481d-ba42-32dc215a2769": {
     "rule_name": "Potential Protocol Tunneling via EarthWorm",
-    "sha256": "e84ca016541f24c87c4d6c934d39f4813e5a7a50b4ed2b828368fb604f691e47",
+    "sha256": "03ea09bf741f0864cbfcd01045657c731176e2cb81f0a022f61644e68e543e95",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "9f962927-1a4f-45f3-a57b-287f2c7029c1": {
     "rule_name": "Potential Credential Access via DCSync",
-    "sha256": "43fe08ed07e605533a34a15977f617fbc2df8f092e0786ca9163476e5a8153e3",
+    "sha256": "8ca3cc529b90e43084ed7e700fdb9909e21585b9856284780c92bb4d7493c348",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "9f9a2a82-93a8-4b1a-8778-1780895626d4": {
     "rule_name": "File Permission Modification in Writable Directory",
@@ -2731,9 +2576,9 @@
   },
   "a16612dd-b30e-4d41-86a0-ebe70974ec00": {
     "rule_name": "Potential LSASS Clone Creation via PssCaptureSnapShot",
-    "sha256": "596140887b6a28641d8551b50ee645155d7df979bc273d712f257e2a87321c18",
+    "sha256": "03bdeac5057893f51610fb230139686e35a436d905b7465555966dcfe1769fa9",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "a17bcc91-297b-459b-b5ce-bc7460d8f82a": {
     "rule_name": "GCP Virtual Private Cloud Route Deletion",
@@ -2743,28 +2588,21 @@
   },
   "a1a0375f-22c2-48c0-81a4-7c2d11cc6856": {
     "rule_name": "Potential Reverse Shell Activity via Terminal",
-    "sha256": "f7d04cf28dd823e7ebe26abce688167b82cf1cf48dd91e557b4aa59ddcde9245",
+    "sha256": "c9bf1fe195602f505c43eda209be7267cf3997e49d86773f719a0a4300d70db8",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "a22a09c2-2162-4df0-a356-9aacbeb56a04": {
     "rule_name": "DNS-over-HTTPS Enabled via Registry",
-    "sha256": "fa8466cd045c26e5eed2ae6102ce495db7eaebf6dab6ff45ef2d4e1a9b3424fa",
+    "sha256": "6f78fd32e25cee20e54d68955f70146f8fef6c8a9a407838c98a204075d706b2",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "a3ea12f3-0d4e-4667-8b44-4230c63f3c75": {
     "rule_name": "Execution via local SxS Shared Module",
-    "sha256": "36acbd4e14f049fc24ccafaf677ff9c0d60f8de3a10d259e3702bdbcd62a8ebc",
+    "sha256": "fee8b8d1d56be16d7fe1a0de049286cf7095506b3bf9cc39d48e18ea8fbfd356",
     "type": "eql",
-    "version": 5
-  },
-  "a4c7473a-5cb4-4bc1-9d06-e4a75adbc494": {
-    "min_stack_version": "7.15.0",
-    "rule_name": "Windows Registry File Creation in SMB Share",
-    "sha256": "cc90a0587f15e6896fcc7fcdf8b94c2a6ca43a67d0fcd2a20023a79cc5da21d3",
-    "type": "eql",
-    "version": 1
+    "version": 4
   },
   "a4ec1382-4557-452b-89ba-e413b22ed4b8": {
     "rule_name": "Network Connection via Mshta",
@@ -2786,27 +2624,27 @@
   },
   "a624863f-a70d-417f-a7d2-7a404638d47f": {
     "rule_name": "Suspicious MS Office Child Process",
-    "sha256": "cebc6b72197a1e19dcd4e282b646edae5d0ce561248b867325375fcb0499af68",
+    "sha256": "e07a208a63f777c6b78eb3e2d91fc678372672774e5c42448f1cc5dddd54d893",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "a6bf4dd4-743e-4da8-8c03-3ebd753a6c90": {
     "rule_name": "Emond Rules Creation or Modification",
-    "sha256": "6ca94a6a62b97c72a2074a2a01c670851905fd3244a244190411743a14d9797a",
+    "sha256": "59289eddd2040bc752795a3b4b65166988f1d4f1444723421c506d184777a7d9",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "a7ccae7b-9d2c-44b2-a061-98e5946971fa": {
     "rule_name": "Suspicious PrintSpooler SPL File Created",
-    "sha256": "2bf22a09a09e4e8ad307bb84a60f1ec7f5846e26ce56c5202da4008ab73c7d0a",
+    "sha256": "f4e0b1722307631cf5e4d40f510227283e04df89bb1190886dc8016879566d4a",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "a7e7bfa3-088e-4f13-b29e-3986e0e756b8": {
     "rule_name": "Credential Acquisition via Registry Hive Dumping",
-    "sha256": "46db472c6e6f0ed4f21ae620146ad473a93dd5d96e2f53541a5f40fdc9a80330",
+    "sha256": "44e523ff34b1fc8bc57e3691d0d7688ee9adabcb86d83dca1175a98f5352746f",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "a87a4e42-1d82-44bd-b0bf-d9b7f91fb89e": {
     "rule_name": "Web Application Suspicious Activity: POST Request Declined",
@@ -2833,19 +2671,19 @@
         "rule_name": "Google Workspace Password Policy Modified",
         "sha256": "cadc95b5eb7938b3b7310150089830d4dad51e3499916cd2f5c82446659b4051",
         "type": "query",
-        "version": 10
+        "version": 8
       }
     },
     "rule_name": "Google Workspace Password Policy Modified",
     "sha256": "7741aa9c38ba126329fbb075496847374a2dd8d65aadd49aa25b7f0f00e6aeb5",
     "type": "query",
-    "version": 11
+    "version": 9
   },
   "a9b05c3b-b304-4bf9-970d-acdfaef2944c": {
     "rule_name": "Persistence via Hidden Run Key Detected",
-    "sha256": "a9a699185b39bab4117e8a996852590bfc99e93898674e94bc027c3dd6dca030",
+    "sha256": "09f364282ecc1369272d232ea563722f124c9be5636ae2c9bcbfd6821f8721b7",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "a9cb3641-ff4b-4cdc-a063-b4b8d02a67c7": {
     "rule_name": "IPSEC NAT Traversal Port Activity",
@@ -2861,9 +2699,9 @@
   },
   "aa895aea-b69c-4411-b110-8d7599634b30": {
     "rule_name": "System Log File Deletion",
-    "sha256": "32886e295aee99147e0c0079d526e97343bc4fe6c27706ef5e991e3913f9ce22",
+    "sha256": "0d46a18e785f0b5daee88973ca06fdcadeb743a9736224a965e472343ca74d30",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "aa9a274d-6b53-424d-ac5e-cb8ca4251650": {
     "rule_name": "Remotely Started Services via RPC",
@@ -2891,9 +2729,9 @@
   },
   "ac5012b8-8da8-440b-aaaf-aedafdea2dff": {
     "rule_name": "Suspicious WerFault Child Process",
-    "sha256": "9775c5accf062b0d84429dafeecc379e22a6f2f54a09fa49b77e265012c3d712",
+    "sha256": "f9937673d94c8d62bfbabf458c5e1153c72a785fbe91043e3598f248d75f9f98",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "ac706eae-d5ec-4b14-b4fd-e8ba8086f0e1": {
     "rule_name": "Unusual AWS Command for a User",
@@ -2908,13 +2746,13 @@
         "rule_name": "Google Workspace API Access Granted via Domain-Wide Delegation of Authority",
         "sha256": "01a8beca2e8f570d63e7614d558243b1d0b9c42d9e0ce9f439b10016f06eaea3",
         "type": "query",
-        "version": 9
+        "version": 7
       }
     },
     "rule_name": "Google Workspace API Access Granted via Domain-Wide Delegation of Authority",
     "sha256": "3d8eab60bf795ae6756c1c6058a7c1be2eb14e1c1777a7b4bda27e1906206c95",
     "type": "query",
-    "version": 10
+    "version": 8
   },
   "acd611f3-2b93-47b3-a0a3-7723bcc46f6d": {
     "rule_name": "Potential Command and Control via Internet Explorer",
@@ -2930,15 +2768,9 @@
   },
   "acf738b5-b5b2-4acc-bad9-1e18ee234f40": {
     "rule_name": "Suspicious Managed Code Hosting Process",
-    "sha256": "a357b9a510442209bb5f8d23dabe74e4309831848d7ac1c52301f236013ec19d",
+    "sha256": "471a87bc02e6f7d085e50a6378130101e802abd05fc78def073643851037c95d",
     "type": "eql",
-    "version": 5
-  },
-  "ad0d2742-9a49-11ec-8d6b-acde48001122": {
-    "rule_name": "Signed Proxy Execution via MS WorkFolders",
-    "sha256": "9a4da22d2ca3a439a861ba534233154b481ece85272d40a4d5b79103465b6039",
-    "type": "eql",
-    "version": 1
+    "version": 4
   },
   "ad0e5e75-dd89-4875-8d0a-dfdc1828b5f3": {
     "rule_name": "Proxy Port Activity to the Internet",
@@ -2953,19 +2785,19 @@
         "rule_name": "Google Workspace Custom Admin Role Created",
         "sha256": "8b04328630ae74389a2b77d23700d2bfd3900c6008bf0aa9654c2432b427b9c9",
         "type": "query",
-        "version": 9
+        "version": 7
       }
     },
     "rule_name": "Google Workspace Custom Admin Role Created",
     "sha256": "72ff218857ba09e7c08970ebc6cdfcba3cd1dd4f0711dbd403b074fee911011c",
     "type": "query",
-    "version": 10
+    "version": 8
   },
   "ad84d445-b1ce-4377-82d9-7c633f28bf9a": {
     "rule_name": "Suspicious Portable Executable Encoded in Powershell Script",
-    "sha256": "595203c7bd02d7aa640feb6640002bcc3ea2c49602a4366ddc30df6b68ce68d8",
+    "sha256": "357d02c45f3021968f8a30e2a4a9c4f8756fc98f2a06c67e1b05cad44efe8ec0",
     "type": "query",
-    "version": 5
+    "version": 4
   },
   "ad88231f-e2ab-491c-8fc6-64746da26cfe": {
     "rule_name": "Kerberos Cached Credentials Dumping",
@@ -2980,24 +2812,16 @@
     "version": 6
   },
   "afcce5ad-65de-4ed2-8516-5e093d3ac99a": {
-    "min_stack_version": "7.16.0",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Local Scheduled Task Creation",
-        "sha256": "6bef89b0823728244b1f9f53b3bb4cf878d031d22d66d8f1a9ea4ad014ae3537",
-        "version": 11
-      }
-    },
     "rule_name": "Local Scheduled Task Creation",
-    "sha256": "ea88687da0b3e350cbec589c89e6b91be2999547a3762f95b3ee42423842539b",
+    "sha256": "f0210dc49e358f7039b60f9f0ff7b2339cf65c5cfeda0b549e0dcd4e0071888c",
     "type": "eql",
-    "version": 12
+    "version": 10
   },
   "b0046934-486e-462f-9487-0d4cf9e429c6": {
     "rule_name": "Timestomping using Touch Command",
-    "sha256": "06532e4b42fc010315bdb2ff6a7743d79cab998f7801afc857a1c41f0637ba22",
+    "sha256": "46f80cee555f16f5b0d6567797b79aff56bf202703fcc3d718d0b057fc05d2d3",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "b00bcd89-000c-4425-b94c-716ef67762f6": {
     "rule_name": "TCC Bypass via Mounted APFS Snapshot Access",
@@ -3019,9 +2843,9 @@
   },
   "b25a7df2-120a-4db2-bd3f-3e4b86b24bee": {
     "rule_name": "Remote File Copy via TeamViewer",
-    "sha256": "5cabfcfa49acb508a645e669ae1a3b9a8453e9d71a32cb365a32eb869d2be0c7",
+    "sha256": "da3c30b2325fde833e7f51119907e7fe036c63d2c519ebc209219678adcaf401",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "b2951150-658f-4a60-832f-a00d1e6c6745": {
     "rule_name": "Microsoft 365 Unusual Volume of File Deletion",
@@ -3043,9 +2867,9 @@
   },
   "b41a13c6-ba45-4bab-a534-df53d0cfed6a": {
     "rule_name": "Suspicious Endpoint Security Parent Process",
-    "sha256": "9bbdf50c864df5b81be0c6fc6f74032af769a6e57fa73aab899d75d6d19aaeb7",
+    "sha256": "f54b395d6dfa7b126c8bd7c5e445821fe436f4e33c99dd76f6beb89929d6e454",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "b4449455-f986-4b5a-82ed-e36b129331f7": {
     "rule_name": "Potential Persistence via Atom Init Script Modification",
@@ -3067,15 +2891,15 @@
   },
   "b5877334-677f-4fb9-86d5-a9721274223b": {
     "rule_name": "Clearing Windows Console History",
-    "sha256": "b1b1242e639188790fc49c1b14998f746358dc7842e380a8cc4263bc75e91d0c",
+    "sha256": "7019e4bc7049a79eaaa17917e400a2267ed18d60a47401930de10ac006e4c426",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "b5ea4bfe-a1b2-421f-9d47-22a75a6f2921": {
     "rule_name": "Volume Shadow Copy Deleted or Resized via VssAdmin",
-    "sha256": "93e3837fce54c54aa393d2afc036472d007425eaca1413fd955a684f14d9911e",
+    "sha256": "1232ea6310a97df413022bbeba916d1067e8d6a7e9e5910df9f95ac3a1631575",
     "type": "eql",
-    "version": 12
+    "version": 11
   },
   "b64b183e-1a76-422d-9179-7b389513e74d": {
     "rule_name": "Windows Script Interpreter Executing Process via WMI",
@@ -3103,9 +2927,9 @@
   },
   "b83a7e96-2eb3-4edf-8346-427b6858d3bd": {
     "rule_name": "Creation or Modification of Domain Backup DPAPI private key",
-    "sha256": "d99501faedbcbfd5604de2e284b3e817a880a71abf439135e70cf7bd9f6370ff",
+    "sha256": "f2337e3bf6ede7fe3d56f1b71e0c49055ccbacb5d1e3490fca8e6d0ad3b803a7",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "b86afe07-0d98-4738-b15d-8d7465f95ff5": {
     "rule_name": "Network Connection via MsXsl",
@@ -3115,28 +2939,28 @@
   },
   "b90cdde7-7e0d-4359-8bf0-2c112ce2008a": {
     "rule_name": "UAC Bypass Attempt with IEditionUpgradeManager Elevated COM Interface",
-    "sha256": "313395d41d74e5f9ea9140c5b4cf4b7df1459a827c75a252a1a19ab50f72e16e",
+    "sha256": "051717de0f6c9db9ae1ebe6405e072627948848da2868a8c0deb5e624f0cd2e5",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "b9554892-5e0e-424b-83a0-5aef95aa43bf": {
     "rule_name": "Group Policy Abuse for Privilege Addition",
-    "sha256": "16df9b62d513df2c32180b356aa0ef1aa20c44710b61da67fec8e70c9e04e587",
+    "sha256": "d7cab2144989c107af3b92511c7d537f09bd71feea642b68bf1618580999ca4f",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "b9666521-4742-49ce-9ddc-b8e84c35acae": {
     "min_stack_version": "7.13.0",
     "rule_name": "Creation of Hidden Files and Directories",
-    "sha256": "9515b6e94011f55aaec0a81fd8c343771c1bd922a16a699075e105558cb4be3e",
+    "sha256": "8e1e234b34a64f445bf854bc5c68bfa88bb2958a08ffcb995ccfe2db81e123e6",
     "type": "eql",
-    "version": 8
+    "version": 7
   },
   "b9960fef-82c6-4816-befa-44745030e917": {
     "rule_name": "SolarWinds Process Disabling Services via Registry",
-    "sha256": "c96ba2d6f75119ca2862fdcaf518dd485818272f81ce245a976d86583904e4f1",
+    "sha256": "fb5ff8beabd1977f3f402a145b5142fb38ebfc46926df7ef1830d696692d8897",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "ba342eb2-583c-439f-b04d-1fdd7c1417cc": {
     "rule_name": "Unusual Windows Network Activity",
@@ -3146,9 +2970,9 @@
   },
   "baa5d22c-5e1c-4f33-bfc9-efa73bb53022": {
     "rule_name": "Suspicious Image Load (taskschd.dll) from MS Office",
-    "sha256": "132b4ed3fc8b5103df86b8e2adca81b8f64b27052f04f4592590316e4a333741",
+    "sha256": "4359dc522ac5d74051800cc05272be74bda5c0d5a2a914038c13a13642eb25a6",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "bb4fe8d2-7ae2-475c-8b5d-55b449e4264f": {
     "rule_name": "Azure Resource Group Deletion",
@@ -3194,9 +3018,9 @@
   },
   "bc48bba7-4a23-4232-b551-eca3ca1e3f20": {
     "rule_name": "Azure Conditional Access Policy Modified",
-    "sha256": "ca527af48e84456c10753f6defd407323000ee60b09246ce33f95422e2242b16",
+    "sha256": "a00630117e151eb94950ab0413bee80f0492d7520ffb5cf7f4444e9206eb6752",
     "type": "query",
-    "version": 6
+    "version": 5
   },
   "bca7d28e-4a48-47b1-adb7-5074310e9a61": {
     "rule_name": "GCP Service Account Disabled",
@@ -3206,9 +3030,9 @@
   },
   "bd2c86a0-8b61-4457-ab38-96943984e889": {
     "rule_name": "PowerShell Keylogging Script",
-    "sha256": "6bc0cf9d4c533e8088498db20d276e4d852ce7b1be110fce699f99e9854897da",
+    "sha256": "199201b60e09a340510fcf44f7d7e6a585f9994694d4aa9733417311eef15edd",
     "type": "query",
-    "version": 4
+    "version": 3
   },
   "bd7eefee-f671-494e-98df-f01daf9e5f17": {
     "rule_name": "Suspicious Print Spooler Point and Print DLL",
@@ -3218,15 +3042,15 @@
   },
   "bdcf646b-08d4-492c-870a-6c04e3700034": {
     "rule_name": "Potential Privileged Escalation via SamAccountName Spoofing",
-    "sha256": "04258ae19d93d55519d8f7ae64489c495a94c74ce09fb8f4c786d7a646b3eebe",
+    "sha256": "1ab2d4264e5364a263cf0fa8de1fa0560dd6e7bc17b7da303eb226263f58c3b7",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "be8afaed-4bcd-4e0a-b5f9-5562003dde81": {
     "rule_name": "Searching for Saved Credentials via VaultCmd",
-    "sha256": "07df828e644721285f763fc179a56a42543204d8f075be83ace6ad790ca6d3ad",
+    "sha256": "992fc3eb2005070d0a2eb094b89e093b57426cbe863e2c35c946265fb8f0d23c",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "bf1073bf-ce26-4607-b405-ba1ed8e9e204": {
     "rule_name": "AWS RDS Snapshot Restored",
@@ -3236,21 +3060,21 @@
   },
   "bfeaf89b-a2a7-48a3-817f-e41829dc61ee": {
     "rule_name": "Suspicious DLL Loaded for Persistence or Privilege Escalation",
-    "sha256": "c938dbc56d3bd5635cce18f040dd9ec53fa57aa4c5ec1465f22e0b0b5ec6252a",
-    "type": "eql",
-    "version": 3
-  },
-  "c02c8b9f-5e1d-463c-a1b0-04edcdfe1a3d": {
-    "rule_name": "Potential Privacy Control Bypass via Localhost Secure Copy",
-    "sha256": "fd35291fa9dcfb77c5a0fce79b165bd99b7b86d051bf14f9d410819b87669ee5",
+    "sha256": "2e2cc6d275afd2b0ad2082fc64d16ff251c7b91b0ad5370583bc7fb460166ee5",
     "type": "eql",
     "version": 2
   },
+  "c02c8b9f-5e1d-463c-a1b0-04edcdfe1a3d": {
+    "rule_name": "Potential Privacy Control Bypass via Localhost Secure Copy",
+    "sha256": "56997e25c16d915db541338be6e5a8c2fb86ea53e874dabdb5648b8dac17026b",
+    "type": "eql",
+    "version": 1
+  },
   "c0429aa8-9974-42da-bfb6-53a0a515a145": {
     "rule_name": "Creation or Modification of a new GPO Scheduled Task or Service",
-    "sha256": "3b663d2296f62cf34af39c377fbddc713cf42ae0a391532be2b3e6b619b90e76",
+    "sha256": "b252b1b0ae3130cc2aa2af9cd752d49af6d14fd275f6252fa6171a2c9a3ae506",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "c0be5f31-e180-48ed-aa08-96b36899d48f": {
     "rule_name": "Credential Manipulation - Detected - Elastic Endgame",
@@ -3266,9 +3090,9 @@
   },
   "c25e9c87-95e1-4368-bfab-9fd34cf867ec": {
     "rule_name": "Microsoft IIS Connection Strings Decryption",
-    "sha256": "da21a85bbd297173cd6188781e98d632908ae30503793b557fdda2278be8da0f",
+    "sha256": "e0426acc19d28951632e6d51dc170face86a592f82ae4eb55ee3144a9848b31c",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "c28c4d8c-f014-40ef-88b6-79a1d67cd499": {
     "rule_name": "Unusual Linux Network Connection Discovery",
@@ -3278,9 +3102,9 @@
   },
   "c292fa52-4115-408a-b897-e14f684b3cb7": {
     "rule_name": "Persistence via Folder Action Script",
-    "sha256": "80afa22868cdc85eb346cd133de505801f0b1dfcacb6244d49f865e0a376f74b",
+    "sha256": "ab6c806117ab8f06a992321c114ddfe378ad6f83439ab3b977a52868201c48aa",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "c2d90150-0133-451c-a783-533e736c12d7": {
     "rule_name": "Mshta Making Network Connections",
@@ -3296,33 +3120,33 @@
   },
   "c3b915e0-22f3-4bf7-991d-b643513c722f": {
     "rule_name": "Persistence via BITS Job Notify Cmdline",
-    "sha256": "1b4d93df41d8da4c5ebc6a68f84831693819f5b97543ea49de2b31aaaf1c0d24",
+    "sha256": "15021e6cafece04e5c66ecb8390c4a899e2cd9d5728ff2a165a0ff303dc24d4e",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "c3f5e1d8-910e-43b4-8d44-d748e498ca86": {
     "rule_name": "Potential JAVA/JNDI Exploitation Attempt",
-    "sha256": "f60fe5b32ff54a35a502abef27b7a8c4a8294ad3ad27523e6a38c233611f7732",
+    "sha256": "693df7d5173a8307da3c937d1bbb6e29f69db99529a960ce4fe9bcae2c331c5b",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "c4210e1c-64f2-4f48-b67e-b5a8ffe3aa14": {
     "rule_name": "Mounting Hidden or WebDav Remote Shares",
-    "sha256": "5cd684e5352c22873f97c7431f13d4339b4d6605723012d1b3ea94395874bd12",
+    "sha256": "fd98829f6683e70e5a3d3fe8ed5fe7ea2a35a9eb323b012ee895ea1e3b563c46",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "c4818812-d44f-47be-aaef-4cfb2f9cc799": {
     "rule_name": "Suspicious Print Spooler File Deletion",
-    "sha256": "8995efdaf76a976352c15573f17b0e1ec96daf916f4d6e1faeab3f009dd299da",
+    "sha256": "d3e940a5c8517168cdd443783e02286039c72a78c5c9f24dad0eb7be0b1fffb3",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "c57f8579-e2a5-4804-847f-f2732edc5156": {
     "rule_name": "Potential Remote Desktop Shadowing Activity",
-    "sha256": "f580607b967e59493bde8739bf54c97efe2356bf910bf8bd884eed7063ff7afa",
+    "sha256": "7a378b1a7fa710354f67ee1b8b60ce93653a48edd7466d796f3e9d64d03aed7b",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "c58c3081-2e1d-4497-8491-e73a45d1a6d6": {
     "rule_name": "GCP Virtual Private Cloud Network Deletion",
@@ -3332,9 +3156,9 @@
   },
   "c5c9f591-d111-4cf8-baec-c26a39bc31ef": {
     "rule_name": "Potential Credential Access via Renamed COM+ Services DLL",
-    "sha256": "3e9b6fe3e1a7ff2c5a3c69f87b339ecd78c4f441e79c9f5927e9388c628a1d68",
+    "sha256": "90f5901627a5d6c6563a83d379a323230fbdff1ea541807afe7fea4660970e01",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "c5ce48a6-7f57-4ee8-9313-3d0024caee10": {
     "rule_name": "Installation of Custom Shim Databases",
@@ -3344,9 +3168,9 @@
   },
   "c5dc3223-13a2-44a2-946c-e9dc0aa0449c": {
     "rule_name": "Microsoft Build Engine Started by an Office Application",
-    "sha256": "8b74062307c6bc0f782c49eac88b553c420674e680905532cd167293ca1da13c",
+    "sha256": "1998ec75b5eb81ab21dc332a0101d5fb3564ec7fd4023c45d8bc0707c1a9b36b",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "c5f81243-56e0-47f9-b5bb-55a5ed89ba57": {
     "min_stack_version": "7.14.0",
@@ -3357,9 +3181,9 @@
   },
   "c6453e73-90eb-4fe7-a98c-cde7bbfc504a": {
     "rule_name": "Remote File Download via MpCmdRun",
-    "sha256": "9b766f37d918077afac27580acb1162b83acd901e206252467fedaada5a6275f",
+    "sha256": "0677ca2d233fcadf37a6e15f291d8266722f3b18c926aa5b76f3b1b71f57bde0",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "c6474c34-4953-447a-903e-9fcb7b6661aa": {
     "rule_name": "IRC (Internet Relay Chat) Protocol Activity to the Internet",
@@ -3381,15 +3205,15 @@
   },
   "c7894234-7814-44c2-92a9-f7d851ea246a": {
     "rule_name": "Unusual Network Connection via DllHost",
-    "sha256": "c2a6cf1e4086cf935e57ab571366cfab426f9e6481e9e5a3bbeec1d1efbc4535",
+    "sha256": "3e28a8bb55979694d9772245c4b8a44aeb04b4b6ea95f171ba58752e77a128c8",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "c7ce36c0-32ff-4f9a-bfc2-dcb242bf99f9": {
     "rule_name": "Unusual File Modification by dns.exe",
-    "sha256": "317ff29db74a71fc93aa6b026358d64e13c35cb7b53ef0760f91a6489e20bc08",
+    "sha256": "28d8ceeeae367d91ddfcc5654ea7a2a4f188e3914886461d1379da1a9e2a4e48",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "c7db5533-ca2a-41f6-a8b0-ee98abe0f573": {
     "rule_name": "Spike in Network Traffic To a Country",
@@ -3417,9 +3241,9 @@
   },
   "c85eb82c-d2c8-485c-a36f-534f914b7663": {
     "rule_name": "Virtual Machine Fingerprinting via Grep",
-    "sha256": "1b4d02fffbdf3a1cc36547e5a68f20c38ab32701b8177ba87697a3b99c6e66bc",
+    "sha256": "bf300101c83a76a56196a6d061a1495f30d48c3bab5d7eccc5a121967d04c754",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "c87fca17-b3a9-4e83-b545-f30746c53920": {
     "rule_name": "Nmap Process Activity",
@@ -3435,15 +3259,15 @@
   },
   "c8b150f0-0164-475b-a75e-74b47800a9ff": {
     "rule_name": "Suspicious Startup Shell Folder Modification",
-    "sha256": "1909632e3c969f69f05e2678860ab0045baa8ed17e8b2d10fb60316d63dec7e7",
+    "sha256": "df47026f246008b97ac1129190ed1ad88a0f5ee9e13f9740f947380078db82a8",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "c8cccb06-faf2-4cd5-886e-2c9636cfcb87": {
     "rule_name": "Disabling Windows Defender Security Settings via PowerShell",
-    "sha256": "25c95946bf344f63ac94a1fc18564d54f8ff89ba5343ee409f5574df6f06ea05",
+    "sha256": "611d2771b89ee0ba4bddee2fe900cec60a79a0b9a76e4428365fb04bfbec58f3",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "c9e38e64-3f4c-4bf3-ad48-0e61a60ea1fa": {
     "rule_name": "Credential Manipulation - Prevented - Elastic Endgame",
@@ -3470,13 +3294,13 @@
         "rule_name": "Google Workspace MFA Enforcement Disabled",
         "sha256": "f8496e8188b47da802b79dba6b01c3f9f4e4d7fe9c0adf98503ec33e0a2f6747",
         "type": "query",
-        "version": 10
+        "version": 8
       }
     },
     "rule_name": "Google Workspace MFA Enforcement Disabled",
     "sha256": "de718fed93c2314061daddd300ddb5e01064210ddc42d687fcdd988aa2595d5a",
     "type": "query",
-    "version": 11
+    "version": 9
   },
   "cb71aa62-55c8-42f0-b0dd-afb0bb0b1f51": {
     "rule_name": "Suspicious Calendar File Modification",
@@ -3544,17 +3368,11 @@
     "type": "query",
     "version": 6
   },
-  "cdbebdc1-dc97-43c6-a538-f26a20c0a911": {
-    "rule_name": "Okta User Session Impersonation",
-    "sha256": "71a7458a8e3515afa344a0b8fdf7d9c4ca6140e089769facca129a107f3ea389",
-    "type": "query",
-    "version": 1
-  },
   "ce64d965-6cb0-466d-b74f-8d2c76f47f05": {
     "rule_name": "New ActiveSyncAllowedDeviceID Added via PowerShell",
-    "sha256": "5caf92535f99df8d56a98abed7b55510cd3786bf0736e4da940b6df0f5504399",
+    "sha256": "c3ab50eea009a6df031ff727cb6f5ab3e6699ab059766dd11702e0e67ae8522a",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "cf53f532-9cc9-445a-9ae7-fced307ec53c": {
     "rule_name": "Cobalt Strike Command and Control Beacon",
@@ -3569,31 +3387,31 @@
         "rule_name": "Domain Added to Google Workspace Trusted Domains",
         "sha256": "5cbeb7ba36d4bca274e78516b67aa418552a39af7ff07d0605a306cacb27a1ef",
         "type": "query",
-        "version": 9
+        "version": 7
       }
     },
     "rule_name": "Domain Added to Google Workspace Trusted Domains",
     "sha256": "734ba85eb72a8c8167a1247c75d48bbd9abb0a9954f8a357a20017258da978de",
     "type": "query",
-    "version": 10
+    "version": 8
   },
   "cff92c41-2225-4763-b4ce-6f71e5bda5e6": {
     "rule_name": "Execution from Unusual Directory - Command Line",
-    "sha256": "d00a417959deca1431571d2146033409bf9cee846323b38c246d0484e9c4e59a",
-    "type": "eql",
-    "version": 5
-  },
-  "d0e159cf-73e9-40d1-a9ed-077e3158a855": {
-    "rule_name": "Registry Persistence via AppInit DLL",
-    "sha256": "854b575f4546fffea89fb744d7d2f319a16bd9ce204eb9d386f9319fdd753494",
+    "sha256": "a361597bb52abf436cbf188b582ac1d3f77be85d7fe6c10a6e00c6acbc6938cc",
     "type": "eql",
     "version": 4
   },
-  "d117cbb4-7d56-41b4-b999-bdf8c25648a0": {
-    "rule_name": "Symbolic Link to Shadow Copy Created",
-    "sha256": "e83e96779d7bc8c89103bf100c4bb596f9aeb387931909a39a021dbd0af35f6c",
+  "d0e159cf-73e9-40d1-a9ed-077e3158a855": {
+    "rule_name": "Registry Persistence via AppInit DLL",
+    "sha256": "8e0d01f097a813b149534720764b6fdbd833f36728870e242c7c1292ba2dc249",
     "type": "eql",
     "version": 3
+  },
+  "d117cbb4-7d56-41b4-b999-bdf8c25648a0": {
+    "rule_name": "Symbolic Link to Shadow Copy Created",
+    "sha256": "bf42a9a4a18efc72f87194d38872a565e6a5bf75e6baeef8789293f6854950f0",
+    "type": "eql",
+    "version": 2
   },
   "d2053495-8fe7-4168-b3df-dad844046be3": {
     "rule_name": "PPTP (Point to Point Tunneling Protocol) Activity",
@@ -3609,15 +3427,15 @@
   },
   "d31f183a-e5b1-451b-8534-ba62bca0b404": {
     "rule_name": "Disabling User Account Control via Registry Modification",
-    "sha256": "3d11166da33b53f57ca622686e784d92d97742fb74ce962e3d39a909c6c9b84c",
+    "sha256": "ee9768020aceeec742747d02c10584b87657ba6490ddcff4553dd8fc8a23a58e",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "d331bbe2-6db4-4941-80a5-8270db72eb61": {
     "rule_name": "Clearing Windows Event Logs",
-    "sha256": "1f23c465db09e249755d3b09fb418edf53deca54b7445ea237f238b358b35bf7",
+    "sha256": "ecbbc7859552c8437157063f812772cb9577843591fc62608079300e3210e66a",
     "type": "eql",
-    "version": 12
+    "version": 11
   },
   "d461fac0-43e8-49e2-85ea-3a58fe120b4f": {
     "rule_name": "Shell Execution via Apple Scripting",
@@ -3694,15 +3512,15 @@
   },
   "d703a5af-d5b0-43bd-8ddb-7a5d500b7da5": {
     "rule_name": "Modification of WDigest Security Provider",
-    "sha256": "7d63d0abff428bf67a031e4be391caf6ec142d6044d5ec8e0c97c1835872e490",
+    "sha256": "cf76266315915f3366228a95730f540c6069fac0024bee0055de9054f16c5c1c",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "d72e33fc-6e91-42ff-ac8b-e573268c5a87": {
     "rule_name": "Command Execution via SolarWinds Process",
-    "sha256": "7b99b1f37d4afb6f85cb3358aa89d765eb877dd3c9f4354b71fa319a88ce039b",
+    "sha256": "fd80e63af37f8a2a7921dc49a3a6d8c2835e23bc3c4595ae3febaf378127ca72",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "d743ff2a-203e-4a46-a3e3-40512cfe8fbb": {
     "rule_name": "Microsoft 365 Exchange Malware Filter Policy Deletion",
@@ -3712,23 +3530,15 @@
   },
   "d75991f2-b989-419d-b797-ac1e54ec2d61": {
     "rule_name": "SystemKey Access via Command Line",
-    "sha256": "bad21256e2539ed2889697b46ad97e31897d99ae6b81423aa0ed71e86c03c165",
+    "sha256": "a18ebe990afbe127f7ea57580737c9d7db9d0e80b10c21bdb54457f92be02107",
     "type": "query",
-    "version": 2
+    "version": 1
   },
   "d76b02ef-fc95-4001-9297-01cb7412232f": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Interactive Terminal Spawned via Python",
-        "sha256": "1b8e9ea27c151d2de3fd5c94f0ff8de14098ccc0348a81ac3a39dc28f0dd118f",
-        "version": 6
-      }
-    },
     "rule_name": "Interactive Terminal Spawned via Python",
-    "sha256": "fb31d0eaf6786a71496f8d2605f731b9e3770b5a16af3d6e301e5b5432154634",
+    "sha256": "1b8e9ea27c151d2de3fd5c94f0ff8de14098ccc0348a81ac3a39dc28f0dd118f",
     "type": "query",
-    "version": 7
+    "version": 6
   },
   "d79c4b2a-6134-4edd-86e6-564a92a933f9": {
     "rule_name": "Azure Blob Permissions Modification",
@@ -3757,15 +3567,9 @@
   },
   "d99a037b-c8e2-47a5-97b9-170d076827c4": {
     "rule_name": "Volume Shadow Copy Deletion via PowerShell",
-    "sha256": "388ee1ef5e4170596ff60bac0033454aee9dd9bd0b146b99f3306e7f52aef1f4",
+    "sha256": "c564a84bd80412505c6c368bbaa4901157515871a4dca9ef8642fad1cdbdf2e1",
     "type": "eql",
-    "version": 3
-  },
-  "da986d2c-ffbf-4fd6-af96-a88dbf68f386": {
-    "rule_name": "Linux Restricted Shell Breakout via the gcc command",
-    "sha256": "0dcf883b0cf19432784e5b592f0e8a9b03bef386eb8d86065ca7d27c3b395443",
-    "type": "eql",
-    "version": 1
+    "version": 2
   },
   "dafa3235-76dc-40e2-9f71-1773b96d24cf": {
     "rule_name": "Multi-Factor Authentication Disabled for an Azure User",
@@ -3787,15 +3591,15 @@
   },
   "dc9c1f74-dac3-48e3-b47f-eb79db358f57": {
     "rule_name": "Volume Shadow Copy Deletion via WMIC",
-    "sha256": "73718af6cf5f96c1d96a0e33fc3a4dbc1295856ee436189ad912e94ac829640b",
+    "sha256": "c7114e3a146e9a6f433e98cf3f746fd92dc8fec7c778c85f81593faa766a1295",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "dca28dee-c999-400f-b640-50a081cc0fd1": {
     "rule_name": "Unusual Country For an AWS Command",
-    "sha256": "4a8c5adcb913d0b9b5b0cbed928925d7a23d8457a0956225a2d036c8ec10f301",
+    "sha256": "f63e24c5a39e77b1e2b0464b83698f95e46229dfcaee35404a06ca3d23e91ce6",
     "type": "machine_learning",
-    "version": 9
+    "version": 8
   },
   "ddab1f5f-7089-44f5-9fda-de5b11322e77": {
     "rule_name": "NullSessionPipe Registry Modification",
@@ -3805,9 +3609,9 @@
   },
   "de9bd7e0-49e9-4e92-a64d-53ade2e66af1": {
     "rule_name": "Unusual Child Process from a System Virtual Process",
-    "sha256": "df0d9aa6e72770666c31afdde320557514d6318422eaa781b5cd48590657bbb7",
+    "sha256": "25b0e6100151bd4ff5c5484ce7221fc4dda10c7d24dfd447a7f604fe70ae74d2",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "debff20a-46bc-4a4d-bae5-5cdd14222795": {
     "rule_name": "Base16 or Base32 Encoding/Decoding Activity",
@@ -3858,13 +3662,13 @@
         "rule_name": "Whitespace Padding in Process Command Line",
         "sha256": "de0b525b55b31026d29a5a835b5e420d95ceaa8d6c6f7e377c3b2cdae2064fdf",
         "type": "eql",
-        "version": 7
+        "version": 5
       }
     },
     "rule_name": "Whitespace Padding in Process Command Line",
-    "sha256": "ab5ccb25f6a2009b8ef47f280cb8c27210fe1bf06e1bff55746754b6d021a2a0",
+    "sha256": "f182f841954adaa9009a1b62d0b98506f864adc4d7ab93e8467f26ada0f518d0",
     "type": "eql",
-    "version": 8
+    "version": 6
   },
   "e0f36de1-0342-453d-95a9-a068b257b053": {
     "rule_name": "Azure Event Hub Deletion",
@@ -3911,9 +3715,9 @@
   },
   "e2f9fdf5-8076-45ad-9427-41e0e03dc9c2": {
     "rule_name": "Suspicious Process Execution via Renamed PsExec Executable",
-    "sha256": "a1f5ea3baf0cdac73a57a9e180cf61389ace52590fbc6f7ca99deefaff67f2c8",
+    "sha256": "866137e7aaff75679d9cb9daec327239af72cebed02ddf3e877a76afd1116ecf",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "e2fb5b18-e33c-4270-851e-c3d675c9afcd": {
     "rule_name": "GCP IAM Role Deletion",
@@ -3923,9 +3727,9 @@
   },
   "e3343ab9-4245-4715-b344-e11c56b0a47f": {
     "rule_name": "Process Activity via Compiled HTML File",
-    "sha256": "14866e4d65402730ee83038804d67b9ad1cd9cd8b5e29b60a6a2a3102d574154",
+    "sha256": "b4768d0f8f0ed9689db41b8f284dda3bc646f7b85d32b60293e82285d6dfa9fc",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "e3c27562-709a-42bd-82f2-3ed926cced19": {
     "rule_name": "AWS Route53 private hosted zone associated with a VPC",
@@ -3941,15 +3745,15 @@
   },
   "e3cf38fa-d5b8-46cc-87f9-4a7513e4281d": {
     "rule_name": "Connection to Commonly Abused Free SSL Certificate Providers",
-    "sha256": "0108b231b6ff6fd18135af37e0c9f0a4946bf4d9930a5a0b2218c5d6f8b84092",
+    "sha256": "b055eb46d4206980a676f50c0e7043bca37dabc37a33fcbd47ceb640532adf6f",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "e3e904b3-0a8e-4e68-86a8-977a163e21d3": {
     "rule_name": "Persistence via KDE AutoStart Script or Desktop File Modification",
-    "sha256": "76403b5bb1d921124b3e30083e2ae88bbeccef82d93ce47455ce0919d5a675a8",
+    "sha256": "b0987f3c7fe63baa9cf5f7327fcd5eb56ef9c49670d24d64de92f40d958e602d",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "e48236ca-b67a-4b4e-840c-fdc7782bc0c3": {
     "rule_name": "Attempt to Modify an Okta Network Zone",
@@ -3958,10 +3762,10 @@
     "version": 6
   },
   "e514d8cd-ed15-4011-84e2-d15147e059f1": {
-    "rule_name": "Kerberos Pre-authentication Disabled for User",
-    "sha256": "de6cb18e9e8679722f5480bca5c052aaf3cb2ae7e478bafe600e2c9b9ef46506",
+    "rule_name": "Kerberos Preauthentication Disabled for User",
+    "sha256": "6da2733caeb41cd77fe6dab1b5fd5441349cef2efd8c0d39481f0cf8f454461e",
     "type": "query",
-    "version": 2
+    "version": 1
   },
   "e555105c-ba6d-481f-82bb-9b633e7b4827": {
     "min_stack_version": "8.0",
@@ -3970,13 +3774,13 @@
         "rule_name": "MFA Disabled for Google Workspace Organization",
         "sha256": "1b8f18bfcd5ebd6a7ef2cad523000d799d2cba09cde203a94541c9ad03327c82",
         "type": "query",
-        "version": 10
+        "version": 8
       }
     },
     "rule_name": "MFA Disabled for Google Workspace Organization",
     "sha256": "aea30c3bf1eb96e0c6f0c64da484ca2310b1ae26e8679030c0a30a8058982a77",
     "type": "query",
-    "version": 11
+    "version": 9
   },
   "e56993d2-759c-4120-984c-9ec9bb940fd5": {
     "rule_name": "RDP (Remote Desktop Protocol) to the Internet",
@@ -4004,9 +3808,9 @@
   },
   "e6e8912f-283f-4d0d-8442-e0dcaf49944b": {
     "rule_name": "Screensaver Plist File Modified by Unexpected Process",
-    "sha256": "b78ca456fd5276e71fb4dd70cc65b83bf83647865562528ed06ee91c4542b971",
+    "sha256": "246d03e49a68169a248914b3d7010e3707f42a27ef57fc08b24727a3b5f06773",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "e7075e8d-a966-458e-a183-85cd331af255": {
     "rule_name": "Default Cobalt Strike Team Server Certificate",
@@ -4028,15 +3832,15 @@
   },
   "e8571d5f-bea1-46c2-9f56-998de2d3ed95": {
     "rule_name": "Service Control Spawned via Script Interpreter",
-    "sha256": "8fe19c0b6cca7e5777e54058ef0f6079b4c4209b2616679bbee54cdace3a536f",
+    "sha256": "8151b1deb537fd602fd988f92448e6eef5ff8ecce725851068f3338f4de8a95e",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "e86da94d-e54b-4fb5-b96c-cecff87e8787": {
     "rule_name": "Installation of Security Support Provider",
-    "sha256": "bae364e240fb0a873de25f69f6f79e34aaad7dc142c41af69719f0bbb657836c",
+    "sha256": "12abcbd73be1245f4c4a087b27c82ce94378f2a0372631b3391c8cf696e7cefa",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "e90ee3af-45fc-432e-a850-4a58cf14a457": {
     "rule_name": "High Number of Okta User Password Reset or Unlock Attempts",
@@ -4052,21 +3856,15 @@
   },
   "e94262f2-c1e9-4d3f-a907-aeab16712e1a": {
     "rule_name": "Unusual Executable File Creation by a System Critical Process",
-    "sha256": "ba48b83e8f0e385808256873cab3e57bce0d236c1c9feea16110362486871dbb",
+    "sha256": "dd2054d650d5ab62a662b60e2b292f49f99261c71ae4c360686b78ea3f5362f8",
     "type": "eql",
-    "version": 5
+    "version": 4
   },
   "e9abe69b-1deb-4e19-ac4a-5d5ac00f72eb": {
     "rule_name": "Potential LSA Authentication Package Abuse",
     "sha256": "8d77171cf0f3a00f7c7f86fa5a55cf2a6f92fb20fe2ac7515ec1c11255a015f9",
     "type": "eql",
     "version": 2
-  },
-  "e9b4a3c7-24fc-49fd-a00f-9c938031eef1": {
-    "rule_name": "Linux Restricted Shell Breakout via busybox Shell Evasion",
-    "sha256": "f5726e1a8ce8508e84699dd4648108f26b624ea175aeb4a0cdace248925f0d8a",
-    "type": "eql",
-    "version": 1
   },
   "e9ff9c1c-fe36-4d0d-b3fd-9e0bf4853a62": {
     "rule_name": "Azure Automation Webhook Created",
@@ -4100,9 +3898,9 @@
   },
   "eb610e70-f9e6-4949-82b9-f1c5bcd37c39": {
     "rule_name": "PowerShell Kerberos Ticket Request",
-    "sha256": "12e68865764cb1f05d6ebb9353693e06d2c742cf994b547711f7fd379654ba42",
+    "sha256": "3b60bd1e0f1c27fe50d75322e0e94e81d6569d94d048a2382ea656abc9e4dcaf",
     "type": "query",
-    "version": 2
+    "version": 1
   },
   "eb9eb8ba-a983-41d9-9c93-a1c05112ca5e": {
     "rule_name": "Potential Disabling of SELinux",
@@ -4112,27 +3910,27 @@
   },
   "ebb200e8-adf0-43f8-a0bb-4ee5b5d852c6": {
     "rule_name": "Mimikatz Memssp Log File Detected",
-    "sha256": "a8103bcc41bedfd85a8511f7e6d3bf8b3b13ca107aba3e48a1ddd7ada099fe1a",
-    "type": "eql",
-    "version": 5
-  },
-  "ebf1adea-ccf2-4943-8b96-7ab11ca173a5": {
-    "rule_name": "IIS HTTP Logging Disabled",
-    "sha256": "0e2278ad91f8c5b1fd3b990bc776e2698ba2713b14833deeb6c76bbdc625341c",
-    "type": "eql",
-    "version": 7
-  },
-  "ebfe1448-7fac-4d59-acea-181bd89b1f7f": {
-    "rule_name": "Process Execution from an Unusual Directory",
-    "sha256": "413005382e39995f1a65b24a1c0e3efb5e4f0fdca179613f9e714a09e199b7b5",
+    "sha256": "df9854e81170ce396fdfc35f6fdfb40c97ee5a8edc656f3e146e11102777b8fb",
     "type": "eql",
     "version": 4
   },
+  "ebf1adea-ccf2-4943-8b96-7ab11ca173a5": {
+    "rule_name": "IIS HTTP Logging Disabled",
+    "sha256": "09683401b4fff4e70db85bd1e692716a304d674c78fa75013cb09ab1e0236835",
+    "type": "eql",
+    "version": 6
+  },
+  "ebfe1448-7fac-4d59-acea-181bd89b1f7f": {
+    "rule_name": "Process Execution from an Unusual Directory",
+    "sha256": "5aeab7a2f59aecec28d8a1dc26d6183214c0b766a78fe542ffa59d282b42e2db",
+    "type": "eql",
+    "version": 3
+  },
   "ec8efb0c-604d-42fa-ac46-ed1cfbc38f78": {
     "rule_name": "Microsoft 365 Inbox Forwarding Rule Created",
-    "sha256": "424f3ef1d9ddc7dc2705c1b02e6ef01b017795d1d812e0b10c9563a4ff232c37",
+    "sha256": "607732c4fa53c679773c0154a36d176db4fc120c4d05c90139bc610165d853b7",
     "type": "query",
-    "version": 3
+    "version": 2
   },
   "ecf2b32c-e221-4bd4-aa3b-c7d59b3bc01d": {
     "rule_name": "AWS RDS Instance/Cluster Stoppage",
@@ -4148,9 +3946,9 @@
   },
   "eda499b8-a073-4e35-9733-22ec71f57f3a": {
     "rule_name": "AdFind Command Activity",
-    "sha256": "11c4de8ecd2064c2bc618687d9ceb19b1b8c051ac157631b679ceff497fae548",
+    "sha256": "aa759afe354ea02b1178b85a62e449549a60c66f29fa1f9bbc36cc6ecc03c7ab",
     "type": "eql",
-    "version": 7
+    "version": 6
   },
   "edb91186-1c7e-4db8-b53e-bfa33a1a0a8a": {
     "rule_name": "Attempt to Deactivate an Okta Application",
@@ -4159,50 +3957,28 @@
     "version": 4
   },
   "edf8ee23-5ea7-4123-ba19-56b41e424ae3": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "ImageLoad via Windows Update Auto Update Client",
-        "sha256": "6f44ec751ed71022884f3953e3b7f63827bdd82eab59cc5f47fbe4322f3f8414",
-        "version": 3
-      }
-    },
     "rule_name": "ImageLoad via Windows Update Auto Update Client",
-    "sha256": "538353688cf30c572e7050514a45b8f636b08280eae7673aad7b225f50b5f744",
-    "type": "eql",
-    "version": 4
-  },
-  "ee5300a7-7e31-4a72-a258-250abb8b3aa1": {
-    "min_stack_version": "7.16.0",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Unusual Print Spooler Child Process",
-        "sha256": "fe16e0a19a093e954a5c00eb0065d8cb2c1f7064b970bee83ceb761555c259c2",
-        "version": 4
-      }
-    },
-    "rule_name": "Unusual Print Spooler Child Process",
-    "sha256": "ddb1a4dc2a91661de7dcfb7b0694d46aeab631523f60a9069b45cee20a794644",
-    "type": "eql",
-    "version": 5
-  },
-  "ee619805-54d7-4c56-ba6f-7717282ddd73": {
-    "rule_name": "Linux Restricted Shell Breakout via crash Shell evasion",
-    "sha256": "284931b7332c5d8775ad1b0d93e012b6b7391afd6b546209c576ebbb44f85a80",
-    "type": "eql",
-    "version": 1
-  },
-  "eea82229-b002-470e-a9e1-00be38b14d32": {
-    "rule_name": "Potential Privacy Control Bypass via TCCDB Modification",
-    "sha256": "6fa6e956eb12b63782fc63c6f32c520a9f7b0d87f3837a9c5514b2bdf35ca6ee",
+    "sha256": "6f44ec751ed71022884f3953e3b7f63827bdd82eab59cc5f47fbe4322f3f8414",
     "type": "eql",
     "version": 3
   },
+  "ee5300a7-7e31-4a72-a258-250abb8b3aa1": {
+    "rule_name": "Unusual Print Spooler Child Process",
+    "sha256": "58881af4b4b5bc650329bddcf9a241e080d105eca0fc158b58ae94fe71c8e753",
+    "type": "eql",
+    "version": 3
+  },
+  "eea82229-b002-470e-a9e1-00be38b14d32": {
+    "rule_name": "Potential Privacy Control Bypass via TCCDB Modification",
+    "sha256": "db0c018993905d4f31b0d66f2b4dc8757c3c7d2228c2e56d1c15d4bc3309075c",
+    "type": "eql",
+    "version": 2
+  },
   "ef862985-3f13-4262-a686-5f357bbb9bc2": {
     "rule_name": "Whoami Process Activity",
-    "sha256": "319c4123b31ad2196672f2a0ff57e66a3ab8862dd8f2f7b537e2cd5fc6603068",
+    "sha256": "fe2c910bebef36620062b269c0448a3fd9b43c00833778137700385bfcca4a7b",
     "type": "eql",
-    "version": 8
+    "version": 7
   },
   "f036953a-4615-4707-a1ca-dc53bf69dcd5": {
     "rule_name": "Unusual Child Processes of RunDLL32",
@@ -4218,9 +3994,9 @@
   },
   "f0b48bbc-549e-4bcf-8ee0-a7a72586c6a7": {
     "rule_name": "Attempt to Remove File Quarantine Attribute",
-    "sha256": "4ff19316c8b3536f59deae663c274c2a8ab6a2addcef635c347b28e515d4bd38",
+    "sha256": "0f27489f0578b5596891555022bb25c63bfe725160ab7d93c8c02efb92a40463",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "f0bc081a-2346-4744-a6a4-81514817e888": {
     "rule_name": "Azure Alert Suppression Rule Created or Modified",
@@ -4236,15 +4012,15 @@
   },
   "f24bcae1-8980-4b30-b5dd-f851b055c9e7": {
     "rule_name": "Creation of Hidden Login Item via Apple Script",
-    "sha256": "ba0c743f8ab5070eed3f4c95b7373da00c1c49f8919bccc4113a4d73c733391b",
+    "sha256": "687a91ad38f1a50dc0a07c13c05aa7655159f7537889038cd0ef4c720ff24fd9",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "f28e2be4-6eca-4349-bdd9-381573730c22": {
     "rule_name": "Potential OpenSSH Backdoor Logging Activity",
-    "sha256": "3cbd01915b107fea443d95d3745e5e570e2a31f0087d7029f3feb633371fe181",
+    "sha256": "0bf0f53f6fd19a94d99b558b91d1893ebe242c85c4d77ad0f853700b0be8d614",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "f2c7b914-eda3-40c2-96ac-d23ef91776ca": {
     "rule_name": "SIP Provider Modification",
@@ -4253,18 +4029,10 @@
     "version": 2
   },
   "f2f46686-6f3c-4724-bd7d-24e31c70f98f": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "LSASS Memory Dump Creation",
-        "sha256": "1bb7f26beff47b579126c16832e72166cee2812ed3b488223fd921bcfc96f456",
-        "version": 5
-      }
-    },
     "rule_name": "LSASS Memory Dump Creation",
-    "sha256": "fe88f88d9dffe80847b75edf70c1e2c4e578b0f4105a52f19723aa9cf4a87603",
+    "sha256": "1bb7f26beff47b579126c16832e72166cee2812ed3b488223fd921bcfc96f456",
     "type": "eql",
-    "version": 6
+    "version": 5
   },
   "f30f3443-4fbb-4c27-ab89-c3ad49d62315": {
     "rule_name": "AWS RDS Instance Creation",
@@ -4286,39 +4054,33 @@
   },
   "f44fa4b6-524c-4e87-8d9e-a32599e4fb7c": {
     "rule_name": "Persistence via Microsoft Office AddIns",
-    "sha256": "d8203073cb9b2238107d828480603ad46f5042d8a81704a91e7e71b0e0c38c6d",
+    "sha256": "e10cd34197457df5ffa89b628dfbd7d9ccbb89c295b5b2de5d3a305df3a8d158",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "f494c678-3c33-43aa-b169-bb3d5198c41d": {
     "rule_name": "Sensitive Privilege SeEnableDelegationPrivilege assigned to a User",
-    "sha256": "eecab9d844d7c668c58ebc73c275471aaa3eb0488535c2b08afd0f980a77a175",
+    "sha256": "f289922736ffd6e74e180daa7f30a3b93686535463b8d9949f29722388e2a75f",
     "type": "query",
-    "version": 2
-  },
-  "f52362cd-baf1-4b6d-84be-064efc826461": {
-    "rule_name": "Linux Restricted Shell Breakout via flock Shell evasion",
-    "sha256": "9a30702aaa4b583d4dfed22529c75be33a32d661580c7885d29a45fb627ec6b7",
-    "type": "eql",
     "version": 1
   },
   "f545ff26-3c94-4fd0-bd33-3c7f95a3a0fc": {
     "rule_name": "Windows Script Executing PowerShell",
-    "sha256": "16bb5b4d0080ab3334bf9efb00c73a6e7ddeefc07a959db37ba971f1b12f3e17",
+    "sha256": "9675f6c2d6b7bc26b770ed6f8bb5668058bb865b782423786a1ebb70bf5de797",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "f63c8e3c-d396-404f-b2ea-0379d3942d73": {
     "rule_name": "Windows Firewall Disabled via PowerShell",
-    "sha256": "ec71a3ed4b21d685b3c9930d353d7916e9e5eb903d2c8cb8848b2f39e1da8098",
+    "sha256": "841cadac1dd3470f4549689e834749aef7cee102c1ab901ea1e65ea87af475d6",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "f675872f-6d85-40a3-b502-c0d2ef101e92": {
     "rule_name": "Delete Volume USN Journal with Fsutil",
-    "sha256": "81dd7f5072dfe02a8bc46c3235883cda82b0941f34c4334fbfe738f8373079a2",
+    "sha256": "cc34e136a98a0c3da501db77e87e4418a36d9fa1a9af7f2809b0e876a0685baa",
     "type": "eql",
-    "version": 10
+    "version": 9
   },
   "f683dcdf-a018-4801-b066-193d4ae6c8e5": {
     "rule_name": "SoftwareUpdate Preferences Modification",
@@ -4328,9 +4090,9 @@
   },
   "f766ffaf-9568-4909-b734-75d19b35cbf4": {
     "rule_name": "Azure Service Principal Credentials Added",
-    "sha256": "66ef58015fb2d2ff7483def6fea4d52755e99bc2cdc2a12f63ccba87b16641db",
+    "sha256": "4b1671042f16430f483118a068274d7d28eb2e09124df8365a96a357899dd742",
     "type": "query",
-    "version": 2
+    "version": 1
   },
   "f772ec8a-e182-483c-91d2-72058f76a44c": {
     "rule_name": "AWS CloudWatch Alarm Deletion",
@@ -4340,15 +4102,15 @@
   },
   "f7c4dc5a-a58d-491d-9f14-9b66507121c0": {
     "rule_name": "Persistent Scripts in the Startup Directory",
-    "sha256": "bb1191d6f9f749c46e6b4c3e716044498d576f5349622f9806ddb108a66b76b3",
+    "sha256": "e4fc24490738631aa609769246c6540ec8b95528a75c4ba57e34c547985bc047",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "f81ee52c-297e-46d9-9205-07e66931df26": {
     "rule_name": "Microsoft Exchange Worker Spawning Suspicious Processes",
-    "sha256": "dbfc825366177f189fda86d93c1a1a0c0c78ee47a6cb4bd8d6632cb38292641e",
+    "sha256": "ec14e52e83826d9560d3fd5517acd8ea8328d2ee89f66fdfdc679bc2843e2eb3",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "f85ce03f-d8a8-4c83-acdc-5c8cd0592be7": {
     "rule_name": "Suspicious Child Process of Adobe Acrobat Reader Update Service",
@@ -4358,9 +4120,9 @@
   },
   "f874315d-5188-4b4a-8521-d1c73093a7e4": {
     "rule_name": "Modification of AmsiEnable Registry Key",
-    "sha256": "405111199c8c503d24778b4d2fb10946691622b1eb16de257a6fc695f20d3133",
+    "sha256": "0533f464fc056492b1be7563a334064ed3a94794b0fc726a8f6c58af99f3fc69",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "f9590f47-6bd5-4a49-bd49-a2f886476fb9": {
     "rule_name": "Unusual Linux System Network Configuration Discovery",
@@ -4376,23 +4138,15 @@
   },
   "fa01341d-6662-426b-9d0c-6d81e33c8a9d": {
     "rule_name": "Remote File Copy to a Hidden Share",
-    "sha256": "4e1765ba0371caf2c48160431eb226f0090b88ade59e8d702f98df7448cc788b",
+    "sha256": "0bcc52e13022bb037d72173ac8df764dc3ed52b276fb65e89798744dcaac3aff",
     "type": "eql",
-    "version": 4
+    "version": 3
   },
   "fb02b8d3-71ee-4af1-bacd-215d23f17efa": {
-    "min_stack_version": "7.16.0",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Network Connection via Registration Utility",
-        "sha256": "cdee88e91070d7a8c85aaec9d595418a9392d5e0a0a561789d4a51234aa790c8",
-        "version": 10
-      }
-    },
     "rule_name": "Network Connection via Registration Utility",
-    "sha256": "e8a62abdfa0057ddc9ccfb78efdf4c3c8ab6e01fe6540087df5df85320283d52",
+    "sha256": "cdee88e91070d7a8c85aaec9d595418a9392d5e0a0a561789d4a51234aa790c8",
     "type": "eql",
-    "version": 11
+    "version": 10
   },
   "fb9937ce-7e21-46bf-831d-1ad96eac674d": {
     "rule_name": "Auditd Max Failed Login Attempts",
@@ -4408,61 +4162,39 @@
   },
   "fc7c0fa4-8f03-4b3e-8336-c5feab0be022": {
     "rule_name": "UAC Bypass Attempt via Elevated COM Internet Explorer Add-On Installer",
-    "sha256": "dfe655097f29b7564cc2d0e02c7f3301948e3054b605caaedd2808d8651c113e",
+    "sha256": "8519a65c58825cc9ac20c90228acf96311026b61e6cfd0e17b73f27434bdf4d2",
     "type": "eql",
-    "version": 5
-  },
-  "fd3fc25e-7c7c-4613-8209-97942ac609f6": {
-    "rule_name": "Linux Restricted Shell Breakout via the expect command",
-    "sha256": "39518f23768d9d8d0aee453661f03bc6b0f23cbb1de79fc370a7816ecebba032",
-    "type": "eql",
-    "version": 1
+    "version": 4
   },
   "fd4a992d-6130-4802-9ff8-829b89ae801f": {
     "rule_name": "Potential Application Shimming via Sdbinst",
-    "sha256": "3c48f13a701de32361892a981d4eb05f2a8c7149984328496e2c10413facd24a",
+    "sha256": "96d6852fdd698f7298c41ddc6f5f45e8b8a82fefa5c52e1d9183b97850470400",
     "type": "eql",
-    "version": 9
+    "version": 8
   },
   "fd70c98a-c410-42dc-a2e3-761c71848acf": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Suspicious CertUtil Commands",
-        "sha256": "122b3b7f61d4146ddcd3551328c63fd1c56f01dad1616d83022d2265375ce1ac",
-        "version": 10
-      }
-    },
     "rule_name": "Suspicious CertUtil Commands",
-    "sha256": "48842212ae6455135f5ac627d1ff61491e2c46152f841707485ccc13ddd506ce",
-    "type": "eql",
-    "version": 11
-  },
-  "fd7a6052-58fa-4397-93c3-4795249ccfa2": {
-    "min_stack_version": "8.2",
-    "previous": {
-      "7.13.0": {
-        "rule_name": "Svchost spawning Cmd",
-        "sha256": "9886a3ef5cce6fcdc6eeab91abaf4ffd8543a0ef56a76d6d9588eb585d71f3ec",
-        "version": 9
-      }
-    },
-    "rule_name": "Svchost spawning Cmd",
-    "sha256": "bc1c7141ea3d1793d032e8ef37e991fa5b75f3dbffabeb5843f5625f90a7291d",
+    "sha256": "122b3b7f61d4146ddcd3551328c63fd1c56f01dad1616d83022d2265375ce1ac",
     "type": "eql",
     "version": 10
   },
+  "fd7a6052-58fa-4397-93c3-4795249ccfa2": {
+    "rule_name": "Svchost spawning Cmd",
+    "sha256": "3d1669ea32950b0330c14ea0ed19dd4205c656d44f4860b304c3b103c487c717",
+    "type": "eql",
+    "version": 8
+  },
   "fe794edd-487f-4a90-b285-3ee54f2af2d3": {
     "rule_name": "Microsoft Windows Defender Tampering",
-    "sha256": "ca7354db67f950fb406782499a38954ab5d8065ce2876236971f85afa96d0cb9",
+    "sha256": "96e700cedbd912428d2141285aeb62d039ba2b0ef593f70f72c0faaca1896dd4",
     "type": "eql",
-    "version": 3
+    "version": 2
   },
   "feeed87c-5e95-4339-aef1-47fd79bcfbe3": {
     "rule_name": "MS Office Macro Security Registry Modifications",
-    "sha256": "6792430fea2750424fd5efe256cbb96c69b93767b45e0fc15ba33a9732c92b76",
+    "sha256": "5fdc6d766a59b36c16b02377c9284e22b5a2df1d9d3fcca9e215378f032e4e59",
     "type": "eql",
-    "version": 2
+    "version": 1
   },
   "ff013cb4-274d-434a-96bb-fe15ddd3ae92": {
     "rule_name": "Roshal Archive (RAR) or PowerShell File Downloaded from the Internet",
@@ -4472,9 +4204,9 @@
   },
   "ff4dd44a-0ac6-44c4-8609-3f81bc820f02": {
     "rule_name": "Microsoft 365 Exchange Transport Rule Creation",
-    "sha256": "c9b9e41a62d00bd5dfba4dea0aa6963a3f2ae3ca40b2e997c0cd0f05725e3749",
+    "sha256": "ccdc2ee09712e2a2ea42f40d9aa8bbb35835b6251cfc22ca520f2f5eec5ae28e",
     "type": "query",
-    "version": 6
+    "version": 5
   },
   "ff9b571e-61d6-4f6c-9561-eb4cca3bafe1": {
     "rule_name": "GCP Firewall Rule Deletion",


### PR DESCRIPTION
## Issues

related to #1924 

## Summary

Reverts elastic/detection-rules#1922

No updates or releases pushed since the lock, so reverting should be fine in this case
