### PR TITLE
[New Rule] First Time Seen Driver Loaded

### DIFF
--- a/rules/windows/persistence_driver_newterm_imphash.toml
+++ b/rules/windows/persistence_driver_newterm_imphash.toml
@@ -49,7 +49,6 @@ reference = "https://attack.mitre.org/tactics/TA0003/"
 [rule.new_terms]
 field = "new_terms_fields"
 value = ["dll.pe.imphash"]
-SubjectUserName
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-30d"

--- a/rules/windows/persistence_driver_newterm_imphash.toml
+++ b/rules/windows/persistence_driver_newterm_imphash.toml
@@ -1,0 +1,55 @@
+[metadata]
+creation_date = "2022/12/19"
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup, New Term"
+min_stack_version = "8.4.0"
+updated_date = "2022/12/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies the load of a driver with an import hash value that wasn't observed during the last 30 days. This rule 
+type can help baseline drivers installation within your environment.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "First Time Seen Driver by ImpHash"
+references = ["https://www.elastic.co/kr/security-labs/stopping-vulnerable-driver-attacks"]
+risk_score = 47
+rule_id = "df0fd41e-5590-4965-ad5e-cd079ec22fa9"
+severity = "medium"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
+timestamp_override = "event.ingested"
+type = "new_terms"
+
+query = '''
+event.category : "driver" and event.action : "load" 
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+[[rule.threat.technique.subtechnique]]
+id = "T1543.003"
+name = "Windows Service"
+reference = "https://attack.mitre.org/techniques/T1543/003/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["dll.pe.imphash"]
+SubjectUserName
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-30d"

--- a/rules/windows/persistence_driver_newterm_imphash.toml
+++ b/rules/windows/persistence_driver_newterm_imphash.toml
@@ -8,14 +8,15 @@ updated_date = "2022/12/19"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the load of a driver with an import hash value that wasn't observed during the last 30 days. This rule 
-type can help baseline drivers installation within your environment.
+Identifies the load of a driver with an original file name and signature values that were observed 
+for the first time during the last 30 days. This rule type can help baseline drivers installation 
+within your environment.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "First Time Seen Driver by ImpHash"
+name = "First Time Seen Driver Loaded"
 references = ["https://www.elastic.co/kr/security-labs/stopping-vulnerable-driver-attacks"]
 risk_score = 47
 rule_id = "df0fd41e-5590-4965-ad5e-cd079ec22fa9"
@@ -48,7 +49,7 @@ reference = "https://attack.mitre.org/tactics/TA0003/"
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["dll.pe.imphash"]
+value = ["dll.pe.original_file_name", "dll.code_signature.subject_name"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-30d"

--- a/rules/windows/persistence_driver_newterm_imphash.toml
+++ b/rules/windows/persistence_driver_newterm_imphash.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/12/19"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup, New Term"
-min_stack_version = "8.4.0"
+min_stack_version = "8.6.0"
 updated_date = "2022/12/19"
 
 [rule]


### PR DESCRIPTION
`New Term` rule to detect when a new driver is loaded based on the unique ` ["dll.pe.original_file_name", "dll.code_signature.subject_name"]` for the last 30 days. 

https://www.elastic.co/kr/security-labs/stopping-vulnerable-driver-attacks