### PR TITLE
[New Rule] Reverse Shell Created via Named Pipe

### DIFF
--- a/rules/linux/execution_reverse_shell_via_named_pipe.toml
+++ b/rules/linux/execution_reverse_shell_via_named_pipe.toml
@@ -38,7 +38,7 @@ type = "eql"
 
 query = '''
 sequence by host.id with maxspan = 5s
-    [process where process.executable : ("/usr/bin/mkfifo","/usr/bin/mknod") and process.args:("/tmp/*","$*")]
+    [process where event.type == "start" and process.executable : ("/usr/bin/mkfifo","/usr/bin/mknod") and process.args:("/tmp/*","$*")]
     [process where process.executable : ("/bin/sh","/bin/bash") and process.args:("-i") or
         (process.executable: ("/usr/bin/openssl") and process.args: ("-connect"))]
     [process where (process.name:("nc","ncat","netcat","netcat.openbsd","netcat.traditional") or

--- a/rules/linux/execution_reverse_shell_via_named_pipe.toml
+++ b/rules/linux/execution_reverse_shell_via_named_pipe.toml
@@ -1,0 +1,66 @@
+[metadata]
+creation_date = "2022/11/14"
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2022/11/14"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies a reverse shell via the abuse of named pipes on Linux with the help of OpenSSL or Netcat. First in, first out
+(FIFO) files are special files for reading and writing to by Linux processes. For this to work, a named pipe is created
+and passed to a Linux shell where the use of a network connection tool such as Netcat or OpenSSL has been established.
+The stdout and stderr are captured in the named pipe from the network connection and passed back to the shell for
+execution.
+"""
+false_positives = [
+    """
+    Netcat and OpenSSL are common tools used for establishing network connections and creating encryption keys. While
+    they are popular, capturing the stdout and stderr in a named pipe pointed to a shell is anomalous.
+    """,
+]
+from = "now-9m"
+index = ["auditbeat-*", "logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Reverse Shell Created via Named Pipe"
+references = [
+    "https://int0x33.medium.com/day-43-reverse-shell-with-openssl-1ee2574aa998",
+    "https://blog.gregscharf.com/2021/03/22/tar-in-cronjob-to-privilege-escalation/",
+    "https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Reverse%20Shell%20Cheatsheet.md#openssl",
+]
+risk_score = 47
+rule_id = "dd7f1524-643e-11ed-9e35-f661ea17fbcd"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Execution", "has_guide"]
+type = "eql"
+
+query = '''
+sequence by host.id with maxspan = 5s
+    [process where process.executable : ("/usr/bin/mkfifo","/usr/bin/mknod") and process.args:("/tmp/*","$*")]
+    [process where process.executable : ("/bin/sh","/bin/bash") and process.args:("-i") or
+        (process.executable: ("/usr/bin/openssl") and process.args: ("-connect"))]
+    [process where (process.name:("nc","ncat","netcat","netcat.openbsd","netcat.traditional") or
+                    (process.name: "openssl" and process.executable: "/usr/bin/openssl"))]
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+


### PR DESCRIPTION
## Related
* https://github.com/elastic/detection-rules/pull/2395

## Summary
Identifies a reverse shell via the abuse of named pipes on Linux with the help of OpenSSL or Netcat. First in, first out
(FIFO) files are special files for reading and writing to by Linux processes. For this to work, a named pipe is created
and passed to a Linux shell where the use of a network connection tool such as Netcat or OpenSSL has been established.
The stdout and stderr are captured in the named pipe from the network connection and passed back to the shell for
execution.

## Screenshots

EQL Search Results:
<img width="1281" alt="Screen Shot 2022-11-14 at 12 31 06 PM" src="https://user-images.githubusercontent.com/99630311/201727643-3b5213c8-a9d9-43e1-b1db-b3e10b1ccd03.png">

Reverse Shell Established:
<img width="1016" alt="Screen Shot 2022-11-14 at 12 34 04 PM" src="https://user-images.githubusercontent.com/99630311/201727738-a601c9b3-4bf8-4e3f-bd96-28cb8e2bec2c.png">
<img width="852" alt="Screen Shot 2022-11-14 at 12 40 09 PM" src="https://user-images.githubusercontent.com/99630311/201728768-a8db79d1-d8c1-49d2-b731-25e8cef73fc9.png">


