### PR TITLE
[Rule Tuning] Adjust Index Pattern on Windows rules to support WEF

### DIFF
--- a/rules/windows/credential_access_bruteforce_admin_account.toml
+++ b/rules/windows/credential_access_bruteforce_admin_account.toml
@@ -62,7 +62,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
 type = "eql"
 
 query = '''
-sequence by host.id, source.ip with maxspan=10s
+sequence by winlog.computer_name, source.ip with maxspan=10s
   [authentication where event.action == "logon-failed" and
     winlog.logon.type : "Network" and
     source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1" and user.name : "*admin*" and

--- a/rules/windows/credential_access_bruteforce_admin_account.toml
+++ b/rules/windows/credential_access_bruteforce_admin_account.toml
@@ -3,7 +3,7 @@ creation_date = "2020/08/29"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/29"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ short time interval. Adversaries will often brute force login attempts across mu
 password, in an attempt to gain access to accounts.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Privileged Account Brute Force"

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
@@ -62,7 +62,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
 type = "eql"
 
 query = '''
-sequence by host.id, source.ip with maxspan=5s
+sequence by winlog.computer_name, source.ip with maxspan=5s
   [authentication where event.action == "logon-failed" and
     /* event 4625 need to be logged */
     winlog.logon.type : "Network" and

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
@@ -3,7 +3,7 @@ creation_date = "2020/08/29"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/29"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ brute force login attempts across multiple users with a common or known password
 accounts.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Multiple Logon Failure Followed by Logon Success"

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
@@ -66,7 +66,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
 type = "eql"
 
 query = '''
-sequence by host.id, source.ip with maxspan=10s
+sequence by winlog.computer_name, source.ip with maxspan=10s
   [authentication where event.action == "logon-failed" and
     /* event 4625 need to be logged */
     winlog.logon.type : "Network" and

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
@@ -3,7 +3,7 @@ creation_date = "2020/08/29"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/29"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ Adversaries will often brute force login attempts across multiple users with a c
 to gain access to accounts.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Multiple Logon Failure from the same Source Address"

--- a/rules/windows/credential_access_dcsync_replication_rights.toml
+++ b/rules/windows/credential_access_dcsync_replication_rights.toml
@@ -3,7 +3,7 @@ creation_date = "2022/02/08"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ technique to get credential information of individual accounts or the entire dom
 domain.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Credential Access via DCSync"

--- a/rules/windows/credential_access_disable_kerberos_preauth.toml
+++ b/rules/windows/credential_access_disable_kerberos_preauth.toml
@@ -3,7 +3,7 @@ creation_date = "2022/01/24"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies the modification of an account's Kerberos pre-authentication options.
 the account can maliciously modify these settings to perform offline password cracking attacks such as AS-REP roasting.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kerberos Pre-authentication Disabled for User"
@@ -79,7 +79,7 @@ references = [
 risk_score = 47
 rule_id = "e514d8cd-ed15-4011-84e2-d15147e059f1"
 severity = "medium"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Investigation Guide"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "Investigation Guide", "Active Directory"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/windows/credential_access_ldap_attributes.toml
+++ b/rules/windows/credential_access_ldap_attributes.toml
@@ -3,7 +3,7 @@ creation_date = "2022/11/09"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/15"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identify access to sensitive Active Directory object attributes that contains cr
 unixUserPassword, ms-PKI-AccountCredentials and msPKI-CredentialRoamingTokens.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Access to a Sensitive LDAP Attribute"

--- a/rules/windows/credential_access_lsass_memdump_handle_access.toml
+++ b/rules/windows/credential_access_lsass_memdump_handle_access.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/02/16"
 maturity = "production"
-updated_date = "2022/11/04"
+updated_date = "2022/12/21"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -15,7 +15,7 @@ Procdump, Mimikatz, Comsvcs etc. It detects this behavior at a low level and doe
 file name.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "LSASS Memory Dump Handle Access"

--- a/rules/windows/credential_access_remote_sam_secretsdump.toml
+++ b/rules/windows/credential_access_remote_sam_secretsdump.toml
@@ -3,7 +3,7 @@ creation_date = "2022/03/01"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/07"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies remote access to the registry to potentially dump credential data fro
 registry hive in preparation for credential access and privileges elevation.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*", "logs-endpoint.events.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Remote Credential Access via Registry"

--- a/rules/windows/credential_access_remote_sam_secretsdump.toml
+++ b/rules/windows/credential_access_remote_sam_secretsdump.toml
@@ -78,7 +78,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement", "C
 type = "eql"
 
 query = '''
-sequence by host.id, user.id with maxspan=1m
+sequence by winlog.computer_name, user.id with maxspan=1m
  [authentication where
    event.outcome == "success" and event.action == "logged-in" and
    winlog.logon.type == "Network" and not user.name == "ANONYMOUS LOGON" and

--- a/rules/windows/credential_access_saved_creds_vault_winlog.toml
+++ b/rules/windows/credential_access_saved_creds_vault_winlog.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/30"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/07"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ applications, and networks. An adversary may abuse this to list or dump credenti
 saved usernames and passwords. This may also be performed in preparation of lateral movement.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Multiple Vault Web Credentials Read"

--- a/rules/windows/credential_access_saved_creds_vault_winlog.toml
+++ b/rules/windows/credential_access_saved_creds_vault_winlog.toml
@@ -31,7 +31,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access"]
 type = "eql"
 
 query = '''
-sequence by host.id, winlog.process.pid with maxspan=1s
+sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
  /* 2 consecutive vault reads from same pid for web creds */
 

--- a/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
+++ b/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
@@ -3,7 +3,7 @@ creation_date = "2022/01/27"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ SeEnableDelegationPrivilege "user right" enables computer and user accounts to b
 abuse this right to compromise Active Directory accounts and elevate their privileges.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Sensitive Privilege SeEnableDelegationPrivilege assigned to a User"

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -3,7 +3,7 @@ creation_date = "2022/01/26"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/10/15"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Potential Shadow Credentials added to AD Object"

--- a/rules/windows/credential_access_spn_attribute_modified.toml
+++ b/rules/windows/credential_access_spn_attribute_modified.toml
@@ -3,7 +3,7 @@ creation_date = "2022/02/22"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ user to configure Service Principle Names (SPNs) so that they can perform Kerber
 configure this for legitimate purposes, exposing the account to Kerberoasting.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "User account exposed to Kerberoasting"

--- a/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
+++ b/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
@@ -3,7 +3,7 @@ creation_date = "2022/02/16"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/07"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ attempt to exfiltrate credentials by dumping the Security Account Manager (SAM) 
 credential access and privileges elevation.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Remote Registry Access via SeBackupPrivilege"
@@ -94,7 +94,7 @@ references = [
 risk_score = 47
 rule_id = "47e22836-4a16-4b35-beee-98f6c4ee9bf2"
 severity = "medium"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement", "Credential Access", "Investigation Guide"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement", "Credential Access", "Investigation Guide", "Active Directory"]
 type = "eql"
 
 query = '''

--- a/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
+++ b/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
@@ -98,7 +98,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement", "C
 type = "eql"
 
 query = '''
-sequence by host.id, winlog.event_data.SubjectLogonId with maxspan=1m
+sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
  [iam where event.action == "logged-in-special"  and
   winlog.event_data.PrivilegeList : "SeBackupPrivilege" and
 

--- a/rules/windows/defense_evasion_clearing_windows_security_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_security_logs.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/12"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/12"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic", "Anabella Cristaldi"]
@@ -12,7 +12,7 @@ Identifies attempts to clear Windows event log stores. This is often done by att
 or destroy forensic evidence on a system.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Windows Event Logs Cleared"

--- a/rules/windows/discovery_privileged_localgroup_membership.toml
+++ b/rules/windows/discovery_privileged_localgroup_membership.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/10/15"
 maturity = "production"
-updated_date = "2022/11/04"
+updated_date = "2022/12/21"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -12,7 +12,7 @@ Identifies instances of an unusual process enumerating built-in Windows privileg
 Administrators or Remote Desktop users.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Enumeration of Privileged Local Groups Membership"

--- a/rules/windows/lateral_movement_remote_service_installed_winlog.toml
+++ b/rules/windows/lateral_movement_remote_service_installed_winlog.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/30"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/30"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies a network logon followed by Windows service creation with same LogonI
 movement, but will be noisy if commonly done by administrators."
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote Windows Service Installed"

--- a/rules/windows/lateral_movement_remote_service_installed_winlog.toml
+++ b/rules/windows/lateral_movement_remote_service_installed_winlog.toml
@@ -23,7 +23,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Lateral Movement", "P
 type = "eql"
 
 query = '''
-sequence by winlog.logon.id, host.id with maxspan=1m
+sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 [authentication where event.action == "logged-in" and winlog.logon.type : "Network" and
 event.outcome=="success" and source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1"]
 [iam where event.action == "service-installed" and

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/29"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/29"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies a remote logon followed by a scheduled task creation on the target ho
 adversary lateral movement.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote Logon followed by Scheduled Task Creation"

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -65,7 +65,7 @@ type = "eql"
 query = '''
 /* Network Logon followed by Scheduled Task creation  */
 
-sequence by host.id with maxspan=1m
+sequence by winlog.computer_name with maxspan=1m
   [authentication where event.action == "logged-in" and
    winlog.logon.type == "Network" and event.outcome == "success" and
    not user.name == "ANONYMOUS LOGON" and not winlog.event_data.SubjectUserName : "*$" and

--- a/rules/windows/lateral_movement_service_control_spawned_script_int.toml
+++ b/rules/windows/lateral_movement_service_control_spawned_script_int.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies Service Control (sc.exe) spawning from script interpreter processes t
 This could be indicative of adversary lateral movement but will be noisy if commonly done by admins.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "logs-system.*", "winlogbeat-*"]
+index = ["logs-endpoint.events.*", "logs-system.*", "winlogbeat-*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Service Control Spawned via Script Interpreter"

--- a/rules/windows/persistence_ad_adminsdholder.toml
+++ b/rules/windows/persistence_ad_adminsdholder.toml
@@ -3,7 +3,7 @@ creation_date = "2022/01/31"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +15,7 @@ the protected accounts and groups are reset to match those of the domain's Admin
 Administrative Privileges.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AdminSDHolder Backdoor"

--- a/rules/windows/persistence_dontexpirepasswd_account.toml
+++ b/rules/windows/persistence_dontexpirepasswd_account.toml
@@ -3,7 +3,7 @@ creation_date = "2022/02/22"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Account Configured with Never-Expiring Password"

--- a/rules/windows/persistence_msds_alloweddelegateto_krbtgt.toml
+++ b/rules/windows/persistence_msds_alloweddelegateto_krbtgt.toml
@@ -3,7 +3,7 @@ creation_date = "2022/01/27"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies the modification of the msDS-AllowedToDelegateTo attribute to KRBTGT.
 maintain persistence to the domain by having the ability to request tickets for the KRBTGT service.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "KRBTGT Delegation Backdoor"

--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -30,7 +30,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence"]
 type = "eql"
 
 query = '''
-sequence by host.id with maxspan=5m
+sequence by winlog.computer_name with maxspan=5m
   [authentication where event.action == "logged-in" and
     /* event 4624 need to be logged */
     winlog.logon.type : "Network" and event.outcome == "success" and source.ip != null and

--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -3,7 +3,7 @@ creation_date = "2021/10/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/07"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ passwords to maintain access or evade password duration policies and preserve co
 """
 false_positives = ["Legitimate remote account administration."]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Account Password Reset Remotely"

--- a/rules/windows/persistence_scheduled_task_creation_winlog.toml
+++ b/rules/windows/persistence_scheduled_task_creation_winlog.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/29"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/10/26"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ move laterally, and/or escalate privileges.
 """
 false_positives = ["Legitimate scheduled tasks may be created during installation of new software."]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "A scheduled task was created"

--- a/rules/windows/persistence_scheduled_task_updated.toml
+++ b/rules/windows/persistence_scheduled_task_updated.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/29"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/10/26"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ common and may may generate noise.
 """
 false_positives = ["Legitimate scheduled tasks may be created during installation of new software."]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "A scheduled task was updated"

--- a/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
+++ b/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
@@ -3,7 +3,7 @@ creation_date = "2022/02/24"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ remain unchanged. Attackers can abuse this misconfiguration to maintain long-ter
 groups.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "AdminSDHolder SDProp Exclusion Added"

--- a/rules/windows/persistence_service_windows_service_winlog.toml
+++ b/rules/windows/persistence_service_windows_service_winlog.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/30"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/30"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies the creation of a new Windows service with suspicious Service command
 as SYSTEM and can be used for privilege escalation and persistence.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious service was installed in the system"

--- a/rules/windows/persistence_temp_scheduled_task.toml
+++ b/rules/windows/persistence_temp_scheduled_task.toml
@@ -25,7 +25,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Defense Evasion", "Pe
 type = "eql"
 
 query = '''
-sequence by host.id, winlog.event_data.TaskName with maxspan=5m
+sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
    [iam where event.action == "scheduled-task-created" and not user.name : "*$"]
    [iam where event.action == "scheduled-task-deleted" and not user.name : "*$"]
 '''

--- a/rules/windows/persistence_temp_scheduled_task.toml
+++ b/rules/windows/persistence_temp_scheduled_task.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/29"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/12"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ malicious execution via the schedule service and perform clean up.
 """
 false_positives = ["Legitimate scheduled tasks may be created during installation of new software."]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Temporarily Scheduled Task Creation"

--- a/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
+++ b/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
@@ -3,7 +3,7 @@ creation_date = "2021/01/09"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/01"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic", "Skoetting"]
@@ -13,7 +13,7 @@ Directory are those to which powerful rights, privileges, and permissions are gr
 any action in Active Directory and on domain-joined systems.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "User Added to Privileged Group"
@@ -61,7 +61,7 @@ references = [
 risk_score = 47
 rule_id = "5cd8e1f7-0050-4afc-b2df-904e40b2f5ae"
 severity = "medium"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence", "Investigation Guide"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence", "Investigation Guide", "Active Directory"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/persistence_user_account_creation_event_logs.toml
+++ b/rules/windows/persistence_user_account_creation_event_logs.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/01/04"
 maturity = "development"
-updated_date = "2022/11/01"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Skoetting"]
@@ -16,7 +16,7 @@ false_positives = [
     behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Windows User Account Creation"

--- a/rules/windows/privilege_escalation_create_process_as_different_user.toml
+++ b/rules/windows/privilege_escalation_create_process_as_different_user.toml
@@ -31,7 +31,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"
 type = "eql"
 
 query = '''
-sequence by host.id with maxspan=1m
+sequence by winlog.computer_name with maxspan=1m
 
 [authentication where event.action:"logged-in" and
  event.outcome == "success" and user.id : ("S-1-5-21-*", "S-1-12-1-*") and

--- a/rules/windows/privilege_escalation_create_process_as_different_user.toml
+++ b/rules/windows/privilege_escalation_create_process_as_different_user.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/30"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/10/26"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies process creation with alternate credentials. Adversaries may create a
 escalate privileges and bypass access controls.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Process Creation via Secondary Logon"

--- a/rules/windows/privilege_escalation_credroaming_ldap.toml
+++ b/rules/windows/privilege_escalation_credroaming_ldap.toml
@@ -3,7 +3,7 @@ creation_date = "2022/11/09"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/09"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ contains binary large objects (BLOBs) of encrypted credential objects from the c
 certificates, and certificate requests.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Modification of the msPKIAccountCredentials"

--- a/rules/windows/privilege_escalation_group_policy_iniscript.toml
+++ b/rules/windows/privilege_escalation_group_policy_iniscript.toml
@@ -3,7 +3,7 @@ creation_date = "2021/11/08"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ description = """
 Detects the modification of Group Policy Objects (GPO) to add a startup/logon script to users or computer objects.
 """
 false_positives = ["Legitimate Administrative Activity"]
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Startup/Logon Script added to Group Policy Object"

--- a/rules/windows/privilege_escalation_group_policy_privileged_groups.toml
+++ b/rules/windows/privilege_escalation_group_policy_privileged_groups.toml
@@ -3,7 +3,7 @@ creation_date = "2021/11/08"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ description = """
 Detects the first occurrence of a modification to Group Policy Object Attributes to add privileges to user accounts or
 use them to add users as local admins.
 """
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Group Policy Abuse for Privilege Addition"

--- a/rules/windows/privilege_escalation_group_policy_scheduled_task.toml
+++ b/rules/windows/privilege_escalation_group_policy_scheduled_task.toml
@@ -3,14 +3,14 @@ creation_date = "2021/11/08"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/09/13"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
 description = """
 Detects the modification of Group Policy Object attributes to execute a scheduled task in the objects controlled by the GPO.
 """
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Scheduled Task Execution at Scale via GPO"

--- a/rules/windows/privilege_escalation_krbrelayup_service_creation.toml
+++ b/rules/windows/privilege_escalation_krbrelayup_service_creation.toml
@@ -30,7 +30,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"
 type = "eql"
 
 query = '''
-sequence by host.id with maxspan=5m
+sequence by winlog.computer_name with maxspan=5m
  [authentication where
 
   /* event 4624 need to be logged */

--- a/rules/windows/privilege_escalation_krbrelayup_service_creation.toml
+++ b/rules/windows/privilege_escalation_krbrelayup_service_creation.toml
@@ -3,7 +3,7 @@ creation_date = "2022/04/27"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ localhost, followed by a sevice creation from the same LogonId. This may indicat
 relay attack variant that can be used to elevate privilege locally from a domain joined user to local System privileges.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Service Creation via Local Kerberos Authentication"
@@ -26,7 +26,7 @@ references = [
 risk_score = 73
 rule_id = "e4e31051-ee01-4307-a6ee-b21b186958f4"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation", "Credential Access"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation", "Credential Access", "Active Directory"]
 type = "eql"
 
 query = '''

--- a/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
+++ b/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
@@ -3,7 +3,7 @@ creation_date = "2021/12/12"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ elevate privileges from a standard domain user to a user with domain admin privi
 vulnerability that allows potential attackers to impersonate a domain controller via samAccountName attribute spoofing.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privileged Escalation via SamAccountName Spoofing"
@@ -31,7 +31,7 @@ references = [
 risk_score = 73
 rule_id = "bdcf646b-08d4-492c-870a-6c04e3700034"
 severity = "high"
-tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence", "Privilege Escalation"]
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Persistence", "Privilege Escalation", "Active Directory"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
+++ b/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
@@ -3,7 +3,7 @@ creation_date = "2022/05/11"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/10"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ controller DNS hostname and the subject computer name is not a domain controller
 step to exploit CVE-2022-26923 in an attempt to elevate privileges from a standard domain user to domain admin privileges.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote Computer Account DnsHostName Update"

--- a/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
+++ b/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
@@ -28,7 +28,7 @@ tags = ["Elastic", "Host", "Windows", "Threat Detection", "Privilege Escalation"
 type = "eql"
 
 query = '''
-sequence by host.id with maxspan=5m
+sequence by winlog.computer_name with maxspan=5m
 
   [authentication where event.action == "logged-in" and
    winlog.logon.type == "Network" and event.outcome == "success" and

--- a/rules/windows/privilege_escalation_windows_service_via_unusual_client.toml
+++ b/rules/windows/privilege_escalation_windows_service_via_unusual_client.toml
@@ -3,7 +3,7 @@ creation_date = "2022/02/07"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/12/21"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ privileges but are executed under SYSTEM privileges, so an adversary may also us
 administrator to SYSTEM.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*"]
+index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Windows Service Installed via an Unusual Client"


### PR DESCRIPTION
## Issues

Resolves #2417 & #2415 

## Summary

When users ingest windows logs via WEF, they are collected by the Windows Integration instead of the System Integration, causing the logs to be written to the `logs-windows.*` index. This PR adds the index pattern to those rules that are compatible.