### PR TITLE
Add MITRE Details for missing rules

### DIFF
--- a/rules/linux/defense_evasion_linux_iodine_activity.toml
+++ b/rules/linux/defense_evasion_linux_iodine_activity.toml
@@ -24,7 +24,7 @@ references = ["https://code.kryo.se/iodine/"]
 risk_score = 73
 rule_id = "041d4d41-9589-43e2-ba13-5680af75ebc2"
 severity = "high"
-tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
 type = "query"
 
@@ -32,3 +32,16 @@ query = '''
 event.category:process and event.type:(start or process_started) and process.name:(iodine or iodined)
 '''
 
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1599"
+name = "Network Boundary Bridging"
+reference = "https://attack.mitre.org/techniques/T1599/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/linux/defense_evasion_linux_process_started_in_temp_directory.toml
+++ b/rules/linux/defense_evasion_linux_process_started_in_temp_directory.toml
@@ -36,3 +36,18 @@ event.category:process and event.type:(start or process_started) and process.wor
                     /var/lib/command-not-found/)
 '''
 
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1211"
+name = "Exploitation for Defense Evasion"
+reference = "https://attack.mitre.org/techniques/T1211/
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"

--- a/rules/linux/discovery_linux_netcat_network_connection.toml
+++ b/rules/linux/discovery_linux_netcat_network_connection.toml
@@ -30,7 +30,7 @@ references = [
 risk_score = 47
 rule_id = "adb961e0-cb74-42a0-af9e-29fc41f88f5f"
 severity = "medium"
-tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Discovery"]
 type = "eql"
 
 query = '''
@@ -42,3 +42,16 @@ sequence by process.entity_id
                   process.name == "netcat.openbsd" or process.name == "netcat.traditional")]
 '''
 
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1049"
+name = "System Network Connections Discovery"
+reference = "https://attack.mitre.org/techniques/T1049/"
+
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"

--- a/rules/linux/discovery_linux_nping_activity.toml
+++ b/rules/linux/discovery_linux_nping_activity.toml
@@ -24,7 +24,7 @@ references = ["https://en.wikipedia.org/wiki/Nmap"]
 risk_score = 47
 rule_id = "0d69150b-96f8-467c-a86d-a67a3378ce77"
 severity = "medium"
-tags = ["Elastic", "Host", "Linux", "Threat Detection"]
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Discovery"]
 timestamp_override = "event.ingested"
 type = "query"
 
@@ -32,3 +32,16 @@ query = '''
 event.category:process and event.type:(start or process_started) and process.name:nping
 '''
 
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1082"
+name = "System Information Discovery"
+reference = "https://attack.mitre.org/techniques/T1082/"
+
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"


### PR DESCRIPTION
## Issues
#2114

## Summary
As part of #elastic/security-team/issues/4094, Linux rule tuning scoped out for 8.4 has identified the above 4 rules with missing MITRE details. This PR handles the below changes

- Add MITRE details
- Change file names
- Add tags suiting the changes


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
