### PR TITLE
[Rule Tuning] Tuning "Netcat Network Activity" Rule

### DIFF
--- a/rules/linux/execution_file_transfer_or_listener_established_via_netcat.toml
+++ b/rules/linux/execution_file_transfer_or_listener_established_via_netcat.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/10/11"
+updated_date = "2022/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,7 @@ from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
-name = "Netcat Network Activity"
+name = "File Transfer or Listener Established via Netcat"
 note = """## Triage and analysis
 
 ### Investigating Netcat Network Activity
@@ -81,6 +81,9 @@ references = [
     "http://pentestmonkey.net/cheat-sheet/shells/reverse-shell-cheat-sheet",
     "https://www.sans.org/security-resources/sec560/netcat_cheat_sheet_v1.pdf",
     "https://en.wikipedia.org/wiki/Netcat",
+    "https://www.hackers-arise.com/hacking-fundamentals",
+    "https://null-byte.wonderhowto.com/how-to/hack-like-pro-use-netcat-swiss-army-knife-hacking-tools-0148657/",
+    "https://levelup.gitconnected.com/ethical-hacking-part-15-netcat-nc-and-netcat-f6a8f7df43fd",
 ]
 risk_score = 47
 rule_id = "adb961e0-cb74-42a0-af9e-29fc41f88f5f"
@@ -90,12 +93,22 @@ type = "eql"
 
 query = '''
 sequence by process.entity_id
-  [process where (process.name == "nc" or process.name == "ncat" or process.name == "netcat" or
-                  process.name == "netcat.openbsd" or process.name == "netcat.traditional") and
-     event.type == "start"]
+  [process where process.name:("nc","ncat","netcat","netcat.openbsd","netcat.traditional") and (
+          /* bind shell to echo for command execution */
+          (process.args:("-l","-p") and process.args:("-c","echo","$*"))
+          /* bind shell to specific port */
+          or process.args:("-l","-p","-lp")
+          /* reverse shell to command-line interpreter used for command execution */
+          or (process.args:("-e") and process.args:("/bin/bash","/bin/sh"))
+          /* file transfer via stdout */
+          or process.args:(">","<")
+          /* file transfer via pipe */
+          or (process.args:("|") and process.args:("nc","ncat"))
+      )]
   [network where (process.name == "nc" or process.name == "ncat" or process.name == "netcat" or
                   process.name == "netcat.openbsd" or process.name == "netcat.traditional")]
 '''
+
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
@@ -103,9 +116,15 @@ framework = "MITRE ATT&CK"
 id = "T1059"
 name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
 
 
 [rule.threat.tactic]
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+


### PR DESCRIPTION
## Summary
The "Netcat Network Activity" detection rule deserves some additional tuning from it's current state. At the moment, the rule uses a sequence of Netcat process start and Netcat network connection established. This logic is very generic for a native tool still used by network administrators. Instead, the logic has been tuned to focus on the command line arguments or flags used. This allows us to detect either a file transfer attempt via piping or stdout and identify listeners that are used for bind or reverse shells.

From a global telemetry perspective, ~284K alerts were identified within a 10-day period from (November 4-14, 2022). The following changes will reduce these alerts by 99%, leaving roughly 30 TP alerts within the same time range.

Global Telemetry Screenshot:
<img width="1091" alt="Screen Shot 2022-11-14 at 10 47 03 AM" src="https://user-images.githubusercontent.com/99630311/201703913-39b5c9f0-40b8-4f90-a10e-5dc9de4e08aa.png">

The following has been accounted for regarding this tuning:

* File transfer ingress and egress via stdout and stdin
* Bind shell listener established
* Reverse shell pointed to command scripting /bin/bash and /bin/sh
* Potential reverse shell to named pipe or from echo tool

## Additional Information
The sequence of events for establishing a reverse shell with named pipes does not fit properly into this rule and therefore was broken out into a separate rule listed below that resulted from the same tuning efforts.

 * TBD

Personal Cluster Screenshot:
<img width="1298" alt="Screen Shot 2022-11-14 at 10 47 47 AM" src="https://user-images.githubusercontent.com/99630311/201703998-527f213c-8209-48fd-9115-b5a2630d560b.png">
