### PR TITLE
[Bug] related_integration added to all rule versions

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -714,7 +714,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
                             if package["integration"] not in policy_templates:
                                 del package["integration"]
 
-            obj.setdefault("related_integrations", package_integrations)
+                obj.setdefault("related_integrations", package_integrations)
 
     def _add_required_fields(self, obj: dict) -> None:
         """Add restricted field required_fields to the obj, derived from the query AST."""


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

Continuation of https://github.com/elastic/detection-rules/pull/2060

## Summary

Branch status checks are failing due to a missing indent in related integrations causing the new field to be added to all rule stack versions.

- Only add related integration if it's on the correct stack.
