### PR TITLE
[Rule Tuning] Suspicious DLL Loaded for Persistence or Privilege Escalation

### DIFF
--- a/rules/windows/privilege_escalation_persistence_phantom_dll.toml
+++ b/rules/windows/privilege_escalation_persistence_phantom_dll.toml
@@ -3,7 +3,7 @@ creation_date = "2020/01/07"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/10/11"
+updated_date = "2022/12/28"
 
 [rule]
 author = ["Elastic"]
@@ -92,13 +92,15 @@ any where
   /* compatible with Elastic Endpoint Library Events */
   (dll.name : ("wlbsctrl.dll", "wbemcomn.dll", "WptsExtensions.dll", "Tsmsisrv.dll", "TSVIPSrv.dll", "Msfte.dll",
                "wow64log.dll", "WindowsCoreDeviceInfo.dll", "Ualapi.dll", "wlanhlp.dll", "phoneinfo.dll", "EdgeGdi.dll",
-               "cdpsgshims.dll", "windowsperformancerecordercontrol.dll", "diagtrack_win.dll")
+               "cdpsgshims.dll", "windowsperformancerecordercontrol.dll", "diagtrack_win.dll", "oci.dll", "TPPCOIPW32.dll", 
+               "tpgenlic.dll", "thinmon.dll", "fxsst.dll", "msTracer.dll")
    and (dll.code_signature.trusted == false or dll.code_signature.exists == false)) or
 
   /* compatible with Sysmon EventID 7 - Image Load */
   (file.name : ("wlbsctrl.dll", "wbemcomn.dll", "WptsExtensions.dll", "Tsmsisrv.dll", "TSVIPSrv.dll", "Msfte.dll",
                "wow64log.dll", "WindowsCoreDeviceInfo.dll", "Ualapi.dll", "wlanhlp.dll", "phoneinfo.dll", "EdgeGdi.dll",
-               "cdpsgshims.dll", "windowsperformancerecordercontrol.dll", "diagtrack_win.dll")
+               "cdpsgshims.dll", "windowsperformancerecordercontrol.dll", "diagtrack_win.dll", "oci.dll", "TPPCOIPW32.dll", 
+               "tpgenlic.dll", "thinmon.dll", "fxsst.dll", "msTracer.dll")
    and not file.code_signature.status == "Valid")
   )
 '''


### PR DESCRIPTION
Updating Missing DLL list with few more ones (`"oci.dll", "TPPCOIPW32.dll", "tpgenlic.dll", "thinmon.dll", "fxsst.dll", "msTracer.dll"`)