### PR TITLE
[Bug] fixing unnecessary version bumps for forked rules

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -400,16 +400,14 @@ class BaseRuleContents(ABC):
     def lock_info(self, bump=True) -> dict:
         version = self.autobumped_version if bump else (self.latest_version or 1)
         contents = {"rule_name": self.name, "sha256": self.sha256(), "version": version, "type": self.type}
-
         return contents
-
 
     @property
     def is_dirty(self) -> Optional[bool]:
         """Determine if the rule has changed since its version was locked."""
         existing_sha256 = self.version_lock.get_locked_hash(self.id, self.metadata.get('min_stack_version'))
 
-        ## if forked rule, compare hashes of previous to previous
+        # if forked rule, compare hashes of previous to previous
         if self.id in self.version_lock.version_lock.data:
             rule_contents = self.version_lock.version_lock.data[self.id]
             if rule_contents.previous:
@@ -430,7 +428,7 @@ class BaseRuleContents(ABC):
     def autobumped_version(self) -> Optional[int]:
         """Retrieve the current version of the rule, accounting for automatic increments."""
 
-        ## if forked rule, compare hashes of previous to previous
+        # if forked rule, compare hashes of previous to previous
         if self.id in self.version_lock.version_lock.data:
             rule_contents = self.version_lock.version_lock.data[self.id]
             if rule_contents.previous:

--- a/detection_rules/version_lock.py
+++ b/detection_rules/version_lock.py
@@ -210,6 +210,14 @@ class VersionLock:
                 existing_rule_lock: dict = lock_file_contents.setdefault(rule.id, {})
                 original_hash = existing_rule_lock.get('sha256')
 
+                # if current rule lock sha256 is the same as the previous forked sha256, ignore and continue
+                previous_match = False
+                if "previous" in existing_rule_lock.keys():
+                    for previous in existing_rule_lock["previous"].values():
+                        if current_rule_lock["sha256"] == previous["sha256"]:
+                            previous_match = True
+                if previous_match: continue
+
                 # prevent rule type changes for already locked and released rules (#1854)
                 if existing_rule_lock:
                     name = current_rule_lock['rule_name']

--- a/detection_rules/version_lock.py
+++ b/detection_rules/version_lock.py
@@ -216,7 +216,8 @@ class VersionLock:
                     for previous in existing_rule_lock["previous"].values():
                         if current_rule_lock["sha256"] == previous["sha256"]:
                             previous_match = True
-                if previous_match: continue
+                if previous_match:
+                    continue
 
                 # prevent rule type changes for already locked and released rules (#1854)
                 if existing_rule_lock:


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

Resolves #1949 

## Summary

Attempts to address the unnecessary version bumps for forked rules in three ways:

- is_dirty : now checks previous hashes 
- autobumped_version : now checks previous hashes 
- version lock checks for previous hashes and continues current rule hash matches


Co Dev @Mikaayenson @terrancedejesus 