### PR TITLE
[Rule Tuning] GCP Firewall Rules Should Include App Engine

### DIFF
--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml
@@ -37,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:gcp.audit and event.action:(v*.compute.firewalls.insert or google.appengine.v*.Firewall.Create*Rule)
+event.dataset:gcp.audit and event.action:(*.compute.firewalls.insert or google.appengine.*.Firewall.Create*Rule)
 '''
 
 

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml
@@ -1,16 +1,16 @@
 [metadata]
 creation_date = "2020/09/21"
-maturity = "production"
-updated_date = "2021/07/20"
 integration = "gcp"
+maturity = "production"
+updated_date = "2022/07/15"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when a firewall rule is created in Google Cloud Platform (GCP). Virtual Private Cloud (VPC) firewall rules
-can be configured to allow or deny connections to or from virtual machine (VM) instances. An adversary may create a new
-firewall rule in order to weaken their target's security controls and allow more permissive ingress or egress traffic
-flows for their benefit.
+Identifies when a firewall rule is created in Google Cloud Platform (GCP) for Virtual Private Cloud (VPC) or App Engine.
+These firewall rules can be configured to allow or deny connections to or from virtual machine (VM) instances or
+specific applications. An adversary may create a new firewall rule in order to weaken their target's security controls
+and allow more permissive ingress or egress traffic flows for their benefit.
 """
 false_positives = [
     """
@@ -25,7 +25,10 @@ name = "GCP Firewall Rule Creation"
 note = """## Config
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
-references = ["https://cloud.google.com/vpc/docs/firewalls"]
+references = [
+    "https://cloud.google.com/vpc/docs/firewalls",
+    "https://cloud.google.com/appengine/docs/standard/python/understanding-firewalls",
+]
 risk_score = 21
 rule_id = "30562697-9859-4ae0-a8c5-dab45d664170"
 severity = "low"
@@ -34,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:(googlecloud.audit or gcp.audit) and event.action:v*.compute.firewalls.insert
+event.dataset:gcp.audit and event.action:(v*.compute.firewalls.insert or event.google.appengine.v*.Firewall.Create*Rule)
 '''
 
 

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml
@@ -37,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:gcp.audit and event.action:(v*.compute.firewalls.insert or event.google.appengine.v*.Firewall.Create*Rule)
+event.dataset:gcp.audit and event.action:(v*.compute.firewalls.insert or google.appengine.v*.Firewall.Create*Rule)
 '''
 
 

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
@@ -1,15 +1,15 @@
 [metadata]
 creation_date = "2020/09/21"
-maturity = "production"
-updated_date = "2021/07/20"
 integration = "gcp"
+maturity = "production"
+updated_date = "2021/07/15"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when a firewall rule is deleted in Google Cloud Platform (GCP). Virtual Private Cloud (VPC) firewall rules
-can be configured to allow or deny connections to or from virtual machine (VM) instances. An adversary may delete a
-firewall rule in order to weaken their target's security controls.
+Identifies when a firewall rule is deleted in Google Cloud Platform (GCP) for Virtual Private Cloud (VPC) or App Engine.
+These firewall rules can be configured to allow or deny connections to or from virtual machine (VM) instances or
+specific applications. An adversary may delete a firewall rule in order to weaken their target's security controls.
 """
 false_positives = [
     """
@@ -24,7 +24,10 @@ name = "GCP Firewall Rule Deletion"
 note = """## Config
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
-references = ["https://cloud.google.com/vpc/docs/firewalls"]
+references = [
+    "https://cloud.google.com/vpc/docs/firewalls",
+    "https://cloud.google.com/appengine/docs/standard/python/understanding-firewalls",
+]
 risk_score = 47
 rule_id = "ff9b571e-61d6-4f6c-9561-eb4cca3bafe1"
 severity = "medium"
@@ -33,7 +36,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:(googlecloud.audit or gcp.audit) and event.action:v*.compute.firewalls.delete
+event.dataset:gcp.audit and event.action:(v*.compute.firewalls.delete or google.appengine.v*.Firewall.Delete*Rule)
 '''
 
 

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/21"
 integration = "gcp"
 maturity = "production"
-updated_date = "2021/07/15"
+updated_date = "2022/07/15"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_deleted.toml
@@ -36,7 +36,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:gcp.audit and event.action:(v*.compute.firewalls.delete or google.appengine.v*.Firewall.Delete*Rule)
+event.dataset:gcp.audit and event.action:(*.compute.firewalls.delete or google.appengine.*.Firewall.Delete*Rule)
 '''
 
 

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_modified.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_modified.toml
@@ -1,15 +1,16 @@
 [metadata]
 creation_date = "2020/09/21"
-maturity = "production"
-updated_date = "2021/07/20"
 integration = "gcp"
+maturity = "production"
+updated_date = "2022/07/15"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when a firewall rule is modified in Google Cloud Platform (GCP). Virtual Private Cloud (VPC) firewall rules
-can be configured to allow or deny connections to or from virtual machine (VM) instances. An adversary may modify a
-firewall rule in order to weaken their target's security controls.
+Identifies when a firewall rule is modified in Google Cloud Platform (GCP) for Virtual Private Cloud (VPC) or App
+Engine. These firewall rules can be modified to allow or deny connections to or from virtual machine (VM) instances or
+specific applications. An adversary may modify an existing firewall rule in order to weaken their target's security
+controls and allow more permissive ingress or egress traffic flows for their benefit.
 """
 false_positives = [
     """
@@ -24,7 +25,10 @@ name = "GCP Firewall Rule Modification"
 note = """## Config
 
 The GCP Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
-references = ["https://cloud.google.com/vpc/docs/firewalls"]
+references = [
+    "https://cloud.google.com/vpc/docs/firewalls",
+    "https://cloud.google.com/appengine/docs/standard/python/understanding-firewalls",
+]
 risk_score = 47
 rule_id = "2783d84f-5091-4d7d-9319-9fceda8fa71b"
 severity = "medium"
@@ -33,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:(googlecloud.audit or gcp.audit) and event.action:v*.compute.firewalls.patch
+event.dataset:gcp.audit and event.action:(v*.compute.firewalls.patch or google.appengine.v*.Firewall.Update*Rule)
 '''
 
 

--- a/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_modified.toml
+++ b/rules/integrations/gcp/defense_evasion_gcp_firewall_rule_modified.toml
@@ -37,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:gcp.audit and event.action:(v*.compute.firewalls.patch or google.appengine.v*.Firewall.Update*Rule)
+event.dataset:gcp.audit and event.action:(*.compute.firewalls.patch or google.appengine.*.Firewall.Update*Rule)
 '''
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
* https://github.com/elastic/detection-rules/issues/2106

## Summary
GCP Firewall rules are only for VPC and do not include App Engine. `event.action` values specifying firewall rule activity should be included.

*Checklist*

- Adjust dates
- Adjust verbiage that is VPC only to include App Engine as well
- Update references
- Adjust query to include App Engine values for `event.action` as well as replace any `v*` reference to `*`.


Rule Created
<img width="1160" alt="Screen Shot 2022-07-15 at 1 26 15 PM" src="https://user-images.githubusercontent.com/99630311/179276887-36f69c48-1271-4910-b8d4-727ed167afb6.png">


Rule Updated
<img width="955" alt="Screen Shot 2022-07-15 at 1 26 33 PM" src="https://user-images.githubusercontent.com/99630311/179276882-7e11b3eb-5a92-4aaf-8953-d636807424bd.png">


Rule Deleted
<img width="948" alt="Screen Shot 2022-07-15 at 1 26 47 PM" src="https://user-images.githubusercontent.com/99630311/179276872-259e9609-4552-4efd-b03b-824519bdb1ae.png">


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
