### PR TITLE
[Bug] Convert config to pathlib.Path

### DIFF
--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -50,7 +50,7 @@ def root(ctx, debug):
               help='Type of rule to create')
 def create_rule(path, config, required_only, rule_type):
     """Create a detection rule."""
-    contents = load_rule_contents(config, single_only=True)[0] if config else {}
+    contents = load_rule_contents(Path(config), single_only=True)[0] if config else {}
     return rule_prompt(path, rule_type=rule_type, required_only=required_only, save=True, **contents)
 
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -44,13 +44,14 @@ def root(ctx, debug):
 
 @root.command('create-rule')
 @click.argument('path', type=Path)
-@click.option('--config', '-c', type=click.Path(exists=True, dir_okay=False), help='Rule or config file')
+@click.option('--config', '-c', type=click.Path(exists=True, dir_okay=False, path_type=Path),
+              help='Rule or config file')
 @click.option('--required-only', is_flag=True, help='Only prompt for required fields')
 @click.option('--rule-type', '-t', type=click.Choice(sorted(TOMLRuleContents.all_rule_types())),
               help='Type of rule to create')
 def create_rule(path, config, required_only, rule_type):
     """Create a detection rule."""
-    contents = load_rule_contents(Path(config), single_only=True)[0] if config else {}
+    contents = load_rule_contents(config, single_only=True)[0] if config else {}
     return rule_prompt(path, rule_type=rule_type, required_only=required_only, save=True, **contents)
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #2376 

## Summary
Converts the config to a `pathlib.Path` obj as the default `click.Path` obj defaults to a `str` per the [docs](https://click.palletsprojects.com/en/8.1.x/api/?highlight=click%20path#click.Path)

