### PR TITLE
[Rule Tuning] Potential Reverse Shell Activity via Terminal

### DIFF
--- a/rules/cross-platform/execution_revershell_via_shell_cmd.toml
+++ b/rules/cross-platform/execution_revershell_via_shell_cmd.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/01/07"
 maturity = "production"
-updated_date = "2022/03/31"
+updated_date = "2022/07/06"
 
 [rule]
 author = ["Elastic"]
@@ -28,9 +28,14 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type in ("start", "process_started") and
+process where event.action == "exec" and
   process.name in ("sh", "bash", "zsh", "dash", "zmodload") and
-  process.args:("*/dev/tcp/*", "*/dev/udp/*", "zsh/net/tcp", "zsh/net/udp")
+  process.args : ("*/dev/tcp/*", "*/dev/udp/*", "*zsh/net/tcp*", "*zsh/net/udp*") and
+
+  /* noisy FPs */
+  not (process.parent.name : "timeout" and process.executable : "/var/lib/docker/overlay*") and
+  not process.command_line : ("*/dev/tcp/sirh_db/*", "*/dev/tcp/remoteiot.com/*", "*dev/tcp/elk.stag.one/*", "*dev/tcp/kafka/*", "*/dev/tcp/$0/$1*", "*/dev/tcp/127.*", "*/dev/udp/127.*", "*/dev/tcp/localhost/*") and
+  not process.parent.command_line : "runc init"
 '''
 
 

--- a/rules/cross-platform/execution_revershell_via_shell_cmd.toml
+++ b/rules/cross-platform/execution_revershell_via_shell_cmd.toml
@@ -28,7 +28,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.action == "exec" and
+process where event.type in ("start", "process_started") and
   process.name in ("sh", "bash", "zsh", "dash", "zmodload") and
   process.args : ("*/dev/tcp/*", "*/dev/udp/*", "*zsh/net/tcp*", "*zsh/net/udp*") and
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
* https://github.com/elastic/detection-rules/issues/2076

## Summary
@aarju suggested we take a look at this rule for additional tuning as it is generating a number of false-positives within their environment due to scripts accessing container systems.

We have discovered a large amount of false-positives from endpoint behavior rules and will be investigating detection rule telemetry as well. We have ~1,002 detections within the last 90 days. Removing `/dev/tcp/127.0.0.1` and `/dev/udp/127.0.0.1` removes ~97% of false-positives for this activity.
