### PR TITLE
Rule to Identify Non-Standard Port SSH connection(s)

### DIFF
--- a/rules/linux/command_and_control_non_standard_port.toml
+++ b/rules/linux/command_and_control_non_standard_port.toml
@@ -1,0 +1,54 @@
+[metadata]
+creation_date = "2022/10/18"
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2022/10/18"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies adversaries (malicious process) who(which) may communicate using a protocol and port paring that are
+typically not associated with ssh. For example, ssh over port 2200 or port 2222 as opposed to the traditional port 22.
+Adversaries may make changes to the standard port used by a protocol to bypass filtering or
+muddle analysis/parsing of network data.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Non-Standard Port SSH connection(s)"
+references = [
+    "https://attack.mitre.org/techniques/T1571/"
+]
+risk_score = 47
+rule_id = "bc8ca7e0-92fd-4b7c-b11e-ee0266b8d9c9"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Command and Control"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+sequence by process.entity_id with maxspan=5m
+[process where event.action == "exec" and process.name:"ssh"]
+[network where process.name:"ssh"
+ and event.action in ("connection_attempted", "connection_accepted")
+ and destination.port != 22
+ and destination.ip != "127.0.0.1"
+]
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1571"
+name = "Non-Standard Port"
+reference = "https://attack.mitre.org/techniques/T1571/"
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+


### PR DESCRIPTION
## Issues
#2363 

## Summary
Adversaries may communicate using a protocol and port paring that are typically not associated. For example, ssh over port 2200 or port 2222 as opposed to the traditional port 22. Adversaries may make changes to the standard port used by a protocol to bypass filtering or muddle analysis/parsing of network data.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
