### PR TITLE
[Rule Tuning] Kubernetes - update min_stack for new rules

### DIFF
--- a/rules/integrations/kubernetes/discovery_denied_service_account_request.toml
+++ b/rules/integrations/kubernetes/discovery_denied_service_account_request.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/09/13"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/09/15"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/09/20"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
+++ b/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/09/13"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/09/20"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/09/13"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/09/15"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/09/20"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2309 

## Link to rules
- https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/discovery_denied_service_account_request.toml 
- https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml 
- https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml

## Description
<!-- Provide a detailed description of the suggested changes --> min_stack change to 8.4 with new required fields added to Kubernetes Integration

![image](https://user-images.githubusercontent.com/59296946/191351181-9ef8606a-6a8c-455b-92bd-9f3b07c0030b.png)
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

