### PR TITLE
Linux binary(s) ftp shell evasion threat

### DIFF
--- a/rules/linux/execution_shell_evasion_linux_binary.toml
+++ b/rules/linux/execution_shell_evasion_linux_binary.toml
@@ -91,6 +91,7 @@ references = [
     "https://gtfobins.github.io/gtfobins/capsh/",
     "https://gtfobins.github.io/gtfobins/byebug/",
     "https://gtfobins.github.io/gtfobins/git/",
+    "https://gtfobins.github.io/gtfobins/ftp/"
 ]
 risk_score = 47
 rule_id = "52376a86-ee86-4967-97ae-1a05f55816f0"
@@ -107,7 +108,7 @@ process where event.type == "start" and
 
   /* launching shells from unusual parents or parent+arg combos */
   (process.name in ("bash", "sh", "dash","ash") and
-    (process.parent.name in ("byebug","git")) or
+    (process.parent.name in ("byebug","git","ftp")) or
 
     /* shells specified in parent args */
     /* nice rule is broken in 8.2 */


### PR DESCRIPTION
## Issues
#2006 

## Summary
FTP (File Transfer Protocol) is a network protocol for transmitting files between computers, this Unix binary can be abused to breakout out of restricted shells or environments by spawning an interactive system shell. This activity is not standard use of this binary for a user or system administrator. It indicates a potentially malicious actor attempting to improve the capabilities or stability of their access.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
