### PR TITLE
[Rule Tuning] Remove `logs-windows.*` index

### DIFF
--- a/rules/windows/credential_access_disable_kerberos_preauth.toml
+++ b/rules/windows/credential_access_disable_kerberos_preauth.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/01/24"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies the modification of an account's Kerberos pre-authentication options.
 the account can maliciously modify these settings to perform offline password cracking attacks such as AS-REP roasting.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kerberos Pre-authentication Disabled for User"

--- a/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
+++ b/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/01/27"
 maturity = "production"
-updated_date = "2022/02/28"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ SeEnableDelegationPrivilege "user right" enables computer and user accounts to b
 abuse this right to compromise Active Directory accounts and elevate their privileges.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Sensitive Privilege SeEnableDelegationPrivilege assigned to a User"

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/01/26"
 maturity = "production"
-updated_date = "2022/01/31"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Potential Shadow Credentials added to AD Object"

--- a/rules/windows/defense_evasion_clearing_windows_security_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_security_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/12"
 maturity = "production"
-updated_date = "2021/09/23"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic", "Anabella Cristaldi"]
@@ -10,7 +10,7 @@ Identifies attempts to clear Windows event log stores. This is often done by att
 or destroy forensic evidence on a system.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Windows Event Logs Cleared"

--- a/rules/windows/discovery_privileged_localgroup_membership.toml
+++ b/rules/windows/discovery_privileged_localgroup_membership.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/15"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_privileged_localgroup_membership.toml
+++ b/rules/windows/discovery_privileged_localgroup_membership.toml
@@ -10,7 +10,7 @@ Identifies instances of an unusual process enumerating built-in Windows privileg
 Administrators or Remote Desktop users.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Enumeration of Privileged Local Groups Membership"

--- a/rules/windows/persistence_ad_adminsdholder.toml
+++ b/rules/windows/persistence_ad_adminsdholder.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/01/31"
 maturity = "production"
-updated_date = "2022/01/31"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ the protected accounts and groups are reset to match those of the domain's Admin
 Administrative Privileges.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AdminSDHolder Backdoor"

--- a/rules/windows/persistence_msds_alloweddelegateto_krbtgt.toml
+++ b/rules/windows/persistence_msds_alloweddelegateto_krbtgt.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/01/27"
 maturity = "production"
-updated_date = "2022/01/27"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic"]
@@ -10,7 +10,7 @@ Identifies the modification of the msDS-AllowedToDelegateTo attribute to KRBTGT.
 maintain persistence to the domain by having the ability to request tickets for the KRBTGT service.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "KRBTGT Delegation Backdoor"

--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/10/18"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ access or evade password duration policies and preserve compromised credentials.
 """
 false_positives = ["Legitimate remote account administration."]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Account Password Reset Remotely"

--- a/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
+++ b/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/09"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic", "Skoetting"]
@@ -11,7 +11,7 @@ Directory are those to which powerful rights, privileges, and permissions are gr
 any action in Active Directory and on domain-joined systems.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "User Added to Privileged Group in Active Directory"

--- a/rules/windows/persistence_user_account_creation_event_logs.toml
+++ b/rules/windows/persistence_user_account_creation_event_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/04"
 maturity = "development"
-updated_date = "2021/09/23"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Skoetting"]
@@ -16,7 +16,7 @@ false_positives = [
     behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
-index = ["winlogbeat-*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Creation of a local user account"

--- a/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
+++ b/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/12/12"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/04/13"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ elevate privileges from a standard domain user to a user with domain admin privi
 vulnerability that allows potential attackers to impersonate a domain controller via samAccountName attribute spoofing.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-system.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privileged Escalation via SamAccountName Spoofing"


### PR DESCRIPTION
## Summary

Remove the `logs-windows.*` index from rules that uses security, application or system logs.

> Note that for 7.11, security, application and system logs have been moved to the system package.
https://github.com/elastic/integrations/tree/main/packages/windows