### PR TITLE
[New Rule] Tc BPF Filter 

### DIFF
--- a/rules/linux/execution_tc_bpf_filter.toml
+++ b/rules/linux/execution_tc_bpf_filter.toml
@@ -1,0 +1,48 @@
+[metadata]
+creation_date = "2022/07/11"
+maturity = "production"
+updated_date = "2022/07/11"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when the tc (transmission control) binary is utilized to set a BPF (Berkeley Packet Filter) on a network interface. Tc is used to configure Traffic Control in the Linux kernel. It can shape, schedule, police and drop traffic. A threat actor can utilize tc to set a bpf filter on an interface for the purpose of manipulating the incoming traffic. This technique is not at all common and should indicate abnormal, suspicious or malicious activity.
+"""
+from = "now-9m"
+index = ["logs-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "BPF filter applied using TC"
+references = [
+    "https://linuxsecurity.com/features/fileless-malware-on-linux",
+    "https://twitter.com/GossiTheDog/status/1522964028284411907",
+]
+risk_score = 73
+rule_id = "ef04a476-07ec-48fc-8f3d-5e1742de76d3"
+severity = "high"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "TripleCross"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where event.type != "end" and process.executable : "/usr/sbin/tc" and process.args : "filter" and process.args : "add" and process.args : "bpf" and not process.parent.executable: "/usr/sbin/libvirtd"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

https://github.com/elastic/detection-rules/issues/2079

## Summary

This rule will detect when the tc (transmission control) binary is utilized to set a BPF (Berkeley Packet Filter) on a network interface. Tc is used to configure Traffic Control in the Linux kernel. It can shape, schedule, police and drop traffic. A threat actor can utilize tc to set a bpf filter on an interface for the purpose of manipulating the incoming traffic. This technique is not at all common and should indicate abnormal or suspicious activity.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
