### PR TITLE
[Rule Tuning] Adversary Behavior - Detected - Elastic Endgame

### DIFF
--- a/rules/promotions/endgame_adversary_behavior_detected.toml
+++ b/rules/promotions/endgame_adversary_behavior_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/10/31"
 
 [rule]
 author = ["Elastic"]
@@ -25,6 +25,6 @@ tags = ["Elastic", "Elastic Endgame"]
 type = "query"
 
 query = '''
-event.kind:alert and event.module:endgame and (event.action:rules_engine_event or endgame.event_subtype_full:rules_engine_event)
+event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
 '''
 


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/detection-rules/issues/2381

## Summary

Replaces `rules_engine_event` event.action and subtype with `behavior_protection_event` as per commit 5ac0b3531e6731afdf16da5f3c3a68b192ef08bc in endgame-sensor (04/2021)