### PR TITLE
[Rule Tuning] Whoami Process Activity - Support Event 4688

### DIFF
--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/02/18"
 maturity = "production"
-updated_date = "2022/04/21"
+updated_date = "2022/06/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*", "logs-system.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Whoami Process Activity"


### PR DESCRIPTION
## Issues

https://github.com/elastic/sdh-security-team/issues/398

## Summary

Including the `logs-system.*` index pattern to the rule, as the process creation logs are enough to trigger it