### PR TITLE
2058 add setup field to metadata

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -33,6 +33,10 @@ Currently supported arguments:
 Environment variables using the argument format: `DR_<UPPERCASED_ARG_NAME>` will be parsed in commands which expect it.
 EX: `DR_USER=joe`
 
+
+Using the environment variable `DR_BYPASS_NOTE_VALIDATION_AND_PARSE` will bypass the Detection Rules validation on the `note` field in toml files.
+
+
 ## Importing rules into the repo
 
 You can import rules into the repo using the `create-rule` or `import-rules` commands. Both of these commands will

--- a/detection_rules/mixins.py
+++ b/detection_rules/mixins.py
@@ -6,16 +6,19 @@
 """Generic mixin classes."""
 
 from pathlib import Path
-from typing import TypeVar, Type, Optional, Any
+from typing import Any, Optional, TypeVar, Type
 
 import json
 import marshmallow_dataclass
 import marshmallow_dataclass.union_field
 import marshmallow_jsonschema
 import marshmallow_union
-from marshmallow import Schema, ValidationError, fields
+from marshmallow import Schema, ValidationError, fields, validates_schema
 
+from .misc import load_current_package_version
 from .schemas import definitions
+from .schemas.stack_compat import get_incompatible_fields
+from .semver import Version
 from .utils import cached, dict_hash
 
 T = TypeVar('T')
@@ -169,6 +172,26 @@ class LockDataclassMixin:
         assert path, 'No path passed or set'
         contents = self.to_dict()
         path.write_text(json.dumps(contents, indent=2, sort_keys=True))
+
+
+class StackCompatMixin:
+    """Mixin to restrict schema compatibility to defined stack versions."""
+
+    @validates_schema
+    def validate_field_compatibility(self, data: dict, **kwargs):
+        """Verify stack-specific fields are properly applied to schema."""
+        package_version = Version(load_current_package_version())
+        schema_fields = getattr(self, 'fields', {})
+        incompatible = get_incompatible_fields(list(schema_fields.values()), package_version)
+        if not incompatible:
+            return
+
+        package_version = load_current_package_version()
+        for field, bounds in incompatible.items():
+            min_compat, max_compat = bounds
+            if data.get(field) is not None:
+                raise ValidationError(f'Invalid field: "{field}" for stack version: {package_version}, '
+                                      f'min compatibility: {min_compat}, max compatibility: {max_compat}')
 
 
 class PatchedJSONSchema(marshmallow_jsonschema.JSONSchema):

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -277,7 +277,7 @@ class DataValidator:
         return os.environ.get('DR_BYPASS_NOTE_VALIDATION_AND_PARSE') is not None
 
     def validate_note(self):
-        if not (self.skip_validate_note or self.note):
+        if self.skip_validate_note or not self.note:
             return
 
         try:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -632,7 +632,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         setup = []
 
         for child in note_tree:
-            if child.get_type() == "BlankLine":
+            if child.get_type() == "BlankLine" or child.get_type() == "LineBreak":
                 setup.append("\n")
             elif child.get_type() == "CodeSpan":
                 setup.append(f"`{MarkdownRenderer.render_raw_text(self, child)}`")

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -615,7 +615,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
             # parse note tree
             for i, child in enumerate(note_tree.children):
                 if child.get_type() == "Heading" and "Setup" in marko.render(child):
-                    field_value = self.get_setup_paragraph(note_tree.children[i:])
+                    field_value = self.get_setup_paragraph(note_tree.children[i + 1:])
 
                     # clean up old note field
                     investigation_guide = rule_note.replace("## Setup\n\n", "")
@@ -630,7 +630,6 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
     def get_setup_paragraph(self, note_tree: list) -> str:
         """Get note paragraph starting from the setup header."""
         setup = []
-
         for child in note_tree:
             if child.get_type() == "BlankLine" or child.get_type() == "LineBreak":
                 setup.append("\n")
@@ -639,8 +638,12 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
             elif child.get_type() == "Paragraph":
                 setup.append(self.get_setup_paragraph(child.children))
                 setup.append("\n")
-            elif child.get_type() != "Heading":
+            elif child.get_type() == "RawText":
                 setup.append(MarkdownRenderer.render_raw_text(self, child))
+            elif child.get_type() == "Heading" and child.level == 2:
+                break
+            else:
+                setup.append(self.get_setup_paragraph(child.children))
 
         return "".join(setup).strip()
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -728,7 +728,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
                 setup.append(f"```\n{self._get_setup_content(child.children)}\n```")
                 setup.append("\n")
             elif child.get_type() == "RawText":
-                setup.append(gfm.renderer.render_raw_text(child))
+                setup.append(child.children)
             elif child.get_type() == "Heading" and child.level >= 2:
                 break
             else:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -221,6 +221,8 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
             except Exception as e:
                 raise ValidationError(f"Invalid markdown: {e}")
 
+            return setup_header_in_field
+
         note = data.get("note", "")
         setup = data.get("setup", "")
         skip_setup_validation = data.get("skip_setup_validation", False)
@@ -235,10 +237,6 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
         if setup_header_in_note and setup_header_in_setup:
             raise ValidationError("Setup header found in both note and setup fields.")
         return data
-
-
-
-        return setup_header_in_field
 
     @classmethod
     def save_schema(cls):

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -268,6 +268,7 @@ def get_stack_versions(drop_patch=False) -> List[str]:
         return versions
 
 
+@cached
 def get_min_supported_stack_version(drop_patch=False) -> Version:
     """Get the minimum defined and supported stack version."""
     stack_map = load_stack_schema_map()

--- a/detection_rules/schemas/stack_compat.py
+++ b/detection_rules/schemas/stack_compat.py
@@ -1,0 +1,51 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+from dataclasses import Field
+from typing import Dict, List, Optional, Tuple
+
+from ..misc import cached
+from ..semver import Version
+
+
+@cached
+def get_restricted_field(schema_field: Field) -> Tuple[Optional[Version], Optional[Version]]:
+    """Get an optional min and max compatible versions of a field (from a schema or dataclass)."""
+    # nested get is to support schema fields being passed directly from dataclass or fields in schema class, since
+    # marshmallow_dataclass passes the embedded metadata directly
+    min_compat = schema_field.metadata.get('metadata', schema_field.metadata).get('min_compat')
+    max_compat = schema_field.metadata.get('metadata', schema_field.metadata).get('max_compat')
+    min_compat = Version(min_compat) if min_compat else None
+    max_compat = Version(max_compat) if max_compat else None
+    return min_compat, max_compat
+
+
+@cached
+def get_restricted_fields(schema_fields: List[Field]) -> Dict[str, Tuple[Optional[Version], Optional[Version]]]:
+    """Get a list of optional min and max compatible versions of fields (from a schema or dataclass)."""
+    restricted = {}
+    for _field in schema_fields:
+        min_compat, max_compat = get_restricted_field(_field)
+        if min_compat or max_compat:
+            restricted[_field.name] = (min_compat, max_compat)
+
+    return restricted
+
+
+@cached
+def get_incompatible_fields(schema_fields: List[Field], package_version: Version) -> Optional[Dict[str, tuple]]:
+    """Get a list of fields that are incompatible with the package version."""
+    if not schema_fields:
+        return
+
+    incompatible = {}
+    restricted_fields = get_restricted_fields(schema_fields)
+    for field_name, values in restricted_fields.items():
+        min_compat, max_compat = values
+
+        if min_compat and package_version < min_compat or max_compat and package_version > max_compat:
+            incompatible[field_name] = (min_compat, max_compat)
+
+    return incompatible

--- a/docs/experimental-machine-learning/readme.md
+++ b/docs/experimental-machine-learning/readme.md
@@ -7,6 +7,7 @@ This repo contains some additional information and files to use experimental[*](
 * [ProblemChild](problem-child.md)
 * [HostRiskScore](host-risk-score.md)
 * [URLSpoof](url-spoof.md)
+* [UserRiskScore](user-risk-score.md)
 * [experimental detections](experimental-detections.md)
 
 ## Releases

--- a/docs/experimental-machine-learning/user-risk-score.md
+++ b/docs/experimental-machine-learning/user-risk-score.md
@@ -1,0 +1,170 @@
+# User Risk Score
+
+The User Risk Score feature highlights risky usernames from within your environment. It utilizes a transform with a scripted metric aggregation to calculate user risk scores based on alerts that were generated within the past three months. The transform runs hourly to update the score as new alerts are generated. Each alert's contribution to the user risk score is based on the alert's risk score (`signal.rule.risk_score`). The risk score is calculated using a weighted sum where rules with higher time-corrected risk scores also have higher weights. Each risk score is normalized to a scale of 0 to 100.
+
+User Risk Score is an experimental feature that assigns risk scores to usernames in a given Kibana space. Risk scores are calculated for each username by utilizing transforms on the alerting indices. The transform updates the score as new alerts are generated. The User Risk Score [package](https://github.com/elastic/detection-rules/releases/tag/ML-UserRiskScore-20220628-1) contains all of the required artifacts for setup. The User Risk Score feature provides Lens dashboards for viewing summary and detailed username risk score information. The detail view dashboard - Drilldown of User Risk Score - presents detail on why a username has been given a high risk score. In addition, user risk scores are presented in the detailed view for a username in the Elastic Security App.
+
+
+### On Usernames and Risk Scores
+
+ Many alerts contain usernames which were present in the original log or event documents that alert rules, or anomaly rules, matched. These are discrete usernames, not (yet) pointers to a user *entity*. In most environments, each human user has multiple usernames across the various applications and systems they use. In order to investigate a user, it may be necessary to add each of their usernames to the list of usernames being used to filter the output of the detail dashboard. 
+
+In some cases, there are certain usernames that are not readily individuated. The Local System, or SYSTEM account, under Windows, for example, has the same name and the same SID (security identifier) on every Windows host. In order to individuate a particular Local System user account, it is necessary to add its hostname as a filter. The user risk score detail dashboard contains tables of alerts by hostname, in addition to username, in order to help identify the hostname(s) associated with a local user that has been given a risk score. 
+
+## Setup Instructions
+
+ 1. [Obtain artifacts](#obtain-artifacts) 
+ 2. [Upload scripts](#upload-scripts)
+ 3. [Upload ingest pipeline](#upload-ingest-pipeline)
+ 4. [Upload and start the `pivot` transform](#upload-start-pivot)
+ 5. [Create the User Risk Score index](#user-risk-index)
+ 6. [Upload and start the `latest` transform](#upload-start-latest)
+ 7. [Import dashboards](#import-dashboards)
+ 8. [(Optional) Enable Kibana features](#enable-kibana)
+
+<h3 id="modify-artifacts">1. Obtain artifacts</h3>
+
+The User Risk Score functionality is space aware for privacy. Downloaded artifacts must be modified with the desired space before they can be used.
+
+ - Download the release bundle from [here](https://github.com/elastic/detection-rules/releases/tag/ML-UserRiskScore-20220628-1). The User Risk Score releases can be identified by the tag `ML-UserRiskScore-YYYYMMDD-N`. Check the release description to make sure it is compatible with the Elastic Stack version you are running.
+ - Unzip the contents of `ML-UserRiskScore-YYYYMMDD-N.zip`.
+ - Run `ml_userriskscore_generate_scripts.py` script in the unzipped directory with your Kibana space as the argument.
+<div style="margin-left: 40px">   
+<i>Example of modifying artifacts for the default space</i>
+   <pre style="margin-top:-2px"><code>python ml_userriskscore_generate_scripts.py --space default
+</code></pre></div>
+
+ - Find a new folder named after your space in the unzipped directory. **You will be using the scripts within this directory for the next steps.**
+
+<h3 id="upload-scripts">2. Upload scripts</h3>
+
+- Navigate to `Management / Dev Tools` in Kibana.
+- Upload the contents of `ml_userriskscore_levels_script.json`, `ml_userriskscore_map_script.json`, `ml_userriskscore_reduce_script.json` using the Script API with the following syntax.
+- Ensure that your space name (such as `default`) replaces `<your-space-name>` in the script names below.
+
+<div style="margin-left: 40px">   
+<i>uploading scripts</i>
+   <pre style="margin-top:-2px"><code>
+PUT _scripts/ml_userriskscore_levels_script_&lt;your-space-name&gt;
+{contents of ml_userriskscore_levels_script.json file}
+</code></pre></div>
+
+<div style="margin-left: 40px">
+   <pre><code>
+PUT _scripts/ml_userriskscore_map_script_&lt;your-space-name&gt;
+{contents of ml_userriskscore_map_script.json file}
+</code></pre></div>
+
+<div style="margin-left: 40px">
+   <pre><code>
+PUT _scripts/ml_userriskscore_reduce_script_&lt;your-space-name&gt;
+{contents of ml_userriskscore_reduce_script.json file}
+</code></pre></div>
+
+<i>For Elastic Stack version 8.1+ only</i>
+<div style="margin-left: 40px">
+   <pre><code>
+PUT _scripts/ml_userriskscore_init_script_&lt;your-space-name&gt;
+{contents of ml_userriskscore_init_script.json file}
+</code></pre></div>
+
+
+<h3 id="upload-ingest-pipeline">3. Upload ingest pipeline</h3>
+
+- Upload the contents of `ml_userriskscore_ingest_pipeline.json` using the Ingest API with the following syntax.
+- Ensure that your space name (such as `default`) replaces `<your-space-name>` below.
+
+<div style="margin-left: 40px">   
+<i>uploading ingest pipeline</i>
+   <pre style="margin-top:-2px"><code>PUT _ingest/pipeline/ml_usertriskscore_ingest_pipeline_&lt;your-space-name&gt;
+{contents of ml_userriskscore_ingest_pipeline.json file}
+</code></pre></div>
+
+
+
+<h3 id="upload-start-pivot">4. Upload and start the <code>pivot</code> transform</h3>
+
+This transform calculates the risk level every hour for each username in the Kibana space specified.
+
+- Upload the contents of `ml_userriskscore_pivot_transform.json` using the Transform API with the following syntax.
+- Ensure that your space name (such as `default`) replaces `<your-space-name>` below.
+
+<div style="margin-left: 40px">   
+<i>uploading pivot transform</i>
+   <pre style="margin-top:-2px"><code>PUT _transform/ml_userriskscore_pivot_transform_&lt;your-space-name&gt;
+{contents of ml_userriskscore_pivot_transform.json file}
+</code></pre></div>
+
+- Navigate to `Transforms` under `Management / Stack Management` in Kibana. Find the transform with the ID `ml_userriskscore_pivot_transform_<your-space-name>`. Open the `Actions` menu on the right side of the row, then click `Start`.
+- Confirm the transform is working as expected by navigating to `Management / Dev Tools` and ensuring the target index exists.
+
+<div style="margin-left: 40px">   
+<i>sample test query</i>
+   <pre style="margin-top:-2px"><code>GET ml_user_risk_score_&lt;your-space-name&gt;/_search
+</code></pre></div>
+
+<h3 id="user-risk-index">5. Create the User Risk Score index</h3>
+
+- Navigate to `Management / Dev Tools` in Kibana.
+- Create the User Risk Score index (`ml_user_risk_score_latest_<your-space-name>`) with the following mappings.
+- Ensure that your space name (such as `default`) replaces `<your-space-name>` below.
+
+<div style="margin-left: 40px">   
+<i>creating the User Risk Score index</i>
+   <pre style="margin-top:-2px"><code>PUT ml_user_risk_score_latest_&lt;your-space-name&gt;
+{
+  "mappings":{
+    "properties":{
+      "user.name":{
+        "type":"keyword"
+      }
+    }
+  }
+}
+</code></pre></div>
+
+<h3 id="upload-start-latest">6. Upload and start the <code>latest</code> transform</h3>
+
+This transform recurrently calculates risk levels for all usernames in the Kibana space specified.
+
+- Upload the contents of `ml_userriskscore_latest_transform.json` using the Transform API with the following syntax.
+- Ensure that your space name (such as `default`) replaces `<your-space-name>` below.
+
+<div style="margin-left: 40px">   
+<i>uploading latest transform</i>
+   <pre style="margin-top:-2px"><code>PUT _transform/ml_userriskscore_latest_transform_&lt;your-space-name&gt;
+{contents of ml_userriskscore_latest_transform.json file}
+</code></pre></div>
+
+- Navigate to `Transforms` under `Management / Stack Management` in Kibana. Find the transform with the ID `ml_userriskscore_latest_transform_<your-space-name>`. Open the `Actions` menu on the right side of the row, and click `Start`.
+- Confirm the transform is working as expected by navigating to `Management / Dev Tools` and ensuring the target index exists. You should see documents starting to appear in the index if there is ongoing alerting activity associated with usernames.
+
+<div style="margin-left: 40px">   
+<i>sample test query</i>
+   <pre style="margin-top:-2px"><code>GET ml_user_risk_score_latest_&lt;your-space-name&gt;/_search
+</code></pre></div>
+
+<h3 id="import-dashboards">7. Import dashboards</h3>
+
+- Navigate to `Management / Stack Management / Kibana / Saved Objects` in Kibana.
+- Click on `Import` and import the `ml_userriskscore_dashboards.ndjson` file.
+- Navigate to `Analytics / Dashboard`.
+- Confirm you can see a dashboard named `Current Risk Scores for Users`, which displays the current list (Top 20) of  usernames for which a risk score has been computed.
+- Confirm you can see a dashboard named `Drilldown of User Risk Score`, which allows you to further drill down into details of the risk associated with a particular username of interest.
+
+<h3 id="enable-kibana">8. Enable Kibana features</h3>
+
+To enable the Kibana features for User Risk Score, you will first need to add the following configuration to `kibana.yml`.
+
+```
+xpack.securitySolution.enableExperimental: ['riskyUsersEnabled']
+```
+This can be added by editing the kibana.yml file, on a Kibana server instance, or by modifying a Kibana server configuration, in an Elastic Cloud deployment, using the steps documented here:
+
+https://www.elastic.co/guide/en/cloud-enterprise/current/ece-manage-kibana-settings.html
+
+Once you have modified the `kibana.yml` file, you will find User Risk Scoring features in the "User Risk" tab in the detail view for a username. The detail view is reached by clicking a username in the Users page in the Security Solution:
+
+<hr/>
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jsl==0.2.4
+marko
 pytoml
 toml==0.10.0
 requests~=2.27

--- a/rules/_deprecated/exfiltration_rds_snapshot_export.toml
+++ b/rules/_deprecated/exfiltration_rds_snapshot_export.toml
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Snapshot Export"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartExportTask.html"]

--- a/rules/_deprecated/exfiltration_rds_snapshot_export.toml
+++ b/rules/_deprecated/exfiltration_rds_snapshot_export.toml
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Snapshot Export"
-note = """## Setup
+note = """## Config
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartExportTask.html"]

--- a/rules/cross-platform/credential_access_cookies_chromium_browsers_debugging.toml
+++ b/rules/cross-platform/credential_access_cookies_chromium_browsers_debugging.toml
@@ -17,7 +17,7 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Potential Cookies Theft via Browser Debugging"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -44,8 +44,8 @@ process where event.type in ("start", "process_started", "info") and
              "google-chrome-beta",
              "google-chrome",
              "msedge.exe") and
-   process.args : ("--remote-debugging-port=*", 
-                   "--remote-debugging-targets=*",  
+   process.args : ("--remote-debugging-port=*",
+                   "--remote-debugging-targets=*",
                    "--remote-debugging-pipe=*") and
    process.args : "--user-data-dir=*" and not process.args:"--remote-debugging-port=0"
 '''

--- a/rules/cross-platform/defense_evasion_deleting_websvr_access_logs.toml
+++ b/rules/cross-platform/defense_evasion_deleting_websvr_access_logs.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "winlogbeat-*", "logs-endpoint.events.*", "logs-windows.
 language = "eql"
 license = "Elastic License v2"
 name = "WebServer Access Logs Deleted"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -27,10 +27,10 @@ type = "eql"
 
 query = '''
 file where event.type == "deletion" and
-  file.path : ("C:\\inetpub\\logs\\LogFiles\\*.log", 
+  file.path : ("C:\\inetpub\\logs\\LogFiles\\*.log",
                "/var/log/apache*/access.log",
-               "/etc/httpd/logs/access_log", 
-               "/var/log/httpd/access_log", 
+               "/etc/httpd/logs/access_log",
+               "/var/log/httpd/access_log",
                "/var/www/*/logs/access.log")
 '''
 

--- a/rules/cross-platform/defense_evasion_deletion_of_bash_command_line_history.toml
+++ b/rules/cross-platform/defense_evasion_deletion_of_bash_command_line_history.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Tampering of Bash Command-Line History"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/cross-platform/defense_evasion_elastic_agent_service_terminated.toml
+++ b/rules/cross-platform/defense_evasion_elastic_agent_service_terminated.toml
@@ -16,7 +16,7 @@ index = ["logs-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Elastic Agent Service Terminated"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -31,18 +31,18 @@ query = '''
 process where
 /* net, sc or wmic stopping or deleting Elastic Agent on Windows */
 (event.type == "start" and
-  process.name : ("net.exe", "sc.exe", "wmic.exe","powershell.exe","taskkill.exe","PsKill.exe","ProcessHacker.exe") and 
+  process.name : ("net.exe", "sc.exe", "wmic.exe","powershell.exe","taskkill.exe","PsKill.exe","ProcessHacker.exe") and
   process.args : ("stopservice","uninstall", "stop", "disabled","Stop-Process","terminate","suspend") and
-  process.args : ("elasticendpoint", "Elastic Agent","elastic-agent","elastic-endpoint")) 
+  process.args : ("elasticendpoint", "Elastic Agent","elastic-agent","elastic-endpoint"))
 or
 /* service or systemctl used to stop Elastic Agent on Linux */
 (event.type == "end" and
-  (process.name : ("systemctl","service") and 
-    process.args : ("elastic-agent", "stop")) 
-  or 
+  (process.name : ("systemctl","service") and
+    process.args : ("elastic-agent", "stop"))
+  or
   /* Unload Elastic Agent extension on MacOS */
   (process.name : "kextunload" and
-    process.args : "com.apple.iokit.EndpointSecurity" and 
+    process.args : "com.apple.iokit.EndpointSecurity" and
     event.action : "end"))
 '''
 

--- a/rules/cross-platform/defense_evasion_timestomp_touch.toml
+++ b/rules/cross-platform/defense_evasion_timestomp_touch.toml
@@ -15,7 +15,7 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Timestomping using Touch Command"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/cross-platform/discovery_security_software_grep.toml
+++ b/rules/cross-platform/discovery_security_software_grep.toml
@@ -15,7 +15,7 @@ index = ["logs-endpoint.events.*", "auditbeat-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Security Software Discovery via Grep"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/cross-platform/discovery_virtual_machine_fingerprinting_grep.toml
+++ b/rules/cross-platform/discovery_virtual_machine_fingerprinting_grep.toml
@@ -21,7 +21,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Virtual Machine Fingerprinting via Grep"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -36,7 +36,7 @@ type = "eql"
 query = '''
 process where event.type == "start" and
  process.name in ("grep", "egrep") and user.id != "0" and
- process.args : ("parallels*", "vmware*", "virtualbox*") and process.args : "Manufacturer*" and 
+ process.args : ("parallels*", "vmware*", "virtualbox*") and process.args : "Manufacturer*" and
  not process.parent.executable in ("/Applications/Docker.app/Contents/MacOS/Docker", "/usr/libexec/kcare/virt-what")
 '''
 

--- a/rules/cross-platform/execution_python_script_in_cmdline.toml
+++ b/rules/cross-platform/execution_python_script_in_cmdline.toml
@@ -15,7 +15,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Python Script Execution via Command Line"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/cross-platform/execution_revershell_via_shell_cmd.toml
+++ b/rules/cross-platform/execution_revershell_via_shell_cmd.toml
@@ -11,7 +11,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Reverse Shell Activity via Terminal"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/cross-platform/execution_suspicious_jar_child_process.toml
+++ b/rules/cross-platform/execution_suspicious_jar_child_process.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious JAVA Child Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -18,7 +18,7 @@ index = ["auditbeat-*", "winlogbeat-*", "logs-endpoint.events.*", "logs-windows.
 language = "eql"
 license = "Elastic License v2"
 name = "Hosts File Modified"
-note = """## Config
+note = """## Setup
 
 For Windows systems using Auditbeat, this rule requires adding `C:/Windows/System32/drivers/etc` as an additional path in the 'file_integrity' module of auditbeat.yml.
 

--- a/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
+++ b/rules/cross-platform/initial_access_zoom_meeting_with_no_passcode.toml
@@ -16,7 +16,7 @@ index = ["filebeat-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Zoom Meeting with no Passcode"
-note = """## Config
+note = """## Setup
 
 The Zoom Filebeat module or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/integrations/aws/collection_cloudtrail_logging_created.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudTrail Log Created"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/integrations/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -16,7 +16,7 @@ index = ["filebeat-*", "logs-aws*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Brute Force of Assume Role Policy"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/integrations/aws/credential_access_iam_user_addition_to_group.toml
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM User Addition to Group"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/IAM/latest/APIReference/API_AddUserToGroup.html"]

--- a/rules/integrations/aws/credential_access_root_console_failure_brute_force.toml
+++ b/rules/integrations/aws/credential_access_root_console_failure_brute_force.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-aws*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Management Console Brute Force of Root User Identity"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]

--- a/rules/integrations/aws/credential_access_secretsmanager_getsecretvalue.toml
+++ b/rules/integrations/aws/credential_access_secretsmanager_getsecretvalue.toml
@@ -22,7 +22,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Access Secret in Secrets Manager"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudTrail Log Deleted"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudTrail Log Suspended"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudWatch Alarm Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_config_service_rule_deletion.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Config Service Tampering"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/integrations/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Configuration Recorder Stopped"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Flow Log Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Network Access Control List Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_elasticache_security_group_creation.toml
+++ b/rules/integrations/aws/defense_evasion_elasticache_security_group_creation.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS ElastiCache Security Group Created"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateCacheSecurityGroup.html"]
@@ -32,7 +32,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:elasticache.amazonaws.com and event.action:"Create Cache Security Group" and 
+event.dataset:aws.cloudtrail and event.provider:elasticache.amazonaws.com and event.action:"Create Cache Security Group" and
 event.outcome:success
 '''
 
@@ -47,7 +47,7 @@ reference = "https://attack.mitre.org/techniques/T1562/"
   id = "T1562.007"
   name = "Disable or Modify Cloud Firewall"
   reference = "https://attack.mitre.org/techniques/T1562/007/"
-  
+
 [rule.threat.tactic]
 name = "Defense Evasion"
 id = "TA0005"

--- a/rules/integrations/aws/defense_evasion_elasticache_security_group_modified_or_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_elasticache_security_group_modified_or_deleted.toml
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS ElastiCache Security Group Modified or Deleted"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/Welcome.html"]
@@ -33,8 +33,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:elasticache.amazonaws.com and event.action:("Delete Cache Security Group" or 
-"Authorize Cache Security Group Ingress" or  "Revoke Cache Security Group Ingress" or "AuthorizeCacheSecurityGroupEgress" or 
+event.dataset:aws.cloudtrail and event.provider:elasticache.amazonaws.com and event.action:("Delete Cache Security Group" or
+"Authorize Cache Security Group Ingress" or  "Revoke Cache Security Group Ingress" or "AuthorizeCacheSecurityGroupEgress" or
 "RevokeCacheSecurityGroupEgress") and event.outcome:success
 '''
 

--- a/rules/integrations/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS GuardDuty Detector Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS S3 Bucket Configuration Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_waf_acl_deletion.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS WAF Access Control List Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS WAF Rule or Rule Group Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/exfiltration_ec2_full_network_packet_capture_detected.toml
+++ b/rules/integrations/aws/exfiltration_ec2_full_network_packet_capture_detected.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Full Network Packet Capture Detected"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -39,8 +39,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and 
-event.action:(CreateTrafficMirrorFilter or CreateTrafficMirrorFilterRule or CreateTrafficMirrorSession or CreateTrafficMirrorTarget) and 
+event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and
+event.action:(CreateTrafficMirrorFilter or CreateTrafficMirrorFilterRule or CreateTrafficMirrorSession or CreateTrafficMirrorTarget) and
 event.outcome:success
 '''
 

--- a/rules/integrations/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/integrations/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Snapshot Activity"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/exfiltration_ec2_vm_export_failure.toml
+++ b/rules/integrations/aws/exfiltration_ec2_vm_export_failure.toml
@@ -22,7 +22,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 VM Export Failure"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/vm-import/latest/userguide/vmexport.html#export-instance"]

--- a/rules/integrations/aws/exfiltration_rds_snapshot_export.toml
+++ b/rules/integrations/aws/exfiltration_rds_snapshot_export.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Snapshot Export"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_StartExportTask.html"]

--- a/rules/integrations/aws/exfiltration_rds_snapshot_restored.toml
+++ b/rules/integrations/aws/exfiltration_rds_snapshot_restored.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-aws*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Snapshot Restored"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/impact_aws_eventbridge_rule_disabled_or_deleted.toml
+++ b/rules/integrations/aws/impact_aws_eventbridge_rule_disabled_or_deleted.toml
@@ -12,7 +12,7 @@ visibility in applications or a break in the flow with other AWS services.
 """
 false_positives = [
     """
-    EventBridge Rules could be deleted or disabled by a system administrator. Verify whether the user identity, user agent, and/or 
+    EventBridge Rules could be deleted or disabled by a system administrator. Verify whether the user identity, user agent, and/or
     hostname should be making changes in your environment. EventBridge Rules being deleted or disabled by unfamiliar users should
     be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-aws*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EventBridge Rule Disabled or Deleted"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -38,7 +38,7 @@ type = "query"
 
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:eventbridge.amazonaws.com and event.action:(DeleteRule or DisableRule) and 
+event.dataset:aws.cloudtrail and event.provider:eventbridge.amazonaws.com and event.action:(DeleteRule or DisableRule) and
 event.outcome:success
 '''
 

--- a/rules/integrations/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/integrations/aws/impact_cloudtrail_logging_updated.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudTrail Log Updated"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudWatch Log Group Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS CloudWatch Log Stream Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/integrations/aws/impact_ec2_disable_ebs_encryption.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Encryption Disabled"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/impact_efs_filesystem_or_mount_deleted.toml
+++ b/rules/integrations/aws/impact_efs_filesystem_or_mount_deleted.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EFS File System or Mount Deleted"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -39,7 +39,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:elasticfilesystem.amazonaws.com and 
+event.dataset:aws.cloudtrail and event.provider:elasticfilesystem.amazonaws.com and
 event.action:(DeleteMountTarget or DeleteFileSystem) and event.outcome:success
 '''
 

--- a/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Deactivation of MFA Device"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/impact_iam_group_deletion.toml
+++ b/rules/integrations/aws/impact_iam_group_deletion.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Group Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/impact_rds_group_deletion.toml
+++ b/rules/integrations/aws/impact_rds_group_deletion.toml
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Security Group Deletion"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DeleteDBSecurityGroup.html"]

--- a/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Deletion of RDS Instance or Cluster"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -43,7 +43,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:rds.amazonaws.com and event.action:(DeleteDBCluster or DeleteGlobalCluster or DeleteDBInstance) 
+event.dataset:aws.cloudtrail and event.provider:rds.amazonaws.com and event.action:(DeleteDBCluster or DeleteGlobalCluster or DeleteDBInstance)
 and event.outcome:success
 '''
 

--- a/rules/integrations/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_stoppage.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Instance/Cluster Stoppage"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/initial_access_console_login_root.toml
+++ b/rules/integrations/aws/initial_access_console_login_root.toml
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Management Console Root Login"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]

--- a/rules/integrations/aws/initial_access_password_recovery.toml
+++ b/rules/integrations/aws/initial_access_password_recovery.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Password Recovery Requested"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://www.cadosecurity.com/an-ongoing-aws-phishing-campaign/"]

--- a/rules/integrations/aws/initial_access_via_system_manager.toml
+++ b/rules/integrations/aws/initial_access_via_system_manager.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Execution via System Manager"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-plugins.html"]

--- a/rules/integrations/aws/ml_cloudtrail_error_message_spike.toml
+++ b/rules/integrations/aws/ml_cloudtrail_error_message_spike.toml
@@ -24,7 +24,7 @@ license = "Elastic License v2"
 machine_learning_job_id = "high_distinct_count_error_message"
 name = "Spike in AWS Error Messages"
 note = """
-## Config
+## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/aws/ml_cloudtrail_rare_error_code.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_error_code.toml
@@ -24,7 +24,7 @@ license = "Elastic License v2"
 machine_learning_job_id = "rare_error_code"
 name = "Rare AWS Error Code"
 note = """
-## Config
+## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_city.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_city.toml
@@ -25,7 +25,7 @@ license = "Elastic License v2"
 machine_learning_job_id = "rare_method_for_a_city"
 name = "Unusual City For an AWS Command"
 note = """
-## Config
+## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_country.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_country.toml
@@ -25,7 +25,7 @@ license = "Elastic License v2"
 machine_learning_job_id = "rare_method_for_a_country"
 name = "Unusual Country For an AWS Command"
 note = """
-## Config
+## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_user.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_user.toml
@@ -24,7 +24,7 @@ license = "Elastic License v2"
 machine_learning_job_id = "rare_method_for_a_username"
 name = "Unusual AWS Command for a User"
 note = """
-## Config
+## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/integrations/aws/persistence_ec2_network_acl_creation.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Network Access Control List Creation"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/persistence_ec2_security_group_configuration_change_detection.toml
+++ b/rules/integrations/aws/persistence_ec2_security_group_configuration_change_detection.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Security Group Configuration Change Detection"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-security-groups.html"]
@@ -36,8 +36,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and event.action:(AuthorizeSecurityGroupEgress or 
-CreateSecurityGroup or ModifyInstanceAttribute or ModifySecurityGroupRules or RevokeSecurityGroupEgress or 
+event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and event.action:(AuthorizeSecurityGroupEgress or
+CreateSecurityGroup or ModifyInstanceAttribute or ModifySecurityGroupRules or RevokeSecurityGroupEgress or
 RevokeSecurityGroupIngress) and event.outcome:success
 '''
 

--- a/rules/integrations/aws/persistence_iam_group_creation.toml
+++ b/rules/integrations/aws/persistence_iam_group_creation.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Group Creation"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/persistence_rds_cluster_creation.toml
+++ b/rules/integrations/aws/persistence_rds_cluster_creation.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Cluster Creation"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/persistence_rds_group_creation.toml
+++ b/rules/integrations/aws/persistence_rds_group_creation.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Security Group Creation"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBSecurityGroup.html"]

--- a/rules/integrations/aws/persistence_rds_instance_creation.toml
+++ b/rules/integrations/aws/persistence_rds_instance_creation.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Instance Creation"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html"]

--- a/rules/integrations/aws/persistence_redshift_instance_creation.toml
+++ b/rules/integrations/aws/persistence_redshift_instance_creation.toml
@@ -7,8 +7,8 @@ integration = "aws"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the creation of an Amazon Redshift cluster. Unexpected creation of this cluster by a non-administrative user 
-may indicate a permission or role issue with current users. If unexpected, the resource may not properly be configured 
+Identifies the creation of an Amazon Redshift cluster. Unexpected creation of this cluster by a non-administrative user
+may indicate a permission or role issue with current users. If unexpected, the resource may not properly be configured
 and could introduce security vulnerabilities.
 """
 false_positives = [
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Redshift Cluster Creation"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/redshift/latest/APIReference/API_CreateCluster.html"]

--- a/rules/integrations/aws/persistence_route_53_domain_transfer_lock_disabled.toml
+++ b/rules/integrations/aws/persistence_route_53_domain_transfer_lock_disabled.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Route 53 Domain Transfer Lock Disabled"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/persistence_route_53_domain_transferred_to_another_account.toml
+++ b/rules/integrations/aws/persistence_route_53_domain_transferred_to_another_account.toml
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Route 53 Domain Transferred to Another Account"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/Route53/latest/APIReference/API_Operations_Amazon_Route_53.html"]

--- a/rules/integrations/aws/persistence_route_53_hosted_zone_associated_with_a_vpc.toml
+++ b/rules/integrations/aws/persistence_route_53_hosted_zone_associated_with_a_vpc.toml
@@ -20,7 +20,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Route53 private hosted zone associated with a VPC"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/Route53/latest/APIReference/API_AssociateVPCWithHostedZone.html"]
@@ -32,7 +32,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:route53.amazonaws.com and event.action:AssociateVPCWithHostedZone and 
+event.dataset:aws.cloudtrail and event.provider:route53.amazonaws.com and event.action:AssociateVPCWithHostedZone and
 event.outcome:success
 '''
 

--- a/rules/integrations/aws/persistence_route_table_created.toml
+++ b/rules/integrations/aws/persistence_route_table_created.toml
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Route Table Created"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -37,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:cloudtrail.amazonaws.com and event.action:(CreateRoute or CreateRouteTable) and 
+event.dataset:aws.cloudtrail and event.provider:cloudtrail.amazonaws.com and event.action:(CreateRoute or CreateRouteTable) and
 event.outcome:success
 '''
 

--- a/rules/integrations/aws/persistence_route_table_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_route_table_modified_or_deleted.toml
@@ -9,9 +9,9 @@ author = ["Elastic", "Austin Songer"]
 description = "Identifies when an AWS Route Table has been modified or deleted."
 false_positives = [
     """
-    Route Table could be modified or deleted by a system administrator. Verify whether the user identity, 
+    Route Table could be modified or deleted by a system administrator. Verify whether the user identity,
     user agent, and/or hostname should be making changes in your environment. Route Table being modified
-    from unfamiliar users should be investigated. If known behavior is causing false positives, it can be 
+    from unfamiliar users should be investigated. If known behavior is causing false positives, it can be
     exempted from the rule. Also automated processes that use Terraform may lead to false positives.
     """,
 ]
@@ -21,7 +21,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Route Table Modified or Deleted"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/aws/privilege_escalation_aws_suspicious_saml_activity.toml
+++ b/rules/integrations/aws/privilege_escalation_aws_suspicious_saml_activity.toml
@@ -11,7 +11,7 @@ Identifies when SAML activity has occurred in AWS. An adversary could manipulate
 """
 false_positives = [
     """
-    SAML Provider could be updated by a system administrator. Verify whether the user identity, user agent, and/or 
+    SAML Provider could be updated by a system administrator. Verify whether the user identity, user agent, and/or
     hostname should be making changes in your environment. SAML Provider updates by unfamiliar users should
     be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-aws*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS SAML Activity"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -36,7 +36,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:(iam.amazonaws.com or sts.amazonaws.com) and event.action:(Assumerolewithsaml or 
+event.dataset:aws.cloudtrail and event.provider:(iam.amazonaws.com or sts.amazonaws.com) and event.action:(Assumerolewithsaml or
 UpdateSAMLProvider) and event.outcome:success
 '''
 

--- a/rules/integrations/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/integrations/aws/privilege_escalation_root_login_without_mfa.toml
@@ -22,7 +22,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Root Login Without MFA"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html"]

--- a/rules/integrations/aws/privilege_escalation_sts_assumerole_usage.toml
+++ b/rules/integrations/aws/privilege_escalation_sts_assumerole_usage.toml
@@ -20,7 +20,7 @@ language = "kuery"
 license = "Elastic License v2"
 name = "AWS Security Token Service (STS) AssumeRole Usage"
 references = ["https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html"]
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 21
@@ -31,7 +31,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:sts.amazonaws.com and event.action:AssumedRole and 
+event.dataset:aws.cloudtrail and event.provider:sts.amazonaws.com and event.action:AssumedRole and
 aws.cloudtrail.user_identity.session_context.session_issuer.type:Role and event.outcome:success
 '''
 

--- a/rules/integrations/aws/privilege_escalation_sts_getsessiontoken_abuse.toml
+++ b/rules/integrations/aws/privilege_escalation_sts_getsessiontoken_abuse.toml
@@ -7,13 +7,13 @@ integration = "aws"
 [rule]
 author = ["Austin Songer"]
 description = """
-Identifies the suspicious use of GetSessionToken. Tokens could be created and used by attackers to move laterally and 
+Identifies the suspicious use of GetSessionToken. Tokens could be created and used by attackers to move laterally and
 escalate privileges.
 """
 false_positives = [
     """
-    GetSessionToken may be done by a system or network administrator. Verify whether the user identity, user 
-    agent, and/or hostname should be making changes in your environment. GetSessionToken from unfamiliar users or 
+    GetSessionToken may be done by a system or network administrator. Verify whether the user identity, user
+    agent, and/or hostname should be making changes in your environment. GetSessionToken from unfamiliar users or
     hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-aws*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS STS GetSessionToken Abuse"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -36,7 +36,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:sts.amazonaws.com and event.action:GetSessionToken and 
+event.dataset:aws.cloudtrail and event.provider:sts.amazonaws.com and event.action:GetSessionToken and
 aws.cloudtrail.user_identity.type:IAMUser and event.outcome:success
 '''
 

--- a/rules/integrations/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/integrations/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -23,7 +23,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Assume Role Policy Update"
-note = """## Config
+note = """## Setup
 
 The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://labs.bishopfox.com/tech-blog/5-privesc-attack-vectors-in-aws"]

--- a/rules/integrations/azure/collection_update_event_hub_auth_rule.toml
+++ b/rules/integrations/azure/collection_update_event_hub_auth_rule.toml
@@ -25,7 +25,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Event Hub Authorization Rule Created or Updated"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/event-hubs/authorize-access-shared-access-signature"]

--- a/rules/integrations/azure/credential_access_azure_full_network_packet_capture_detected.toml
+++ b/rules/integrations/azure/credential_access_azure_full_network_packet_capture_detected.toml
@@ -14,7 +14,7 @@ internal traffic.
 """
 false_positives = [
     """
-    Full Network Packet Capture may be done by a system or network administrator. Verify whether the user identity, 
+    Full Network Packet Capture may be done by a system or network administrator. Verify whether the user identity,
     user agent, and/or hostname should be making changes in your environment. Full Network Packet Capture from unfamiliar
     users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
@@ -24,7 +24,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Full Network Packet Capture Detected"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations"]
@@ -41,7 +41,7 @@ event.dataset:azure.activitylogs and azure.activitylogs.operation_name:
         "MICROSOFT.NETWORK/*/STARTPACKETCAPTURE/ACTION" or
         "MICROSOFT.NETWORK/*/VPNCONNECTIONS/STARTPACKETCAPTURE/ACTION" or
         "MICROSOFT.NETWORK/*/PACKETCAPTURES/WRITE"
-    ) and 
+    ) and
 event.outcome:(Success or success)
 '''
 

--- a/rules/integrations/azure/credential_access_key_vault_modified.toml
+++ b/rules/integrations/azure/credential_access_key_vault_modified.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Key Vault Modified"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/credential_access_storage_account_key_regenerated.toml
+++ b/rules/integrations/azure/credential_access_storage_account_key_regenerated.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Storage Account Key Regenerated"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/defense_evasion_azure_application_credential_modification.toml
+++ b/rules/integrations/azure/defense_evasion_azure_application_credential_modification.toml
@@ -25,7 +25,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Application Credential Modification"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/defense_evasion_azure_blob_permissions_modified.toml
+++ b/rules/integrations/azure/defense_evasion_azure_blob_permissions_modified.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Blob Permissions Modification"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles"]
@@ -35,7 +35,7 @@ type = "query"
 query = '''
 event.dataset:azure.activitylogs and azure.activitylogs.operation_name:(
      "MICROSOFT.STORAGE/STORAGEACCOUNTS/BLOBSERVICES/CONTAINERS/BLOBS/MANAGEOWNERSHIP/ACTION" or
-     "MICROSOFT.STORAGE/STORAGEACCOUNTS/BLOBSERVICES/CONTAINERS/BLOBS/MODIFYPERMISSIONS/ACTION") and 
+     "MICROSOFT.STORAGE/STORAGEACCOUNTS/BLOBSERVICES/CONTAINERS/BLOBS/MODIFYPERMISSIONS/ACTION") and
   event.outcome:(Success or success)
 '''
 

--- a/rules/integrations/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
+++ b/rules/integrations/azure/defense_evasion_azure_diagnostic_settings_deletion.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Diagnostic Settings Deletion"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings"]

--- a/rules/integrations/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/integrations/azure/defense_evasion_azure_service_principal_addition.toml
@@ -24,7 +24,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Service Principal Addition"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/defense_evasion_event_hub_deletion.toml
+++ b/rules/integrations/azure/defense_evasion_event_hub_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Event Hub Deletion"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/defense_evasion_firewall_policy_deletion.toml
+++ b/rules/integrations/azure/defense_evasion_firewall_policy_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Firewall Policy Deletion"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/firewall-manager/policy-overview"]

--- a/rules/integrations/azure/defense_evasion_frontdoor_firewall_policy_deletion.toml
+++ b/rules/integrations/azure/defense_evasion_frontdoor_firewall_policy_deletion.toml
@@ -7,12 +7,12 @@ integration = "azure"
 [rule]
 author = ["Austin Songer"]
 description = """
-Identifies the deletion of a Frontdoor Web Application Firewall (WAF) Policy in Azure. An adversary may delete a Frontdoor Web Application Firewall 
+Identifies the deletion of a Frontdoor Web Application Firewall (WAF) Policy in Azure. An adversary may delete a Frontdoor Web Application Firewall
 (WAF) Policy in an attempt to evade defenses and/or to eliminate barriers to their objective.
 """
 false_positives = [
     """
-    Azure Front Web Application Firewall (WAF) Policy deletions may be done by a system or network administrator. Verify whether the username, 
+    Azure Front Web Application Firewall (WAF) Policy deletions may be done by a system or network administrator. Verify whether the username,
     hostname, and/or resource name should be making changes in your environment. Azure Front Web Application Firewall (WAF) Policy deletions by
     unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Frontdoor Web Application Firewall (WAF) Policy Deleted"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/defense_evasion_kubernetes_events_deleted.toml
+++ b/rules/integrations/azure/defense_evasion_kubernetes_events_deleted.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Kubernetes Events Deleted"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -37,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:azure.activitylogs and azure.activitylogs.operation_name:"MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/EVENTS.K8S.IO/EVENTS/DELETE" and 
+event.dataset:azure.activitylogs and azure.activitylogs.operation_name:"MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/EVENTS.K8S.IO/EVENTS/DELETE" and
 event.outcome:(Success or success)
 '''
 

--- a/rules/integrations/azure/defense_evasion_network_watcher_deletion.toml
+++ b/rules/integrations/azure/defense_evasion_network_watcher_deletion.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Network Watcher Deletion"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/network-watcher/network-watcher-monitoring-overview"]

--- a/rules/integrations/azure/defense_evasion_suppression_rule_created.toml
+++ b/rules/integrations/azure/defense_evasion_suppression_rule_created.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Alert Suppression Rule Created or Modified"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -38,7 +38,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:azure.activitylogs and azure.activitylogs.operation_name:"MICROSOFT.SECURITY/ALERTSSUPPRESSIONRULES/WRITE" and 
+event.dataset:azure.activitylogs and azure.activitylogs.operation_name:"MICROSOFT.SECURITY/ALERTSSUPPRESSIONRULES/WRITE" and
 event.outcome: "success"
 '''
 

--- a/rules/integrations/azure/discovery_blob_container_access_mod.toml
+++ b/rules/integrations/azure/discovery_blob_container_access_mod.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Blob Container Access Level Modification"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-prevent"]

--- a/rules/integrations/azure/execution_command_virtual_machine.toml
+++ b/rules/integrations/azure/execution_command_virtual_machine.toml
@@ -25,7 +25,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Command Execution on Virtual Machine"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/impact_azure_automation_runbook_deleted.toml
+++ b/rules/integrations/azure/impact_azure_automation_runbook_deleted.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Automation Runbook Deleted"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/impact_azure_service_principal_credentials_added.toml
+++ b/rules/integrations/azure/impact_azure_service_principal_credentials_added.toml
@@ -25,7 +25,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Service Principal Credentials Added"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://www.fireeye.com/content/dam/collateral/en/wp-m-unc2452.pdf"]

--- a/rules/integrations/azure/impact_kubernetes_pod_deleted.toml
+++ b/rules/integrations/azure/impact_kubernetes_pod_deleted.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Kubernetes Pods Deleted"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -36,7 +36,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:azure.activitylogs and azure.activitylogs.operation_name:"MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/PODS/DELETE" and 
+event.dataset:azure.activitylogs and azure.activitylogs.operation_name:"MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/PODS/DELETE" and
 event.outcome:(Success or success)
 '''
 

--- a/rules/integrations/azure/impact_resource_group_deletion.toml
+++ b/rules/integrations/azure/impact_resource_group_deletion.toml
@@ -24,7 +24,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Resource Group Deletion"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/impact_virtual_network_device_modified.toml
+++ b/rules/integrations/azure/impact_virtual_network_device_modified.toml
@@ -13,7 +13,7 @@ appliance, virtual hub, or virtual router.
 false_positives = [
     """
     Virtual Network Device modification or deletion may be performed by a system administrator. Verify
-    whether the user identity, user agent, and/or hostname should be making changes in your environment. 
+    whether the user identity, user agent, and/or hostname should be making changes in your environment.
     Virtual Network Device modification or deletion by unfamiliar users should be investigated. If known
     behavior is causing false positives, it can be exempted from the rule.
     """,
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Virtual Network Device Modified or Deleted"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations"]
@@ -40,7 +40,7 @@ event.dataset:azure.activitylogs and azure.activitylogs.operation_name:("MICROSO
 "MICROSOFT.NETWORK/NETWORKINTERFACES/JOIN/ACTION" or "MICROSOFT.NETWORK/NETWORKINTERFACES/DELETE" or
 "MICROSOFT.NETWORK/NETWORKVIRTUALAPPLIANCES/DELETE" or "MICROSOFT.NETWORK/NETWORKVIRTUALAPPLIANCES/WRITE" or
 "MICROSOFT.NETWORK/VIRTUALHUBS/DELETE" or "MICROSOFT.NETWORK/VIRTUALHUBS/WRITE" or
-"MICROSOFT.NETWORK/VIRTUALROUTERS/WRITE" or "MICROSOFT.NETWORK/VIRTUALROUTERS/DELETE") and 
+"MICROSOFT.NETWORK/VIRTUALROUTERS/WRITE" or "MICROSOFT.NETWORK/VIRTUALROUTERS/DELETE") and
 event.outcome:(Success or success)
 '''
 

--- a/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin.toml
+++ b/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin.toml
@@ -17,7 +17,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Active Directory High Risk Sign-in"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin_atrisk_or_confirmed.toml
+++ b/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin_atrisk_or_confirmed.toml
@@ -8,14 +8,14 @@ integration = "azure"
 author = ["Austin Songer"]
 description = """
 Identifies high risk Azure Active Directory (AD) sign-ins by leveraging Microsoft Identity Protection machine learning
-and heuristics. 
+and heuristics.
 """
 from = "now-25m"
 index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Active Directory High Risk User Sign-in Heuristic"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/initial_access_azure_active_directory_powershell_signin.toml
+++ b/rules/integrations/azure/initial_access_azure_active_directory_powershell_signin.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Active Directory PowerShell Sign-in"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -23,7 +23,7 @@ note = """## Triage and analysis
 - Security analysts should review the list of trusted applications for any suspicious items.
 
 
-## Config
+## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -37,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:(azure.activitylogs or azure.auditlogs or o365.audit) and 
+event.dataset:(azure.activitylogs or azure.auditlogs or o365.audit) and
   (
     azure.activitylogs.operation_name:"Consent to application" or
     azure.auditlogs.operation_name:"Consent to application" or

--- a/rules/integrations/azure/initial_access_external_guest_user_invite.toml
+++ b/rules/integrations/azure/initial_access_external_guest_user_invite.toml
@@ -24,7 +24,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure External Guest User Invitation"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/governance/policy/samples/cis-azure-1-1-0"]

--- a/rules/integrations/azure/persistence_azure_automation_account_created.toml
+++ b/rules/integrations/azure/persistence_azure_automation_account_created.toml
@@ -16,7 +16,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Automation Account Created"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/persistence_azure_automation_runbook_created_or_modified.toml
+++ b/rules/integrations/azure/persistence_azure_automation_runbook_created_or_modified.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Automation Runbook Created or Modified"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/persistence_azure_automation_webhook_created.toml
+++ b/rules/integrations/azure/persistence_azure_automation_webhook_created.toml
@@ -16,7 +16,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Automation Webhook Created"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/persistence_azure_conditional_access_policy_modified.toml
+++ b/rules/integrations/azure/persistence_azure_conditional_access_policy_modified.toml
@@ -17,7 +17,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Conditional Access Policy Modified"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/overview"]

--- a/rules/integrations/azure/persistence_azure_global_administrator_role_assigned.toml
+++ b/rules/integrations/azure/persistence_azure_global_administrator_role_assigned.toml
@@ -18,7 +18,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure AD Global Administrator Role Assigned"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/persistence_azure_pim_user_added_global_admin.toml
+++ b/rules/integrations/azure/persistence_azure_pim_user_added_global_admin.toml
@@ -24,7 +24,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Global Administrator Role Addition to PIM User"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/persistence_azure_privileged_identity_management_role_modified.toml
+++ b/rules/integrations/azure/persistence_azure_privileged_identity_management_role_modified.toml
@@ -17,7 +17,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Privilege Identity Management Role Modified"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/persistence_mfa_disabled_for_azure_user.toml
+++ b/rules/integrations/azure/persistence_mfa_disabled_for_azure_user.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Multi-Factor Authentication Disabled for an Azure User"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 47

--- a/rules/integrations/azure/persistence_user_added_as_owner_for_azure_application.toml
+++ b/rules/integrations/azure/persistence_user_added_as_owner_for_azure_application.toml
@@ -16,7 +16,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "User Added as Owner for Azure Application"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 21

--- a/rules/integrations/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
+++ b/rules/integrations/azure/persistence_user_added_as_owner_for_azure_service_principal.toml
@@ -18,7 +18,7 @@ index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "User Added as Owner for Azure Service Principal"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/azure/privilege_escalation_azure_kubernetes_rolebinding_created.toml
+++ b/rules/integrations/azure/privilege_escalation_azure_kubernetes_rolebinding_created.toml
@@ -7,17 +7,17 @@ integration = "azure"
 [rule]
 author = ["Austin Songer"]
 description = """
-Identifies the creation of role binding or cluster role bindings. You can assign these roles to Kubernetes subjects 
+Identifies the creation of role binding or cluster role bindings. You can assign these roles to Kubernetes subjects
 (users, groups, or service accounts) with role bindings and cluster role bindings. An adversary who has permissions to create
 bindings and cluster-bindings in the cluster can create a binding to the cluster-admin ClusterRole or to other high privileges
-roles. 
+roles.
 """
 from = "now-20m"
 index = ["filebeat-*", "logs-azure*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure Kubernetes Rolebindings Created"
-note = """## Config
+note = """## Setup
 
 The Azure Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -34,7 +34,7 @@ type = "query"
 query = '''
 event.dataset:azure.activitylogs and azure.activitylogs.operation_name:
 	("MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/ROLEBINDINGS/WRITE" or
-	 "MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLEBINDINGS/WRITE") and 
+	 "MICROSOFT.KUBERNETES/CONNECTEDCLUSTERS/RBAC.AUTHORIZATION.K8S.IO/CLUSTERROLEBINDINGS/WRITE") and
 event.outcome:(Success or success)
 '''
 

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
@@ -8,7 +8,7 @@ min_stack_version = "7.14.0"
 
 [rule]
 author = ["Elastic"]
-description = """Identifies the occurrence of a CyberArk Privileged Access Security (PAS) error level audit event. The 
+description = """Identifies the occurrence of a CyberArk Privileged Access Security (PAS) error level audit event. The
 event.code correlates to the CyberArk Vault Audit Action Code.
 """
 false_positives = ["To tune this rule, add exceptions to exclude any event.code which should not trigger this rule."]
@@ -17,7 +17,7 @@ index = ["filebeat-*", "logs-cyberarkpas.audit*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "CyberArk Privileged Access Security Error"
-note = """## Config
+note = """## Setup
 
 The CyberArk Privileged Access Security (PAS) Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
@@ -18,7 +18,7 @@ index = ["filebeat-*", "logs-cyberarkpas.audit*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "CyberArk Privileged Access Security Recommended Monitor"
-note = """## Config
+note = """## Setup
 
 The CyberArk Privileged Access Security (PAS) Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/gcp/collection_gcp_pub_sub_subscription_creation.toml
+++ b/rules/integrations/gcp/collection_gcp_pub_sub_subscription_creation.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Pub/Sub Subscription Creation"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/pubsub/docs/overview"]

--- a/rules/integrations/gcp/collection_gcp_pub_sub_topic_creation.toml
+++ b/rules/integrations/gcp/collection_gcp_pub_sub_topic_creation.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Pub/Sub Topic Creation"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/pubsub/docs/admin"]

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Firewall Rule Creation"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/firewalls"]

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Firewall Rule Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/firewalls"]

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_modified.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_modified.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Firewall Rule Modification"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/firewalls"]

--- a/rules/integrations/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_logging_bucket_deletion.toml
@@ -24,7 +24,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Logging Bucket Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/logging/docs/buckets", "https://cloud.google.com/logging/docs/storage"]

--- a/rules/integrations/gcp/defense_evasion_gcp_logging_sink_deletion.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_logging_sink_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Logging Sink Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/logging/docs/export"]

--- a/rules/integrations/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_pub_sub_subscription_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Pub/Sub Subscription Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/pubsub/docs/overview"]

--- a/rules/integrations/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_pub_sub_topic_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Pub/Sub Topic Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/pubsub/docs/overview"]

--- a/rules/integrations/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_storage_bucket_configuration_modified.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Storage Bucket Configuration Modification"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/storage/docs/key-terms#buckets"]

--- a/rules/integrations/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_storage_bucket_permissions_modified.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Storage Bucket Permissions Modification"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/storage/docs/access-control/iam-permissions"]

--- a/rules/integrations/gcp/exfiltration_gcp_logging_sink_modification.toml
+++ b/rules/integrations/gcp/exfiltration_gcp_logging_sink_modification.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Logging Sink Modification"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/logging/docs/export#how_sinks_work"]

--- a/rules/integrations/gcp/impact_gcp_iam_role_deletion.toml
+++ b/rules/integrations/gcp/impact_gcp_iam_role_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP IAM Role Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/understanding-roles"]

--- a/rules/integrations/gcp/impact_gcp_service_account_deleted.toml
+++ b/rules/integrations/gcp/impact_gcp_service_account_deleted.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Service Account Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/service-accounts"]

--- a/rules/integrations/gcp/impact_gcp_service_account_disabled.toml
+++ b/rules/integrations/gcp/impact_gcp_service_account_disabled.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Service Account Disabled"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/service-accounts"]

--- a/rules/integrations/gcp/impact_gcp_storage_bucket_deleted.toml
+++ b/rules/integrations/gcp/impact_gcp_storage_bucket_deleted.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Storage Bucket Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/storage/docs/key-terms#buckets"]

--- a/rules/integrations/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
+++ b/rules/integrations/gcp/impact_gcp_virtual_private_cloud_network_deleted.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Virtual Private Cloud Network Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/vpc"]

--- a/rules/integrations/gcp/impact_gcp_virtual_private_cloud_route_created.toml
+++ b/rules/integrations/gcp/impact_gcp_virtual_private_cloud_route_created.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Virtual Private Cloud Route Creation"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/routes", "https://cloud.google.com/vpc/docs/using-routes"]

--- a/rules/integrations/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
+++ b/rules/integrations/gcp/impact_gcp_virtual_private_cloud_route_deleted.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Virtual Private Cloud Route Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/vpc/docs/routes", "https://cloud.google.com/vpc/docs/using-routes"]

--- a/rules/integrations/gcp/initial_access_gcp_iam_custom_role_creation.toml
+++ b/rules/integrations/gcp/initial_access_gcp_iam_custom_role_creation.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP IAM Custom Role Creation"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/understanding-custom-roles"]

--- a/rules/integrations/gcp/persistence_gcp_iam_service_account_key_deletion.toml
+++ b/rules/integrations/gcp/persistence_gcp_iam_service_account_key_deletion.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP IAM Service Account Key Deletion"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/gcp/persistence_gcp_key_created_for_service_account.toml
+++ b/rules/integrations/gcp/persistence_gcp_key_created_for_service_account.toml
@@ -24,7 +24,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Service Account Key Creation"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/gcp/persistence_gcp_service_account_created.toml
+++ b/rules/integrations/gcp/persistence_gcp_service_account_created.toml
@@ -24,7 +24,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Service Account Creation"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://cloud.google.com/iam/docs/service-accounts"]

--- a/rules/integrations/gcp/privilege_escalation_gcp_kubernetes_rolebindings_created_or_patched.toml
+++ b/rules/integrations/gcp/privilege_escalation_gcp_kubernetes_rolebindings_created_or_patched.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-gcp*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "GCP Kubernetes Rolebindings Created or Patched"
-note = """## Config
+note = """## Setup
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -31,8 +31,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:(googlecloud.audit or gcp.audit) and event.action:(io.k8s.authorization.rbac.v*.clusterrolebindings.create or 
-io.k8s.authorization.rbac.v*.rolebindings.create or io.k8s.authorization.rbac.v*.clusterrolebindings.patch or 
+event.dataset:(googlecloud.audit or gcp.audit) and event.action:(io.k8s.authorization.rbac.v*.clusterrolebindings.create or
+io.k8s.authorization.rbac.v*.rolebindings.create or io.k8s.authorization.rbac.v*.clusterrolebindings.patch or
 io.k8s.authorization.rbac.v*.rolebindings.patch) and event.outcome:success and
 not gcp.audit.authentication_info.principal_email:"system:addon-manager"
 '''

--- a/rules/integrations/google_workspace/application_added_to_google_workspace_domain.toml
+++ b/rules/integrations/google_workspace/application_added_to_google_workspace_domain.toml
@@ -25,7 +25,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Application Added to Google Workspace Domain"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/integrations/google_workspace/domain_added_to_google_workspace_trusted_domains.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Domain Added to Google Workspace Trusted Domains"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/google_workspace_admin_role_deletion.toml
+++ b/rules/integrations/google_workspace/google_workspace_admin_role_deletion.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Admin Role Deletion"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/integrations/google_workspace/google_workspace_mfa_enforcement_disabled.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace MFA Enforcement Disabled"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/google_workspace_policy_modified.toml
+++ b/rules/integrations/google_workspace/google_workspace_policy_modified.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Password Policy Modified"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/integrations/google_workspace/mfa_disabled_for_google_workspace_organization.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "MFA Disabled for Google Workspace Organization"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Admin Role Assigned to a User"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
@@ -25,7 +25,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace API Access Granted via Domain-Wide Delegation of Authority"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/persistence_google_workspace_custom_admin_role_created.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_custom_admin_role_created.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Custom Admin Role Created"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/google_workspace/persistence_google_workspace_role_modified.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_role_modified.toml
@@ -24,7 +24,7 @@ interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace Role Modified"
-note = """## Config
+note = """## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 

--- a/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
+++ b/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
@@ -28,7 +28,7 @@ index = ["logs-kubernetes.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes User Exec into Pod"
-note = """## Config
+note = """## Setup
 
 The Kubernetes Fleet integration with Audit Logs enabled or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -43,8 +43,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:"kubernetes.audit_logs" 
-  and kubernetes.audit.objectRef.resource:"pods" 
+event.dataset:"kubernetes.audit_logs"
+  and kubernetes.audit.objectRef.resource:"pods"
   and kubernetes.audit.objectRef.subresource:"exec"
 '''
 

--- a/rules/integrations/o365/collection_microsoft_365_new_inbox_rule.toml
+++ b/rules/integrations/o365/collection_microsoft_365_new_inbox_rule.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Inbox Forwarding Rule Created"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -46,7 +46,7 @@ event.category:web and event.action:"New-InboxRule" and
         o365.audit.Parameters.ForwardTo:* or
         o365.audit.Parameters.ForwardAsAttachmentTo:* or
         o365.audit.Parameters.RedirectTo:*
-    ) 
+    )
     and event.outcome:success
 '''
 

--- a/rules/integrations/o365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
+++ b/rules/integrations/o365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempts to Brute Force a Microsoft 365 User Account"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://blueteamblog.com/7-ways-to-monitor-your-office-365-logs-using-siem"]

--- a/rules/integrations/o365/credential_access_microsoft_365_potential_password_spraying_attack.toml
+++ b/rules/integrations/o365/credential_access_microsoft_365_potential_password_spraying_attack.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Potential Password Spraying of Microsoft 365 User Accounts"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 73
@@ -32,7 +32,7 @@ tags = ["Elastic", "Cloud", "Microsoft 365", "Continuous Monitoring", "SecOps", 
 type = "threshold"
 
 query = '''
-event.dataset:o365.audit and event.provider:(Exchange or AzureActiveDirectory) and event.category:authentication and 
+event.dataset:o365.audit and event.provider:(Exchange or AzureActiveDirectory) and event.category:authentication and
 event.action:("UserLoginFailed" or "PasswordLogonInitialAuthUsingPassword")
 '''
 

--- a/rules/integrations/o365/credential_access_user_excessive_sso_logon_errors.toml
+++ b/rules/integrations/o365/credential_access_user_excessive_sso_logon_errors.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "O365 Excessive Single Sign-On Logon Errors"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 73

--- a/rules/integrations/o365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange DLP Policy Removed"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Malware Filter Policy Deletion"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Malware Filter Rule Modification"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Safe Attachment Rule Disabled"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/defense_evasion_microsoft_365_mailboxauditbypassassociation.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_mailboxauditbypassassociation.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "O365 Mailbox Audit Logging Bypass"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
+++ b/rules/integrations/o365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Transport Rule Creation"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
+++ b/rules/integrations/o365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Transport Rule Modification"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/impact_microsoft_365_mass_download_by_a_single_user.toml
+++ b/rules/integrations/o365/impact_microsoft_365_mass_download_by_a_single_user.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Mass download by a single user"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 """

--- a/rules/integrations/o365/impact_microsoft_365_potential_ransomware_activity.toml
+++ b/rules/integrations/o365/impact_microsoft_365_potential_ransomware_activity.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Potential ransomware activity"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 """

--- a/rules/integrations/o365/impact_microsoft_365_unusual_volume_of_file_deletion.toml
+++ b/rules/integrations/o365/impact_microsoft_365_unusual_volume_of_file_deletion.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Unusual Volume of File Deletion"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 """

--- a/rules/integrations/o365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Anti-Phish Policy Deletion"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Anti-Phish Rule Modification"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Safe Link Policy Disabled"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/initial_access_microsoft_365_impossible_travel_activity.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_impossible_travel_activity.toml
@@ -16,7 +16,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Impossible travel activity"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 """

--- a/rules/integrations/o365/initial_access_microsoft_365_user_restricted_from_sending_email.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_user_restricted_from_sending_email.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 User Restricted from Sending Email"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 """

--- a/rules/integrations/o365/initial_access_o365_user_reported_phish_malware.toml
+++ b/rules/integrations/o365/initial_access_o365_user_reported_phish_malware.toml
@@ -18,7 +18,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "O365 Email Reported by User as Malware or Phish"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/lateral_movement_malware_uploaded_onedrive.toml
+++ b/rules/integrations/o365/lateral_movement_malware_uploaded_onedrive.toml
@@ -18,7 +18,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "OneDrive Malware File Upload"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/lateral_movement_malware_uploaded_sharepoint.toml
+++ b/rules/integrations/o365/lateral_movement_malware_uploaded_sharepoint.toml
@@ -18,7 +18,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "SharePoint Malware File Upload"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/microsoft_365_exchange_dkim_signing_config_disabled.toml
+++ b/rules/integrations/o365/microsoft_365_exchange_dkim_signing_config_disabled.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange DKIM Signing Configuration Disabled"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/microsoft_365_teams_custom_app_interaction_allowed.toml
+++ b/rules/integrations/o365/microsoft_365_teams_custom_app_interaction_allowed.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Teams Custom Application Interaction Allowed"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-upload"]

--- a/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
+++ b/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
@@ -16,7 +16,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "O365 Exchange Suspicious Mailbox Right Delegation"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 21
@@ -27,7 +27,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:o365.audit and event.provider:Exchange and event.action:Add-MailboxPermission and 
+event.dataset:o365.audit and event.provider:Exchange and event.action:Add-MailboxPermission and
 o365.audit.Parameters.AccessRights:(FullAccess or SendAs or SendOnBehalf) and event.outcome:success and
 not user.id : "NT AUTHORITY\SYSTEM (Microsoft.Exchange.Servicehost)"
 '''

--- a/rules/integrations/o365/persistence_microsoft_365_exchange_management_role_assignment.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_exchange_management_role_assignment.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Exchange Management Group Role Assignment"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/persistence_microsoft_365_global_administrator_role_assign.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_global_administrator_role_assign.toml
@@ -18,7 +18,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Global Administrator Role Assigned"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/persistence_microsoft_365_teams_external_access_enabled.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_teams_external_access_enabled.toml
@@ -22,7 +22,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Teams External Access Enabled"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://docs.microsoft.com/en-us/microsoftteams/manage-external-access"]

--- a/rules/integrations/o365/persistence_microsoft_365_teams_guest_access_enabled.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_teams_guest_access_enabled.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Microsoft 365 Teams Guest Access Enabled"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/o365/privilege_escalation_new_or_modified_federation_domain.toml
+++ b/rules/integrations/o365/privilege_escalation_new_or_modified_federation_domain.toml
@@ -14,7 +14,7 @@ index = ["filebeat-*", "logs-o365*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "New or Modified Federation Domain"
-note = """## Config
+note = """## Setup
 
 The Office 365 Logs Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -33,8 +33,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:("Set-AcceptedDomain" or 
-"Set-MsolDomainFederationSettings" or "Add-FederatedDomain" or "New-AcceptedDomain" or "Remove-AcceptedDomain" or "Remove-FederatedDomain") and 
+event.dataset:o365.audit and event.provider:Exchange and event.category:web and event.action:("Set-AcceptedDomain" or
+"Set-MsolDomainFederationSettings" or "Add-FederatedDomain" or "New-AcceptedDomain" or "Remove-AcceptedDomain" or "Remove-FederatedDomain") and
 event.outcome:success
 '''
 

--- a/rules/integrations/okta/attempt_to_deactivate_okta_network_zone.toml
+++ b/rules/integrations/okta/attempt_to_deactivate_okta_network_zone.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate an Okta Network Zone"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/attempt_to_delete_okta_network_zone.toml
+++ b/rules/integrations/okta/attempt_to_delete_okta_network_zone.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Delete an Okta Network Zone"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/integrations/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -14,7 +14,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempted Bypass of Okta MFA"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
+++ b/rules/integrations/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
@@ -16,7 +16,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempts to Brute Force an Okta User Account"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/credential_access_mfa_push_brute_force.toml
+++ b/rules/integrations/okta/credential_access_mfa_push_brute_force.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Abuse of Repeated MFA Push Notifications"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = ["https://www.mandiant.com/resources/russian-targeting-gov-business"]

--- a/rules/integrations/okta/credential_access_okta_brute_force_or_password_spraying.toml
+++ b/rules/integrations/okta/credential_access_okta_brute_force_or_password_spraying.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Okta Brute Force or Password Spraying Attack"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/credential_access_user_impersonation_access.toml
+++ b/rules/integrations/okta/credential_access_user_impersonation_access.toml
@@ -17,7 +17,7 @@ interval = "15m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Okta User Session Impersonation"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/defense_evasion_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/integrations/okta/defense_evasion_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -7,8 +7,8 @@ integration = "okta"
 [rule]
 author = ["Elastic", "@BenB196", "Austin Songer"]
 description = """
-Identifies a high number of Okta user password reset or account unlock attempts. An adversary may attempt to obtain 
-unauthorized access to Okta user accounts using these methods and attempt to blend in with normal activity in their 
+Identifies a high number of Okta user password reset or account unlock attempts. An adversary may attempt to obtain
+unauthorized access to Okta user accounts using these methods and attempt to blend in with normal activity in their
 target's environment and evade detection.
 """
 false_positives = [
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "High Number of Okta User Password Reset or Unlock Attempts"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
@@ -86,4 +86,4 @@ reference = "https://attack.mitre.org/tactics/TA0001/"
 field = ["okta.actor.alternate_id"]
 value = 5
 
- 
+

--- a/rules/integrations/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/integrations/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Revoke Okta API Token"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/integrations/okta/impact_possible_okta_dos_attack.toml
@@ -14,7 +14,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Possible Okta DoS Attack"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/initial_access_okta_user_attempted_unauthorized_access.toml
+++ b/rules/integrations/okta/initial_access_okta_user_attempted_unauthorized_access.toml
@@ -11,7 +11,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Unauthorized Access to an Okta Application"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 risk_score = 21

--- a/rules/integrations/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/integrations/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Suspicious Activity Reported by Okta User"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_deactivate_okta_application.toml
+++ b/rules/integrations/okta/okta_attempt_to_deactivate_okta_application.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate an Okta Application"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_deactivate_okta_policy.toml
+++ b/rules/integrations/okta/okta_attempt_to_deactivate_okta_policy.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate an Okta Policy"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
+++ b/rules/integrations/okta/okta_attempt_to_deactivate_okta_policy_rule.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate an Okta Policy Rule"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_delete_okta_application.toml
+++ b/rules/integrations/okta/okta_attempt_to_delete_okta_application.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Delete an Okta Application"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_delete_okta_policy.toml
+++ b/rules/integrations/okta/okta_attempt_to_delete_okta_policy.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Delete an Okta Policy"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_delete_okta_policy_rule.toml
+++ b/rules/integrations/okta/okta_attempt_to_delete_okta_policy_rule.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Delete an Okta Policy Rule"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_modify_okta_application.toml
+++ b/rules/integrations/okta/okta_attempt_to_modify_okta_application.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Modify an Okta Application"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/integrations/okta/okta_attempt_to_modify_okta_network_zone.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Modify an Okta Network Zone"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_modify_okta_policy.toml
+++ b/rules/integrations/okta/okta_attempt_to_modify_okta_policy.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Modify an Okta Policy"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_modify_okta_policy_rule.toml
+++ b/rules/integrations/okta/okta_attempt_to_modify_okta_policy_rule.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Modify an Okta Policy Rule"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/integrations/okta/okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Modification or Removal of an Okta Application Sign-On Policy"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/okta_threat_detected_by_okta_threatinsight.toml
+++ b/rules/integrations/okta/okta_threat_detected_by_okta_threatinsight.toml
@@ -15,7 +15,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Threat Detected by Okta ThreatInsight"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/integrations/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Administrator Privileges Assigned to an Okta Group"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/integrations/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Administrator Role Assigned to an Okta User"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/integrations/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Create Okta API Token"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/integrations/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -20,7 +20,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Deactivate MFA for an Okta User Account"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/integrations/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/integrations/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -21,7 +21,7 @@ index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Attempt to Reset MFA Factors for an Okta User Account"
-note = """## Config
+note = """## Setup
 
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [

--- a/rules/linux/command_and_control_tunneling_via_earthworm.toml
+++ b/rules/linux/command_and_control_tunneling_via_earthworm.toml
@@ -15,7 +15,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Protocol Tunneling via EarthWorm"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/linux/credential_access_ssh_backdoor_log.toml
+++ b/rules/linux/credential_access_ssh_backdoor_log.toml
@@ -16,7 +16,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential OpenSSH Backdoor Logging Activity"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -36,24 +36,24 @@ file where event.type == "change" and process.executable : ("/usr/sbin/sshd", "/
   (
     file.name : (".*", "~*") or
     file.extension : ("in", "out", "ini", "h", "gz", "so", "sock", "sync", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9") or
-    file.path : 
+    file.path :
     (
-      "/private/etc/*--", 
-      "/usr/share/*", 
-      "/usr/include/*", 
-      "/usr/local/include/*", 
-      "/private/tmp/*", 
+      "/private/etc/*--",
+      "/usr/share/*",
+      "/usr/include/*",
+      "/usr/local/include/*",
+      "/private/tmp/*",
       "/private/var/tmp/*",
-      "/usr/tmp/*", 
-      "/usr/share/man/*", 
-      "/usr/local/share/*", 
-      "/usr/lib/*.so.*", 
+      "/usr/tmp/*",
+      "/usr/share/man/*",
+      "/usr/local/share/*",
+      "/usr/lib/*.so.*",
       "/private/etc/ssh/.sshd_auth",
-      "/usr/bin/ssd", 
-      "/private/var/opt/power", 
-      "/private/etc/ssh/ssh_known_hosts", 
-      "/private/var/html/lol", 
-      "/private/var/log/utmp", 
+      "/usr/bin/ssd",
+      "/private/var/opt/power",
+      "/private/etc/ssh/ssh_known_hosts",
+      "/private/var/html/lol",
+      "/private/var/log/utmp",
       "/private/var/lib",
       "/var/run/sshd/sshd.pid",
       "/var/run/nscd/ns.pid",

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -24,7 +24,7 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Creation of Hidden Files and Directories"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/linux/defense_evasion_log_files_deleted.toml
+++ b/rules/linux/defense_evasion_log_files_deleted.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "System Log File Deletion"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -29,17 +29,17 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where event.type == "deletion" and 
-  file.path : 
+file where event.type == "deletion" and
+  file.path :
     (
-    "/var/run/utmp", 
-    "/var/log/wtmp", 
-    "/var/log/btmp", 
-    "/var/log/lastlog", 
+    "/var/run/utmp",
+    "/var/log/wtmp",
+    "/var/log/btmp",
+    "/var/log/lastlog",
     "/var/log/faillog",
-    "/var/log/syslog", 
-    "/var/log/messages", 
-    "/var/log/secure", 
+    "/var/log/syslog",
+    "/var/log/messages",
+    "/var/log/secure",
     "/var/log/auth.log"
     )
 '''

--- a/rules/linux/execution_shell_evasion_linux_binary.toml
+++ b/rules/linux/execution_shell_evasion_linux_binary.toml
@@ -62,7 +62,7 @@ Initiate the incident response process based on the outcome of the triage.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The session view analysis for the command alerted is avalible in versions 8.2 and above.
 """

--- a/rules/linux/persistence_kde_autostart_modification.toml
+++ b/rules/linux/persistence_kde_autostart_modification.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via KDE AutoStart Script or Desktop File Modification"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
+++ b/rules/macos/credential_access_access_to_browser_credentials_procargs.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Access of Stored Browser Credentials"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -30,17 +30,17 @@ query = '''
 process where event.type in ("start", "process_started") and
   process.args :
     (
-      "/Users/*/Library/Application Support/Google/Chrome/Default/Login Data", 
-      "/Users/*/Library/Application Support/Google/Chrome/Default/Cookies", 
-      "/Users/*/Library/Cookies*", 
-      "/Users/*/Library/Application Support/Firefox/Profiles/*.default/cookies.sqlite", 
-      "/Users/*/Library/Application Support/Firefox/Profiles/*.default/key*.db", 
-      "/Users/*/Library/Application Support/Firefox/Profiles/*.default/logins.json", 
+      "/Users/*/Library/Application Support/Google/Chrome/Default/Login Data",
+      "/Users/*/Library/Application Support/Google/Chrome/Default/Cookies",
+      "/Users/*/Library/Cookies*",
+      "/Users/*/Library/Application Support/Firefox/Profiles/*.default/cookies.sqlite",
+      "/Users/*/Library/Application Support/Firefox/Profiles/*.default/key*.db",
+      "/Users/*/Library/Application Support/Firefox/Profiles/*.default/logins.json",
       "Login Data",
-      "Cookies.binarycookies", 
-      "key4.db", 
-      "key3.db", 
-      "logins.json", 
+      "Cookies.binarycookies",
+      "key4.db",
+      "key3.db",
+      "logins.json",
       "cookies.sqlite"
     )
 '''

--- a/rules/macos/credential_access_credentials_keychains.toml
+++ b/rules/macos/credential_access_credentials_keychains.toml
@@ -15,7 +15,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Access to Keychain Credentials Directories"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/credential_access_dumping_keychain_security.toml
+++ b/rules/macos/credential_access_dumping_keychain_security.toml
@@ -15,7 +15,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Dumping of Keychain Content via Security Command"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/credential_access_keychain_pwd_retrieval_security_cmd.toml
+++ b/rules/macos/credential_access_keychain_pwd_retrieval_security_cmd.toml
@@ -16,7 +16,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Keychain Password Retrieval via Command Line"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
+++ b/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Prompt for Credentials with OSASCRIPT"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
+++ b/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
@@ -15,7 +15,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Attempt to Remove File Quarantine Attribute"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/defense_evasion_privacy_controls_tcc_database_modification.toml
+++ b/rules/macos/defense_evasion_privacy_controls_tcc_database_modification.toml
@@ -15,7 +15,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privacy Control Bypass via TCCDB Modification"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -32,7 +32,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start", "process_started") and process.name : "sqlite*" and 
+process where event.type in ("start", "process_started") and process.name : "sqlite*" and
  process.args : "/*/Application Support/com.apple.TCC/TCC.db"
 '''
 

--- a/rules/macos/defense_evasion_privilege_escalation_privacy_pref_sshd_fulldiskaccess.toml
+++ b/rules/macos/defense_evasion_privilege_escalation_privacy_pref_sshd_fulldiskaccess.toml
@@ -15,7 +15,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privacy Control Bypass via Localhost Secure Copy"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -30,9 +30,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start", "process_started") and 
+process where event.type in ("start", "process_started") and
  process.name:"scp" and
- process.args:"StrictHostKeyChecking=no" and 
+ process.args:"StrictHostKeyChecking=no" and
  process.command_line:("scp *localhost:/*", "scp *127.0.0.1:/*") and
  not process.args:"vagrant@*127.0.0.1*"
 '''

--- a/rules/macos/discovery_users_domain_built_in_commands.toml
+++ b/rules/macos/discovery_users_domain_built_in_commands.toml
@@ -11,7 +11,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Enumeration of Users or Groups via Built-in Commands"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -24,16 +24,16 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
-  not process.parent.executable : ("/Applications/NoMAD.app/Contents/MacOS/NoMAD", 
+  not process.parent.executable : ("/Applications/NoMAD.app/Contents/MacOS/NoMAD",
     "/Applications/ZoomPresence.app/Contents/MacOS/ZoomPresence",
      "/Applications/Sourcetree.app/Contents/MacOS/Sourcetree",
      "/Library/Application Support/JAMF/Jamf.app/Contents/MacOS/JamfDaemon.app/Contents/MacOS/JamfDaemon",
      "/Applications/Jamf Connect.app/Contents/MacOS/Jamf Connect",
      "/usr/local/jamf/bin/jamf"
-    ) and 
+    ) and
   process.name : ("ldapsearch", "dsmemberutil") or
-  (process.name : "dscl" and 
-     process.args : ("read", "-read", "list", "-list", "ls", "search", "-search") and 
+  (process.name : "dscl" and
+     process.args : ("read", "-read", "list", "-list", "ls", "search", "-search") and
      process.args : ("/Active Directory/*", "/Users*", "/Groups*"))
 '''
 

--- a/rules/macos/lateral_movement_mounting_smb_share.toml
+++ b/rules/macos/lateral_movement_mounting_smb_share.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Attempt to Mount SMB Share via Command Line"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/lateral_movement_vpn_connection_attempt.toml
+++ b/rules/macos/lateral_movement_vpn_connection_attempt.toml
@@ -11,7 +11,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Virtual Private Network Connection Attempt"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/persistence_creation_hidden_login_item_osascript.toml
+++ b/rules/macos/persistence_creation_hidden_login_item_osascript.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation of Hidden Login Item via Apple Script"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/persistence_emond_rules_file_creation.toml
+++ b/rules/macos/persistence_emond_rules_file_creation.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Emond Rules Creation or Modification"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/persistence_evasion_hidden_launch_agent_deamon_creation.toml
+++ b/rules/macos/persistence_evasion_hidden_launch_agent_deamon_creation.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation of Hidden Launch Agent or Daemon"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -30,7 +30,7 @@ type = "eql"
 
 query = '''
 file where event.type != "deletion" and
-  file.path : 
+  file.path :
   (
     "/System/Library/LaunchAgents/.*.plist",
     "/Library/LaunchAgents/.*.plist",

--- a/rules/macos/persistence_login_logout_hooks_defaults.toml
+++ b/rules/macos/persistence_login_logout_hooks_defaults.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Login or Logout Hook"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/persistence_modification_sublime_app_plugin_or_script.toml
+++ b/rules/macos/persistence_modification_sublime_app_plugin_or_script.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Sublime Plugin or Application Script Modification"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -28,17 +28,17 @@ type = "eql"
 
 query = '''
 file where event.type in ("change", "creation") and file.extension : "py" and
-  file.path : 
+  file.path :
     (
-      "/Users/*/Library/Application Support/Sublime Text*/Packages/*.py", 
+      "/Users/*/Library/Application Support/Sublime Text*/Packages/*.py",
       "/Applications/Sublime Text.app/Contents/MacOS/sublime.py"
     ) and
-  not process.executable : 
+  not process.executable :
     (
-      "/Applications/Sublime Text*.app/Contents/MacOS/Sublime Text*", 
-      "/usr/local/Cellar/git/*/bin/git", 
-      "/usr/libexec/xpcproxy", 
-      "/System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/Resources/DesktopServicesHelper", 
+      "/Applications/Sublime Text*.app/Contents/MacOS/Sublime Text*",
+      "/usr/local/Cellar/git/*/bin/git",
+      "/usr/libexec/xpcproxy",
+      "/System/Library/PrivateFrameworks/DesktopServicesPriv.framework/Versions/A/Resources/DesktopServicesHelper",
       "/Applications/Sublime Text.app/Contents/MacOS/plugin_host"
     )
 '''

--- a/rules/macos/persistence_screensaver_engine_unexpected_child_process.toml
+++ b/rules/macos/persistence_screensaver_engine_unexpected_child_process.toml
@@ -24,7 +24,7 @@ as a download of a payload from a server.
 identify whether the file is malicious or not.
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/persistence_screensaver_plist_file_modification.toml
+++ b/rules/macos/persistence_screensaver_plist_file_modification.toml
@@ -21,7 +21,7 @@ note = """## Triage and analysis
 - Investigate the process that modified the plist file for malicious code or other suspicious behavior
 - Identify if any suspicious or known malicious screensaver (.saver) files were recently written to or modified on the host
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/macos/privilege_escalation_applescript_with_admin_privs.toml
+++ b/rules/macos/privilege_escalation_applescript_with_admin_privs.toml
@@ -14,7 +14,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Apple Scripting Execution with Administrator Privileges"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/network/initial_access_unsecure_elasticsearch_node.toml
+++ b/rules/network/initial_access_unsecure_elasticsearch_node.toml
@@ -20,7 +20,7 @@ index = ["auditbeat-*", "filebeat-*", "packetbeat-*", "logs-endpoint.events.*"]
 language = "lucene"
 license = "Elastic License v2"
 name = "Inbound Connection to an Unsecure Elasticsearch Node"
-note = """## Config
+note = """## Setup
 
 This rule requires the addition of port `9200` and `send_all_headers` to the `HTTP` protocol configuration in `packetbeat.yml`. See the References section for additional configuration documentation."""
 references = [

--- a/rules/windows/collection_email_powershell_exchange_mailbox.toml
+++ b/rules/windows/collection_email_powershell_exchange_mailbox.toml
@@ -65,7 +65,7 @@ persistence mechanisms, and malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/collection_posh_audio_capture.toml
+++ b/rules/windows/collection_posh_audio_capture.toml
@@ -61,15 +61,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -88,7 +88,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text : (
     "Get-MicrophoneAudio" or (waveInGetNumDevs and mciSendStringA)
   )

--- a/rules/windows/collection_posh_keylogger.toml
+++ b/rules/windows/collection_posh_keylogger.toml
@@ -61,15 +61,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -91,9 +91,9 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
-  ( 
-   powershell.file.script_block_text : (GetAsyncKeyState or NtUserGetAsyncKeyState or GetKeyboardState or "Get-Keystrokes") or 
+event.category:process and
+  (
+   powershell.file.script_block_text : (GetAsyncKeyState or NtUserGetAsyncKeyState or GetKeyboardState or "Get-Keystrokes") or
    powershell.file.script_block_text : (
         (SetWindowsHookA or SetWindowsHookW or SetWindowsHookEx or SetWindowsHookExA or NtUserSetWindowsHookEx) and
         (GetForegroundWindow or GetWindowTextA or GetWindowTextW or "WM_KEYBOARD_LL")

--- a/rules/windows/collection_posh_screen_grabber.toml
+++ b/rules/windows/collection_posh_screen_grabber.toml
@@ -60,15 +60,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -87,7 +87,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text : (
     CopyFromScreen and
     ("System.Drawing.Bitmap" or "Drawing.Bitmap")

--- a/rules/windows/collection_winrar_encryption.toml
+++ b/rules/windows/collection_winrar_encryption.toml
@@ -56,7 +56,7 @@ malware components.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/command_and_control_encrypted_channel_freesslcert.toml
+++ b/rules/windows/command_and_control_encrypted_channel_freesslcert.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Connection to Commonly Abused Free SSL Certificate Providers"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -29,7 +29,7 @@ query = '''
 network where network.protocol == "dns" and
   /* Add new free SSL certificate provider domains here */
   dns.question.name : ("*letsencrypt.org", "*.sslforfree.com", "*.zerossl.com", "*.freessl.org") and
-  
+
   /* Native Windows process paths that are unlikely to have network connections to domains secured using free SSL certificates */
   process.executable : ("C:\\Windows\\System32\\*.exe",
                         "C:\\Windows\\System\\*.exe",
@@ -37,7 +37,7 @@ network where network.protocol == "dns" and
 		          "C:\\Windows\\Microsoft.NET\\Framework*\\*.exe",
 		          "C:\\Windows\\explorer.exe",
 		          "C:\\Windows\\notepad.exe") and
-  
+
   /* Insert noisy false positives here */
   not process.name : ("svchost.exe", "MicrosoftEdge*.exe", "msedge.exe")
 '''

--- a/rules/windows/command_and_control_port_forwarding_added_registry.toml
+++ b/rules/windows/command_and_control_port_forwarding_added_registry.toml
@@ -67,7 +67,7 @@ systems, and web services.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/command_and_control_rdp_tunnel_plink.toml
+++ b/rules/windows/command_and_control_rdp_tunnel_plink.toml
@@ -59,7 +59,7 @@ malware components.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
+++ b/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
@@ -72,7 +72,7 @@ malware components.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -64,7 +64,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
+++ b/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
@@ -65,7 +65,7 @@ systems, and web services.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_cmdline_dump_tool.toml
+++ b/rules/windows/credential_access_cmdline_dump_tool.toml
@@ -16,7 +16,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Credential Access via Windows Utilities"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
+++ b/rules/windows/credential_access_copy_ntds_sam_volshadowcp_cmdline.toml
@@ -15,7 +15,7 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "NTDS or SAM Database File Copied"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_dcsync_replication_rights.toml
+++ b/rules/windows/credential_access_dcsync_replication_rights.toml
@@ -25,7 +25,7 @@ automatically transferred to other domain controllers that store the same data.
 Active Directory data consists of objects that have properties, or attributes. Each object is an instance of an object
 class, and object classes and their respective attributes are defined in the Active Directory schema. Objects are
 defined by the values of their attributes, and changes to attribute values must be transferred from the domain
-controller on which they occur to every other domain controller that stores a replica of an affected object. 
+controller on which they occur to every other domain controller that stores a replica of an affected object.
 
 Adversaries can use the DCSync technique that uses Windows Domain Controller's API to simulate the replication process
 from a remote domain controller, compromising major credential material such as the Kerberos krbtgt keys used
@@ -39,7 +39,7 @@ More details can be found on [Threat Hunter Playbook](https://threathunterplaybo
 This rule monitors for Event ID 4662 (Operation was performed on an Active Directory object) and identifies events that
 use the access mask 0x100 (Control Access) and properties that contain at least one of the following or their equivalent:
 Schema-Id-GUID (DS-Replication-Get-Changes, DS-Replication-Get-Changes-All, DS-Replication-Get-Changes-In-Filtered-Set).
-It also filters out events that use computer accounts and also Azure AD Connect MSOL accounts (more details [here](https://techcommunity.microsoft.com/t5/microsoft-defender-for-identity/ad-connect-msol-user-suspected-dcsync-attack/m-p/788028)). 
+It also filters out events that use computer accounts and also Azure AD Connect MSOL accounts (more details [here](https://techcommunity.microsoft.com/t5/microsoft-defender-for-identity/ad-connect-msol-user-suspected-dcsync-attack/m-p/788028)).
 
 #### Possible investigation steps
 
@@ -51,7 +51,7 @@ It also filters out events that use computer accounts and also Azure AD Connect 
 came from another DC or not.
 - Scope which credentials were compromised (for example, whether all accounts were replicated or specific ones).
 
-### False positive analysis 
+### False positive analysis
 
 - This activity should not happen legitimately, since replication should be done by Domain Controllers only. Any
 potential benign true positive (B-TP) should be mapped and monitored by the security team. Any account that performs
@@ -74,7 +74,7 @@ information to scope ways that the attacker could use to regain access to the en
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'Audit Directory Service Changes' logging policy must be configured for (Success, Failure).
 Steps to implement the logging policy with Advanced Audit Configuration:
@@ -121,8 +121,8 @@ any where event.action == "Directory Service Access" and
 
     "*1131f6ad-9c07-11d1-f79f-00c04fc2dcd2*",
     "*1131f6aa-9c07-11d1-f79f-00c04fc2dcd2*",
-    "*89e95b76-444d-4c62-991a-0facbeda640c*") 
-    
+    "*89e95b76-444d-4c62-991a-0facbeda640c*")
+
     /* The right to perform an operation controlled by an extended access right. */
 
     and winlog.event_data.AccessMask : "0x100" and

--- a/rules/windows/credential_access_disable_kerberos_preauth.toml
+++ b/rules/windows/credential_access_disable_kerberos_preauth.toml
@@ -53,19 +53,19 @@ systems, and web services.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'Audit User Account Management' logging policy must be configured for (Success, Failure).
 Steps to implement the logging policy with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-Account Management > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+Account Management >
 Audit User Account Management (Success,Failure)
 ```
 """

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -18,7 +18,7 @@ note = """## Triage and analysis
 
 Domain DPAPI Backup keys are stored on domain controllers and can be dumped remotely with tools such as Mimikatz. The resulting .pvk private key can be used to decrypt ANY domain user masterkeys, which then can be used to decrypt any secrets protected by those keys.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_dump_registry_hives.toml
+++ b/rules/windows/credential_access_dump_registry_hives.toml
@@ -59,7 +59,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
+++ b/rules/windows/credential_access_iis_apppoolsa_pwd_appcmd.toml
@@ -15,7 +15,7 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Microsoft IIS Service Account Password Dumped"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -29,7 +29,7 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
-   (process.name : "appcmd.exe" or process.pe.original_file_name == "appcmd.exe") and 
+   (process.name : "appcmd.exe" or process.pe.original_file_name == "appcmd.exe") and
    process.args : "/list" and process.args : "/text*password"
 '''
 

--- a/rules/windows/credential_access_iis_connectionstrings_dumping.toml
+++ b/rules/windows/credential_access_iis_connectionstrings_dumping.toml
@@ -16,7 +16,7 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "Microsoft IIS Connection Strings Decryption"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_kerberoasting_unusual_process.toml
+++ b/rules/windows/credential_access_kerberoasting_unusual_process.toml
@@ -74,7 +74,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_lsass_memdump_file_created.toml
+++ b/rules/windows/credential_access_lsass_memdump_file_created.toml
@@ -17,7 +17,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "LSASS Memory Dump Creation"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_lsass_memdump_handle_access.toml
+++ b/rules/windows/credential_access_lsass_memdump_handle_access.toml
@@ -28,7 +28,7 @@ password changes, and creates access tokens.
 Adversaries may attempt to access credential material stored in LSASS process memory. After a user logs on,the system
 generates and stores a variety of credential materials in LSASS process memory. This is meant to facilitate single
 sign-on (SSO) ensuring a user isn’t prompted each time resource access is requested. These credential materials can be
-harvested by an adversary using administrative user or SYSTEM privileges to conduct lateral movement using 
+harvested by an adversary using administrative user or SYSTEM privileges to conduct lateral movement using
 [alternate authentication material](https://attack.mitre.org/techniques/T1550/).
 
 #### Possible investigation steps
@@ -74,7 +74,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 Ensure advanced audit policies for Windows are enabled, specifically:
 Object Access policies [Event ID 4656](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4656) (Handle to an Object was Requested)

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -64,7 +64,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_mimikatz_powershell_module.toml
+++ b/rules/windows/credential_access_mimikatz_powershell_module.toml
@@ -75,16 +75,16 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be configured (Enable).
 
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 

--- a/rules/windows/credential_access_mod_wdigest_security_provider.toml
+++ b/rules/windows/credential_access_mod_wdigest_security_provider.toml
@@ -73,7 +73,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -91,7 +91,7 @@ type = "eql"
 
 query = '''
 registry where event.type : ("creation", "change") and
-    registry.path : 
+    registry.path :
         "HKLM\\SYSTEM\\*ControlSet*\\Control\\SecurityProviders\\WDigest\\UseLogonCredential"
     and registry.data.strings : ("1", "0x00000001")
 '''

--- a/rules/windows/credential_access_posh_minidump.toml
+++ b/rules/windows/credential_access_posh_minidump.toml
@@ -60,15 +60,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 

--- a/rules/windows/credential_access_posh_request_ticket.toml
+++ b/rules/windows/credential_access_posh_request_ticket.toml
@@ -59,15 +59,15 @@ systems, and web services. Prioritize privileged accounts.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -89,7 +89,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text : (
     KerberosRequestorSecurityToken
   )

--- a/rules/windows/credential_access_potential_lsa_memdump_via_mirrordump.toml
+++ b/rules/windows/credential_access_potential_lsa_memdump_via_mirrordump.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Credential Access via DuplicateHandle in LSASS"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -27,7 +27,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.code == "10" and 
+process where event.code == "10" and
 
  /* LSASS requesting DuplicateHandle access right to another process */
  process.name : "lsass.exe" and winlog.event_data.GrantedAccess == "0x40" and

--- a/rules/windows/credential_access_remote_sam_secretsdump.toml
+++ b/rules/windows/credential_access_remote_sam_secretsdump.toml
@@ -20,7 +20,7 @@ note = """## Triage and analysis
 
 ### Investigating Potential Remote Credential Access via Registry
 
-Dumping registry hives is a common way to access credential information. Some hives store credential material, 
+Dumping registry hives is a common way to access credential information. Some hives store credential material,
 such as the SAM hive, which stores locally cached credentials (SAM secrets), and the SECURITY hive, which stores domain
 cached credentials (LSA secrets). Dumping these hives in combination with the SYSTEM hive enables the attacker to
 decrypt these secrets.
@@ -61,7 +61,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 This rule uses Elastic Endpoint file creation and system integration events for correlation. Both data should be
 collected from the host for this detection to work.

--- a/rules/windows/credential_access_saved_creds_vaultcmd.toml
+++ b/rules/windows/credential_access_saved_creds_vaultcmd.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Searching for Saved Credentials via VaultCmd"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
+++ b/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
@@ -36,7 +36,7 @@ delegation**.
 
 It is critical to control the assignment of this privilege. A user with this privilege and write access to a computer
 can control delegation settings, perform the attacks described above, and harvest TGTs from any user that connects to
-the system. 
+the system.
 
 #### Possible investigation steps
 
@@ -63,7 +63,7 @@ environment legitimately, the security team should notify the administrators abo
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'Audit Authorization Policy Change' logging policy must be configured for (Success, Failure).
 Steps to implement the logging policy with Advanced Audit Configuration:

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -21,19 +21,19 @@ index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Potential Shadow Credentials added to AD Object"
-note = """## Config
+note = """## Setup
 
 The 'Audit Directory Service Changes' logging policy must be configured for (Success, Failure).
 Steps to implement the logging policy with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-DS Access > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+DS Access >
 Audit Directory Service Changes (Success,Failure)
 ```
 

--- a/rules/windows/credential_access_spn_attribute_modified.toml
+++ b/rules/windows/credential_access_spn_attribute_modified.toml
@@ -54,7 +54,7 @@ Domain Administrators that define this kind of setting can put the domain at ris
 security standards as computer accounts (which have long, complex, random passwords that change frequently), exposing
 them to credential cracking attacks (Kerberoasting, brute force, etc.).
 
-### Response and remediation 
+### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
@@ -65,7 +65,7 @@ systems, and web services. Prioritize privileged accounts.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'Audit Directory Service Changes' logging policy must be configured for (Success, Failure).
 Steps to implement the logging policy with Advanced Audit Configuration:
@@ -104,7 +104,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.action:"Directory Service Changes" and event.code:5136 and winlog.event_data.ObjectClass:"user" 
+event.action:"Directory Service Changes" and event.code:5136 and winlog.event_data.ObjectClass:"user"
 and winlog.event_data.AttributeLDAPDisplayName:"servicePrincipalName"
 '''
 

--- a/rules/windows/credential_access_suspicious_comsvcs_imageload.toml
+++ b/rules/windows/credential_access_suspicious_comsvcs_imageload.toml
@@ -16,7 +16,7 @@ index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Credential Access via Renamed COM+ Services DLL"
-note = """## Config
+note = """## Setup
 
 You will need to enable logging of ImageLoads in your Sysmon configuration to include COMSVCS.DLL by Imphash or Original
 File Name."""

--- a/rules/windows/credential_access_suspicious_lsass_access_memdump.toml
+++ b/rules/windows/credential_access_suspicious_lsass_access_memdump.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Credential Access via LSASS Memory Dump"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -31,10 +31,10 @@ type = "eql"
 query = '''
 process where event.code == "10" and
   winlog.event_data.TargetImage : "?:\\WINDOWS\\system32\\lsass.exe" and
-  
+
    /* DLLs exporting MiniDumpWriteDump API to create an lsass mdmp*/
   winlog.event_data.CallTrace : ("*dbghelp*", "*dbgcore*") and
-  
+
    /* case of lsass crashing */
   not process.executable : ("?:\\Windows\\System32\\WerFault.exe", "?:\\Windows\\System32\\WerFaultSecure.exe")
 '''

--- a/rules/windows/credential_access_suspicious_lsass_access_via_snapshot.toml
+++ b/rules/windows/credential_access_suspicious_lsass_access_via_snapshot.toml
@@ -18,7 +18,7 @@ index = ["winlogbeat-*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Potential LSASS Memory Dump via PssCaptureSnapShot"
-note = """## Config
+note = """## Setup
 
 This is meant to run only on datasources using Elastic Agent 7.14+ since versions prior to that will be missing the threshold
 rule cardinality feature."""

--- a/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
+++ b/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-system.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Remote Registry Access via SeBackupPrivilege"
-note = """## Config
+note = """## Setup
 
 The 'Audit Detailed File Share' audit policy is required be configured (Success) on Domain Controllers and Sensitive Windows Servers.
 Steps to implement the logging policy with with Advanced Audit Configuration:

--- a/rules/windows/credential_access_symbolic_link_to_shadow_copy_created.toml
+++ b/rules/windows/credential_access_symbolic_link_to_shadow_copy_created.toml
@@ -41,11 +41,11 @@ for prevalence, whether they are located in expected locations, and if they are 
 
 - This rule should cause very few false positives. Benign true positives (B-TPs) can be added as exceptions if necessary.
 
-### Related rules 
+### Related rules
 
 - NTDS or SAM Database File Copied - 3bc6deaa-fbd4-433a-ae21-3e892f95624f
 
-### Response and remediation 
+### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
@@ -62,28 +62,28 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 Ensure advanced audit policies for Windows are enabled, specifically:
-Object Access policies [Event ID 4656](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4656) (Handle to an Object was Requested) 
- 
-``` 
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-System Audit Policies > 
-Object Access > 
-Audit File System (Success,Failure) 
-Audit Handle Manipulation (Success,Failure) 
-``` 
- 
-This event will only trigger if symbolic links are created from a new process spawning cmd.exe or powershell.exe with the correct arguments. 
-Direct access to a shell and calling symbolic link creation tools will not generate an event matching this rule. 
+Object Access policies [Event ID 4656](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4656) (Handle to an Object was Requested)
+
+```
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+System Audit Policies >
+Object Access >
+Audit File System (Success,Failure)
+Audit Handle Manipulation (Success,Failure)
+```
+
+This event will only trigger if symbolic links are created from a new process spawning cmd.exe or powershell.exe with the correct arguments.
+Direct access to a shell and calling symbolic link creation tools will not generate an event matching this rule.
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
-""" 
+"""
 references = [
     "https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mklink",
     "https://2017.zeronights.org/wp-content/uploads/materials/ZN17_Kheirkhabarov_Hunting_for_Credentials_Dumping_in_Windows_Environment.pdf",
@@ -98,9 +98,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start","process_created") and 
- process.pe.original_file_name in ("Cmd.Exe","PowerShell.EXE") and    
- 
+process where event.type in ("start","process_created") and
+ process.pe.original_file_name in ("Cmd.Exe","PowerShell.EXE") and
+
  /* Create Symbolic Link to Shadow Copies */
  process.args : ("*mklink*", "*SymbolicLink*") and process.command_line : ("*HarddiskVolumeShadowCopy*")
 '''

--- a/rules/windows/credential_access_via_snapshot_lsass_clone_creation.toml
+++ b/rules/windows/credential_access_via_snapshot_lsass_clone_creation.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential LSASS Clone Creation via PssCaptureSnapShot"
-note = """## Config
+note = """## Setup
 
 This is meant to run only on datasources using Windows security event 4688 that captures the process clone creation.
 

--- a/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
+++ b/rules/windows/defense_evasion_adding_the_hidden_file_attribute_with_via_attribexe.toml
@@ -13,7 +13,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Adding Hidden File Attribute via Attrib"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_amsienable_key_mod.toml
+++ b/rules/windows/defense_evasion_amsienable_key_mod.toml
@@ -72,7 +72,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_clearing_windows_console_history.toml
+++ b/rules/windows/defense_evasion_clearing_windows_console_history.toml
@@ -54,7 +54,7 @@ malware components.
 mean time to respond (MTTR).
   - Ensure that PowerShell auditing policies and log collection are in place to grant future visibility.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -56,7 +56,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_code_injection_conhost.toml
+++ b/rules/windows/defense_evasion_code_injection_conhost.toml
@@ -68,7 +68,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_create_mod_root_certificate.toml
+++ b/rules/windows/defense_evasion_create_mod_root_certificate.toml
@@ -16,7 +16,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation or Modification of Root Certificate"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_defender_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_defender_disabled_via_registry.toml
@@ -60,7 +60,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_defender_exclusion_via_powershell.toml
+++ b/rules/windows/defense_evasion_defender_exclusion_via_powershell.toml
@@ -22,7 +22,7 @@ Microsoft Windows Defender is an antivirus product built into Microsoft Windows.
 used to prevent and stop malware, it's important to monitor what specific exclusions are made to the product's configuration
 settings. These can often be signs of an adversary or malware trying to bypass Windows Defender's capabilities. One of
 the more notable [examples](https://www.cyberbit.com/blog/endpoint-security/latest-trickbot-variant-has-new-tricks-up-its-sleeve/)
-was observed in 2018 where Trickbot incorporated mechanisms to disable Windows Defender to avoid detection. 
+was observed in 2018 where Trickbot incorporated mechanisms to disable Windows Defender to avoid detection.
 
 #### Possible investigation steps
 
@@ -71,10 +71,10 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
-""" 
+"""
 references = ["https://www.bitdefender.com/files/News/CaseStudies/study/400/Bitdefender-PR-Whitepaper-MosaicLoader-creat5540-en-EN.pdf"]
 risk_score = 47
 rule_id = "2c17e5d7-08b9-43b2-b58a-0270d65ac85b"

--- a/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
+++ b/rules/windows/defense_evasion_delete_volume_usn_journal_with_fsutil.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Delete Volume USN Journal with Fsutil"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -27,7 +27,7 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
-  (process.name : "fsutil.exe" or process.pe.original_file_name == "fsutil.exe") and 
+  (process.name : "fsutil.exe" or process.pe.original_file_name == "fsutil.exe") and
   process.args : "deletejournal" and process.args : "usn"
 '''
 

--- a/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
+++ b/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
@@ -59,16 +59,16 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be configured (Enable).
 
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -92,7 +92,7 @@ type = "eql"
 
 query = '''
 registry where event.type == "change" and
-    registry.path : 
+    registry.path :
         "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\\EnableScriptBlockLogging"
     and registry.data.strings : ("0", "0x00000000")
 '''

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -48,7 +48,7 @@ troubleshooting.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_disabling_windows_defender_powershell.toml
+++ b/rules/windows/defense_evasion_disabling_windows_defender_powershell.toml
@@ -59,7 +59,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_disabling_windows_logs.toml
+++ b/rules/windows/defense_evasion_disabling_windows_logs.toml
@@ -51,7 +51,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -75,7 +75,7 @@ process where event.type in ("start", "process_started") and
   ((process.name : ("pwsh.exe", "powershell.exe", "powershell_ise.exe") or process.pe.original_file_name in
       ("pwsh.exe", "powershell.exe", "powershell_ise.exe")) and
 	process.args : "Set-Service" and process.args: "EventLog" and process.args : "Disabled")  or
-	
+
   ((process.name:"auditpol.exe" or process.pe.original_file_name == "AUDITPOL.EXE") and process.args : "/success:disable")
 '''
 

--- a/rules/windows/defense_evasion_dns_over_https_enabled.toml
+++ b/rules/windows/defense_evasion_dns_over_https_enabled.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "DNS-over-HTTPS Enabled via Registry"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
+++ b/rules/windows/defense_evasion_dotnet_compiler_parent_process.toml
@@ -11,7 +11,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious .NET Code Compilation"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
+++ b/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
@@ -56,7 +56,7 @@ of it, whether RDP should be open, and whether the action exposes the environmen
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_enable_network_discovery_with_netsh.toml
+++ b/rules/windows/defense_evasion_enable_network_discovery_with_netsh.toml
@@ -54,7 +54,7 @@ systems, and web services.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_control_panel_suspicious_args.toml
+++ b/rules/windows/defense_evasion_execution_control_panel_suspicious_args.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Control Panel Process with Unusual Arguments"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
+++ b/rules/windows/defense_evasion_execution_lolbas_wuauclt.toml
@@ -16,7 +16,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "ImageLoad via Windows Update Auto Update Client"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -20,7 +20,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by an Office Application"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_script.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by a Script Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_system_process.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started by a System Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_renamed.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Using an Alternate Name"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_unusal_process.toml
@@ -20,7 +20,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Build Engine Started an Unusual Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
+++ b/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential DLL SideLoading via Trusted Microsoft Programs"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_execution_windefend_unusual_path.toml
+++ b/rules/windows/defense_evasion_execution_windefend_unusual_path.toml
@@ -16,7 +16,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential DLL Side-Loading via Microsoft Antimalware Service Executable"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -17,7 +17,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Executable File Creation with Multiple Extensions"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_iis_httplogging_disabled.toml
+++ b/rules/windows/defense_evasion_iis_httplogging_disabled.toml
@@ -15,7 +15,7 @@ language = "eql"
 license = "Elastic License v2"
 max_signals = 33
 name = "IIS HTTP Logging Disabled"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
+++ b/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Endpoint Security Parent Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -30,9 +30,9 @@ process where event.type in ("start", "process_started", "info") and
  process.name : ("esensor.exe", "elastic-endpoint.exe") and
  process.parent.executable != null and
   /* add FPs here */
- not process.parent.executable : ("C:\\Program Files\\Elastic\\*", 
-                                  "C:\\Windows\\System32\\services.exe", 
-                                  "C:\\Windows\\System32\\WerFault*.exe", 
+ not process.parent.executable : ("C:\\Program Files\\Elastic\\*",
+                                  "C:\\Windows\\System32\\services.exe",
+                                  "C:\\Windows\\System32\\WerFault*.exe",
                                   "C:\\Windows\\System32\\wermgr.exe")
 '''
 

--- a/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
+++ b/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Renamed AutoIt Scripts Interpreter"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
+++ b/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious WerFault Child Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_masquerading_trusted_directory.toml
+++ b/rules/windows/defense_evasion_masquerading_trusted_directory.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Program Files Directory Masquerading"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_microsoft_defender_tampering.toml
+++ b/rules/windows/defense_evasion_microsoft_defender_tampering.toml
@@ -62,7 +62,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
+++ b/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
@@ -78,7 +78,7 @@ malware components.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -94,7 +94,7 @@ registry where event.type == "change" and
     registry.path : (
         "HKU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
         "HKU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings"
-        ) and 
+        ) and
     registry.data.strings == "0x00000001" and
     process.name : ("cscript.exe", "wscript.exe", "mshta.exe", "mshta.exe", "winword.exe", "excel.exe")
 '''

--- a/rules/windows/defense_evasion_posh_assembly_load.toml
+++ b/rules/windows/defense_evasion_posh_assembly_load.toml
@@ -75,15 +75,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -104,7 +104,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text : (
     "[System.Reflection.Assembly]::Load" or
     "[Reflection.Assembly]::Load"

--- a/rules/windows/defense_evasion_posh_compressed.toml
+++ b/rules/windows/defense_evasion_posh_compressed.toml
@@ -6,7 +6,7 @@ updated_date = "2022/05/21"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the use of .NET functionality for decompression and base64 decoding combined in PowerShell scripts, which 
+Identifies the use of .NET functionality for decompression and base64 decoding combined in PowerShell scripts, which
 malware and security tools heavily use to deobfuscate payloads and load them directly in memory to bypass defenses.
 """
 false_positives = ["Legitimate PowerShell Scripts which makes use of compression and encoding."]
@@ -76,15 +76,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -102,7 +102,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text : (
     (
       "System.IO.Compression.DeflateStream" or

--- a/rules/windows/defense_evasion_posh_process_injection.toml
+++ b/rules/windows/defense_evasion_posh_process_injection.toml
@@ -6,7 +6,7 @@ updated_date = "2022/05/09"
 [rule]
 author = ["Elastic"]
 description = """
-Detects the use of Windows API functions that are commonly abused by malware and security tools to load 
+Detects the use of Windows API functions that are commonly abused by malware and security tools to load
 malicious code or inject it into remote processes.
 """
 false_positives = ["Legitimate PowerShell scripts that make use of these functions."]
@@ -62,15 +62,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -93,7 +93,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text : (
    (VirtualAlloc or VirtualAllocEx or VirtualProtect or LdrLoadDll or LoadLibrary or LoadLibraryA or
       LoadLibraryEx or GetProcAddress or OpenProcess or OpenProcessToken or AdjustTokenPrivileges) and

--- a/rules/windows/defense_evasion_powershell_windows_firewall_disabled.toml
+++ b/rules/windows/defense_evasion_powershell_windows_firewall_disabled.toml
@@ -61,7 +61,7 @@ systems, and web services.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_proxy_execution_via_msdt.toml
+++ b/rules/windows/defense_evasion_proxy_execution_via_msdt.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Microsoft Diagnostics Wizard Execution"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -34,7 +34,7 @@ process where event.type in ("start", "process_started") and
    (
     process.args : ("IT_RebrowseForFile=*", "ms-msdt:/id", "ms-msdt:-id", "*FromBase64*") or
 
-    (process.args : "-af" and process.args : "/skip" and 
+    (process.args : "-af" and process.args : "/skip" and
      process.parent.name : ("explorer.exe", "cmd.exe", "powershell.exe", "cscript.exe", "wscript.exe", "mshta.exe", "rundll32.exe", "regsvr32.exe") and
      process.args : ("?:\\WINDOWS\\diagnostics\\index\\PCWDiagnostic.xml", "PCWDiagnostic.xml", "?:\\Users\\Public\\*", "?:\\Windows\\Temp\\*")) or
 

--- a/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
+++ b/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Scheduled Tasks AT Command Enabled"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -28,8 +28,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where 
- registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt" and 
+registry where
+ registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt" and
  registry.data.strings : ("1", "0x00000001")
 '''
 

--- a/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
+++ b/rules/windows/defense_evasion_sdelete_like_filename_rename.toml
@@ -18,7 +18,7 @@ note = """## Triage and analysis
 
 Verify process details such as command line and hash to confirm this activity legitimacy.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "SolarWinds Process Disabling Services via Registry"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -32,12 +32,12 @@ query = '''
 registry where registry.path : "HKLM\\SYSTEM\\*ControlSet*\\Services\\*\\Start" and
   registry.data.strings : ("4", "0x00000004") and
   process.name : (
-      "SolarWinds.BusinessLayerHost*.exe", 
-      "ConfigurationWizard*.exe", 
-      "NetflowDatabaseMaintenance*.exe", 
-      "NetFlowService*.exe", 
-      "SolarWinds.Administration*.exe", 
-      "SolarWinds.Collector.Service*.exe" , 
+      "SolarWinds.BusinessLayerHost*.exe",
+      "ConfigurationWizard*.exe",
+      "NetflowDatabaseMaintenance*.exe",
+      "NetFlowService*.exe",
+      "SolarWinds.Administration*.exe",
+      "SolarWinds.Collector.Service*.exe" ,
       "SolarwindsDiagnostics*.exe")
 '''
 

--- a/rules/windows/defense_evasion_suspicious_certutil_commands.toml
+++ b/rules/windows/defense_evasion_suspicious_certutil_commands.toml
@@ -17,7 +17,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious CertUtil Commands"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -38,7 +38,7 @@ type = "eql"
 
 query = '''
 process where event.type == "start" and
-  (process.name : "certutil.exe" or process.pe.original_file_name == "CertUtil.exe") and 
+  (process.name : "certutil.exe" or process.pe.original_file_name == "CertUtil.exe") and
   process.args : ("?decode", "?encode", "?urlcache", "?verifyctl", "?encodehex", "?decodehex", "?exportPFX")
 '''
 

--- a/rules/windows/defense_evasion_suspicious_execution_from_mounted_device.toml
+++ b/rules/windows/defense_evasion_suspicious_execution_from_mounted_device.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Execution from a Mounted Device"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_suspicious_process_access_direct_syscall.toml
+++ b/rules/windows/defense_evasion_suspicious_process_access_direct_syscall.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Process Access via Direct System Call"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -33,7 +33,7 @@ type = "eql"
 query = '''
 process where event.code == "10" and
  length(winlog.event_data.CallTrace) > 0 and
- 
+
  /* Sysmon CallTrace starting with unknown memory module instead of ntdll which host Windows NT Syscalls */
  not winlog.event_data.CallTrace : ("?:\\WINDOWS\\SYSTEM32\\ntdll.dll*", "?:\\WINDOWS\\SysWOW64\\ntdll.dll*")
 '''

--- a/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
+++ b/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Zoom Child Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
+++ b/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Executable File Creation by a System Critical Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_unusual_ads_file_creation.toml
+++ b/rules/windows/defense_evasion_unusual_ads_file_creation.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual File Creation - Alternate Data Stream"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_unusual_dir_ads.toml
+++ b/rules/windows/defense_evasion_unusual_dir_ads.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Process Execution Path - Alternate Data Stream"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
+++ b/rules/windows/defense_evasion_unusual_system_vp_child_program.toml
@@ -11,7 +11,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Child Process from a System Virtual Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Evasion via Filter Manager"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -26,7 +26,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start", "process_started") and 
+process where event.type in ("start", "process_started") and
  process.name : "fltMC.exe" and process.args : "unload"
 '''
 

--- a/rules/windows/defense_evasion_whitespace_padding_in_command_line.toml
+++ b/rules/windows/defense_evasion_whitespace_padding_in_command_line.toml
@@ -23,7 +23,7 @@ note = """## Triage and analysis
 - Analyze the command line of the process in question for evidence of malicious code execution.
 - Review the ancestor and child processes spawned by the process in question for indicators of further malicious code execution.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -37,8 +37,8 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
-  process.command_line regex ".*[ ]{20,}.*" or 
-  
+  process.command_line regex ".*[ ]{20,}.*" or
+
   /* this will match on 3 or more separate occurrences of 3+ contiguous whitespace characters */
   process.command_line regex "([^ ]+[ ]{3,}[^ ]*){3,}.*"
 '''

--- a/rules/windows/defense_evasion_workfolders_control_execution.toml
+++ b/rules/windows/defense_evasion_workfolders_control_execution.toml
@@ -25,7 +25,7 @@ accessing the synced share.
 
 Using Work Folders to execute a masqueraded control.exe could allow an adversary to bypass application controls and
 increase privileges.
- 
+
 #### Possible investigation steps
 
 - Investigate the process tree starting with parent process WorkFolders.exe and child process control.exe to determine
@@ -38,13 +38,13 @@ or network traffic.
 - Determine if control.exe was synced to sync share, indicating potential lateral movement.
 - Review how control.exe was originally delivered on the host, such as emailed, downloaded from the web, or written to
 disk from a separate binary.
- 
-### False positive analysis 
+
+### False positive analysis
 
 - Windows Work Folders are used legitimately by end users and administrators for file sharing and syncing but not in the
 instance where a suspicious control.exe is passed as an argument.
 
-### Response and remediation 
+### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
@@ -55,7 +55,7 @@ control.exe binary as well as any additional artifacts identified during investi
 Work Folders.
 - Confirm with the user whether this was expected or not, and reset their password.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/discovery_adfind_command_activity.toml
+++ b/rules/windows/discovery_adfind_command_activity.toml
@@ -61,7 +61,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -81,12 +81,12 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start", "process_started") and 
-  (process.name : "AdFind.exe" or process.pe.original_file_name == "AdFind.exe") and 
-  process.args : ("objectcategory=computer", "(objectcategory=computer)", 
+process where event.type in ("start", "process_started") and
+  (process.name : "AdFind.exe" or process.pe.original_file_name == "AdFind.exe") and
+  process.args : ("objectcategory=computer", "(objectcategory=computer)",
                   "objectcategory=person", "(objectcategory=person)",
                   "objectcategory=subnet", "(objectcategory=subnet)",
-                  "objectcategory=group", "(objectcategory=group)", 
+                  "objectcategory=group", "(objectcategory=group)",
                   "objectcategory=organizationalunit", "(objectcategory=organizationalunit)",
                   "objectcategory=attributeschema", "(objectcategory=attributeschema)",
                   "domainlist", "dcmodes", "adinfo", "dclist", "computers_pwnotreqd", "trustdmp")

--- a/rules/windows/discovery_admin_recon.toml
+++ b/rules/windows/discovery_admin_recon.toml
@@ -22,7 +22,7 @@ After successfully compromising an environment, attackers may try to gain situat
 This can happen by running commands to enumerate network resources, users, connections, files, and installed security
 software.
 
-This rule looks for the execution of the `net` and `wmic` utilities to enumerate administrator-related users or groups 
+This rule looks for the execution of the `net` and `wmic` utilities to enumerate administrator-related users or groups
 in the domain and local machine scope. Attackers can use this information to plan their next steps of the attack, such
 as mapping targets for credential compromise and other post-exploitation activities.
 
@@ -57,7 +57,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/discovery_command_system_account.toml
+++ b/rules/windows/discovery_command_system_account.toml
@@ -57,7 +57,7 @@ malware components.
 mean time to respond (MTTR).
 - Use the data collected through the analysis to investigate other machines affected in the environment.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -69,7 +69,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start", "process_started") and 
+process where event.type in ("start", "process_started") and
   (?process.Ext.token.integrity_level_name : "System" or
   ?winlog.event_data.IntegrityLevel : "System") and
   (process.name : "whoami.exe" or

--- a/rules/windows/discovery_net_view.toml
+++ b/rules/windows/discovery_net_view.toml
@@ -50,7 +50,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/discovery_peripheral_device.toml
+++ b/rules/windows/discovery_peripheral_device.toml
@@ -55,7 +55,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -68,7 +68,7 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
-  (process.name : "fsutil.exe" or process.pe.original_file_name == "fsutil.exe") and 
+  (process.name : "fsutil.exe" or process.pe.original_file_name == "fsutil.exe") and
   process.args : "fsinfo" and process.args : "drives"
 '''
 

--- a/rules/windows/discovery_posh_suspicious_api_functions.toml
+++ b/rules/windows/discovery_posh_suspicious_api_functions.toml
@@ -58,15 +58,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -88,7 +88,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text : (
     NetShareEnum or
     NetWkstaUserEnum or

--- a/rules/windows/discovery_privileged_localgroup_membership.toml
+++ b/rules/windows/discovery_privileged_localgroup_membership.toml
@@ -63,18 +63,18 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'Audit Security Group Management' audit policy must be configured (Success).
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
 Account Management >
 Audit Security Group Management (Success)
 ```

--- a/rules/windows/discovery_remote_system_discovery_commands_windows.toml
+++ b/rules/windows/discovery_remote_system_discovery_commands_windows.toml
@@ -49,7 +49,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/discovery_security_software_wmic.toml
+++ b/rules/windows/discovery_security_software_wmic.toml
@@ -53,7 +53,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -62,7 +62,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_apt_solarwinds_backdoor_child_cmd_powershell.toml
+++ b/rules/windows/execution_apt_solarwinds_backdoor_child_cmd_powershell.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Command Execution via SolarWinds Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_apt_solarwinds_backdoor_unusual_child_processes.toml
+++ b/rules/windows/execution_apt_solarwinds_backdoor_unusual_child_processes.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious SolarWinds Child Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_com_object_xwizard.toml
+++ b/rules/windows/execution_com_object_xwizard.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Execution of COM object via Xwizard"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -13,7 +13,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Svchost spawning Cmd"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -28,7 +28,7 @@ type = "eql"
 
 query = '''
 process where event.type == "start" and
-  process.parent.name : "svchost.exe" and process.name : "cmd.exe" and 
+  process.parent.name : "svchost.exe" and process.name : "cmd.exe" and
   not (process.pe.original_file_name : "cmd.exe" and process.args : (
     "??:\\Program Files\\Npcap\\CheckStatus.bat?",
     "?:\\Program Files\\Npcap\\CheckStatus.bat",

--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -11,7 +11,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Parent Process for cmd.exe"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_command_shell_via_rundll32.toml
+++ b/rules/windows/execution_command_shell_via_rundll32.toml
@@ -12,7 +12,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Command Shell Activity Started via RunDLL32"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_enumeration_via_wmiprvse.toml
+++ b/rules/windows/execution_enumeration_via_wmiprvse.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Enumeration Command Spawned via WMIPrvSE"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_from_unusual_directory.toml
+++ b/rules/windows/execution_from_unusual_directory.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Process Execution from an Unusual Directory"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_from_unusual_path_cmdline.toml
+++ b/rules/windows/execution_from_unusual_path_cmdline.toml
@@ -18,7 +18,7 @@ note = """## Triage and analysis
 
 This is related to the `Process Execution from an Unusual Directory rule`.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -31,27 +31,27 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started", "info") and
-  process.name : ("wscript.exe", 
-                  "cscript.exe", 
-                  "rundll32.exe", 
-                  "regsvr32.exe", 
+  process.name : ("wscript.exe",
+                  "cscript.exe",
+                  "rundll32.exe",
+                  "regsvr32.exe",
                   "cmstp.exe",
                   "RegAsm.exe",
                   "installutil.exe",
                   "mshta.exe",
-                  "RegSvcs.exe", 
-                  "powershell.exe", 
-                  "pwsh.exe", 
+                  "RegSvcs.exe",
+                  "powershell.exe",
+                  "pwsh.exe",
                   "cmd.exe") and
-                  
+
   /* add suspicious execution paths here */
   process.args : ("C:\\PerfLogs\\*",
                   "C:\\Users\\Public\\*",
                   "C:\\Users\\Default\\*",
                   "C:\\Windows\\Tasks\\*",
-                  "C:\\Intel\\*", 
-                  "C:\\AMD\\Temp\\*", 
-                  "C:\\Windows\\AppReadiness\\*", 
+                  "C:\\Intel\\*",
+                  "C:\\AMD\\Temp\\*",
+                  "C:\\Windows\\AppReadiness\\*",
                   "C:\\Windows\\ServiceState\\*",
                   "C:\\Windows\\security\\*",
                   "C:\\Windows\\IdentityCRL\\*",

--- a/rules/windows/execution_posh_portable_executable.toml
+++ b/rules/windows/execution_posh_portable_executable.toml
@@ -71,15 +71,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -100,7 +100,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text : (
     TVqQAAMAAAAEAAAA
   )

--- a/rules/windows/execution_posh_psreflect.toml
+++ b/rules/windows/execution_posh_psreflect.toml
@@ -84,16 +84,16 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be configured (Enable).
 
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -115,7 +115,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and 
+event.category:process and
   powershell.file.script_block_text:(
     "New-InMemoryModule" or
     "Add-Win32Type" or

--- a/rules/windows/execution_shared_modules_local_sxs_dll.toml
+++ b/rules/windows/execution_shared_modules_local_sxs_dll.toml
@@ -19,7 +19,7 @@ note = """## Triage and analysis
 
 The SxS DotLocal folder is a legitimate feature that can be abused to hijack standard modules loading order by forcing an executable on the same application.exe.local folder to load a malicious DLL module from the same directory.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_suspicious_cmd_wmi.toml
+++ b/rules/windows/execution_suspicious_cmd_wmi.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Cmd Execution via WMI"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_suspicious_image_load_wmi_ms_office.toml
+++ b/rules/windows/execution_suspicious_image_load_wmi_ms_office.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious WMI Image Load from MS Office"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -62,7 +62,7 @@ systems, and web services.
 - Remove and block malicious artifacts identified during triage.
 - Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
 persistence mechanisms, and malware components.
-- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector. 
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
   - If the malicious file was delivered via phishing:
     - Block the email sender from sending future emails.
     - Block the malicious web pages.
@@ -71,7 +71,7 @@ persistence mechanisms, and malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_suspicious_powershell_imgload.toml
+++ b/rules/windows/execution_suspicious_powershell_imgload.toml
@@ -70,15 +70,15 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'PowerShell Script Block Logging' logging policy must be enabled.
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Administrative Templates > 
-Windows PowerShell > 
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
 Turn on PowerShell Script Block Logging (Enable)
 ```
 
@@ -88,7 +88,7 @@ Steps to implement the logging policy via registry:
 reg add "hklm\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging" /v EnableScriptBlockLogging /t REG_DWORD /d 1
 ```
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_suspicious_psexesvc.toml
+++ b/rules/windows/execution_suspicious_psexesvc.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Process Execution via Renamed PsExec Executable"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_suspicious_short_program_name.toml
+++ b/rules/windows/execution_suspicious_short_program_name.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Execution - Short Program Name"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_via_compiled_html_file.toml
+++ b/rules/windows/execution_via_compiled_html_file.toml
@@ -22,7 +22,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Process Activity via Compiled HTML File"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -34,8 +34,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start", "process_started") and 
- process.parent.name : "hh.exe" and 
+process where event.type in ("start", "process_started") and
+ process.parent.name : "hh.exe" and
  process.name : ("mshta.exe", "cmd.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe", "cscript.exe", "wscript.exe")
 '''
 

--- a/rules/windows/execution_via_hidden_shell_conhost.toml
+++ b/rules/windows/execution_via_hidden_shell_conhost.toml
@@ -21,7 +21,7 @@ note = """## Triage and analysis
 The Windows Console Host, or `conhost.exe`, is both the server application for all of the Windows Console APIs as well as
 the classic Windows user interface for working with command-line applications.
 
-Attackers often rely on custom shell implementations to avoid using built-in command interpreters like `cmd.exe` and 
+Attackers often rely on custom shell implementations to avoid using built-in command interpreters like `cmd.exe` and
 `PowerShell.exe` and bypass application allowlisting and security features. Attackers commonly inject these implementations into
 legitimate system processes.
 
@@ -72,7 +72,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Execution via MSSQL xp_cmdshell Stored Procedure"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/impact_backup_file_deletion.toml
+++ b/rules/windows/impact_backup_file_deletion.toml
@@ -65,7 +65,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/impact_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/impact_deleting_backup_catalogs_with_wbadmin.toml
@@ -60,7 +60,7 @@ for ransomware preparation and execution activities.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/impact_modification_of_boot_config.toml
+++ b/rules/windows/impact_modification_of_boot_config.toml
@@ -61,7 +61,7 @@ for ransomware preparation and execution activities.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
@@ -82,7 +82,7 @@ malware components.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_powershell.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_powershell.toml
@@ -81,7 +81,7 @@ malware components.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -99,7 +99,7 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
-  process.name : ("powershell.exe", "pwsh.exe", "powershell_ise.exe") and 
+  process.name : ("powershell.exe", "pwsh.exe", "powershell_ise.exe") and
   process.args : ("*Get-WmiObject*", "*gwmi*", "*Get-CimInstance*", "*gcim*") and
   process.args : ("*Win32_ShadowCopy*") and
   process.args : ("*.Delete()*", "*Remove-WmiObject*", "*rwmi*", "*Remove-CimInstance*", "*rcim*")

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_wmic.toml
@@ -81,7 +81,7 @@ malware components.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/initial_access_script_executing_powershell.toml
+++ b/rules/windows/initial_access_script_executing_powershell.toml
@@ -71,7 +71,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/initial_access_suspicious_ms_exchange_files.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_files.toml
@@ -34,7 +34,7 @@ from existing intrusions. Other tools for detecting and mitigating can be found 
 [repository](https://github.com/microsoft/CSS-Exchange/tree/main/Security)
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/initial_access_suspicious_ms_exchange_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_process.toml
@@ -20,7 +20,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Exchange Server UM Spawning Suspicious Processes"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/initial_access_suspicious_ms_exchange_worker_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_exchange_worker_child_process.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Exchange Worker Spawning Suspicious Processes"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/initial_access_suspicious_ms_office_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_office_child_process.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious MS Office Child Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -30,10 +30,10 @@ query = '''
 process where event.type in ("start", "process_started") and
   process.parent.name : ("eqnedt32.exe", "excel.exe", "fltldr.exe", "msaccess.exe", "mspub.exe", "powerpnt.exe", "winword.exe", "outlook.exe") and
   process.name : ("Microsoft.Workflow.Compiler.exe", "arp.exe", "atbroker.exe", "bginfo.exe", "bitsadmin.exe", "cdb.exe", "certutil.exe",
-                "cmd.exe", "cmstp.exe", "control.exe", "cscript.exe", "csi.exe", "dnx.exe", "dsget.exe", "dsquery.exe", "forfiles.exe", 
-                "fsi.exe", "ftp.exe", "gpresult.exe", "hostname.exe", "ieexec.exe", "iexpress.exe", "installutil.exe", "ipconfig.exe", 
-                "mshta.exe", "msxsl.exe", "nbtstat.exe", "net.exe", "net1.exe", "netsh.exe", "netstat.exe", "nltest.exe", "odbcconf.exe", 
-                "ping.exe", "powershell.exe", "pwsh.exe", "qprocess.exe", "quser.exe", "qwinsta.exe", "rcsi.exe", "reg.exe", "regasm.exe", 
+                "cmd.exe", "cmstp.exe", "control.exe", "cscript.exe", "csi.exe", "dnx.exe", "dsget.exe", "dsquery.exe", "forfiles.exe",
+                "fsi.exe", "ftp.exe", "gpresult.exe", "hostname.exe", "ieexec.exe", "iexpress.exe", "installutil.exe", "ipconfig.exe",
+                "mshta.exe", "msxsl.exe", "nbtstat.exe", "net.exe", "net1.exe", "netsh.exe", "netstat.exe", "nltest.exe", "odbcconf.exe",
+                "ping.exe", "powershell.exe", "pwsh.exe", "qprocess.exe", "quser.exe", "qwinsta.exe", "rcsi.exe", "reg.exe", "regasm.exe",
                 "regsvcs.exe", "regsvr32.exe", "sc.exe", "schtasks.exe", "systeminfo.exe", "tasklist.exe", "tracert.exe", "whoami.exe",
                 "wmic.exe", "wscript.exe", "xwizard.exe", "explorer.exe", "rundll32.exe", "hh.exe", "msdt.exe")
 '''

--- a/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious MS Outlook Child Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/initial_access_unusual_dns_service_children.toml
+++ b/rules/windows/initial_access_unusual_dns_service_children.toml
@@ -30,7 +30,7 @@ Detection alerts from this rule indicate potential suspicious child processes sp
 - If the DoS exploit is successful and DNS Server service crashes, be mindful of potential child processes related to werfault.exe occurring.
 - Any subsequent activity following the child process spawned related to execution/network activity should be thoroughly reviewed from the endpoint.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/initial_access_unusual_dns_service_file_writes.toml
+++ b/rules/windows/initial_access_unusual_dns_service_file_writes.toml
@@ -21,7 +21,7 @@ Detection alerts from this rule indicate potential unusual/abnormal file writes 
 - Post-exploitation, adversaries may write additional files or payloads to the system as additional discovery/exploitation/persistence mechanisms.
 - Any suspicious or abnormal files written from `dns.exe` should be reviewed and investigated with care.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
+++ b/rules/windows/initial_access_via_explorer_suspicious_child_parent_args.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Explorer Child Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/lateral_movement_evasion_rdp_shadowing.toml
+++ b/rules/windows/lateral_movement_evasion_rdp_shadowing.toml
@@ -15,7 +15,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Remote Desktop Shadowing Activity"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -34,11 +34,11 @@ query = '''
 /* Identifies the modification of RDP Shadow registry or
   the execution of processes indicative of active shadow RDP session */
 
-any where 
+any where
   (event.category == "registry" and
      registry.path : "HKLM\\Software\\Policies\\Microsoft\\Windows NT\\Terminal Services\\Shadow"
   ) or
-  (event.category == "process" and 
+  (event.category == "process" and
      (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
      (process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
   )

--- a/rules/windows/lateral_movement_execution_from_tsclient_mup.toml
+++ b/rules/windows/lateral_movement_execution_from_tsclient_mup.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Execution via TSClient Mountpoint"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/lateral_movement_mount_hidden_or_webdav_share_net.toml
+++ b/rules/windows/lateral_movement_mount_hidden_or_webdav_share_net.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Mounting Hidden or WebDav Remote Shares"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -56,7 +56,7 @@ they are aware of it, whether RDP should be open, and whether the action exposes
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
+++ b/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote File Copy to a Hidden Share"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -27,7 +27,7 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
-  process.name : ("cmd.exe", "powershell.exe", "robocopy.exe", "xcopy.exe") and 
+  process.name : ("cmd.exe", "powershell.exe", "robocopy.exe", "xcopy.exe") and
   process.args : ("copy*", "move*", "cp", "mv") and process.args : "*$*"
 '''
 

--- a/rules/windows/lateral_movement_service_control_spawned_script_int.toml
+++ b/rules/windows/lateral_movement_service_control_spawned_script_int.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "logs-system.*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Service Control Spawned via Script Interpreter"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/lateral_movement_suspicious_rdp_client_imageload.toml
+++ b/rules/windows/lateral_movement_suspicious_rdp_client_imageload.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious RDP ActiveX Client Loaded"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/lateral_movement_via_startup_folder_rdp_smb.toml
+++ b/rules/windows/lateral_movement_via_startup_folder_rdp_smb.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Lateral Movement via Startup Folder"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -60,7 +60,7 @@ systems, and web services.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_appcertdlls_registry.toml
+++ b/rules/windows/persistence_appcertdlls_registry.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Registry Persistence via AppCert DLL"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_appinitdlls_registry.toml
+++ b/rules/windows/persistence_appinitdlls_registry.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Registry Persistence via AppInit DLL"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -27,10 +27,10 @@ type = "eql"
 
 query = '''
 registry where
-   registry.path : ("HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls", 
+   registry.path : ("HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
                     "HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls") and
-   not process.executable : ("C:\\Windows\\System32\\msiexec.exe", 
-                             "C:\\Windows\\SysWOW64\\msiexec.exe", 
+   not process.executable : ("C:\\Windows\\System32\\msiexec.exe",
+                             "C:\\Windows\\SysWOW64\\msiexec.exe",
                              "C:\\Program Files\\Commvault\\ContentStore*\\Base\\cvd.exe",
                              "C:\\Program Files (x86)\\Commvault\\ContentStore*\\Base\\cvd.exe")
 '''

--- a/rules/windows/persistence_evasion_hidden_local_account_creation.toml
+++ b/rules/windows/persistence_evasion_hidden_local_account_creation.toml
@@ -45,7 +45,7 @@ prevalence, whether they are located in expected locations, and if they are sign
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_gpo_schtask_service_creation.toml
+++ b/rules/windows/persistence_gpo_schtask_service_creation.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation or Modification of a new GPO Scheduled Task or Service"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_local_scheduled_job_creation.toml
+++ b/rules/windows/persistence_local_scheduled_job_creation.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Scheduled Job Creation"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_ms_office_addins_file.toml
+++ b/rules/windows/persistence_ms_office_addins_file.toml
@@ -11,7 +11,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Microsoft Office AddIns"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_ms_outlook_vba_template.toml
+++ b/rules/windows/persistence_ms_outlook_vba_template.toml
@@ -12,7 +12,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Microsoft Outlook VBA"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_msds_alloweddelegateto_krbtgt.toml
+++ b/rules/windows/persistence_msds_alloweddelegateto_krbtgt.toml
@@ -14,19 +14,19 @@ index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "KRBTGT Delegation Backdoor"
-note = """## Config
+note = """## Setup
 
 The 'Audit User Account Management' logging policy must be configured for (Success, Failure).
 Steps to implement the logging policy with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-Account Management > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+Account Management >
 Audit User Account Management (Success,Failure)
 ```
 """

--- a/rules/windows/persistence_powershell_exch_mailbox_activesync_add_device.toml
+++ b/rules/windows/persistence_powershell_exch_mailbox_activesync_add_device.toml
@@ -15,7 +15,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "New ActiveSyncAllowedDeviceID Added via PowerShell"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -73,7 +73,7 @@ systems, and web services.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
+++ b/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
@@ -65,13 +65,13 @@ should be mapped and reviewed by the security team for alternatives as this weak
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'Audit Directory Service Changes' logging policy must be configured for (Success).
 Steps to implement the logging policy with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
+Computer Configuration >
 Policies >
 Windows Settings >
 Security Settings >

--- a/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
+++ b/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
@@ -43,7 +43,7 @@ software installations.
 
 ### False positive analysis
 
-- Administrators may add programs to this mechanism via command-line shells. Before the further investigation, 
+- Administrators may add programs to this mechanism via command-line shells. Before the further investigation,
 verify that this activity is not benign.
 
 ### Related rules
@@ -71,10 +71,10 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
-""" 
+"""
 risk_score = 47
 rule_id = "440e2db4-bc7f-4c96-a068-65b78da59bde"
 severity = "medium"
@@ -85,7 +85,7 @@ type = "eql"
 query = '''
 file where event.type != "deletion" and
   user.domain != "NT AUTHORITY" and
-  file.path : ("C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\*", 
+  file.path : ("C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\*",
                "C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\StartUp\\*") and
   process.name : ("cmd.exe",
                   "powershell.exe",

--- a/rules/windows/persistence_startup_folder_scripts.toml
+++ b/rules/windows/persistence_startup_folder_scripts.toml
@@ -70,7 +70,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -83,16 +83,16 @@ type = "eql"
 
 query = '''
 file where event.type != "deletion" and user.domain != "NT AUTHORITY" and
-  
+
   /* detect shortcuts created by wscript.exe or cscript.exe */
   (file.path : "C:\\*\\Programs\\Startup\\*.lnk" and
      process.name : ("wscript.exe", "cscript.exe")) or
 
   /* detect vbs or js files created by any process */
-  file.path : ("C:\\*\\Programs\\Startup\\*.vbs", 
-               "C:\\*\\Programs\\Startup\\*.vbe", 
-               "C:\\*\\Programs\\Startup\\*.wsh", 
-               "C:\\*\\Programs\\Startup\\*.wsf", 
+  file.path : ("C:\\*\\Programs\\Startup\\*.vbs",
+               "C:\\*\\Programs\\Startup\\*.vbe",
+               "C:\\*\\Programs\\Startup\\*.wsh",
+               "C:\\*\\Programs\\Startup\\*.wsf",
                "C:\\*\\Programs\\Startup\\*.js")
 '''
 

--- a/rules/windows/persistence_suspicious_com_hijack_registry.toml
+++ b/rules/windows/persistence_suspicious_com_hijack_registry.toml
@@ -62,7 +62,7 @@ malware components.
 mean time to respond (MTTR).
 
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -79,13 +79,13 @@ type = "eql"
 query = '''
 registry where
  (registry.path : "HK*}\\InprocServer32\\" and registry.data.strings: ("scrobj.dll", "C:\\*\\scrobj.dll") and
- not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*") 
+ not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*")
  or
  /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
  (registry.path : ("HKEY_USERS\\*Classes\\*\\InprocServer32\\",
                    "HKEY_USERS\\*Classes\\*\\LocalServer32\\",
-                   "HKEY_USERS\\*Classes\\*\\DelegateExecute\\", 
-                   "HKEY_USERS\\*Classes\\*\\TreatAs\\", 
+                   "HKEY_USERS\\*Classes\\*\\DelegateExecute\\",
+                   "HKEY_USERS\\*Classes\\*\\TreatAs\\",
                    "HKEY_USERS\\*Classes\\CLSID\\*\\ScriptletURL\\") and
  not (process.executable : "?:\\Program Files*\\Veeam\\Backup and Replication\\Console\\veeam.backup.shell.exe" and
       registry.path : "HKEY_USERS\\S-1-5-21-*_Classes\\CLSID\\*\\LocalServer32\\") and

--- a/rules/windows/persistence_suspicious_image_load_scheduled_task_ms_office.toml
+++ b/rules/windows/persistence_suspicious_image_load_scheduled_task_ms_office.toml
@@ -16,7 +16,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Image Load (taskschd.dll) from MS Office"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
+++ b/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
@@ -12,7 +12,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Execution via Scheduled Task"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -50,12 +50,12 @@ process where event.type == "start" and
     /* add suspicious paths here */
     process.args : (
        "C:\\Users\\*",
-       "C:\\ProgramData\\*", 
-       "C:\\Windows\\Temp\\*", 
-       "C:\\Windows\\Tasks\\*", 
-       "C:\\PerfLogs\\*", 
-       "C:\\Intel\\*", 
-       "C:\\Windows\\Debug\\*", 
+       "C:\\ProgramData\\*",
+       "C:\\Windows\\Temp\\*",
+       "C:\\Windows\\Tasks\\*",
+       "C:\\PerfLogs\\*",
+       "C:\\Intel\\*",
+       "C:\\Windows\\Debug\\*",
        "C:\\HP\\*")
 '''
 

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -54,7 +54,7 @@ malware components.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -69,7 +69,7 @@ query = '''
 process where event.type in ("start", "process_started") and
   process.parent.name : "services.exe" and
   process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe") and
-  
+
   /* Third party FP's */
   not process.args : "NVDisplay.ContainerLocalSystem"
 '''

--- a/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
+++ b/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
@@ -49,7 +49,7 @@ this level of privilege.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -51,7 +51,7 @@ systems, and web services.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_via_application_shimming.toml
+++ b/rules/windows/persistence_via_application_shimming.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Application Shimming via Sdbinst"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_via_bits_job_notify_command.toml
+++ b/rules/windows/persistence_via_bits_job_notify_command.toml
@@ -15,7 +15,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via BITS Job Notify Cmdline"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_via_hidden_run_key_valuename.toml
+++ b/rules/windows/persistence_via_hidden_run_key_valuename.toml
@@ -14,7 +14,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Hidden Run Key Detected"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -34,8 +34,8 @@ query = '''
 registry where /* length(registry.data.strings) > 0 and */
  registry.path : ("HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
                   "HKU\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
-                  "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\", 
-                  "HKLM\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run\\", 
+                  "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
+                  "HKLM\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run\\",
                   "HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\",
                   "HKU\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\",
                   "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\")

--- a/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
+++ b/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Installation of Security Support Provider"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -27,7 +27,7 @@ type = "eql"
 
 query = '''
 registry where
-   registry.path : ("HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\Security Packages*", 
+   registry.path : ("HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\Security Packages*",
                     "HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\OSConfig\\Security Packages*") and
    not process.executable : ("C:\\Windows\\System32\\msiexec.exe", "C:\\Windows\\SysWOW64\\msiexec.exe")
 '''

--- a/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
+++ b/rules/windows/persistence_via_telemetrycontroller_scheduledtask_hijack.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via TelemetryController Scheduled Task Hijack"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
+++ b/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Update Orchestrator Service Hijack"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
+++ b/rules/windows/persistence_via_windows_management_instrumentation_event_subscription.toml
@@ -15,7 +15,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via WMI Event Subscription"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/persistence_webshell_detection.toml
+++ b/rules/windows/persistence_webshell_detection.toml
@@ -21,7 +21,7 @@ note = """## Triage and analysis
 
 Detections should be investigated to identify if the activity corresponds to legitimate activity. As this rule detects post-exploitation process activity, investigations into this should be prioritized.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -37,7 +37,7 @@ type = "eql"
 
 query = '''
 process where event.type == "start" and
-  process.parent.name : ("w3wp.exe", "httpd.exe", "nginx.exe", "php.exe", "php-cgi.exe", "tomcat.exe") and 
+  process.parent.name : ("w3wp.exe", "httpd.exe", "nginx.exe", "php.exe", "php-cgi.exe", "tomcat.exe") and
   process.name : ("cmd.exe", "cscript.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe", "wmic.exe", "wscript.exe")
 '''
 

--- a/rules/windows/privilege_escalation_disable_uac_registry.toml
+++ b/rules/windows/privilege_escalation_disable_uac_registry.toml
@@ -16,7 +16,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Disabling User Account Control via Registry Modification"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_group_policy_iniscript.toml
+++ b/rules/windows/privilege_escalation_group_policy_iniscript.toml
@@ -50,19 +50,19 @@ potentially malicious commands or binaries.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'Audit Detailed File Share' audit policy must be configured (Success Failure).
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-Object Access > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+Object Access >
 Audit Detailed File Share (Success,Failure)
 ```
 
@@ -70,13 +70,13 @@ The 'Audit Directory Service Changes' audit policy must be configured (Success F
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-DS Access > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+DS Access >
 Audit Directory Service Changes (Success,Failure)
 ```
 """

--- a/rules/windows/privilege_escalation_group_policy_privileged_groups.toml
+++ b/rules/windows/privilege_escalation_group_policy_privileged_groups.toml
@@ -47,19 +47,19 @@ dangerous high privileges, for example: SeTakeOwnershipPrivilege, SeEnableDelega
 - Remove the script from the GPO.
 - Check if other GPOs have suspicious scripts attached.
 
-## Config
+## Setup
 
 The 'Audit Directory Service Changes' audit policy must be configured (Success Failure).
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-DS Access > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+DS Access >
 Audit Directory Service Changes (Success,Failure)
 ```
 """
@@ -75,7 +75,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code: "5136" and winlog.event_data.AttributeLDAPDisplayName:"gPCMachineExtensionNames" and 
+event.code: "5136" and winlog.event_data.AttributeLDAPDisplayName:"gPCMachineExtensionNames" and
 winlog.event_data.AttributeValue:(*827D319E-6EAC-11D2-A4EA-00C04F79F83A* and *803E14A0-B4FB-11D0-A0D0-00A0C90F574B*)
 '''
 

--- a/rules/windows/privilege_escalation_group_policy_scheduled_task.toml
+++ b/rules/windows/privilege_escalation_group_policy_scheduled_task.toml
@@ -48,19 +48,19 @@ potentially malicious commands or binaries.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 The 'Audit Detailed File Share' audit policy must be configured (Success Failure).
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-Object Access > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+Object Access >
 Audit Detailed File Share (Success,Failure)
 ```
 
@@ -68,13 +68,13 @@ The 'Audit Directory Service Changes' audit policy must be configured (Success F
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-DS Access > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+DS Access >
 Audit Directory Service Changes (Success,Failure)
 ```
 """
@@ -93,8 +93,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-(event.code: "5136" and winlog.event_data.AttributeLDAPDisplayName:("gPCMachineExtensionNames" or "gPCUserExtensionNames") and 
-   winlog.event_data.AttributeValue:(*CAB54552-DEEA-4691-817E-ED4A4D1AFC72* and *AADCED64-746C-4633-A97C-D61349046527*)) 
+(event.code: "5136" and winlog.event_data.AttributeLDAPDisplayName:("gPCMachineExtensionNames" or "gPCUserExtensionNames") and
+   winlog.event_data.AttributeValue:(*CAB54552-DEEA-4691-817E-ED4A4D1AFC72* and *AADCED64-746C-4633-A97C-D61349046527*))
 or
 (event.code: "5145" and winlog.event_data.ShareName: "\\\\*\\SYSVOL" and winlog.event_data.RelativeTargetName: *ScheduledTasks.xml and
   (message: WriteData or winlog.event_data.AccessList: *%%4417*))

--- a/rules/windows/privilege_escalation_installertakeover.toml
+++ b/rules/windows/privilege_escalation_installertakeover.toml
@@ -72,7 +72,7 @@ systems, and web services.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
 mean time to respond (MTTR).
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -87,15 +87,15 @@ type = "eql"
 query = '''
 /* This rule is compatible with both Sysmon and Elastic Endpoint */
 
-process where event.type == "start" and 
+process where event.type == "start" and
     (?process.Ext.token.integrity_level_name : "System" or
     ?winlog.event_data.IntegrityLevel : "System") and
     (
-      (process.name : "elevation_service.exe" and 
+      (process.name : "elevation_service.exe" and
        not process.pe.original_file_name == "elevation_service.exe") or
 
-      (process.parent.name : "elevation_service.exe" and 
-       process.name : ("rundll32.exe", "cmd.exe", "powershell.exe")) 
+      (process.parent.name : "elevation_service.exe" and
+       process.name : ("rundll32.exe", "cmd.exe", "powershell.exe"))
     )
 '''
 

--- a/rules/windows/privilege_escalation_named_pipe_impersonation.toml
+++ b/rules/windows/privilege_escalation_named_pipe_impersonation.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Privilege Escalation via Named Pipe Impersonation"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -30,7 +30,7 @@ type = "eql"
 
 query = '''
 process where event.type in ("start", "process_started") and
- process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE") and 
+ process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE") and
  process.args : "echo" and process.args : ">" and process.args : "\\\\.\\pipe\\*"
 '''
 

--- a/rules/windows/privilege_escalation_persistence_phantom_dll.toml
+++ b/rules/windows/privilege_escalation_persistence_phantom_dll.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious DLL Loaded for Persistence or Privilege Escalation"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -52,7 +52,7 @@ library where dll.name :
   "cdpsgshims.dll",
   "windowsperformancerecordercontrol.dll",
   "diagtrack_win.dll"
-  ) and 
+  ) and
 not (dll.code_signature.subject_name : ("Microsoft Windows", "Microsoft Corporation") and dll.code_signature.status : "trusted")
 '''
 

--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious PrintSpooler Service Executable File Creation"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_printspooler_suspicious_file_deletion.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_file_deletion.toml
@@ -20,7 +20,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Print Spooler File Deletion"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -18,7 +18,7 @@ note = """## Threat intel
 
 Refer to CVEs, CVE-2020-1048 and CVE-2020-1337 for further information on the vulnerability and exploit. Verify that the relevant system is patched.
 
-## Config
+## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
+++ b/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
@@ -15,7 +15,7 @@ index = ["winlogbeat-*", "logs-system.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privileged Escalation via SamAccountName Spoofing"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_clipup.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass Attempt with IEditionUpgradeManager Elevated COM Interface"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_uac_bypass_com_ieinstal.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_ieinstal.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass Attempt via Elevated COM Internet Explorer Add-On Installer"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_uac_bypass_com_interface_icmluautil.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_com_interface_icmluautil.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass via ICMLuaUtil Elevated COM Interface"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_diskcleanup_hijack.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass via DiskCleanup Scheduled Task Hijack"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_uac_bypass_dll_sideloading.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_dll_sideloading.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass Attempt via Privileged IFileOperation COM Interface"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Bypass UAC via Event Viewer"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """
@@ -28,8 +28,8 @@ type = "eql"
 query = '''
 process where event.type in ("start", "process_started") and
   process.parent.name : "eventvwr.exe" and
-  not process.executable : 
-            ("?:\\Windows\\SysWOW64\\mmc.exe", 
+  not process.executable :
+            ("?:\\Windows\\SysWOW64\\mmc.exe",
              "?:\\Windows\\System32\\mmc.exe",
              "?:\\Windows\\SysWOW64\\WerFault.exe",
              "?:\\Windows\\System32\\WerFault.exe")

--- a/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass Attempt via Windows Directory Masquerading"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "UAC Bypass via Windows Firewall Snap-In Hijack"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Parent-Child Relationship"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
+++ b/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
@@ -22,7 +22,7 @@ index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Print Spooler Child Process"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_unusual_svchost_childproc_childless.toml
+++ b/rules/windows/privilege_escalation_unusual_svchost_childproc_childless.toml
@@ -15,7 +15,7 @@ index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Service Host Child Process - Childless Service"
-note = """## Config
+note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
+++ b/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
@@ -14,7 +14,7 @@ index = ["winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Privilege Escalation via Rogue Named Pipe Impersonation"
-note = """## Config
+note = """## Setup
 
 Named Pipe Creation Events need to be enabled within the Sysmon configuration by including the following settings:
 `condition equal "contains" and keyword equal "pipe"`

--- a/rules/windows/privilege_escalation_windows_service_via_unusual_client.toml
+++ b/rules/windows/privilege_escalation_windows_service_via_unusual_client.toml
@@ -15,19 +15,19 @@ index = ["winlogbeat-*", "logs-system.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Windows Service Installed via an Unusual Client"
-note = """## Config
+note = """## Setup
 
 The 'Audit Security System Extension' logging policy must be configured for (Success)
 Steps to implement the logging policy with with Advanced Audit Configuration:
 
 ```
-Computer Configuration > 
-Policies > 
-Windows Settings > 
-Security Settings > 
-Advanced Audit Policies Configuration > 
-Audit Policies > 
-System > 
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policies Configuration >
+Audit Policies >
+System >
 Audit Security System Extension (Success)
 ```
 """

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -677,3 +677,22 @@ class TestIntegrationRules(BaseRuleTest):
                     self.fail(f'{self.rule_str(rule)} expected {integration} config missing\n\n'
                               f'Expected: {note_str}\n\n'
                               f'Actual: {rule.contents.data.note}')
+
+
+class TestIncompatibleFields(BaseRuleTest):
+    """Test stack restricted fields do not backport beyond allowable limits."""
+
+    def test_rule_backports_for_restricted_fields(self):
+        """Test that stack restricted fields will not backport to older rule versions."""
+        invalid_rules = []
+
+        for rule in self.all_rules:
+            invalid = rule.contents.check_restricted_fields_compatibility()
+            if invalid:
+                invalid_rules.append(f'{self.rule_str(rule)} {invalid}')
+
+        if invalid_rules:
+            invalid_str = '\n'.join(invalid_rules)
+            err_msg = 'The following rules have min_stack_versions lower than allowed for restricted fields:\n'
+            err_msg += invalid_str
+            self.fail(err_msg)

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -652,7 +652,7 @@ class TestIntegrationRules(BaseRuleTest):
 
     def test_integration_guide(self):
         """Test that rules which require a config note are using standard verbiage."""
-        config = '## Config\n\n'
+        config = '## Setup\n\n'
         beats_integration_pattern = config + 'The {} Fleet integration, Filebeat module, or similarly ' \
                                              'structured data is required to be compatible with this rule.'
         render = beats_integration_pattern.format


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #2058 

## Summary

- Uses `marko`. to parse the `note` field into a new `setup` restricted field and remove setup info from the original `note`.
- Updated the rules with `Config` to now be `Setup` for consistency with the new field
- Adds minimal but optional validation with a new `DR_BYPASS_NOTE_VALIDATION_AND_PARSE` environment variable which skips validation on the `note` field
- Refactored imports to comply with pep8 (standard lib, third party, local imports)


## Testing

Ran the `view-rule` command against several toml files. (Some without `notes`, some without `setup`.
e.g. 
- `python -m detection_rules view-rule /Users/stryker/workspace/Elastic/detection-rules/rules/integrations/aws/ml_cloudtrail_error_message_spike.toml --api-format`
- Users/stryker/workspace/Elastic/detection-rules/rules/cross-platform/impact_hosts_file_modified.toml
- /Users/stryker/workspace/Elastic/detection-rules/rules/windows/command_and_control_certutil_network_connection.toml
- /Users/stryker/workspace/Elastic/detection-rules/rules/promotions/endgame_malware_detected.toml
- /Users/stryker/workspace/Elastic/detection-rules/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
- /Users/stryker/workspace/Elastic/detection-rules/rules/windows/collection_posh_keylogger.toml

Also run the build to make all rules successfully were generated.

`python -m detection_rules dev build-release --update-version-lock`

