### PR TITLE
Rule(s) to identify potential mining activities

### DIFF
--- a/rules/linux/impact_process_kill_threshold.toml
+++ b/rules/linux/impact_process_kill_threshold.toml
@@ -11,7 +11,7 @@ short time period.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*"]
-language = "eql"
+language = "kquery"
 license = "Elastic License v2"
 name = "High Number of Process Terminations"
 note = """## Triage and analysis
@@ -64,7 +64,7 @@ tags = ["Elastic", "Host", "Linux", "Threat Detection", "Impact"]
 type = "threshold"
 
 query = '''
-process where event.type=="start" and process.name=="pkill" and process.args=="-f"
+event.category:process and event.type:start and process.name:"pkill" and process.args:"-f"
 '''
 
 

--- a/rules/linux/impact_process_kill_threshold.toml
+++ b/rules/linux/impact_process_kill_threshold.toml
@@ -58,7 +58,7 @@ malware components.
 mean time to respond (MTTR).
 """
 risk_score = 47
-rule_id = "035889c4-2686-4583-a7df-67f89c292f2c"
+rule_id = "67f8443a-4ff3-4a70-916d-3cfa3ae9f02b"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Impact"]
 type = "threshold"

--- a/rules/linux/impact_process_kill_threshold.toml
+++ b/rules/linux/impact_process_kill_threshold.toml
@@ -1,0 +1,87 @@
+[metadata]
+creation_date = "2022/07/27"
+maturity = "production"
+updated_date = "2022/07/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule identifies a high number (10) of process terminations via pkill from the same host within a
+short time period.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "High Number of Process Terminations"
+note = """## Triage and analysis
+
+### Investigating High Number of Process Terminations
+
+Attackers can kill processes for a variety of purposes. For example, they can kill process associated
+with business applications and databases to release the lock on files used by these applications so they may be
+encrypted,or stop security and backup solutions, etc.
+
+This rule identifies a high number (10) of process terminations via pkill from the same
+host within a short time period.
+
+#### Possible investigation steps
+
+Detection alerts from this rule indicate High Number of Process Terminations from the same host
+Here are some possible avenues of investigation:
+- Examine the entry point to the host and user in action via the Analyse View.
+  - Identify the session entry leader and session user
+- Examine the contents of session leading to the process termination(s) via the Session View.
+  - Examine the command execution pattern in the session, which may lead to suspricous activities
+- Examine the process killed during the malicious execution
+  - Identify imment threat to the system from the process killed
+  - Take necessary incident response actions to respawn necessary process
+
+### False positive analysis
+
+- This activity is unlikely to happen legitimately. Benign true positives (B-TPs) can be added as exceptions if necessary.
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- Isolate the involved host to prevent further destructive behavior, which is commonly associated with this activity.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Reimage the host operating system or restore it to the operational state.
+- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look
+for ransomware preparation and execution activities.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
+"""
+risk_score = 47
+rule_id = "035889c4-2686-4583-a7df-67f89c292f2c"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Impact"]
+type = "threshold"
+
+query = '''
+process where event.type=="start" and process.name=="pkill" and process.args=="-f"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1489"
+name = "Service Stop"
+reference = "https://attack.mitre.org/techniques/T1489/"
+
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
+
+[rule.threshold]
+field = ["host.id"]
+value = 10
+

--- a/rules/linux/impact_process_kill_threshold.toml
+++ b/rules/linux/impact_process_kill_threshold.toml
@@ -11,7 +11,7 @@ short time period.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*"]
-language = "kquery"
+language = "kuery"
 license = "Elastic License v2"
 name = "High Number of Process Terminations"
 note = """## Triage and analysis


### PR DESCRIPTION
## Issues
#endpoint-rules/issues/1242

## Summary
Rule(s) to identify potential mining activities. The individual rule can highlight suspicious activities leading to potential mining. The rule individually also governs the basic Linux defense controls tampering. 

### Testing

Detonate Scripts mentioned in the Issue are used to test the rules

#### Testing Suspicious Process Kill Events

![image](https://user-images.githubusercontent.com/91139415/181279756-2fbda549-b9b1-4295-b2db-9bc51a358cfd.png)

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
