### PR TITLE
[Rule Tuning] Enumeration of Privileged Local Groups Membership

### DIFF
--- a/rules/windows/discovery_privileged_localgroup_membership.toml
+++ b/rules/windows/discovery_privileged_localgroup_membership.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/15"
 maturity = "production"
-updated_date = "2022/04/21"
+updated_date = "2022/06/20"
 
 [rule]
 author = ["Elastic"]
@@ -93,27 +93,29 @@ type = "eql"
 query = '''
 iam where event.action == "user-member-enumerated" and
 
- /* noisy and usual legit processes excluded */
- not winlog.event_data.CallerProcessName:
-              ("?:\\Windows\\System32\\VSSVC.exe",
-               "?:\\Windows\\System32\\SearchIndexer.exe",
-               "?:\\Windows\\System32\\CompatTelRunner.exe",
-               "?:\\Windows\\System32\\oobe\\msoobe.exe",
-               "?:\\Windows\\System32\\net1.exe",
-               "?:\\Windows\\System32\\svchost.exe",
-               "?:\\Windows\\System32\\Netplwiz.exe",
-               "?:\\Windows\\System32\\msiexec.exe",
-               "?:\\Windows\\System32\\CloudExperienceHostBroker.exe",
-               "?:\\Windows\\System32\\wbem\\WmiPrvSE.exe",
-               "?:\\Windows\\System32\\SrTasks.exe",
-               "?:\\Windows\\System32\\lsass.exe",
-               "?:\\Windows\\System32\\diskshadow.exe",
-               "?:\\Windows\\System32\\dfsrs.exe",
-               "?:\\Program Files\\*.exe",
-               "?:\\Program Files (x86)\\*.exe") and
+  /* noisy and usual legit processes excluded */
+  not winlog.event_data.CallerProcessName:
+               ("?:\\Windows\\System32\\VSSVC.exe",
+                "?:\\Windows\\System32\\SearchIndexer.exe",
+                "?:\\Windows\\System32\\CompatTelRunner.exe",
+                "?:\\Windows\\System32\\oobe\\msoobe.exe",
+                "?:\\Windows\\System32\\net1.exe",
+                "?:\\Windows\\System32\\svchost.exe",
+                "?:\\Windows\\System32\\Netplwiz.exe",
+                "?:\\Windows\\System32\\msiexec.exe",
+                "?:\\Windows\\System32\\CloudExperienceHostBroker.exe",
+                "?:\\Windows\\System32\\wbem\\WmiPrvSE.exe",
+                "?:\\Windows\\System32\\SrTasks.exe",
+                "?:\\Windows\\System32\\lsass.exe",
+                "?:\\Windows\\System32\\diskshadow.exe",
+                "?:\\Windows\\System32\\dfsrs.exe",
+                "?:\\Program Files\\*.exe",
+                "?:\\Program Files (x86)\\*.exe",
+                "?:\\WindowsAzure\\*\\WaAppAgent.exe") and
+
   /* privileged local groups */
- (group.name:("admin*","RemoteDesktopUsers") or
-  winlog.event_data.TargetSid:("S-1-5-32-544","S-1-5-32-555"))
+  (group.name:("admin*","RemoteDesktopUsers") or
+   winlog.event_data.TargetSid:("S-1-5-32-544","S-1-5-32-555"))
 '''
 
 


### PR DESCRIPTION
## Issues

Resolves #2024 

## Summary

Adds `WaAppAgent.exe` as an exception.

Description from [Msdocs](https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows-azure-guest-agent):

> RD Agent Service: This service is responsible for the Installation of Guest Agent. Transparent Installer is also a component of Rd Agent that helps to upgrade other components and services of Guest Agent. RD Agent is also responsible for sending heartbeats from Guest VM to Host Agent on the physical server.
