### PR TITLE
Rule(s) deprecation as part of Linux Detection Rule Review

### DIFF
--- a/rules/_deprecated/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/_deprecated/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -1,7 +1,8 @@
 [metadata]
 creation_date = "2020/04/24"
-maturity = "production"
-updated_date = "2021/03/03"
+deprecation_date = "2022/07/25"
+maturity = "deprecated"
+updated_date = "2022/07/25"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/execution_linux_process_started_in_temp_directory.toml
+++ b/rules/_deprecated/execution_linux_process_started_in_temp_directory.toml
@@ -1,7 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-maturity = "production"
-updated_date = "2022/07/18"
+deprecation_date = "2022/07/25"
+maturity = "deprecated"
+updated_date = "2022/07/25"
 
 [rule]
 author = ["Elastic"]
@@ -36,9 +37,12 @@ event.category:process and event.type:(start or process_started) and process.wor
                     /var/lib/command-not-found/)
 '''
 
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [rule.threat.tactic]
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/_deprecated/initial_access_login_failures.toml
+++ b/rules/_deprecated/initial_access_login_failures.toml
@@ -1,27 +1,28 @@
 [metadata]
 creation_date = "2020/07/08"
-maturity = "production"
-updated_date = "2021/03/03"
+deprecation_date = "2022/07/25"
+maturity = "deprecated"
+updated_date = "2022/07/25"
 
 [rule]
 author = ["Elastic"]
-description = "Identifies that a login attempt occurred at a forbidden time."
+description = "Identifies that the maximum number of failed login attempts has been reached for a user."
 index = ["auditbeat-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "Auditd Login Attempt at Forbidden Time"
+name = "Auditd Max Failed Login Attempts"
 references = [
-    "https://github.com/linux-pam/linux-pam/blob/aac5a8fdc4aa3f7e56335a6343774cc1b63b408d/modules/pam_time/pam_time.c#L666",
+    "https://github.com/linux-pam/linux-pam/blob/0adbaeb273da1d45213134aa271e95987103281c/modules/pam_faillock/pam_faillock.c#L574",
 ]
 risk_score = 47
-rule_id = "90e28af7-1d96-4582-bf11-9a1eff21d0e5"
+rule_id = "fb9937ce-7e21-46bf-831d-1ad96eac674d"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Initial Access"]
 timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.module:auditd and event.action:"attempted-log-in-during-unusual-hour-to"
+event.module:auditd and event.action:"failed-log-in-too-many-times-to"
 '''
 
 

--- a/rules/_deprecated/initial_access_login_location.toml
+++ b/rules/_deprecated/initial_access_login_location.toml
@@ -1,7 +1,8 @@
 [metadata]
 creation_date = "2020/07/08"
-maturity = "production"
-updated_date = "2021/03/03"
+deprecation_date = "2022/07/25"
+maturity = "deprecated"
+updated_date = "2022/07/25"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/initial_access_login_sessions.toml
+++ b/rules/_deprecated/initial_access_login_sessions.toml
@@ -1,27 +1,28 @@
 [metadata]
 creation_date = "2020/07/08"
-maturity = "production"
-updated_date = "2021/03/03"
+deprecation_date = "2022/07/25"
+maturity = "deprecated"
+updated_date = "2022/07/25"
 
 [rule]
 author = ["Elastic"]
-description = "Identifies that the maximum number of failed login attempts has been reached for a user."
+description = "Identifies that the maximum number login sessions has been reached for a user."
 index = ["auditbeat-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "Auditd Max Failed Login Attempts"
+name = "Auditd Max Login Sessions"
 references = [
-    "https://github.com/linux-pam/linux-pam/blob/0adbaeb273da1d45213134aa271e95987103281c/modules/pam_faillock/pam_faillock.c#L574",
+    "https://github.com/linux-pam/linux-pam/blob/70c32cc6fca51338f92afa58eb75b1107a5c2430/modules/pam_limits/pam_limits.c#L1007",
 ]
 risk_score = 47
-rule_id = "fb9937ce-7e21-46bf-831d-1ad96eac674d"
+rule_id = "20dc4620-3b68-4269-8124-ca5091e00ea8"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Initial Access"]
 timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.module:auditd and event.action:"failed-log-in-too-many-times-to"
+event.module:auditd and event.action:"opened-too-many-sessions-to"
 '''
 
 

--- a/rules/_deprecated/initial_access_login_time.toml
+++ b/rules/_deprecated/initial_access_login_time.toml
@@ -1,27 +1,28 @@
 [metadata]
 creation_date = "2020/07/08"
-maturity = "production"
-updated_date = "2021/03/03"
+deprecation_date = "2022/07/25"
+maturity = "deprecated"
+updated_date = "2022/07/25"
 
 [rule]
 author = ["Elastic"]
-description = "Identifies that the maximum number login sessions has been reached for a user."
+description = "Identifies that a login attempt occurred at a forbidden time."
 index = ["auditbeat-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "Auditd Max Login Sessions"
+name = "Auditd Login Attempt at Forbidden Time"
 references = [
-    "https://github.com/linux-pam/linux-pam/blob/70c32cc6fca51338f92afa58eb75b1107a5c2430/modules/pam_limits/pam_limits.c#L1007",
+    "https://github.com/linux-pam/linux-pam/blob/aac5a8fdc4aa3f7e56335a6343774cc1b63b408d/modules/pam_time/pam_time.c#L666",
 ]
 risk_score = 47
-rule_id = "20dc4620-3b68-4269-8124-ca5091e00ea8"
+rule_id = "90e28af7-1d96-4582-bf11-9a1eff21d0e5"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Initial Access"]
 timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.module:auditd and event.action:"opened-too-many-sessions-to"
+event.module:auditd and event.action:"attempted-log-in-during-unusual-hour-to"
 '''
 
 


### PR DESCRIPTION
## Issues
#2162 

## Summary
As part of the Linux Detection Rule Review, the above rules have been identified for deprecation. The detailed reason for deprecation can be found in the review sheet [Linux Detection Rules Review](https://docs.google.com/spreadsheets/d/1oA7vlsqTzm6pg6A6LPNhx6uzV-ClFlD3hP9qSVwu0O4/edit?usp=sharing)

Meta Issue: https://github.com/elastic/security-team/issues/4094

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
