### PR TITLE
[Rule Tuning] Elastic Agent Service Terminated

### DIFF
--- a/rules/cross-platform/defense_evasion_elastic_agent_service_terminated.toml
+++ b/rules/cross-platform/defense_evasion_elastic_agent_service_terminated.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/05/23"
 maturity = "production"
-updated_date = "2022/05/23"
+updated_date = "2022/07/18"
 
 [rule]
 author = ["Elastic"]
@@ -37,8 +37,9 @@ process where
 or
 /* service or systemctl used to stop Elastic Agent on Linux */
 (event.type == "end" and
-  (process.name : ("systemctl","service") and 
-    process.args : ("elastic-agent", "stop")) 
+  (process.name : ("systemctl", "service") and 
+    process.args : "elastic-agent" and
+    process.args : "stop") 
   or 
   /* Unload Elastic Agent extension on MacOS */
   (process.name : "kextunload" and


### PR DESCRIPTION
## Issues

Resolves #2111 

## Summary

The original query uses an or condition that triggers on the stop of any service.
