### PR TITLE
[Rule Tuning] Remote Computer Account DnsHostName Update

### DIFF
--- a/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
+++ b/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
@@ -3,7 +3,7 @@ creation_date = "2022/05/11"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/11/10"
 
 [rule]
 author = ["Elastic"]
@@ -37,8 +37,12 @@ sequence by host.id with maxspan=5m
 
   [iam where event.action == "changed-computer-account" and
 
-   /* if DnsHostName value equal a DC DNS hostname then it's highly suspicious */
-    winlog.event_data.DnsHostName : "??*"] by winlog.event_data.SubjectLogonId
+    /* if DnsHostName value equal a DC DNS hostname then it's highly suspicious */
+    winlog.event_data.DnsHostName : "??*" and 
+    
+    /* exclude FPs where DnsHostName starts with the ComputerName that was changed */
+    not startswith~(winlog.event_data.DnsHostName, substring(winlog.event_data.TargetUserName, 0, length(winlog.event_data.TargetUserName) - 1))
+    ] by winlog.event_data.SubjectLogonId
 '''
 
 


### PR DESCRIPTION
tuning of https://github.com/elastic/detection-rules/blob/main/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml to exclude the main FP pattern (100% of FPs) where the new DnsHostName is equal to the computer account name (for TPs the Dns Hostname should be equal to a Domain Controller computer name).