### PR TITLE
[Rule Tuning] NullSessionPipe Registry Modification

### DIFF
--- a/rules/windows/lateral_movement_defense_evasion_lanman_nullsessionpipe_modification.toml
+++ b/rules/windows/lateral_movement_defense_evasion_lanman_nullsessionpipe_modification.toml
@@ -3,7 +3,7 @@ creation_date = "2021/03/22"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 
 [rule]
 author = ["Elastic"]
@@ -28,9 +28,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where
+registry where event.type in ("creation", "change") and
 registry.path : "HKLM\\SYSTEM\\*ControlSet*\\services\\LanmanServer\\Parameters\\NullSessionPipes" and
-registry.data.strings != null
+registry.data.strings > 0
 '''
 
 


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/sdh-security-team/issues/462

## Summary

Modifies the query to check for the field lenght to avoid FPs where a GPO enforces that the registry key have no values set.