### PR TITLE
Linux rule to detect potential ssh brute force attack

### DIFF
--- a/rules/linux/credential_access_potential_ssh_bruteforce.toml
+++ b/rules/linux/credential_access_potential_ssh_bruteforce.toml
@@ -1,0 +1,46 @@
+[metadata]
+creation_date = "2022/09/07"
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2022/09/07"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies a high number (20) of Linux SSHD process executions to the same host. An adversary may attempt a
+brute force attack to obtain unauthorized access to user accounts
+"""
+from = "now-9m"
+index = ["auditbeat-*", "logs-endpoint.events.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Potential SSH Brute Force Detected"
+risk_score = 47
+rule_id = "1c27fa22-7727-4dd3-81c0-de6da5555feb"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Credential Access"]
+type = "threshold"
+
+query = '''
+event.category:process and event.type:start and process.name:"sshd"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.threshold]
+field = ["host.id"]
+value = 20
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
#2290 

## Summary
Identifies a high number (20) of Linux SSHD process executions to the same host. An adversary may attempt a
brute force attack to obtain unauthorized access to user accounts

Testing updated in issue #2290 


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
