### PR TITLE
Manually reconciled versions from forked rule package generation bug

### DIFF
--- a/detection_rules/etc/version.lock.json
+++ b/detection_rules/etc/version.lock.json
@@ -908,13 +908,13 @@
         "rule_name": "Telnet Port Activity",
         "sha256": "3dd4a438c915920e6ddb0a5212603af5d94fb8a6b51a32f223d930d7e3becb89",
         "type": "query",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Telnet Port Activity",
     "sha256": "b0bdfa73639226fb83eadc0303ad1801e0707743f96a36209aa58228d3bf6a89",
     "type": "query",
-    "version": 10
+    "version": 12
   },
   "35330ba2-c859-4c98-8b7f-c19159ea0e58": {
     "rule_name": "Execution via Electron Child Process Node.js Module",
@@ -1176,13 +1176,13 @@
         "rule_name": "Adding Hidden File Attribute via Attrib",
         "sha256": "0c8c7cbbc5634f75e64baccadab65dea2d7b617c6529b847c00105cadd6b1770",
         "type": "eql",
-        "version": 10
+        "version": 12
       }
     },
     "rule_name": "Adding Hidden File Attribute via Attrib",
     "sha256": "9adc15a3acfef979ec710bc2303ef945a4a40f8ccb39a054838b4eaa6a3ac0b9",
     "type": "eql",
-    "version": 11
+    "version": 13
   },
   "46f804f5-b289-43d6-a881-9387cf594f75": {
     "rule_name": "Unusual Process For a Linux Host",
@@ -1372,13 +1372,13 @@
         "rule_name": "Uncommon Registry Persistence Change",
         "sha256": "53219ff8987584e6547f9575812b0376420e95da290d5f3e600c864516a5d0d4",
         "type": "eql",
-        "version": 6
+        "version": 8
       }
     },
     "rule_name": "Uncommon Registry Persistence Change",
     "sha256": "eab90afc9e1bee717a0f2d2c8d444c6ea131d22bdee7de0f594f43235e7286bc",
     "type": "eql",
-    "version": 7
+    "version": 9
   },
   "54c3d186-0461-4dc3-9b33-2dc5c7473936": {
     "rule_name": "Network Logon Provider Registry Modification",
@@ -1757,13 +1757,13 @@
         "rule_name": "Google Workspace Admin Role Assigned to a User",
         "sha256": "a9e5fed2c237cba481fd05a38576032d3cddf5a3b67341030a4a77725c478b22",
         "type": "query",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Google Workspace Admin Role Assigned to a User",
     "sha256": "afd34ab4f1d7e038c874333fd83de248c0b54d625f489e74359f3ce4ec9ac71b",
     "type": "query",
-    "version": 10
+    "version": 12
   },
   "689b9d57-e4d5-4357-ad17-9c334609d79a": {
     "rule_name": "Scheduled Task Created by a Windows Script",
@@ -1881,13 +1881,13 @@
         "rule_name": "Google Workspace Role Modified",
         "sha256": "4776d80c0d1069ed8363242d7b09b4934c3efc58c9db2b87fb5045eda98284e1",
         "type": "query",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Google Workspace Role Modified",
     "sha256": "33a6f2e64d79ebfed4fe0f1b4e5c4a7968b9b4941e11fa0cf720ef3810e38a15",
     "type": "query",
-    "version": 10
+    "version": 12
   },
   "6f683345-bb10-47a7-86a7-71e9c24fb358": {
     "rule_name": "Linux Restricted Shell Breakout via the find command",
@@ -2029,13 +2029,13 @@
         "rule_name": "Application Added to Google Workspace Domain",
         "sha256": "43a87b2b542b409c6cfbe267485d8b1ba8e32e9ea553f6180b7d0362c46ea2d9",
         "type": "query",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Application Added to Google Workspace Domain",
     "sha256": "ab5ac05b1f57b0e9a197d51506441eee921132528fde66e99b64021454556e71",
     "type": "query",
-    "version": 10
+    "version": 12
   },
   "7882cebf-6cf1-4de3-9662-213aa13e8b80": {
     "rule_name": "Azure Privilege Identity Management Role Modified",
@@ -2305,13 +2305,13 @@
         "rule_name": "RDP (Remote Desktop Protocol) from the Internet",
         "sha256": "b6d7ad4ee2f11ab3ed8aa4bcee08a462a4b3aa3790ae27abd86cee6d921e3283",
         "type": "query",
-        "version": 11
+        "version": 13
       }
     },
     "rule_name": "RDP (Remote Desktop Protocol) from the Internet",
     "sha256": "e8b7d833a2cad5ad92e04ba43b572eb374e775daa2ec9fa71f72a4b5cad614ee",
     "type": "query",
-    "version": 12
+    "version": 14
   },
   "8c37dc0e-e3ac-4c97-8aa0-cf6a9122de45": {
     "rule_name": "Unusual Child Process of dns.exe",
@@ -2458,13 +2458,13 @@
         "rule_name": "Google Workspace Admin Role Deletion",
         "sha256": "3c0f93a51365de485043e4961faba1a74302db6036510abbde8f1b0b60e4de3b",
         "type": "query",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Google Workspace Admin Role Deletion",
     "sha256": "7f3e1672e2c15b1f4386242655493bbd483c0c30d377b65c94cadf17d5dbb100",
     "type": "query",
-    "version": 10
+    "version": 12
   },
   "93f47b6f-5728-4004-ba00-625083b3dcb0": {
     "rule_name": "Modification of Standard Authentication Module or Configuration",
@@ -2545,13 +2545,13 @@
         "rule_name": "Startup or Run Key Registry Modification",
         "sha256": "1827b7a04db141b503dcbe4bdd0c18468ccc43b937e02c76d1f2e7686d2b17ef",
         "type": "eql",
-        "version": 5
+        "version": 7
       }
     },
     "rule_name": "Startup or Run Key Registry Modification",
     "sha256": "d7812909f8d6b7f07a49520b790a1a5d653f213f6d542753f78f0d29e06b612c",
     "type": "eql",
-    "version": 6
+    "version": 8
   },
   "9890ee61-d061-403d-9bf6-64934c51f638": {
     "rule_name": "GCP IAM Service Account Key Deletion",
@@ -2633,7 +2633,7 @@
     "rule_name": "Hosts File Modified",
     "sha256": "49a57a69fbfe3f0af1977b95830f2c3bd244cd7fe73ecdb2f7ebbd5c65183d86",
     "type": "eql",
-    "version": 8
+    "version": 9
   },
   "9ccf3ce0-0057-440a-91f5-870c6ad39093": {
     "rule_name": "Command Shell Activity Started via RunDLL32",
@@ -2841,13 +2841,13 @@
         "rule_name": "Google Workspace Password Policy Modified",
         "sha256": "cadc95b5eb7938b3b7310150089830d4dad51e3499916cd2f5c82446659b4051",
         "type": "query",
-        "version": 10
+        "version": 12
       }
     },
     "rule_name": "Google Workspace Password Policy Modified",
     "sha256": "7741aa9c38ba126329fbb075496847374a2dd8d65aadd49aa25b7f0f00e6aeb5",
     "type": "query",
-    "version": 11
+    "version": 13
   },
   "a9b05c3b-b304-4bf9-970d-acdfaef2944c": {
     "rule_name": "Persistence via Hidden Run Key Detected",
@@ -2916,13 +2916,13 @@
         "rule_name": "Google Workspace API Access Granted via Domain-Wide Delegation of Authority",
         "sha256": "01a8beca2e8f570d63e7614d558243b1d0b9c42d9e0ce9f439b10016f06eaea3",
         "type": "query",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Google Workspace API Access Granted via Domain-Wide Delegation of Authority",
     "sha256": "3d8eab60bf795ae6756c1c6058a7c1be2eb14e1c1777a7b4bda27e1906206c95",
     "type": "query",
-    "version": 10
+    "version": 12
   },
   "acd611f3-2b93-47b3-a0a3-7723bcc46f6d": {
     "rule_name": "Potential Command and Control via Internet Explorer",
@@ -2961,13 +2961,13 @@
         "rule_name": "Google Workspace Custom Admin Role Created",
         "sha256": "8b04328630ae74389a2b77d23700d2bfd3900c6008bf0aa9654c2432b427b9c9",
         "type": "query",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Google Workspace Custom Admin Role Created",
     "sha256": "72ff218857ba09e7c08970ebc6cdfcba3cd1dd4f0711dbd403b074fee911011c",
     "type": "query",
-    "version": 10
+    "version": 12
   },
   "ad84d445-b1ce-4377-82d9-7c633f28bf9a": {
     "rule_name": "Suspicious Portable Executable Encoded in Powershell Script",
@@ -3479,13 +3479,13 @@
         "rule_name": "Google Workspace MFA Enforcement Disabled",
         "sha256": "f8496e8188b47da802b79dba6b01c3f9f4e4d7fe9c0adf98503ec33e0a2f6747",
         "type": "query",
-        "version": 10
+        "version": 12
       }
     },
     "rule_name": "Google Workspace MFA Enforcement Disabled",
     "sha256": "de718fed93c2314061daddd300ddb5e01064210ddc42d687fcdd988aa2595d5a",
     "type": "query",
-    "version": 11
+    "version": 13
   },
   "cb71aa62-55c8-42f0-b0dd-afb0bb0b1f51": {
     "rule_name": "Suspicious Calendar File Modification",
@@ -3578,13 +3578,13 @@
         "rule_name": "Domain Added to Google Workspace Trusted Domains",
         "sha256": "5cbeb7ba36d4bca274e78516b67aa418552a39af7ff07d0605a306cacb27a1ef",
         "type": "query",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Domain Added to Google Workspace Trusted Domains",
     "sha256": "734ba85eb72a8c8167a1247c75d48bbd9abb0a9954f8a357a20017258da978de",
     "type": "query",
-    "version": 10
+    "version": 12
   },
   "cff92c41-2225-4763-b4ce-6f71e5bda5e6": {
     "rule_name": "Execution from Unusual Directory - Command Line",
@@ -3732,13 +3732,13 @@
         "rule_name": "Interactive Terminal Spawned via Python",
         "sha256": "1b8e9ea27c151d2de3fd5c94f0ff8de14098ccc0348a81ac3a39dc28f0dd118f",
         "type": "query",
-        "version": 6
+        "version": 8
       }
     },
     "rule_name": "Interactive Terminal Spawned via Python",
     "sha256": "fb31d0eaf6786a71496f8d2605f731b9e3770b5a16af3d6e301e5b5432154634",
     "type": "query",
-    "version": 7
+    "version": 9
   },
   "d79c4b2a-6134-4edd-86e6-564a92a933f9": {
     "rule_name": "Azure Blob Permissions Modification",
@@ -3980,13 +3980,13 @@
         "rule_name": "MFA Disabled for Google Workspace Organization",
         "sha256": "1b8f18bfcd5ebd6a7ef2cad523000d799d2cba09cde203a94541c9ad03327c82",
         "type": "query",
-        "version": 10
+        "version": 12
       }
     },
     "rule_name": "MFA Disabled for Google Workspace Organization",
     "sha256": "aea30c3bf1eb96e0c6f0c64da484ca2310b1ae26e8679030c0a30a8058982a77",
     "type": "query",
-    "version": 11
+    "version": 13
   },
   "e56993d2-759c-4120-984c-9ec9bb940fd5": {
     "rule_name": "RDP (Remote Desktop Protocol) to the Internet",
@@ -4175,13 +4175,13 @@
         "rule_name": "ImageLoad via Windows Update Auto Update Client",
         "sha256": "e971abb85880898c0a7f38127565be02a2d427cba85fca159380368553ae06ef",
         "type": "eql",
-        "version": 4
+        "version": 6
       }
     },
     "rule_name": "ImageLoad via Windows Update Auto Update Client",
     "sha256": "538353688cf30c572e7050514a45b8f636b08280eae7673aad7b225f50b5f744",
     "type": "eql",
-    "version": 5
+    "version": 7
   },
   "ee5300a7-7e31-4a72-a258-250abb8b3aa1": {
     "min_stack_version": "7.16.0",
@@ -4271,13 +4271,13 @@
         "rule_name": "LSASS Memory Dump Creation",
         "sha256": "c20cf6ad2f9a2341f530aa7cd2335230d2af19bea5f06d81c3d7dbb65e7d38af",
         "type": "eql",
-        "version": 6
+        "version": 8
       }
     },
     "rule_name": "LSASS Memory Dump Creation",
     "sha256": "fe88f88d9dffe80847b75edf70c1e2c4e578b0f4105a52f19723aa9cf4a87603",
     "type": "eql",
-    "version": 7
+    "version": 9
   },
   "f30f3443-4fbb-4c27-ab89-c3ad49d62315": {
     "rule_name": "AWS RDS Instance Creation",
@@ -4445,13 +4445,13 @@
         "rule_name": "Suspicious CertUtil Commands",
         "sha256": "3dbede3d16202481d8949fe2200959f78449ea2e1de2ef9d1b2ec9134d16cb35",
         "type": "eql",
-        "version": 11
+        "version": 13
       }
     },
     "rule_name": "Suspicious CertUtil Commands",
     "sha256": "48842212ae6455135f5ac627d1ff61491e2c46152f841707485ccc13ddd506ce",
     "type": "eql",
-    "version": 12
+    "version": 14
   },
   "fd7a6052-58fa-4397-93c3-4795249ccfa2": {
     "min_stack_version": "8.2",
@@ -4460,13 +4460,13 @@
         "rule_name": "Svchost spawning Cmd",
         "sha256": "8eda893ef038048202bf4c123453ad33bb5c23dd7808822d6382a5a2361054c8",
         "type": "eql",
-        "version": 9
+        "version": 11
       }
     },
     "rule_name": "Svchost spawning Cmd",
     "sha256": "bc1c7141ea3d1793d032e8ef37e991fa5b75f3dbffabeb5843f5625f90a7291d",
     "type": "eql",
-    "version": 10
+    "version": 12
   },
   "fe794edd-487f-4a90-b285-3ee54f2af2d3": {
     "rule_name": "Microsoft Windows Defender Tampering",


### PR DESCRIPTION
## Issues
part of #1949 

## Summary
Building a rules package from any branch other than main creates a bug for any forked rules. This is because it senses forward changes (which are already accounted for in the `versions.lock`) as _new_ changes, and adds an unnecessary bump.

This change reconciles changes made to the integrations OOB release package (elastic/integrations/pull/3238).