### PR TITLE
[Rule Tuning] Add tags to flag Sysmon-only rules

### DIFF
--- a/rules/windows/credential_access_lsass_handle_via_malseclogon.toml
+++ b/rules/windows/credential_access_lsass_handle_via_malseclogon.toml
@@ -3,7 +3,7 @@ creation_date = "2022/06/29"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,7 @@ references = ["https://splintercod3.blogspot.com/p/the-hidden-side-of-seclogon-p
 risk_score = 73
 rule_id = "7ba58110-ae13-439b-8192-357b0fcfa9d7"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Sysmon_Only"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/credential_access_potential_lsa_memdump_via_mirrordump.toml
+++ b/rules/windows/credential_access_potential_lsa_memdump_via_mirrordump.toml
@@ -3,7 +3,7 @@ creation_date = "2021/09/27"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 
 [rule]
 author = ["Elastic"]
@@ -24,7 +24,7 @@ references = ["https://github.com/CCob/MirrorDump"]
 risk_score = 47
 rule_id = "02a4576a-7480-4284-9327-548a806b5e48"
 severity = "medium"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Sysmon_Only"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/credential_access_suspicious_comsvcs_imageload.toml
+++ b/rules/windows/credential_access_suspicious_comsvcs_imageload.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2021/10/17"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
@@ -26,7 +26,7 @@ references = ["https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com
 risk_score = 73
 rule_id = "c5c9f591-d111-4cf8-baec-c26a39bc31ef"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Sysmon_Only"]
 type = "eql"
 
 query = '''

--- a/rules/windows/credential_access_suspicious_lsass_access_memdump.toml
+++ b/rules/windows/credential_access_suspicious_lsass_access_memdump.toml
@@ -3,7 +3,7 @@ creation_date = "2021/10/07"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ references = [
 risk_score = 73
 rule_id = "9960432d-9b26-409f-972b-839a959e79e2"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Sysmon_Only"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/credential_access_suspicious_lsass_access_via_snapshot.toml
+++ b/rules/windows/credential_access_suspicious_lsass_access_via_snapshot.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2021/10/14"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 maturity = "production"
 min_stack_version = "8.3.0"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
@@ -29,7 +29,7 @@ references = [
 risk_score = 73
 rule_id = "0f93cb9a-1931-48c2-8cd0-f173fd3e5283"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Sysmon_Only"]
 timestamp_override = "event.ingested"
 type = "threshold"
 

--- a/rules/windows/credential_access_via_snapshot_lsass_clone_creation.toml
+++ b/rules/windows/credential_access_via_snapshot_lsass_clone_creation.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2021/11/27"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
@@ -30,7 +30,7 @@ references = [
 risk_score = 73
 rule_id = "a16612dd-b30e-4d41-86a0-ebe70974ec00"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Sysmon_Only"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/defense_evasion_injection_msbuild.toml
+++ b/rules/windows/defense_evasion_injection_msbuild.toml
@@ -3,7 +3,7 @@ creation_date = "2020/03/25"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ name = "Process Injection by the Microsoft Build Engine"
 risk_score = 21
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae9"
 severity = "low"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion", "Sysmon_Only"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/windows/defense_evasion_suspicious_process_access_direct_syscall.toml
+++ b/rules/windows/defense_evasion_suspicious_process_access_direct_syscall.toml
@@ -3,7 +3,7 @@ creation_date = "2021/10/11"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/20"
+updated_date = "2022/10/11"
 
 [rule]
 author = ["Elastic"]
@@ -83,7 +83,7 @@ references = [
 risk_score = 73
 rule_id = "2dd480be-1263-4d9c-8672-172928f6789a"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion", "has_guide"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion", "has_guide", "Sysmon_Only"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/defense_evasion_suspicious_process_creation_calltrace.toml
+++ b/rules/windows/defense_evasion_suspicious_process_creation_calltrace.toml
@@ -56,7 +56,7 @@ mean time to respond (MTTR).
 risk_score = 47
 rule_id = "3ed032b2-45d8-4406-bc79-7ad1eabb2c72"
 severity = "medium"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion", "has_guide"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion", "has_guide", "Sysmon_Only"]
 type = "eql"
 
 query = '''

--- a/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
+++ b/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
@@ -3,7 +3,7 @@ creation_date = "2021/10/13"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/10/11"
 
 [rule]
 author = ["Elastic"]
@@ -32,7 +32,7 @@ references = [
 risk_score = 73
 rule_id = "76ddb638-abf7-42d5-be22-4a70b0bf7241"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation", "Sysmon_Only"]
 timestamp_override = "event.ingested"
 type = "eql"
 


### PR DESCRIPTION
## Issues

Relates to https://github.com/elastic/sdh-security-team/issues/468

## Summary

Suggests the addition of a tag to flag rules that only support sysmon, making it easier to disable or enable, depending on the customer environment.