### PR TITLE
Rule Tuning as part of 8.6

### DIFF
--- a/rules/linux/persistence_etc_file_creation.toml
+++ b/rules/linux/persistence_etc_file_creation.toml
@@ -27,7 +27,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where event.action == "creation" and user.name == "root" and file.path : ("/etc/ld.so.conf.d/*", "/etc/cron.d/*", "/etc/sudoers.d/*", "/etc/rc.d/init.d/*", "/etc/systemd/system/*") and not process.executable : ("*/dpkg", "*/yum", "*/apt", "*/dnf", "*/systemd")
+file where event.action == "creation" and user.name == "root" and
+file.path : ("/etc/ld.so.conf.d/*", "/etc/cron.d/*", "/etc/sudoers.d/*", "/etc/rc.d/init.d/*", "/etc/systemd/system/*")
+and not process.executable : ("*/dpkg", "*/yum", "*/apt", "*/dnf", "*/systemd", "*/snapd")
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Issues
#2348 
#2392

## Summary
Based on False positive analysis the below rules have been tuned. Please Refer to Details on [Rule Tuning ](https://docs.google.com/spreadsheets/d/1oA7vlsqTzm6pg6A6LPNhx6uzV-ClFlD3hP9qSVwu0O4/edit?usp=sharing)

- [ ] rules/linux/persistence_etc_file_creation.toml


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
