### PR TITLE
[Bug] Adding Adjustment to Route C of manage_versions.py

### DIFF
--- a/detection_rules/version_lock.py
+++ b/detection_rules/version_lock.py
@@ -286,7 +286,7 @@ class VersionLock:
                                          f'exceed the max allowable version of {max_allowable_version}')
 
                     if info_from_rule != info_from_file:
-                        lock_from_file["previous"][str(min_stack)] = lock_from_rule
+                        lock_from_file["previous"][str(min_stack)].update(lock_from_rule)
                         new_version = lock_from_rule["version"]
                         log_changes(rule, route, 'unchanged',
                                     f'previous version {min_stack} updated version to {new_version}')


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
* https://github.com/elastic/detection-rules/pull/2272

## Summary
Adjusted route C to update the dictionary for the `lock_from_file` variable as `max_allowable_version` was overwritten and therefore did not exist in the output.

Testing:
1. Check out 8.2
2. Update `command_and_control_telnet_port_activity.toml` in rule contents
3. Run `python -m detection_rules dev build-release --update-version-lock`
4. Check diff for `version.lock.json` file and notice `max_allowable_version` is missing

Bug Screenshot:
<img width="1540" alt="Screen Shot 2022-09-19 at 2 43 17 PM" src="https://user-images.githubusercontent.com/99630311/191092023-aea51641-f514-4c9d-a459-608c81ee341d.png">


Solution Screenshot:
<img width="1554" alt="Screen Shot 2022-09-19 at 2 19 27 PM" src="https://user-images.githubusercontent.com/99630311/191088409-33fc748b-6314-4cae-b8ae-8761a8de7210.png">

