### PR TITLE
Kubernetes Rule Tunings for "allowed" activity

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -88,6 +88,7 @@
     "kubernetes.audit.objectRef.namespace": "keyword",
     "kubernetes.audit.objectRef.serviceAccountName": "keyword",
     "kubernetes.audit.requestObject.spec.serviceAccountName": "keyword",
-    "kubernetes.audit.responseStatus.reason": "keyword"
+    "kubernetes.audit.responseStatus.reason": "keyword",
+    "kubernetes.audit.requestObject.spec.containers.image": "text"
   }
 }

--- a/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml
+++ b/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/06/30"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -41,9 +41,12 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.verb:"create"
-and kubernetes.audit.objectRef.resource:("selfsubjectaccessreviews" or "selfsubjectrulesreviews")
-and kubernetes.audit.user.username:(system\:serviceaccount\:* or system\:node\:*) or kubernetes.audit.impersonatedUser.username:(system\:serviceaccount\:* or system\:node\:*)
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow"
+  and kubernetes.audit.verb:"create"
+  and kubernetes.audit.objectRef.resource:("selfsubjectaccessreviews" or "selfsubjectrulesreviews")
+  and (kubernetes.audit.user.username:(system\:serviceaccount\:* or system\:node\:*) 
+  or kubernetes.audit.impersonatedUser.username:(system\:serviceaccount\:* or system\:node\:*))
 '''
 
 

--- a/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
+++ b/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/05/17"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -43,7 +43,10 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.objectRef.resource:"pods"
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" 
+  and kubernetes.audit.verb:"create" 
+  and kubernetes.audit.objectRef.resource:"pods"
   and kubernetes.audit.objectRef.subresource:"exec"
 '''
 

--- a/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
+++ b/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
@@ -4,7 +4,7 @@ integration = "kubernetes"
 maturity = "production"
 min_stack_comments = "New fields added to Kubernetes Integration"
 min_stack_version = "8.4.0"
-updated_date = "2022/09/20"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -38,7 +38,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" 
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" 
   and (kubernetes.audit.user.username:("system:anonymous" or "system:unauthenticated") or not kubernetes.audit.user.username:*)
   and not kubernetes.audit.objectRef.resource:("healthz" or "livez" or "readyz")
 '''

--- a/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml
+++ b/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/07/05"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -47,7 +47,11 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.objectRef.resource:"services" and kubernetes.audit.verb:("create" or "update" or "patch") and kubernetes.audit.requestObject.spec.type:"NodePort"
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" 
+  and kubernetes.audit.objectRef.resource:"services" 
+  and kubernetes.audit.verb:("create" or "update" or "patch") 
+  and kubernetes.audit.requestObject.spec.type:"NodePort"
 '''
 
 

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml
@@ -2,25 +2,26 @@
 creation_date = "2022/07/05"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
 description = """
 This rule detects an attempt to create or modify a pod using the host IPC namespace. This gives access to data used by
-any pod that also use the host�s IPC namespace. If any process on the host or any processes in a pod uses the host�s
+any pod that also use the hosts IPC namespace. If any process on the host or any processes in a pod uses the hosts
 inter-process communication mechanisms (shared memory, semaphore arrays, message queues, etc.), an attacker can
 read/write to those same mechanisms. They may look for files in /dev/shm or use ipcs to check for any IPC facilities
 being used.
 """
 false_positives = [
     """
-    An administrator or developer may want to use a pod that runs as root and shares the host�s IPC, Network, and PID
+    An administrator or developer may want to use a pod that runs as root and shares the host's IPC, Network, and PID
     namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto
     the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and
-    network namespaces from the host's perspective.
+    network namespaces from the host's perspective. Add exceptions for trusted container images using the query field
+    "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
 index = ["logs-kubernetes.*"]
@@ -43,7 +44,12 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.objectRef.resource:"pods" and kubernetes.audit.verb:("create" or "update" or "patch") and kubernetes.audit.requestObject.spec.hostIPC:true
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" 
+  and kubernetes.audit.objectRef.resource:"pods" 
+  and kubernetes.audit.verb:("create" or "update" or "patch") 
+  and kubernetes.audit.requestObject.spec.hostIPC:true
+  and not kubernetes.audit.requestObject.spec.containers.image: ("docker.elastic.co/beats/elastic-agent:8.4.0")
 '''
 
 

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/07/05"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -16,10 +16,11 @@ applied to its given namespace.
 """
 false_positives = [
     """
-    An administrator or developer may want to use a pod that runs as root and shares the host�s IPC, Network, and PID
+    An administrator or developer may want to use a pod that runs as root and shares the hosts IPC, Network, and PID
     namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto
     the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and
-    network namespaces from the host's perspective.
+    network namespaces from the host's perspective. Add exceptions for trusted container images using the query field
+    "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
 index = ["logs-kubernetes.*"]
@@ -42,7 +43,12 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.objectRef.resource:"pods" and kubernetes.audit.verb:("create" or "update" or "patch") and kubernetes.audit.requestObject.spec.hostNetwork:true
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" 
+  and kubernetes.audit.objectRef.resource:"pods" 
+  and kubernetes.audit.verb:("create" or "update" or "patch") 
+  and kubernetes.audit.requestObject.spec.hostNetwork:true
+  and not kubernetes.audit.requestObject.spec.containers.image: ("docker.elastic.co/beats/elastic-agent:8.4.0")
 '''
 
 

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/07/05"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -17,10 +17,11 @@ they could execute a shell and continue to escalate privileges to root.
 """
 false_positives = [
     """
-    An administrator or developer may want to use a pod that runs as root and shares the host�s IPC, Network, and PID
+    An administrator or developer may want to use a pod that runs as root and shares the hosts IPC, Network, and PID
     namespaces for debugging purposes. If something is going wrong in the cluster and there is no easy way to SSH onto
     the host nodes directly, a privileged pod of this nature can be useful for viewing things like iptable rules and
-    network namespaces from the host's perspective.
+    network namespaces from the host's perspective. Add exceptions for trusted container images using the query field
+    "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
 index = ["logs-kubernetes.*"]
@@ -43,7 +44,12 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.objectRef.resource:"pods" and kubernetes.audit.verb:("create" or "update" or "patch") and kubernetes.audit.requestObject.spec.hostPID:true
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" 
+  and kubernetes.audit.objectRef.resource:"pods" 
+  and kubernetes.audit.verb:("create" or "update" or "patch") 
+  and kubernetes.audit.requestObject.spec.hostPID:true
+  and not kubernetes.audit.requestObject.spec.containers.image: ("docker.elastic.co/beats/elastic-agent:8.4.0")
 '''
 
 

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hostpath_volume.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hostpath_volume.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/07/11"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,8 @@ false_positives = [
     legitimacy by determining if the kuberenetes.audit.requestObject.spec.volumes.hostPath.path triggered is one needed
     by its target container/pod. For example, when the fleet managed elastic agent is deployed as a daemonset it creates
     several hostPath volume mounts, some of which are sensitive host directories like /proc, /etc/kubernetes, and
-    /var/log.
+    /var/log. Add exceptions for trusted container images using the query field
+    "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
 index = ["logs-kubernetes.*"]
@@ -42,9 +43,28 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.objectRef.resource:"pods"
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" 
+  and kubernetes.audit.objectRef.resource:"pods"
   and kubernetes.audit.verb:("create" or "update" or "patch")
-  and kubernetes.audit.requestObject.spec.volumes.hostPath.path:("/" or "/proc" or "/root" or "/var" or "/var/run/docker.sock" or "/var/run/crio/crio.sock" or "/var/run/cri-dockerd.sock" or "/var/lib/kubelet" or "/var/lib/kubelet/pki" or "/var/lib/docker/overlay2" or "/etc" or "/etc/kubernetes" or "/etc/kubernetes/manifests" or "/home/admin")
+  and kubernetes.audit.requestObject.spec.volumes.hostPath.path:
+  ("/" or 
+  "/proc" or 
+  "/root" or 
+  "/var" or 
+  "/var/run" or 
+  "/var/run/docker.sock" or 
+  "/var/run/crio/crio.sock" or 
+  "/var/run/cri-dockerd.sock" or 
+  "/var/lib/kubelet" or 
+  "/var/lib/kubelet/pki" or 
+  "/var/lib/docker/overlay2" or 
+  "/etc" or 
+  "/etc/kubernetes" or 
+  "/etc/kubernetes/manifests" or 
+  "/etc/kubernetes/pki" or
+  "/home/admin")
+  and not kubernetes.audit.requestObject.spec.containers.image: ("docker.elastic.co/beats/elastic-agent:8.4.0")
 '''
 
 

--- a/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/07/05"
 integration = "kubernetes"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+min_stack_comments = "New fields added to Kubernetes Integration"
+min_stack_version = "8.4.0"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,8 @@ false_positives = [
     By default a container is not allowed to access any devices on the host, but a "privileged" container is given
     access to all devices on the host. This allows the container nearly all the same access as processes running on the
     host. An administrator may want to run a privileged container to use operating system administrative capabilities
-    such as manipulating the network stack or accessing hardware devices from within the cluster.
+    such as manipulating the network stack or accessing hardware devices from within the cluster. Add exceptions for
+    trusted container images using the query field "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
 index = ["logs-kubernetes.*"]
@@ -42,8 +43,12 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-kubernetes.audit.objectRef.resource:pods and kubernetes.audit.verb:create and
-  kubernetes.audit.requestObject.spec.containers.securityContext.privileged:true
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow"
+  and kubernetes.audit.objectRef.resource:pods 
+  and kubernetes.audit.verb:create 
+  and kubernetes.audit.requestObject.spec.containers.securityContext.privileged:true
+  and not kubernetes.audit.requestObject.spec.containers.image: ("docker.elastic.co/beats/elastic-agent:8.4.0")
 '''
 
 

--- a/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
@@ -4,7 +4,7 @@ integration = "kubernetes"
 maturity = "production"
 min_stack_comments = "New fields added to Kubernetes Integration"
 min_stack_version = "8.4.0"
-updated_date = "2022/09/20"
+updated_date = "2022/10/03"
 
 [rule]
 author = ["Elastic"]
@@ -40,7 +40,9 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset : "kubernetes.audit_logs" and kubernetes.audit.verb : "create" 
+event.dataset : "kubernetes.audit_logs" 
+  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow"
+  and kubernetes.audit.verb : "create" 
   and kubernetes.audit.objectRef.resource : "pods"
   and kubernetes.audit.objectRef.namespace : "kube-system"
   and kubernetes.audit.requestObject.spec.serviceAccountName:*controller


### PR DESCRIPTION
K8s Rule Changes

<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2336
## Summary
<!-- Provide a detailed description of the suggested changes -->
Several Rule Tuning Opportunities across all K8s Rules. Primarily using new fields to filter for "allowed" activity and to exclude the elastic-agent container image which must run with privileged configurations.

## Link to rules

Rule | Changes | 
:---: | :---: | 
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/discovery_denied_service_account_request.toml | n/a |
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml | min_stack : 8.4 for K8s Integration Fields, Update Date, Query adds : event.dataset + decision : allowed | 
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/execution_user_exec_to_pod.toml | min_stack : 8.4 for K8s Integration Fields, Update Date, Query adds : event.dataset + decision : allowed + verb: create |
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml | Update Date, Query adds : event.dataset |
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml | min_stack : 8.4 for K8s Integration Fields, Update Date, Query adds : event.dataset + decision : allowed |
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml | min_stack : 8.4 for K8s Integration Fields, Update Date, Query adds : event.dataset + decision : allowed, False Positive exception for container.image: elastic-agent |
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml | min_stack : 8.4 for K8s Integration Fields, Update Date, Query adds : event.dataset + decision : allowed, False Positive exception for container.image: elastic-agent  |
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml |  min_stack : 8.4 for K8s Integration Fields, Update Date, Query adds : event.dataset + decision : allowed, False Positive exception for container.image: elastic-agent |
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hospath_volume.toml | min_stack : 8.4 for K8s Integration Fields, Update Date, Query adds : event.dataset + decision : allowed + more sensitive paths, False Positive exception for container.image: elastic-agent |
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml | min_stack : 8.4 for K8s Integration Fields, Update Date, Query adds : event.dataset + decision : allowed, False Positive exception for container.image: elastic-agent | 
https://github.com/elastic/detection-rules/blob/main/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml | Update Date, Query adds : decision : allowed | 



## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
