### PR TITLE
[Rule Tuning] Exclude Elastic Agent from "Potential Process Herpaderping Attempt"

### DIFF
--- a/rules/windows/defense_evasion_potential_processherpaderping.toml
+++ b/rules/windows/defense_evasion_potential_processherpaderping.toml
@@ -27,9 +27,9 @@ query = '''
 sequence with maxspan=5s
    [process where event.type == "start" and not process.parent.executable :
       (
-         "C:\\Windows\\SoftwareDistribution\\*.exe",
-         "C:\\Program Files\\Elastic\\Agent\\data\\*.exe",
-         "C:\\Program Files (x86)\\Trend Micro\\*.exe
+         "?:\\Windows\\SoftwareDistribution\\*.exe",
+         "?:\\Program Files\\Elastic\\Agent\\data\\*.exe",
+         "?:\\Program Files (x86)\\Trend Micro\\*.exe"
       )
    ] by host.id, process.executable, process.parent.entity_id
    [file where event.type == "change" and event.action == "overwrite" and file.extension == "exe"] by host.id, file.path, process.entity_id

--- a/rules/windows/defense_evasion_potential_processherpaderping.toml
+++ b/rules/windows/defense_evasion_potential_processherpaderping.toml
@@ -3,7 +3,7 @@ creation_date = "2020/10/27"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/10/05"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,13 @@ type = "eql"
 
 query = '''
 sequence with maxspan=5s
-   [process where event.type == "start" and not process.parent.executable : "C:\\Windows\\SoftwareDistribution\\*.exe"] by host.id, process.executable, process.parent.entity_id
+   [process where event.type == "start" and not process.parent.executable :
+      (
+         "C:\\Windows\\SoftwareDistribution\\*.exe",
+         "C:\\Program Files\\Elastic\\Agent\\data\\*.exe",
+         "C:\\Program Files (x86)\\Trend Micro\\*.exe
+      )
+   ] by host.id, process.executable, process.parent.entity_id
    [file where event.type == "change" and event.action == "overwrite" and file.extension == "exe"] by host.id, file.path, process.entity_id
 '''
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Summary
The [Potential Process Herpaderping Attempt](https://github.com/elastic/detection-rules/blob/main/rules/windows/defense_evasion_potential_processherpaderping.toml) Windows rule needs tuned to exclude false-positives generated from the Elastic Agent and Trend Micro agent during updates.

The following paths have been added to `not process.parent.executable`:
- `?:\\Program Files\\Elastic\\Agent\\data\\*.exe`
- `?:\\Program Files (x86)\\Trend Micro\\*.exe`
