### PR TITLE
adding new rule

### DIFF
--- a/rules/integrations/google_workspace/persistence_google_workspace_2sv_policy_or_enforcement_disabled.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_2sv_policy_or_enforcement_disabled.toml
@@ -1,0 +1,76 @@
+[metadata]
+creation_date = "2022/08/26"
+integration = "google_workspace"
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2022/08/26"
+
+[rule]
+author = ["Elastic"]
+description = """
+Google Workspace admins may setup 2-step verification (2SV) to add an extra layer of security to user accounts by asking
+users to verify their identity when they use login credentials. Admins have the ability to enforce 2SV from the admin
+console as well as the methods acceptable for verification and enrollment period. 2SV requires enablement on admin
+accounts prior to it being enabled for users within organization units. Adversaries may disable 2SV to lower the
+security requirements to access a valid account.
+"""
+false_positives = [
+    """
+    Administrators may remove 2-step verification (2SV) temporarily for testing or during maintenance. If 2SV was
+    previously enabled, it is not common to disable this policy for extended periods of time.
+    """,
+]
+from = "now-130m"
+index = ["filebeat-*", "logs-google_workspace*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License v2"
+name = "Google Workspace 2SV Policy or Enforcement Disabled"
+note = """## Setup
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
+- As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
+- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
+- By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
+- See the following references for further information:
+  - https://support.google.com/a/answer/7061566
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-google_workspace.html"""
+references = ["https://support.google.com/a/answer/9176657?hl=en"]
+risk_score = 47
+rule_id = "5e161522-2545-11ed-ac47-f661ea17fbce"
+severity = "medium"
+tags = [
+    "Elastic",
+    "Cloud",
+    "Google Workspace",
+    "Continuous Monitoring",
+    "SecOps",
+    "Configuration Audit",
+    "Persistence",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+event.dataset:"google_workspace.admin" and (event.action:"ENFORCE_STRONG_AUTHENTICATION"
+    and google_workspace.admin.new_value:false) or event.action:"2sv_disable"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1556"
+name = "Modify Authentication Process"
+reference = "https://attack.mitre.org/techniques/T1556/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
* https://github.com/elastic/detection-rules/issues/2226

## Summary
Google Workspace admins may setup 2-step verification (2SV) to add an extra layer of security to user accounts by asking users to verify their identity when they use login credentials. Admins have the ability to enforce 2SV from the admin console as well as the methods acceptable for verification and enrollment period. 2SV requires enablement on admin accounts prior to it being enabled for users within organization units. Adversaries may disable 2SV to lower the security requirements to access a valid account.

This rule detects when 2SV is already set but then disabled in Google Workspace.

