### PR TITLE
[Rule Tuning] Adding "MRT.exe" as possible parent process for "svchost.exe"

### DIFF
--- a/rules/windows/persistence_gpo_schtask_service_creation.toml
+++ b/rules/windows/persistence_gpo_schtask_service_creation.toml
@@ -31,7 +31,7 @@ type = "eql"
 query = '''
 file where event.type != "deletion" and
   file.path : ("?:\\Windows\\SYSVOL\\domain\\Policies\\*\\MACHINE\\Preferences\\ScheduledTasks\\ScheduledTasks.xml",
-               "?:\\Windows\\SYSVOL\\domain\\Policies\\*\\MACHINE\\Preferences\\Preferences\\Services\\Services.xml") and
+               "?:\\Windows\\SYSVOL\\domain\\Policies\\*\\MACHINE\\Preferences\\Services\\Services.xml") and
   not process.name : "dfsrs.exe"
 '''
 

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -97,7 +97,7 @@ process.parent.name != null and
    (process.name:("lsass.exe", "LsaIso.exe") and not process.parent.name:"wininit.exe") or
    (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe")) or
    (process.name:"services.exe" and not process.parent.name:"wininit.exe") or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "MRT.exe")) or
    (process.name:"spoolsv.exe" and not process.parent.name:"services.exe") or
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
    (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe")) or


### PR DESCRIPTION
The "Microsoft Windows Malicious Software Removal Tool" can call "svchost.exe"

## Issues

This is creating false positives

## Summary

The "svchost.exe" can be called by "MRT.exe" (Microsoft Windows Malicious Software Removal Tool)

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
