### PR TITLE
[Rule Tuning] Add timestamp_override config note to 8.1 rules

### DIFF
--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/07/07"
 maturity = "production"
-updated_date = "2021/10/27"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,10 @@ license = "Elastic License v2"
 name = "Hosts File Modified"
 note = """## Config
 
-For Windows systems using Auditbeat, this rule requires adding `C:/Windows/System32/drivers/etc` as an additional path in the 'file_integrity' module of auditbeat.yml."""
+For Windows systems using Auditbeat, this rule requires adding `C:/Windows/System32/drivers/etc` as an additional path in the 'file_integrity' module of auditbeat.yml.
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://www.elastic.co/guide/en/beats/auditbeat/current/auditbeat-reference-yml.html"]
 risk_score = 47
 rule_id = "9c260313-c811-4ec8-ab89-8f6530e0246c"

--- a/rules/windows/credential_access_lsass_memdump_file_created.toml
+++ b/rules/windows/credential_access_lsass_memdump_file_created.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/24"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "LSASS Memory Dump Creation"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://github.com/outflanknl/Dumpert", "https://github.com/hoangprod/AndrewSpecial"]
 risk_score = 73
 rule_id = "f2f46686-6f3c-4724-bd7d-24e31c70f98f"
@@ -32,16 +36,16 @@ file where file.name : ("lsass*.dmp", "dumpert.dmp", "Andrew.dmp", "SQLDmpr*.mdm
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1003"
-reference = "https://attack.mitre.org/techniques/T1003/"
 name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.001"
+name = "LSASS Memory"
+reference = "https://attack.mitre.org/techniques/T1003/001/"
 
-  [[rule.threat.technique.subtechnique]]
-  name = "LSASS Memory"
-  id = "T1003.001"
-  reference = "https://attack.mitre.org/techniques/T1003/001/"
+
 
 [rule.threat.tactic]
 id = "TA0006"
-reference = "https://attack.mitre.org/tactics/TA0006/"
 name = "Credential Access"
-
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/04/14"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Adding Hidden File Attribute via Attrib"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "4630d948-40d4-4cef-ac69-4002e29bc3db"
 severity = "low"
@@ -28,24 +32,23 @@ process where event.type in ("start", "process_started") and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1564"
-reference = "https://attack.mitre.org/techniques/T1564/"
 name = "Hide Artifacts"
+reference = "https://attack.mitre.org/techniques/T1564/"
 [[rule.threat.technique.subtechnique]]
 id = "T1564.001"
-reference = "https://attack.mitre.org/techniques/T1564/001/"
 name = "Hidden Files and Directories"
+reference = "https://attack.mitre.org/techniques/T1564/001/"
 
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
 [rule.threat.tactic]
 id = "TA0003"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 name = "Persistence"
-
+reference = "https://attack.mitre.org/tactics/TA0003/"

--- a/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
+++ b/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/13"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -14,6 +14,10 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "ImageLoad via Windows Update Auto Update Client"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = ["https://dtm.uk/wuauclt/"]
 risk_score = 47
 rule_id = "edf8ee23-5ea7-4123-ba19-56b41e424ae3"
@@ -44,4 +48,3 @@ reference = "https://attack.mitre.org/techniques/T1218/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-

--- a/rules/windows/defense_evasion_suspicious_certutil_commands.toml
+++ b/rules/windows/defense_evasion_suspicious_certutil_commands.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2021/10/15"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
 description = """
-Identifies suspicious commands being used with certutil.exe. CertUtil is a native Windows component which is part of 
-Certificate Services. CertUtil is often abused by attackers to live off the land for stealthier command and control or 
+Identifies suspicious commands being used with certutil.exe. CertUtil is a native Windows component which is part of
+Certificate Services. CertUtil is often abused by attackers to live off the land for stealthier command and control or
 data exfiltration.
 """
 from = "now-9m"
@@ -15,6 +15,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious CertUtil Commands"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 references = [
     "https://twitter.com/Moriarty_Meng/status/984380793383370752",
     "https://twitter.com/egre55/status/1087685529016193025",
@@ -39,12 +43,11 @@ process where event.type == "start" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1140"
-reference = "https://attack.mitre.org/techniques/T1140/"
 name = "Deobfuscate/Decode Files or Information"
+reference = "https://attack.mitre.org/techniques/T1140/"
 
 
 [rule.threat.tactic]
 id = "TA0005"
-reference = "https://attack.mitre.org/tactics/TA0005/"
 name = "Defense Evasion"
-
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2022/03/28"
+updated_date = "2022/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -11,6 +11,10 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Svchost spawning Cmd"
+note = """## Config
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
 risk_score = 21
 rule_id = "fd7a6052-58fa-4397-93c3-4795249ccfa2"
 severity = "low"
@@ -35,11 +39,11 @@ process where event.type == "start" and
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1059"
-reference = "https://attack.mitre.org/techniques/T1059/"
 name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
 
 
 [rule.threat.tactic]
 id = "TA0002"
-reference = "https://attack.mitre.org/tactics/TA0002/"
 name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
Resolves #1924 

## Summary

Add config note for expanding timestamp overrides to backport 7.13-8.0. 

