### PR TITLE
[Rule tuning] SSH Authorized Keys File Modification

### DIFF
--- a/rules/cross-platform/persistence_ssh_authorized_keys_modification.toml
+++ b/rules/cross-platform/persistence_ssh_authorized_keys_modification.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/12/22"
 maturity = "production"
-updated_date = "2021/03/03"
+updated_date = "2022/05/04"
 
 [rule]
 author = ["Elastic"]
@@ -34,7 +34,8 @@ event.category:file and event.type:(change or creation) and
               /usr/bin/nautilus or 
               /usr/bin/scp or
               /usr/bin/touch or 
-              /var/lib/docker/*)
+              /var/lib/docker/* or
+              /usr/bin/google_guest_agent)
 '''
 
 


### PR DESCRIPTION
## Issues
None

## Summary
Excludes GCP agent to exempt list. Noticed the rule triggered via a normal ssh session via gcloud.