### PR TITLE
[Rule Tuning] MacOS Installer Package Net Event

### DIFF
--- a/rules/macos/execution_installer_package_spawned_network_event.toml
+++ b/rules/macos/execution_installer_package_spawned_network_event.toml
@@ -8,7 +8,7 @@ author = ["Elastic"]
 description = """
 Detects the execution of a MacOS installer package with an abnormal child process (e.g bash) followed immediately by a network connection via a suspicious process (e.g curl). 
 Threat actors will build and distribute malicious MacOS installer packages, which have a .pkg extension, many times imitating valid software in order to persuade and infect their victims often using the package files (e.g pre/post install scripts etc.) to download additional tools or malicious software. 
-If this rule fires it should indicate a the installation of a malicious or suspicious package.
+If this rule fires it should indicate the installation of a malicious or suspicious package.
 """
 false_positives = [
     """

--- a/rules/macos/execution_installer_package_spawned_network_event.toml
+++ b/rules/macos/execution_installer_package_spawned_network_event.toml
@@ -33,7 +33,7 @@ tags = ["Elastic", "Host", "macOS", "Threat Detection", "Execution", "Command an
 type = "eql"
 
 query = '''
-sequence by host.id, user.id with maxspan=30s
+sequence by host.id, user.id with maxspan=1m
 [process where event.type == "start" and process.parent.name : ("installer", "package_script_service") and process.name : ("bash", "sh", "zsh", "python", "osascript", "tclsh*")] 
 [network where event.type == "start" and process.name : ("curl", "osascript", "wget", "python")] 
 '''

--- a/rules/macos/execution_installer_package_spawned_network_event.toml
+++ b/rules/macos/execution_installer_package_spawned_network_event.toml
@@ -33,8 +33,8 @@ tags = ["Elastic", "Host", "macOS", "Threat Detection", "Execution", "Command an
 type = "eql"
 
 query = '''
-sequence by host.id, user.id with maxspan=1m
-[process where event.type == "start" and process.parent.name : ("installer", "package_script_service") and process.name : ("bash", "sh", "zsh", "python", "osascript", "tclsh*")] 
+sequence by host.id, user.id with maxspan=30s
+[process where event.type == "start" and event.action == "exec" and process.parent.name : ("installer", "package_script_service") and process.name : ("bash", "sh", "zsh", "python", "osascript", "tclsh*")] 
 [network where event.type == "start" and process.name : ("curl", "osascript", "wget", "python")] 
 '''
 

--- a/rules/macos/execution_installer_package_spawned_network_event.toml
+++ b/rules/macos/execution_installer_package_spawned_network_event.toml
@@ -1,13 +1,14 @@
 [metadata]
 creation_date = "2021/02/23"
 maturity = "production"
-updated_date = "2022/07/21"
+updated_date = "2022/07/27"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when the built in macOS Installer program generates a network event after attempting to install a .pkg file.
-This activity has been observed being leveraged by malware.
+Detects the execution of a MacOS installer package with an abnormal child process (e.g bash) followed immediately by a network connection via a suspicious process (e.g curl). 
+Threat actors will build and distribute malicious MacOS installer packages, which have a .pkg extension, many times imitating valid software in order to persuade and infect their victims often using the package files (e.g pre/post install scripts etc.) to download additional tools or malicious software. 
+If this rule fires it should indicate a the installation of a malicious or suspicious package.
 """
 false_positives = [
     """
@@ -19,28 +20,23 @@ from = "now-9m"
 index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
-name = "macOS Installer Spawns Network Event"
+name = "MacOS Installer Package Spawns Network Event"
 references = [
     "https://redcanary.com/blog/clipping-silver-sparrows-wings",
-    "https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml",
+    "https://posts.specterops.io/introducing-mystikal-4fbd2f7ae520",
+    "https://github.com/D00MFist/Mystikal"
 ]
-risk_score = 47
+risk_score = 74
 rule_id = "99239e7d-b0d4-46e3-8609-acafcf99f68c"
 severity = "medium"
 tags = ["Elastic", "Host", "macOS", "Threat Detection", "Execution", "Command and Control"]
 type = "eql"
 
 query = '''
-sequence by process.entity_id with maxspan=1m
-  [process where event.type == "start" and host.os.family == "macos" and
-    process.parent.executable in ("/usr/sbin/installer", "/System/Library/CoreServices/Installer.app/Contents/MacOS/Installer") ]
-  [network where not cidrmatch(destination.ip,
-    "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.0.0.0/29", "192.0.0.8/32",
-    "192.0.0.9/32", "192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24",
-    "192.52.193.0/24", "192.168.0.0/16", "192.88.99.0/24", "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24",
-    "198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", "::1", "FE80::/10", "FF00::/8")]
+sequence by host.id, user.id with maxspan=30s
+[process where event.type == "start" and process.parent.name : ("installer", "package_script_service") and process.name : ("bash", "sh", "zsh", "python", "osascript", "tclsh*")] 
+[network where event.type == "start" and process.name : ("curl", "osascript", "wget", "python")] 
 '''
-
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2189

## Summary

This rule logic is flawed. I spent yesterday afternoon executing every installer package payload [Mystikal](https://github.com/D00MFist/Mystikal) has to offer along with various other malicious [packages](https://redcanary.com/blog/clipping-silver-sparrows-wings/) and this rule did not fire once. The problem with the rule is in the way the process tree spawns with installer packages preventing sequencing on process.entity_id as the child processes spawned from installer or package_script_service are not linked directly by process id and therefore cannot be connected together via the process.entity_id. This will prevent the rule from ever firing.