### PR TITLE
[Bug] Set typing-inspect requirement to 0.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ elasticsearch~=8.1
 XlsxWriter~=1.3.6
 marshmallow~=3.13.0
 marshmallow-dataclass[union]~=8.5.6
+typing-inspect==0.7.1
 
 # test deps
 pyflakes==2.2.0


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

https://github.com/elastic/detection-rules/runs/7886816704?check_suite_focus=true

## Summary

A recent minor update in `typing-inspect==0.7.1` causes dataclass conversions to fail due to typing. This locks in the version to 0.7.1