### PR TITLE
[FR] Add CLI Command to Generate Kibana Security Docs and Create PR

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -109,11 +109,10 @@ def docs_group():
 @click.argument('registry-version', type=str)
 @click.option('--pre', required=True, help='Tag for pre-existing rules')
 @click.option('--post', required=True, help='Tag for rules post updates')
-@click.option('--directory', '-d', type=Path, required=True, help='Output directory to save docs to')
 @click.option('--force', '-f', is_flag=True, help='Bypass the confirmation prompt')
 @click.option('--remote', '-r', default='origin', help='Override the remote from "origin"')
 @click.pass_context
-def generate(ctx: click.Context, feature: str, registry_version: str, pre: str, post: str, directory: Path,
+def generate(ctx: click.Context, feature: str, registry_version: str, pre: str, post: str,
                            force: bool, remote: Optional[str] = 'origin') -> Union[IntegrationSecurityDocs,KibanaSecurityDocs]:
     """Build documents from two git tags for an integration package."""
     if not force:
@@ -122,9 +121,9 @@ def generate(ctx: click.Context, feature: str, registry_version: str, pre: str, 
 
     rules_changes = get_release_diff(pre, post, remote)
     if feature == "integration":
-        docs = IntegrationSecurityDocs(registry_version, directory, True, *rules_changes)
+        docs = IntegrationSecurityDocs(registry_version, True, *rules_changes)
     elif feature == "kibana":
-        docs = KibanaSecurityDocs(registry_version, directory, True, *rule_changes)
+        docs = KibanaSecurityDocs(registry_version, True, *rules_changes)
     package_dir = docs.generate()
 
     click.echo(f'Generated documents saved to: {package_dir}')

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -269,6 +269,13 @@ class SecurityDocs:
 class KibanaSecurityDocs:
     """Generate docs for prebuilt rules in Elastic documentation."""
 
+    #TODO
+    """
+    1. Identify what docs are adjusted for Kibana docs
+    2. Identify parsing library for asciidoc
+
+    """
+
     @staticmethod
     def cmp_value(value):
         if isinstance(value, list):
@@ -279,6 +286,10 @@ class KibanaSecurityDocs:
             cmp_new = value
 
         return cmp_new
+
+
+class KibanaRuleDetail:
+    """Rule detail page generation for Kibana rules."""
 
 
 class IntegrationSecurityDocs:
@@ -304,6 +315,8 @@ class IntegrationSecurityDocs:
 
     @staticmethod
     def parse_registry(registry_version: str) -> (str, str, str):
+        """Determine registry version and rule base."""
+
         registry_version = Version(registry_version)
         short_registry_version = [str(n) for n in registry_version[:3]]
         registry_version_str = '.'.join(short_registry_version)
@@ -313,7 +326,13 @@ class IntegrationSecurityDocs:
         return registry_version_str, base_name, prebuilt_rule_base
 
     def generate_appendix(self):
-        # appendix
+        """Generate and format appendix for pre-built rules."""
+
+        #TODO
+        """
+        1. Optimize string usage and parsing  or store separately
+        """
+
         appendix = self.package_directory / f'prebuilt-rules-{self.base_name}-appendix.asciidoc'
 
         appendix_header = textwrap.dedent(f"""
@@ -330,6 +349,13 @@ class IntegrationSecurityDocs:
         appendix.write_text(appendix_str)
 
     def generate_summary(self):
+        """Generate the summary for pre-built integration package."""
+
+        #TODO
+        """
+        1. Optimize string usage and parsing  or store separately
+        """
+
         summary = self.package_directory / f'prebuilt-rules-{self.base_name}-summary.asciidoc'
 
         summary_header = textwrap.dedent(f"""
@@ -372,6 +398,14 @@ class IntegrationSecurityDocs:
         # https://www.elastic.co/guide/en/security/current/prebuilt-rules-downloadable-updates.html
         today = datetime.today().strftime('%d %b %Y')
 
+
+        #TODO
+        """
+        1. Identify library for parsing asciidoc
+        2. parse prebuilt-rules-downloadable-updates.asciidoc and add values from update_table_include
+        3. parse prebuilt-rules-downloadable-updates.asciidoc and add values from update_table_entry
+        4. parse index.asciidoc and add values from update_index_include
+        """
         updates['detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc'] = {
             'update_table_entry': (f'|<<prebuilt-rule-{self.base_name}-prebuilt-rules-{self.base_name}-summary, '
                                    f'{self.registry_version_str}>> | {today} | {len(self.new_rules)} | '
@@ -396,7 +430,7 @@ class IntegrationSecurityDocs:
 
 
 class IntegrationRuleDetail:
-    """Rule detail page generation."""
+    """Rule detail page generation for pre-built rules integration."""
 
     def __init__(self, rule_id: str, rule: dict, changelog: Dict[str, dict], package_str: str):
         self.rule_id = rule_id

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -13,6 +13,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Union
 
 import click
 import pytoml
+import json
 from marshmallow.exceptions import ValidationError
 
 from . import utils
@@ -81,7 +82,6 @@ production_filter = metadata_filter(maturity="production")
 
 def load_locks_from_tag(remote: str, tag: str) -> (str, dict, dict):
     """Loads version and deprecated lock files from git tag."""
-    import json
     git = utils.make_git()
 
     exists_args = ['ls-remote']


### PR DESCRIPTION

## Issues
* https://github.com/elastic/security-team/issues/1898
* https://github.com/elastic/ia-trade-team/issues/71

## Summary
For quicker detection rules releasing, we should add a command that allows us to auto-generate the security docs associated with rule updates in Kibana. In addition to this, the command should also automatically create a PR to the security docs repository with pre-populated information.

Tasks:
- [ ] Create click `dev.docs` group related to CLI commands for docs
- [ ] Add `generate` CLI command under `dev.docs` click group with feature option
- [ ] Add `KibanaRuleDetail` and `KibanaSecurityDocs` classes
- [ ] Develop workflow to create proper asciidocs for Kibana
- [ ] Add `docs-pr` CLI command within `dev.docs` group to create a security docs PR