### PR TITLE
[FR] Adjusted Build-Release Packaging and Manifest to Scope ^7.15 or ^8.0.0

### DIFF
--- a/detection_rules/etc/packages.yml
+++ b/detection_rules/etc/packages.yml
@@ -26,7 +26,7 @@ package:
   registry_data:
     categories: ["security"]
     conditions:
-      kibana.version: "^8.3.0"
+      kibana.version: "^7.15.0 || ^8.0.0"
     description: Prebuilt detection rules for Elastic Security
     format_version: 1.0.0
     icons:

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -196,6 +196,7 @@ def migrate_to_8_2(version: Version, api_contents: dict) -> dict:
     """Default migration for 8.2."""
     return strip_additional_properties(version, api_contents)
 
+
 @migrate("8.3")
 def migrate_to_8_3(version: Version, api_contents: dict) -> dict:
     """Default migration for 8.3."""

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -196,6 +196,11 @@ def migrate_to_8_2(version: Version, api_contents: dict) -> dict:
     """Default migration for 8.2."""
     return strip_additional_properties(version, api_contents)
 
+@migrate("8.3")
+def migrate_to_8_3(version: Version, api_contents: dict) -> dict:
+    """Default migration for 8.3."""
+    return strip_additional_properties(version, api_contents)
+
 
 def downgrade(api_contents: dict, target_version: str, current_version: Optional[str] = None) -> dict:
     """Downgrade a rule to a target stack version."""

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -22,7 +22,7 @@ SHA256_PATTERN = r'^[a-fA-F0-9]{64}$'
 UUID_PATTERN = r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 
 _version = r'\d+\.\d+(\.\d+[\w-]*)*'
-CONDITION_VERSION_PATTERN = rf'^\^{_version}$'
+CONDITION_VERSION_PATTERN = rf'^\^{_version} || \^{_version}$'
 VERSION_PATTERN = f'^{_version}$'
 BRANCH_PATTERN = f'{VERSION_PATTERN}|^master$'
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/1999

## Summary
We may be able to adjust how the conditions are for packages to account for both 7.x and 8.x series with a YAML OR format instead.

## Testing:
Run the following command: `python -m detection_rules dev build-release`

### Expected Results
<img width="1270" alt="Screen Shot 2022-05-26 at 12 48 46 PM" src="https://user-images.githubusercontent.com/99630311/170535772-eb96eb6d-0175-4248-aa39-de4836e9a835.png">


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
