### PR TITLE
[New Rule] Insmod kernel module load

### DIFF
--- a/rules/linux/persistence_insmod_kernel_module_load.toml
+++ b/rules/linux/persistence_insmod_kernel_module_load.toml
@@ -9,7 +9,7 @@ description = """
 Detects the use of the insmod binary to load a Linux kernel object file. Threat actors can use this binary, given they have root privileges, to load a rootkit on a system providing them with complete control and the ability to hide from security products. Manually loading a kernel module in this manner should not be at all common and can indicate suspcious or malicious behavior. 
 """
 from = "now-9m"
-index = ["auditbeat-*", "logs-*"]
+index = ["logs-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Kernel module load via insmod"

--- a/rules/linux/persistence_insmod_kernel_module_load.toml
+++ b/rules/linux/persistence_insmod_kernel_module_load.toml
@@ -1,0 +1,46 @@
+[metadata]
+creation_date = "2022/07/11"
+maturity = "production"
+updated_date = "2022/07/11"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects the use of the insmod binary to load a Linux kernel object file. Threat actors can use this binary, given they have root privileges, to load a rootkit on a system providing them with complete control and the ability to hide from security products. Manually loading a kernel module in this manner should not be at all common and can indicate suspcious or malicious behavior. 
+"""
+from = "now-9m"
+index = ["auditbeat-*", "logs-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Kernel module load via insmod"
+references = [
+    "https://decoded.avast.io/davidalvarez/linux-threat-hunting-syslogk-a-kernel-rootkit-found-under-development-in-the-wild/"
+]
+risk_score = 85
+rule_id = "2339f03c-f53f-40fa-834b-40c5983fc41f"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Persistence", "Rootkit"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where event.type == "start" and process.executable : "/usr/sbin/insmod" and process.args : "*.ko"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1547"
+name = "Boot or Logon Autostart Execution"
+reference = "https://attack.mitre.org/techniques/T1547/"
+
+[[rule.threat.subtechnique]]
+id = "T1547.006"
+name = "Kernel Modules and Extensions"
+reference = "https://attack.mitre.org/techniques/T1547/006/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/linux/persistence_insmod_kernel_module_load.toml
+++ b/rules/linux/persistence_insmod_kernel_module_load.toml
@@ -34,7 +34,7 @@ id = "T1547"
 name = "Boot or Logon Autostart Execution"
 reference = "https://attack.mitre.org/techniques/T1547/"
 
-[[rule.threat.subtechnique]]
+[[rule.threat.technique.subtechnique]]
 id = "T1547.006"
 name = "Kernel Modules and Extensions"
 reference = "https://attack.mitre.org/techniques/T1547/006/"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2080

## Summary

This rule will detect the use of the insmod binary to load a Linux kernel object file. Threat actors can use this binary, given they have root privileges, to load a rootkit on a system providing them with complete control and the ability to hide from security products.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
