### PR TITLE
[New Rule] Hidden so file

### DIFF
--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -23,7 +23,7 @@ index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 max_signals = 33
-name = "Creation of Hidden Files and Directories"
+name = "Creation of Hidden Files and Directories via CommandLine"
 note = """## Setup
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.

--- a/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
+++ b/rules/linux/defense_evasion_hidden_file_dir_tmp.toml
@@ -3,7 +3,7 @@ creation_date = "2020/04/29"
 maturity = "production"
 min_stack_comments = "EQL regex syntax introduced in 7.12"
 min_stack_version = "7.12.0"
-updated_date = "2022/03/31"
+updated_date = "2022/07/20"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_hidden_shared_object.toml
+++ b/rules/linux/defense_evasion_hidden_shared_object.toml
@@ -6,9 +6,8 @@ updated_date = "2022/07/20"
 [rule]
 author = ["Elastic"]
 description = """
-Users can mark specific files as hidden simply by putting a "." as the first character in the file or folder name.
+Identifies the creation of a hidden shared object (.so) file. Users can mark specific files as hidden simply by putting a "." as the first character in the file or folder name.
 Adversaries can use this to their advantage to hide files and folders on the system for persistence and defense evasion.
-This rule looks for hidden shared object (.so) file creation events.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]

--- a/rules/linux/defense_evasion_hidden_shared_object.toml
+++ b/rules/linux/defense_evasion_hidden_shared_object.toml
@@ -1,0 +1,60 @@
+[metadata]
+creation_date = "2022/07/20"
+maturity = "production"
+min_stack_version = "7.12.0"
+updated_date = "2022/07/20"
+
+[rule]
+author = ["Elastic"]
+description = """
+Users can mark specific files as hidden simply by putting a "." as the first character in the file or folder name.
+Adversaries can use this to their advantage to hide files and folders on the system for persistence and defense evasion.
+This rule looks for hidden shared object (.so) file creation events.
+"""
+from = "now-9m"
+index = ["auditbeat-*", "logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+max_signals = 33
+name = "Creation of Hidden Shared Object File"
+note = """## Setup
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
+risk_score = 47
+rule_id = "766d3f91-3f12-448c-b65f-20123e9e9e8c"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+file where event.action : "creation" and file.extension == "so" and file.name : ".*.so" 
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1564"
+name = "Hide Artifacts"
+reference = "https://attack.mitre.org/techniques/T1564/"
+[[rule.threat.technique.subtechnique]]
+id = "T1564.001"
+name = "Hidden Files and Directories"
+reference = "https://attack.mitre.org/techniques/T1564/001/"
+
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/linux/defense_evasion_hidden_shared_object.toml
+++ b/rules/linux/defense_evasion_hidden_shared_object.toml
@@ -51,8 +51,4 @@ reference = "https://attack.mitre.org/tactics/TA0005/"
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
-[rule.threat.tactic]
-id = "TA0003"
-name = "Persistence"
-reference = "https://attack.mitre.org/tactics/TA0003/"
 

--- a/rules/linux/defense_evasion_hidden_shared_object.toml
+++ b/rules/linux/defense_evasion_hidden_shared_object.toml
@@ -48,7 +48,5 @@ reference = "https://attack.mitre.org/techniques/T1564/001/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-[[rule.threat]]
-framework = "MITRE ATT&CK"
 
 

--- a/rules/linux/defense_evasion_hidden_shared_object.toml
+++ b/rules/linux/defense_evasion_hidden_shared_object.toml
@@ -1,7 +1,6 @@
 [metadata]
 creation_date = "2022/07/20"
 maturity = "production"
-min_stack_version = "7.12.0"
 updated_date = "2022/07/20"
 
 [rule]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2085

## Summary

This rule will detect the creation of a hidden shared object file. Threat actors will commonly drop and hide malicious shared object files which they can then load into an existing and benign system binary in order to hijack system calls and remain hidden.