### PR TITLE
[Bug] Keyerror on rule-survey hits

### DIFF
--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -40,8 +40,10 @@ def parse_unique_field_results(rule_type: str, unique_fields: List[str], search_
     for hit in hits:
         for field in unique_fields:
             if 'events' in hit:
+                match = []
                 for event in hit['events']:
-                    match = nested_get(event['_source'], field)
+                    matched = nested_get(event['_source'], field)
+                    match.extend([matched] if not isinstance(matched, list) else matched)
                     if not match:
                         continue
             else:

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -39,9 +39,15 @@ def parse_unique_field_results(rule_type: str, unique_fields: List[str], search_
     hits = hits['hits'] if rule_type != 'eql' else hits.get('events') or hits.get('sequences', [])
     for hit in hits:
         for field in unique_fields:
-            match = nested_get(hit['_source'], field)
-            if not match:
-                continue
+            if 'events' in hit:
+                for event in hit['events']:
+                    match = nested_get(event['_source'], field)
+                    if not match:
+                        continue
+            else:
+                match = nested_get(hit['_source'], field)
+                if not match:
+                    continue
 
             match = ','.join(sorted(match)) if isinstance(match, list) else match
             parsed_results[field][match] += 1


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #2292 

## Summary
- Checks the list of events for matches instead of only checking the root object.


## Testing

Should complete with no errors. See the original issue for the error that existed.

```bash

(detection_dev) ➜  detection-rules git:(2292-bug-keyerror-on-rule-survey-hits) ✗ python -m detection_rules dev test rule-survey -d now-10s now
Loaded config file: /Users/stryker/workspace/Elastic/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Running survey against 684 rules
Saving detailed dump to: /Users/stryker/workspace/Elastic/detection-rules/surveys/20220912T154106L.json
(detection_dev) ➜  detection-rules git:(2292-bug-keyerror-on-rule-survey-hits)

```