### PR TITLE
[Rule Tuning] Replace EQL Expressions that use backslashes

### DIFF
--- a/rules/windows/credential_access_cmdline_dump_tool.toml
+++ b/rules/windows/credential_access_cmdline_dump_tool.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/24"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/08/30"
 
 [rule]
 author = ["Elastic"]
@@ -78,8 +78,12 @@ query = '''
 process where event.type in ("start", "process_started") and
 /* update here with any new lolbas with dump capability */
 (process.pe.original_file_name == "procdump" and process.args : "-ma") or
-(process.name : "ProcessDump.exe" and not process.parent.executable regex~ """C:\\Program Files( \(x86\))?\\Cisco Systems\\.*""") or
-(process.pe.original_file_name == "WriteMiniDump.exe" and not process.parent.executable regex~ """C:\\Program Files( \(x86\))?\\Steam\\.*""") or
+(process.name : "ProcessDump.exe" and not process.parent.executable : (
+  "C:\\Program Files\\Cisco Systems\\*", "C:\\Program Files (x86)\\Cisco Systems\\*")
+) or
+(process.pe.original_file_name == "WriteMiniDump.exe" and not process.parent.executable : (
+  "C:\\Program Files\\Steam\\*", "C:\\Program Files (x86)\\Steam\\*")
+) or
 (process.pe.original_file_name == "RUNDLL32.EXE" and (process.args : "MiniDump*" or process.command_line : "*comsvcs.dll*#24*")) or
 (process.pe.original_file_name == "RdrLeakDiag.exe" and process.args : "/fullmemdmp") or
 (process.pe.original_file_name == "SqlDumper.exe" and process.args : "0x01100*") or

--- a/rules/windows/execution_suspicious_powershell_imgload.toml
+++ b/rules/windows/execution_suspicious_powershell_imgload.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/08/30"
 
 [rule]
 author = ["Elastic"]
@@ -106,7 +106,7 @@ any where (event.category == "library" or (event.category == "process" and event
 
 /* add false positives relevant to your environment here */
 not process.executable : ("C:\\Windows\\System32\\RemoteFXvGPUDisablement.exe", "C:\\Windows\\System32\\sdiagnhost.exe") and
-not process.executable regex~ """C:\\Program Files( \(x86\))?\\*\.exe""" and
+not process.executable : ("C:\\Program Files\\*.exe", "C:\\Program Files (x86)\\*.exe") and
   not process.name :
   (
     "Altaro.SubAgent.exe",

--- a/rules/windows/persistence_evasion_registry_ifeo_injection.toml
+++ b/rules/windows/persistence_evasion_registry_ifeo_injection.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 maturity = "production"
-updated_date = "2022/08/24"
+updated_date = "2022/08/30"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -28,12 +28,18 @@ type = "eql"
 
 query = '''
 registry where length(registry.data.strings) > 0 and
- registry.path : ("HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*.exe\\Debugger",
-                  "HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*\\Debugger",
-                  "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\*\\MonitorProcess",
-                  "HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\*\\MonitorProcess") and
-   /* add FPs here */
- not registry.data.strings regex~ ("""C:\\Program Files( \(x86\))?\\ThinKiosk\\thinkiosk\.exe""", """.*\\PSAppDeployToolkit\\.*""")
+  registry.path : (
+    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*.exe\\Debugger",
+    "HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*\\Debugger",
+    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\*\\MonitorProcess",
+    "HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows NT\\CurrentVersion\\SilentProcessExit\\*\\MonitorProcess"
+  ) and
+  /* add FPs here */
+  not registry.data.strings : (
+    "?:\\Program Files\\ThinKiosk\\thinkiosk.exe",
+    "?:\\Program Files (x86)\\ThinKiosk\\thinkiosk.exe",
+    "*\\PSAppDeployToolkit\\*"
+  )
 '''
 
 


### PR DESCRIPTION
## Issues

Resolves #2260 

## Summary

Replace regex statements with wildcards on cases where the expressions have backslashes.