### PR TITLE
[New Rule] Dynamic Linker Copy

### DIFF
--- a/rules/linux/persistence_dynamic_linker_backup.toml
+++ b/rules/linux/persistence_dynamic_linker_backup.toml
@@ -20,7 +20,6 @@ risk_score = 85
 rule_id = "df6f62d9-caab-4b88-affa-044f4395a1e0"
 severity = "high"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Persistence", "Orbit"]
-timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/persistence_dynamic_linker_backup.toml
+++ b/rules/linux/persistence_dynamic_linker_backup.toml
@@ -1,0 +1,46 @@
+[metadata]
+creation_date = "2022/07/12"
+maturity = "production"
+updated_date = "2022/07/12"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects the copying of the Linux dynamic loader binary for the purpose of creating a backup copy. This technique was seen recently being utilized by Linux malware prior to patching the dynamic loader in order to inject and preload a malicious shared object file. This activity should never occur and if it does then it should be considered highly suspicious or malicious.
+"""
+from = "now-9m"
+index = ["logs-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Dynamic Linker Copy"
+references = [
+    "https://www.intezer.com/blog/incident-response/orbit-new-undetected-linux-threat/"
+]
+risk_score = 85
+rule_id = "df6f62d9-caab-4b88-affa-044f4395a1e0"
+severity = "high"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Persistence", "Orbit"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where event.type == "start" and process.name : ("cp", "rsync") and process.args : ("/lib/x86_64-linux-gnu/ld-linux-x86-64.so.*")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1574"
+name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1574.006"
+name = "Dynamic Linker Hijacking"
+reference = "https://attack.mitre.org/techniques/T1574/006/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/linux/persistence_dynamic_linker_backup.toml
+++ b/rules/linux/persistence_dynamic_linker_backup.toml
@@ -6,7 +6,7 @@ updated_date = "2022/07/12"
 [rule]
 author = ["Elastic"]
 description = """
-Detects the copying of the Linux dynamic loader binary for the purpose of creating a backup copy. This technique was seen recently being utilized by Linux malware prior to patching the dynamic loader in order to inject and preload a malicious shared object file. This activity should never occur and if it does then it should be considered highly suspicious or malicious.
+Detects the copying of the Linux dynamic loader binary and subsequent file creation for the purpose of creating a backup copy. This technique was seen recently being utilized by Linux malware prior to patching the dynamic loader in order to inject and preload a malicious shared object file. This activity should never occur and if it does then it should be considered highly suspicious or malicious.
 """
 from = "now-9m"
 index = ["logs-*"]

--- a/rules/linux/persistence_dynamic_linker_backup.toml
+++ b/rules/linux/persistence_dynamic_linker_backup.toml
@@ -24,7 +24,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type == "start" and process.name : ("cp", "rsync") and process.args : ("/lib/x86_64-linux-gnu/ld-linux-x86-64.so.*")
+sequence by process.entity_id with maxspan=1m
+[process where event.type == "start" and process.name : ("cp", "rsync") and process.args : ("/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2", "/etc/ld.so.preload")]
+[file where event.action == "creation" and file.extension == "so"]
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2081

## Summary

This rule will detect the copying of the Linux dynamic loader binary for the purpose of creating a backup copy. This technique was seen recently being utilized by advanced Linux malware prior to patching the dynamic loader in order to inject and preload a malicious shared object file. This activity should never occur and if it does then it should be considered suspicious or possibly malicious.

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
