### PR TITLE
[Bug] Add ready_for_review to backport activity types

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,6 +9,7 @@ on:
       - unlabeled
       - labeled
       - closed
+      - converted_to_draft
 
 jobs:
   get-branches:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,7 @@ on:
       - unlabeled
       - labeled
       - closed
-      - converted_to_draft
+      - ready_for_review
 
 jobs:
   get-branches:


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
#2310
#1991

## Summary

When PRs are started in `draft`, then converted to `ready for review`, the `backport: auto` label is not added to drafts and has to be manually added after.  Even worst, GitHub doesn't reflect PR state changes between draft, so you can not go back and look at an issue to tell that it was started as a Draft PR.

This PR adds the `ready_for_review` [activity type](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) which will add the `backport: auto`.
