### PR TITLE
Add test that newly introduced build-time fields for a min_stack for …

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -38,6 +38,7 @@ _META_SCHEMA_REQ_DEFAULTS = {}
 MIN_FLEET_PACKAGE_VERSION = '7.13.0'
 
 BUILD_FIELD_VERSIONS = {
+    "related_integrations": (Version('8.3'), None),
     "required_fields": (Version('8.3'), None),
     "setup": (Version("8.3"), None)
 }
@@ -249,6 +250,17 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
     @property
     def is_elastic_rule(self):
         return 'elastic' in [a.lower() for a in self.author]
+
+    def get_build_fields(self) -> {}:
+        """Get a list of build-time fields along with the stack versions which they will build within."""
+        build_fields = {}
+        rule_fields = {f.name: f for f in dataclasses.fields(self)}
+
+        for fld in BUILD_FIELD_VERSIONS:
+            if fld in rule_fields:
+                build_fields[fld] = BUILD_FIELD_VERSIONS[fld]
+
+        return build_fields
 
 
 class DataValidator:

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -696,3 +696,29 @@ class TestIncompatibleFields(BaseRuleTest):
             err_msg = 'The following rules have min_stack_versions lower than allowed for restricted fields:\n'
             err_msg += invalid_str
             self.fail(err_msg)
+
+
+class TestBuildTimeFields(BaseRuleTest):
+    """Test validity of build-time fields."""
+
+    def test_build_fields_min_stack(self):
+        """Test that newly introduced build-time fields for a min_stack for applicable rules."""
+        invalids = []
+
+        for rule in self.production_rules:
+            min_stack = rule.contents.metadata.min_stack_version
+            build_fields = rule.contents.data.get_build_fields()
+
+            errors = []
+            for build_field, field_versions in build_fields.items():
+                start_ver, end_ver = field_versions
+                if start_ver is not None and not Version(min_stack) >= start_ver:
+                    errors.append(f'{build_field} >= {start_ver}')
+
+            if errors:
+                err_str = ', '.join(errors)
+                invalids.append(f'{self.rule_str(rule)} uses a rule type with build fields requiring min_stack_versions'
+                                f'to be set: {err_str}')
+
+            if invalids:
+                self.fail(invalids)

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -712,13 +712,13 @@ class TestBuildTimeFields(BaseRuleTest):
             errors = []
             for build_field, field_versions in build_fields.items():
                 start_ver, end_ver = field_versions
-                if start_ver is not None and not Version(min_stack) >= start_ver:
+                if start_ver is not None and min_stack is None or not Version(min_stack) >= start_ver:
                     errors.append(f'{build_field} >= {start_ver}')
 
             if errors:
                 err_str = ', '.join(errors)
                 invalids.append(f'{self.rule_str(rule)} uses a rule type with build fields requiring min_stack_versions'
-                                f'to be set: {err_str}')
+                                f' to be set: {err_str}')
 
             if invalids:
                 self.fail(invalids)


### PR DESCRIPTION
## Issues
related to #2251 

## Summary
Build-time fields create changes to rule hashes without being accounted for explicitly within the version lock (essentially creating a "soft" lock). This is problematic because it creates a buggy situation where non-latest rules version bump every time due to the delta hash resulting from the differences from the build time fields. To address this, build time field introduction requires that all fields.

This adds a test to enforce that on any defined build time rule