### PR TITLE
[New Rule] File made Immutable by Chattr

### DIFF
--- a/rules/linux/defense_evasion_chattr_immutable_file.toml
+++ b/rules/linux/defense_evasion_chattr_immutable_file.toml
@@ -34,7 +34,7 @@ process where event.type == "start" and user.name == "root" and process.executab
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1222"
-name = "File and Directory Permissions Modifications"
+name = "File and Directory Permissions Modification"
 reference = "https://attack.mitre.org/techniques/T1222/"
 
 [[rule.threat.technique.subtechnique]]

--- a/rules/linux/defense_evasion_chattr_immutable_file.toml
+++ b/rules/linux/defense_evasion_chattr_immutable_file.toml
@@ -1,0 +1,52 @@
+[metadata]
+creation_date = "2022/07/22"
+maturity = "production"
+updated_date = "2022/07/22"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects a file being made immutable using the chattr binary. Making a file immutable means it cannot be deleted or renamed, no link can be created to this file, most of the file's metadata can not be modified, and the file can not be opened in write mode. Threat actors will commonly utilize this to prevent tampering or modification of their malicious files or any system files they have modified for purposes of persistence (e.g .ssh, /etc/passwd, etc.).
+"""
+from = "now-9m"
+index = ["auditbeat-*", "logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+max_signals = 33
+name = "File made Immutable by Chattr"
+note = """## Setup
+
+If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
+"""
+risk_score = 47
+rule_id = "968ccab9-da51-4a87-9ce2-d3c9782fd759"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where event.type == "start" and user.name == "root" and process.executable : "/usr/bin/chattr" and process.args : ("-*i*", "+*i*") and not process.parent.executable: "/lib/systemd/systemd"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1222"
+name = "File and Directory Permissions Modifications"
+reference = "https://attack.mitre.org/techniques/T1222/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1222.002"
+name = "Linux and Mac File and Directory Permissions Modification"
+reference = "https://attack.mitre.org/techniques/T1222/002/"
+
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2090

## Summary
Detects a file being made immutable using the chattr binary. Making a file immutable means it cannot be deleted or renamed, no link can be created to this file, most of the file's metadata can not be modified, and the file can not be opened in write mode. Threat actors will commonly utilize this to prevent tampering or modification of their malicious files or any system files they have modified for purposes of persistence (e.g .ssh, /etc/passwd, etc.).