### PR TITLE
Revert "[Security Content] Investigation Guides Line breaks refactor"

### DIFF
--- a/rules/_deprecated/defense_evasion_code_injection_conhost.toml
+++ b/rules/_deprecated/defense_evasion_code_injection_conhost.toml
@@ -16,14 +16,18 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious Process from Conhost
 
-The Windows Console Host, or `conhost.exe`, is both the server application for all of the Windows Console APIs as well as the classic Windows user interface for working with command-line applications.
+The Windows Console Host, or `conhost.exe`, is both the server application for all of the Windows Console APIs as well as
+the classic Windows user interface for working with command-line applications.
 
-The `conhost.exe` process doesn't normally have child processes. Any processes spawned by the `conhost.exe` process can indicate code injection activity or a suspicious process masquerading as the `conhost.exe` process.
+The `conhost.exe` process doesn't normally have child processes. Any processes spawned by the `conhost.exe` process can indicate code
+injection activity or a suspicious process masquerading as the `conhost.exe` process.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file
+modifications, and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behaviors in the alert timeframe.
 - Retrieve the process executable and determine if it is malicious:
@@ -53,12 +57,17 @@ The `conhost.exe` process doesn't normally have child processes. Any processes s
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/_deprecated/defense_evasion_whitespace_padding_in_command_line.toml
+++ b/rules/_deprecated/defense_evasion_whitespace_padding_in_command_line.toml
@@ -23,14 +23,18 @@ note = """## Triage and analysis
 
 ### Investigating Whitespace Padding in Process Command Line
 
-This rule identifies process execution events where the command line value contains a long sequence of whitespace characters or multiple occurrences of contiguous whitespace. Attackers may attempt to evade signature-based detections by padding their malicious command with unnecessary whitespace characters.
+This rule identifies process execution events where the command line value contains a long sequence of whitespace
+characters or multiple occurrences of contiguous whitespace. Attackers may attempt to evade signature-based detections
+by padding their malicious command with unnecessary whitespace characters.
 
 #### Possible investigation steps
 
 - Analyze the command line of the process in question for evidence of malicious code execution.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate abnormal behaviors observed by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate abnormal behaviors observed by the subject process such as network connections, registry or file
+modifications, and any spawned child processes.
 - Retrieve the process executable and determine if it is malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
     - Observe and collect information about the following activities:
@@ -43,7 +47,8 @@ This rule identifies process execution events where the command line value conta
 
 ### False positive analysis
 
-- Alerts derived from this rule are not inherently malicious. Analysts can dismiss the alert if they don't find enough evidence of further suspicious activity.
+- Alerts derived from this rule are not inherently malicious. Analysts can dismiss the alert if they don't find enough
+evidence of further suspicious activity.
 
 ### Response and remediation
 
@@ -53,13 +58,18 @@ This rule identifies process execution events where the command line value conta
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove the malicious certificate from the root certificate store.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/_deprecated/discovery_file_dir_discovery.toml
+++ b/rules/_deprecated/discovery_file_dir_discovery.toml
@@ -26,29 +26,39 @@ note = """## Triage and analysis
 
 ### Investigating File and Directory Discovery
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for three directory-listing commands in one minute, which can indicate attempts to locate valuable files, specific file types or installed programs.
+This rule looks for three directory-listing commands in one minute, which can indicate attempts to locate valuable files,
+specific file types or installed programs.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate abnormal behaviors observed using the account, such as commands executed, files created or modified, and network connections.
+- Investigate abnormal behaviors observed using the account, such as commands executed, files created or modified, and
+network connections.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 21
 rule_id = "7b08314d-47a0-4b71-ae4e-16544176924f"

--- a/rules/_deprecated/threat_intel_filebeat7x.toml
+++ b/rules/_deprecated/threat_intel_filebeat7x.toml
@@ -20,9 +20,12 @@ note = """## Triage and Analysis
 
 ### Investigating Threat Intel Indicator Matches
 
-Threat Intel indicator match rules allow matching from a local observation such as an endpoint event that records a file hash with an entry of a file hash stored within the Threat Intel Filebeat module. Other examples of matches can occur on an IP address, registry path, URL and imphash.
+Threat Intel indicator match rules allow matching from a local observation such as an endpoint event that records a file
+hash with an entry of a file hash stored within the Threat Intel Filebeat module. Other examples of matches can occur on
+an IP address, registry path, URL and imphash.
 
-The matches will be based on the incoming feed data so it's important to validate the data and review the results by investigating the associated activity to determine if it requires further investigation.
+The matches will be based on the incoming feed data so it's important to validate the data and review the results by
+investigating the associated activity to determine if it requires further investigation.
 
 If an indicator matches a local observation, the following enriched fields will be generated to identify the indicator, field, and type matched.
 
@@ -33,18 +36,27 @@ If an indicator matches a local observation, the following enriched fields will 
 #### Possible investigation steps:
 - Investigation should be validated and reviewed based on the data (file hash, registry path, URL, imphash) that was matched
 and viewing the source of that activity.
-- Consider the history of the indicator that was matched. Has it happened before? Is it happening on multiple machines? These kinds of questions can help understand if the activity is related to legitimate behavior.
+- Consider the history of the indicator that was matched. Has it happened before? Is it happening on multiple machines?
+These kinds of questions can help understand if the activity is related to legitimate behavior.
 - Consider the user and their role within the company, is this something related to their job or work function?
 
 ### False Positive Analysis
-- For any matches found, it's important to consider the initial release date of that indicator. Threat intelligence can be a great tool for augmenting existing security processes, while at the same time it should be understood that threat intelligence can represent a specific set of activity observed at a point in time. For example, an IP address may have hosted malware observed in a Dridex campaign six months ago, but it's possible that IP has been remediated and no longer represents any threat.
-- Adversaries often use legitimate tools as network administrators such as `PsExec` or `AdFind`, these tools often find their way into indicator lists creating the potential for false positives.
+- For any matches found, it's important to consider the initial release date of that indicator. Threat intelligence can
+be a great tool for augmenting existing security processes, while at the same time it should be understood that threat
+intelligence can represent a specific set of activity observed at a point in time. For example, an IP address
+may have hosted malware observed in a Dridex campaign six months ago, but it's possible that IP has been remediated and
+no longer represents any threat.
+- Adversaries often use legitimate tools as network administrators such as `PsExec` or `AdFind`, these tools often find their
+way into indicator lists creating the potential for false positives.
 - It's possible after large and publicly written campaigns, curious employees might end up going directly to attacker infrastructure and generating these rules
 
 ### Response and Remediation
-- If suspicious or malicious behavior is observed, immediate response should be taken to isolate activity to prevent further post-compromise behavior.
-- One example of a response if a machine matched a command and control IP address would be to add an entry to a network device such as a firewall or proxy appliance to prevent any outbound activity from leaving that machine.
-- Another example of a response with a malicious file hash match would involve validating if the file was properly quarantined, review current running processes looking for any abnormal activity, and investigating for any other follow-up actions such as persistence or lateral movement
+- If suspicious or malicious behavior is observed, immediate response should be taken to isolate activity to prevent further
+post-compromise behavior.
+- One example of a response if a machine matched a command and control IP address would be to add an entry to a network
+device such as a firewall or proxy appliance to prevent any outbound activity from leaving that machine.
+- Another example of a response with a malicious file hash match would involve validating if the file was properly quarantined,
+review current running processes looking for any abnormal activity, and investigating for any other follow-up actions such as persistence or lateral movement
 """
 references = ["https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-threatintel.html"]
 risk_score = 99

--- a/rules/cross-platform/discovery_security_software_grep.toml
+++ b/rules/cross-platform/discovery_security_software_grep.toml
@@ -22,31 +22,44 @@ note = """## Triage and analysis
 
 ### Investigating Security Software Discovery via Grep
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the execution of the `grep` utility with arguments compatible to the enumeration of the security software installed on the host. Attackers can use this information to decide whether or not to infect a system, disable protections, use bypasses, etc.
+This rule looks for the execution of the `grep` utility with arguments compatible to the enumeration of the security
+software installed on the host. Attackers can use this information to decide whether or not to infect a system, disable
+protections, use bypasses, etc.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence and whether they are located in expected locations.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence and whether they are located in expected locations.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
-- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any spawned child processes.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
+- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any
+spawned child processes.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
-- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/cross-platform/execution_revershell_via_shell_cmd.toml
+++ b/rules/cross-platform/execution_revershell_via_shell_cmd.toml
@@ -18,7 +18,10 @@ note = """## Triage and analysis
 
 ### Investigating Potential Reverse Shell Activity via Terminal
 
-A reverse shell is a mechanism that's abused to connect back to an attacker-controlled system. It effectively redirects the system's input and output and delivers a fully functional remote shell to the attacker. Even private systems are vulnerable since the connection is outgoing. This activity is typically the result of vulnerability exploitation, malware infection, or penetration testing.
+A reverse shell is a mechanism that's abused to connect back to an attacker-controlled system. It effectively redirects
+the system's input and output and delivers a fully functional remote shell to the attacker. Even private systems are
+vulnerable since the connection is outgoing. This activity is typically the result of vulnerability exploitation,
+malware infection, or penetration testing.
 
 This rule identifies commands that are potentially related to reverse shell activities using shell applications.
 
@@ -27,24 +30,32 @@ This rule identifies commands that are potentially related to reverse shell acti
 - Examine the command line and extract the target domain or IP address information.
   - Check if the domain is newly registered or unexpected.
   - Check the reputation of the domain or IP address.
-  - Scope other potentially compromised hosts in your environment by mapping hosts that also communicated with the domain or IP address.
+  - Scope other potentially compromised hosts in your environment by mapping hosts that also communicated with the
+  domain or IP address.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
-- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any spawned child processes.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
+- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any
+spawned child processes.
 
 ### False positive analysis
 
-- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently malicious must be monitored by the security team.
+- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently
+malicious must be monitored by the security team.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Take actions to terminate processes and connections used by the attacker.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/cross-platform/execution_suspicious_jar_child_process.toml
+++ b/rules/cross-platform/execution_suspicious_jar_child_process.toml
@@ -21,30 +21,39 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious Java Child Process
 
-This rule identifies a suspicious child process of the Java interpreter process. It may indicate an attempt to execute a malicious JAR file or an exploitation attempt via a Java specific vulnerability.
+This rule identifies a suspicious child process of the Java interpreter process. It may indicate an attempt to execute
+a malicious JAR file or an exploitation attempt via a Java specific vulnerability.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence and whether they are located in expected locations.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence and whether they are located in expected locations.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
-- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any spawned child processes.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
+- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any
+spawned child processes.
 - Examine the command line to determine if the command executed is potentially harmful or malicious.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
 
 ### False positive analysis
 
-- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of process and command line conditions.
+- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination
+of process and command line conditions.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/cross-platform/impact_hosts_file_modified.toml
+++ b/rules/cross-platform/impact_hosts_file_modified.toml
@@ -23,32 +23,46 @@ note = """## Triage and analysis
 
 ### Investigating Hosts File Modified
 
-Operating systems use the hosts file to map a connection between an IP address and domain names before going to domain name servers. Attackers can abuse this mechanism to route traffic to malicious infrastructure or disrupt security that depends on server communications. For example, Russian threat actors modified this file on a domain controller to redirect Duo MFA calls to localhost instead of the Duo server, which prevented the MFA service from contacting its server to validate MFA login. This effectively disabled MFA for active domain accounts because the default policy of Duo for Windows is to "Fail open" if the MFA server is unreachable. This can happen in any MFA implementation and is not exclusive to Duo. Find more details in this [CISA Alert](https://www.cisa.gov/uscert/ncas/alerts/aa22-074a).
+Operating systems use the hosts file to map a connection between an IP address and domain names before going to domain
+name servers. Attackers can abuse this mechanism to route traffic to malicious infrastructure or disrupt security that
+depends on server communications. For example, Russian threat actors modified this file on a domain controller to
+redirect Duo MFA calls to localhost instead of the Duo server, which prevented the MFA service from contacting its
+server to validate MFA login. This effectively disabled MFA for active domain accounts because the default policy of Duo
+for Windows is to "Fail open" if the MFA server is unreachable. This can happen in any MFA implementation and is not
+exclusive to Duo. Find more details in this [CISA Alert](https://www.cisa.gov/uscert/ncas/alerts/aa22-074a).
 
-This rule identifies modifications in the hosts file across multiple operating systems using process creation events for Linux and file events in Windows and macOS.
+This rule identifies modifications in the hosts file across multiple operating systems using process creation events for
+Linux and file events in Windows and macOS.
 
 #### Possible investigation steps
 
 - Identify the specifics of the involved assets, such as role, criticality, and associated users.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Examine the changes to the hosts file by comparing it against file backups, volume shadow copies, and other restoration mechanisms.
+- Examine the changes to the hosts file by comparing it against file backups, volume shadow copies, and other restoration
+mechanisms.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity and the configuration was justified.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity
+and the configuration was justified.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Consider isolating the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Review the privileges of the administrator account that performed the action.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/cross-platform/threat_intel_filebeat8x.toml
+++ b/rules/cross-platform/threat_intel_filebeat8x.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/11/24"
 maturity = "production"
-updated_date = "2022/11/28"
+updated_date = "2022/09/13"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -20,9 +20,12 @@ note = """## Triage and Analysis
 
 ### Investigating Threat Intel Indicator Matches
 
-Threat Intel indicator match rules allow matching from a local observation such as an endpoint event that records a file hash with an entry of a file hash stored within the Threat Intel integrations. Matches can also occur on an IP address, registry path, URL, or imphash.
+Threat Intel indicator match rules allow matching from a local observation such as an endpoint event that records a file
+hash with an entry of a file hash stored within the Threat Intel integrations. Matches can also occur on
+an IP address, registry path, URL, or imphash.
 
-The matches will be based on the incoming last 30 days feed data so it's important to validate the data and review the results by investigating the associated activity to determine if it requires further investigation.
+The matches will be based on the incoming last 30 days feed data so it's important to validate the data and review the results by
+investigating the associated activity to determine if it requires further investigation.
 
 If an indicator matches a local observation, the following enriched fields will be generated to identify the indicator, field, and type matched.
 
@@ -31,19 +34,29 @@ If an indicator matches a local observation, the following enriched fields will 
 - `threat.indicator.matched.type` - this identifies the indicator type that matched the local observation
 
 #### Possible investigation steps:
-- Investigation should be validated and reviewed based on the data (file hash, registry path, URL, imphash) that was matched and by viewing the source of that activity.
-- Consider the history of the indicator that was matched. Has it happened before? Is it happening on multiple machines? These kinds of questions can help understand if the activity is related to legitimate behavior.
+- Investigation should be validated and reviewed based on the data (file hash, registry path, URL, imphash) that was matched
+and by viewing the source of that activity.
+- Consider the history of the indicator that was matched. Has it happened before? Is it happening on multiple machines?
+These kinds of questions can help understand if the activity is related to legitimate behavior.
 - Consider the user and their role within the company: is this something related to their job or work function?
 
 ### False Positive Analysis
-- For any matches found, it's important to consider the initial release date of that indicator. Threat intelligence can be a great tool for augmenting existing security processes, while at the same time it should be understood that threat intelligence can represent a specific set of activity observed at a point in time. For example, an IP address may have hosted malware observed in a Dridex campaign months ago, but it's possible that IP has been remediated and no longer represents any threat.
-- Adversaries often use legitimate tools as network administrators such as `PsExec` or `AdFind`; these tools often find their way into indicator lists creating the potential for false positives.
+- For any matches found, it's important to consider the initial release date of that indicator. Threat intelligence can
+be a great tool for augmenting existing security processes, while at the same time it should be understood that threat
+intelligence can represent a specific set of activity observed at a point in time. For example, an IP address
+may have hosted malware observed in a Dridex campaign months ago, but it's possible that IP has been remediated and
+no longer represents any threat.
+- Adversaries often use legitimate tools as network administrators such as `PsExec` or `AdFind`; these tools often find their
+way into indicator lists creating the potential for false positives.
 - It's possible after large and publicly written campaigns, curious employees might end up going directly to attacker infrastructure and triggering these rules.
 
 ### Response and Remediation
-- If suspicious or malicious behavior is observed, take immediate action to isolate activity to prevent further post-compromise behavior.
-- One example of a response if a machine matched a command and control IP address would be to add an entry to a network device such as a firewall or proxy appliance to prevent any outbound activity from leaving that machine.
-- Another example of a response with a malicious file hash match would involve validating if the file was properly quarantined, reviewing current running processes for any abnormal activity, and investigating for any other follow-up actions such as persistence or lateral movement.
+- If suspicious or malicious behavior is observed, take immediate action to isolate activity to prevent further
+post-compromise behavior.
+- One example of a response if a machine matched a command and control IP address would be to add an entry to a network
+device such as a firewall or proxy appliance to prevent any outbound activity from leaving that machine.
+- Another example of a response with a malicious file hash match would involve validating if the file was properly quarantined,
+reviewing current running processes for any abnormal activity, and investigating for any other follow-up actions such as persistence or lateral movement.
 """
 references = [ "https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-threatintel.html"]
 risk_score = 99

--- a/rules/cross-platform/threat_intel_fleet_integrations.toml
+++ b/rules/cross-platform/threat_intel_fleet_integrations.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/04/21"
 maturity = "production"
-updated_date = "2022/11/28"
+updated_date = "2022/09/13"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -20,9 +20,12 @@ note = """## Triage and Analysis
 
 ### Investigating Threat Intel Indicator Matches
 
-Threat Intel indicator match rules allow matching from a local observation such as an endpoint event that records a file hash with an entry of a file hash stored within the Threat Intel integrations. Matches can also occur on an IP address, registry path, URL, or imphash.
+Threat Intel indicator match rules allow matching from a local observation such as an endpoint event that records a file
+hash with an entry of a file hash stored within the Threat Intel integrations. Matches can also occur on
+an IP address, registry path, URL, or imphash.
 
-The matches will be based on the incoming last 30 days feed data so it's important to validate the data and review the results by investigating the associated activity to determine if it requires further investigation.
+The matches will be based on the incoming last 30 days feed data so it's important to validate the data and review the results by
+investigating the associated activity to determine if it requires further investigation.
 
 If an indicator matches a local observation, the following enriched fields will be generated to identify the indicator, field, and type matched.
 
@@ -31,19 +34,29 @@ If an indicator matches a local observation, the following enriched fields will 
 - `threat.indicator.matched.type` - this identifies the indicator type that matched the local observation
 
 #### Possible investigation steps:
-- Investigation should be validated and reviewed based on the data (file hash, registry path, URL, imphash) that was matched and by viewing the source of that activity.
-- Consider the history of the indicator that was matched. Has it happened before? Is it happening on multiple machines? These kinds of questions can help understand if the activity is related to legitimate behavior.
+- Investigation should be validated and reviewed based on the data (file hash, registry path, URL, imphash) that was matched
+and by viewing the source of that activity.
+- Consider the history of the indicator that was matched. Has it happened before? Is it happening on multiple machines?
+These kinds of questions can help understand if the activity is related to legitimate behavior.
 - Consider the user and their role within the company: is this something related to their job or work function?
 
 ### False Positive Analysis
-- For any matches found, it's important to consider the initial release date of that indicator. Threat intelligence can be a great tool for augmenting existing security processes, while at the same time it should be understood that threat intelligence can represent a specific set of activity observed at a point in time. For example, an IP address may have hosted malware observed in a Dridex campaign months ago, but it's possible that IP has been remediated and no longer represents any threat.
-- Adversaries often use legitimate tools as network administrators such as `PsExec` or `AdFind`; these tools often find their way into indicator lists creating the potential for false positives.
+- For any matches found, it's important to consider the initial release date of that indicator. Threat intelligence can
+be a great tool for augmenting existing security processes, while at the same time it should be understood that threat
+intelligence can represent a specific set of activity observed at a point in time. For example, an IP address
+may have hosted malware observed in a Dridex campaign months ago, but it's possible that IP has been remediated and
+no longer represents any threat.
+- Adversaries often use legitimate tools as network administrators such as `PsExec` or `AdFind`; these tools often find their
+way into indicator lists creating the potential for false positives.
 - It's possible after large and publicly written campaigns, curious employees might end up going directly to attacker infrastructure and triggering these rules.
 
 ### Response and Remediation
-- If suspicious or malicious behavior is observed, take immediate action to isolate activity to prevent further post-compromise behavior.
-- One example of a response if a machine matched a command and control IP address would be to add an entry to a network device such as a firewall or proxy appliance to prevent any outbound activity from leaving that machine.
-- Another example of a response with a malicious file hash match would involve validating if the file was properly quarantined, reviewing current running processes for any abnormal activity, and investigating for any other follow-up actions such as persistence or lateral movement.
+- If suspicious or malicious behavior is observed, take immediate action to isolate activity to prevent further
+post-compromise behavior.
+- One example of a response if a machine matched a command and control IP address would be to add an entry to a network
+device such as a firewall or proxy appliance to prevent any outbound activity from leaving that machine.
+- Another example of a response with a malicious file hash match would involve validating if the file was properly quarantined,
+reviewing current running processes for any abnormal activity, and investigating for any other follow-up actions such as persistence or lateral movement.
 """
 references = [ "https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-threatintel.html"]
 risk_score = 99

--- a/rules/integrations/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/integrations/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -22,25 +22,35 @@ note = """## Triage and analysis
 
 ### Investigating AWS IAM Brute Force of Assume Role Policy
 
-An IAM role is an IAM identity that you can create in your account that has specific permissions. An IAM role is similar to an IAM user, in that it is an AWS identity with permission policies that determine what the identity can and cannot do in AWS. However, instead of being uniquely associated with one person, a role is intended to be assumable by anyone who needs it. Also, a role does not have standard long-term credentials such as a password or access keys associated with it. Instead, when you assume a role, it provides you with temporary security credentials for your role session.
+An IAM role is an IAM identity that you can create in your account that has specific permissions. An IAM role is similar
+to an IAM user, in that it is an AWS identity with permission policies that determine what the identity can and cannot
+do in AWS. However, instead of being uniquely associated with one person, a role is intended to be assumable by anyone
+who needs it. Also, a role does not have standard long-term credentials such as a password or access keys associated
+with it. Instead, when you assume a role, it provides you with temporary security credentials for your role session.
 
-Attackers may attempt to enumerate IAM roles in order to determine if a role exists before attempting to assume or hijack the discovered role.
+Attackers may attempt to enumerate IAM roles in order to determine if a role exists before attempting to assume or
+hijack the discovered role.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
-- Verify if the `RoleName` parameter contains a unique value in all requests or if the activity is potentially a brute force attack.
+- Verify if the `RoleName` parameter contains a unique value in all requests or if the activity is potentially a brute
+force attack.
 - Verify if the user account successfully updated a trust policy in the last 24 hours.
 - Examine whether this role existed in the environment by looking for past occurrences in your logs.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account and resource owners and confirm whether they are aware of this activity.
-- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal time of day?
+- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal
+time of day?
 - Examine the account's commands, API calls, and data management actions in the last 24 hours.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- Verify the roles targeted in the failed attempts, and whether the subject role previously existed in the environment. If only one role was targeted in the requests and that role previously existed, it may be a false positive, since automations can continue targeting roles that existed in the environment in the past and cause false positives (FPs).
+- Verify the roles targeted in the failed attempts, and whether the subject role previously existed in the environment.
+If only one role was targeted in the requests and that role previously existed, it may be a false positive, since
+automations can continue targeting roles that existed in the environment in the past and cause false positives (FPs).
 
 ### Response and remediation
 
@@ -52,13 +62,17 @@ Attackers may attempt to enumerate IAM roles in order to determine if a role exi
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other
+IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/integrations/aws/credential_access_iam_user_addition_to_group.toml
@@ -27,7 +27,9 @@ note = """## Triage and analysis
 
 ### Investigating AWS IAM User Addition to Group
 
-AWS Identity and Access Management (IAM) provides fine-grained access control across all of AWS. With IAM, you can specify who can access which services and resources, and under which conditions. With IAM policies, you manage permissions to your workforce and systems to ensure least-privilege permissions.
+AWS Identity and Access Management (IAM) provides fine-grained access control across all of AWS. With IAM, you can specify
+who can access which services and resources, and under which conditions. With IAM policies, you manage permissions to
+your workforce and systems to ensure least-privilege permissions.
 
 This rule looks for the addition of users to a specified user group.
 
@@ -37,11 +39,14 @@ This rule looks for the addition of users to a specified user group.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account and resource owners and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- False positives may occur due to the intended usage of the service. Tuning is needed in order to have higher confidence. Consider adding exceptions — preferably with a combination of user agent and IP address conditions — to reduce noise from onboarding processes and administrator activities.
+- False positives may occur due to the intended usage of the service. Tuning is needed in order to have higher
+confidence. Consider adding exceptions — preferably with a combination of user agent and IP address conditions — to
+reduce noise from onboarding processes and administrator activities.
 
 ### Response and remediation
 
@@ -53,13 +58,17 @@ This rule looks for the addition of users to a specified user group.
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other
+IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/credential_access_secretsmanager_getsecretvalue.toml
+++ b/rules/integrations/aws/credential_access_secretsmanager_getsecretvalue.toml
@@ -28,7 +28,8 @@ note = """## Triage and analysis
 
 ### Investigating AWS Access Secret in Secrets Manager
 
-AWS Secrets Manager is a service that enables the replacement of hardcoded credentials in code, including passwords, with an API call to Secrets Manager to retrieve the secret programmatically.
+AWS Secrets Manager is a service that enables the replacement of hardcoded credentials in code, including passwords, with
+an API call to Secrets Manager to retrieve the secret programmatically.
 
 This rule looks for the retrieval of credentials using the API `GetSecretValue` action.
 
@@ -37,20 +38,25 @@ This rule looks for the retrieval of credentials using the API `GetSecretValue` 
 - Identify the account and its role in the environment, and inspect the related policy.
 - Identify the applications that should use this account.
 - Investigate other alerts associated with the user account during the past 48 hours.
-- Investigate abnormal values in the `user_agent.original` field by comparing them with the intended and authorized usage and historical data. Suspicious user agent values include non-SDK, AWS CLI, custom user agents, etc.
+- Investigate abnormal values in the `user_agent.original` field by comparing them with the intended and authorized usage
+and historical data. Suspicious user agent values include non-SDK, AWS CLI, custom user agents, etc.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences involving other users.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
 - Review IAM permission policies for the user identity and specific secrets accessed.
 - Examine the request parameters. These might indicate the source of the program or the nature of its tasks.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- False positives may occur due to the intended usage of the service. Tuning is needed in order to have higher confidence. Consider adding exceptions — preferably with a combination of user agent and IP address conditions.
+- False positives may occur due to the intended usage of the service. Tuning is needed in order to have higher
+confidence. Consider adding exceptions — preferably with a combination of user agent and IP address conditions.
 
 ### Response and remediation
 
@@ -62,14 +68,17 @@ This rule looks for the retrieval of credentials using the API `GetSecretValue` 
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Rotate secrets or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Rotate secrets or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -26,9 +26,15 @@ note = """## Triage and analysis
 
 ### Investigating AWS CloudTrail Log Deleted
 
-Amazon CloudTrail is a service that enables governance, compliance, operational auditing, and risk auditing of your Amazon Web Services account. With CloudTrail, you can log, continuously monitor, and retain account activity related to actions across your Amazon Web Services infrastructure. CloudTrail provides event history of your Amazon Web Services account activity, including actions taken through the Amazon Management Console, Amazon SDKs, command line tools, and other Amazon Web Services services. This event history simplifies security analysis, resource change tracking, and troubleshooting.
+Amazon CloudTrail is a service that enables governance, compliance, operational auditing, and risk auditing of your
+Amazon Web Services account. With CloudTrail, you can log, continuously monitor, and retain account activity related to
+actions across your Amazon Web Services infrastructure. CloudTrail provides event history of your Amazon Web Services
+account activity, including actions taken through the Amazon Management Console, Amazon SDKs, command line tools, and
+other Amazon Web Services services. This event history simplifies security analysis, resource change tracking, and
+troubleshooting.
 
-This rule identifies the deletion of an AWS log trail using the API `DeleteTrail` action. Attackers can do this to cover their tracks and impact security monitoring that relies on this source.
+This rule identifies the deletion of an AWS log trail using the API `DeleteTrail` action. Attackers can do this to
+cover their tracks and impact security monitoring that relies on this source.
 
 #### Possible investigation steps
 
@@ -38,14 +44,18 @@ This rule identifies the deletion of an AWS log trail using the API `DeleteTrail
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
 - Investigate the deleted log trail's criticality and whether the responsible team is aware of the deletion.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -57,14 +67,17 @@ This rule identifies the deletion of an AWS log trail using the API `DeleteTrail
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -30,9 +30,15 @@ note = """## Triage and analysis
 
 ### Investigating AWS CloudTrail Log Suspended
 
-Amazon CloudTrail is a service that enables governance, compliance, operational auditing, and risk auditing of your Amazon Web Services account. With CloudTrail, you can log, continuously monitor, and retain account activity related to actions across your Amazon Web Services infrastructure. CloudTrail provides event history of your Amazon Web Services account activity, including actions taken through the Amazon Management Console, Amazon SDKs, command line tools, and other Amazon Web Services services. This event history simplifies security analysis, resource change tracking, and troubleshooting.
+Amazon CloudTrail is a service that enables governance, compliance, operational auditing, and risk auditing of your
+Amazon Web Services account. With CloudTrail, you can log, continuously monitor, and retain account activity related to
+actions across your Amazon Web Services infrastructure. CloudTrail provides event history of your Amazon Web Services
+account activity, including actions taken through the Amazon Management Console, Amazon SDKs, command line tools, and
+other Amazon Web Services services. This event history simplifies security analysis, resource change tracking, and
+troubleshooting.
 
-This rule identifies the suspension of an AWS log trail using the API `StopLogging` action. Attackers can do this to cover their tracks and impact security monitoring that relies on this source.
+This rule identifies the suspension of an AWS log trail using the API `StopLogging` action. Attackers can do this to
+cover their tracks and impact security monitoring that relies on this source.
 
 #### Possible investigation steps
 
@@ -42,14 +48,18 @@ This rule identifies the suspension of an AWS log trail using the API `StopLoggi
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
 - Investigate the deleted log trail's criticality and whether the responsible team is aware of the deletion.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -61,14 +71,17 @@ This rule identifies the suspension of an AWS log trail using the API `StopLoggi
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -45,13 +45,17 @@ tracks and evade security defenses.
 - Check if there is a justification for this behavior.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -63,14 +67,17 @@ tracks and evade security defenses.
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_config_service_rule_deletion.toml
@@ -30,26 +30,34 @@ note = """## Triage and analysis
 
 ### Investigating AWS Config Resource Deletion
 
-AWS Config provides a detailed view of the configuration of AWS resources in your AWS account. This includes how the resources are related to one another and how they were configured in the past so that you can see how the configurations and relationships change over time.
+AWS Config provides a detailed view of the configuration of AWS resources in your AWS account. This includes how the
+resources are related to one another and how they were configured in the past so that you can see how the configurations
+and relationships change over time.
 
-This rule looks for the deletion of AWS Config resources using various API actions. Attackers can do this to cover their tracks and impact security monitoring that relies on these sources.
+This rule looks for the deletion of AWS Config resources using various API actions. Attackers can do this to cover their
+tracks and impact security monitoring that relies on these sources.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
-- Identify the AWS resource that was involved and its criticality, ownership, and role in the environment. Also investigate if the resource is security-related.
+- Identify the AWS resource that was involved and its criticality, ownership, and role in the environment. Also investigate
+if the resource is security-related.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account and resource owners and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -61,14 +69,17 @@ This rule looks for the deletion of AWS Config resources using various API actio
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -29,9 +29,11 @@ note = """## Triage and analysis
 
 ### Investigating AWS VPC Flow Logs Deletion
 
-VPC Flow Logs is an AWS feature that enables you to capture information about the IP traffic going to and from network interfaces in your virtual private cloud (VPC). Flow log data can be published to Amazon CloudWatch Logs or Amazon S3.
+VPC Flow Logs is an AWS feature that enables you to capture information about the IP traffic going to and from network
+interfaces in your virtual private cloud (VPC). Flow log data can be published to Amazon CloudWatch Logs or Amazon S3.
 
-This rule identifies the deletion of VPC flow logs using the API `DeleteFlowLogs` action. Attackers can do this to cover their tracks and impact security monitoring that relies on this source.
+This rule identifies the deletion of VPC flow logs using the API `DeleteFlowLogs` action. Attackers can do this to cover
+their tracks and impact security monitoring that relies on this source.
 
 #### Possible investigation steps
 
@@ -41,14 +43,19 @@ This rule identifies the deletion of VPC flow logs using the API `DeleteFlowLogs
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
-- Administrators may rotate these logs after a certain period as part of their retention policy or after importing them to a SIEM.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
+- Administrators may rotate these logs after a certain period as part of their retention policy or after importing them
+to a SIEM.
 
 ### Response and remediation
 
@@ -60,14 +67,17 @@ This rule identifies the deletion of VPC flow logs using the API `DeleteFlowLogs
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/integrations/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -29,9 +29,11 @@ note = """## Triage and analysis
 
 ### Investigating AWS EC2 Snapshot Activity
 
-Amazon EC2 snapshots are a mechanism to create point-in-time references to data that reside in storage volumes. System administrators commonly use this for backup operations and data recovery.
+Amazon EC2 snapshots are a mechanism to create point-in-time references to data that reside in storage volumes. System
+administrators commonly use this for backup operations and data recovery.
 
-This rule looks for the modification of snapshot attributes using the API `ModifySnapshotAttribute` action. This can be used to share snapshots with unauthorized third parties, giving others access to all the data on the snapshot.
+This rule looks for the modification of snapshot attributes using the API `ModifySnapshotAttribute` action. This can be
+used to share snapshots with unauthorized third parties, giving others access to all the data on the snapshot.
 
 #### Possible investigation steps
 
@@ -42,15 +44,19 @@ This rule looks for the modification of snapshot attributes using the API `Modif
 - Contact the account owner and confirm whether they are aware of this activity.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Check if the shared permissions of the snapshot were modified to `Public` or include unknown account IDs.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -62,14 +68,17 @@ This rule looks for the modification of snapshot attributes using the API `Modif
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/integrations/aws/impact_cloudtrail_logging_updated.toml
@@ -26,9 +26,15 @@ note = """## Triage and analysis
 
 ### Investigating AWS CloudTrail Log Updated
 
-Amazon CloudTrail is a service that enables governance, compliance, operational auditing, and risk auditing of your Amazon Web Services account. With CloudTrail, you can log, continuously monitor, and retain account activity related to actions across your Amazon Web Services infrastructure. CloudTrail provides event history of your Amazon Web Services account activity, including actions taken through the Amazon Management Console, Amazon SDKs, command line tools, and other Amazon Web Services services. This event history simplifies security analysis, resource change tracking, and troubleshooting.
+Amazon CloudTrail is a service that enables governance, compliance, operational auditing, and risk auditing of your
+Amazon Web Services account. With CloudTrail, you can log, continuously monitor, and retain account activity related to
+actions across your Amazon Web Services infrastructure. CloudTrail provides event history of your Amazon Web Services
+account activity, including actions taken through the Amazon Management Console, Amazon SDKs, command line tools, and
+other Amazon Web Services services. This event history simplifies security analysis, resource change tracking, and
+troubleshooting.
 
-This rule identifies a modification on CloudTrail settings using the API `UpdateTrail` action. Attackers can do this to cover their tracks and impact security monitoring that relies on this source.
+This rule identifies a modification on CloudTrail settings using the API `UpdateTrail` action. Attackers can do this to
+cover their tracks and impact security monitoring that relies on this source.
 
 #### Possible investigation steps
 
@@ -39,13 +45,17 @@ This rule identifies a modification on CloudTrail settings using the API `Update
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -57,14 +67,17 @@ This rule identifies a modification on CloudTrail settings using the API `Update
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
@@ -29,11 +29,17 @@ note = """## Triage and analysis
 
 ### Investigating AWS CloudWatch Log Group Deletion
 
-Amazon CloudWatch is a monitoring and observability service that collects monitoring and operational data in the form of logs, metrics, and events for resources and applications. This data can be used to detect anomalous behavior in your environments, set alarms, visualize logs and metrics side by side, take automated actions, troubleshoot issues, and discover insights to keep your applications running smoothly.
+Amazon CloudWatch is a monitoring and observability service that collects monitoring and operational data in the form of
+logs, metrics, and events for resources and applications. This data can be used to detect anomalous behavior in your environments, set alarms, visualize
+logs and metrics side by side, take automated actions, troubleshoot issues, and discover insights to keep your
+applications running smoothly.
 
-A log group is a group of log streams that share the same retention, monitoring, and access control settings. You can define log groups and specify which streams to put into each group. There is no limit on the number of log streams that can belong to one log group.
+A log group is a group of log streams that share the same retention, monitoring, and access control settings. You can
+define log groups and specify which streams to put into each group. There is no limit on the number of log streams that
+can belong to one log group.
 
-This rule looks for the deletion of a log group using the API `DeleteLogGroup` action. Attackers can do this to cover their tracks and impact security monitoring that relies on these sources.
+This rule looks for the deletion of a log group using the API `DeleteLogGroup` action. Attackers can do this to cover
+their tracks and impact security monitoring that relies on these sources.
 
 #### Possible investigation steps
 
@@ -43,14 +49,18 @@ This rule looks for the deletion of a log group using the API `DeleteLogGroup` a
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
 - Investigate the deleted log group's criticality and whether the responsible team is aware of the deletion.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -62,14 +72,17 @@ This rule looks for the deletion of a log group using the API `DeleteLogGroup` a
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -29,11 +29,16 @@ note = """## Triage and analysis
 
 ### Investigating AWS CloudWatch Log Stream Deletion
 
-Amazon CloudWatch is a monitoring and observability service that collects monitoring and operational data in the form of logs, metrics, and events for resources and applications. This data can be used to detect anomalous behavior in your environments, set alarms, visualize logs and metrics side by side, take automated actions, troubleshoot issues, and discover insights to keep your applications running smoothly.
+Amazon CloudWatch is a monitoring and observability service that collects monitoring and operational data in the form of
+logs, metrics, and events for resources and applications. This data can be used to detect anomalous behavior in your environments, set alarms, visualize
+logs and metrics side by side, take automated actions, troubleshoot issues, and discover insights to keep your
+applications running smoothly.
 
-A log stream is a sequence of log events that share the same source. Each separate source of logs in CloudWatch Logs makes up a separate log stream.
+A log stream is a sequence of log events that share the same source. Each separate source of logs in CloudWatch Logs
+makes up a separate log stream.
 
-This rule looks for the deletion of a log stream using the API `DeleteLogStream` action. Attackers can do this to cover their tracks and impact security monitoring that relies on these sources.
+This rule looks for the deletion of a log stream using the API `DeleteLogStream` action. Attackers can do this to cover
+their tracks and impact security monitoring that relies on these sources.
 
 #### Possible investigation steps
 
@@ -43,14 +48,18 @@ This rule looks for the deletion of a log stream using the API `DeleteLogStream`
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
 - Investigate the deleted log stream's criticality and whether the responsible team is aware of the deletion.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -62,14 +71,17 @@ This rule looks for the deletion of a log stream using the API `DeleteLogStream`
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
@@ -30,11 +30,16 @@ note = """## Triage and analysis
 
 ### Investigating AWS IAM Deactivation of MFA Device
 
-Multi-factor authentication (MFA) in AWS is a simple best practice that adds an extra layer of protection on top of your user name and password. With MFA enabled, when a user signs in to an AWS Management Console, they will be prompted for their user name and password (the first factor—what they know), as well as for an authentication code from their AWS MFA device (the second factor—what they have). Taken together, these multiple factors provide increased security for your AWS account settings and resources.
+Multi-factor authentication (MFA) in AWS is a simple best practice that adds an extra layer of protection on top of your
+user name and password. With MFA enabled, when a user signs in to an AWS Management Console, they will be prompted for
+their user name and password (the first factor—what they know), as well as for an authentication code from their AWS MFA
+device (the second factor—what they have). Taken together, these multiple factors provide increased security for your
+AWS account settings and resources.
 
 For more information about using MFA in AWS, access the [official documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html).
 
-This rule looks for the deactivation or deletion of AWS MFA devices. These modifications weaken account security and can lead to the compromise of accounts and other assets.
+This rule looks for the deactivation or deletion of AWS MFA devices. These modifications weaken account security and can
+lead to the compromise of accounts and other assets.
 
 #### Possible investigation steps
 
@@ -42,11 +47,13 @@ This rule looks for the deactivation or deletion of AWS MFA devices. These modif
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account and resource owners and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- While this activity can be done by administrators, all users must use MFA. The security team should address any potential benign true positive (B-TP), as this configuration can risk the user and domain.
+- While this activity can be done by administrators, all users must use MFA. The security team should address any
+potential benign true positive (B-TP), as this configuration can risk the user and domain.
 
 ### Response and remediation
 
@@ -58,12 +65,15 @@ This rule looks for the deactivation or deletion of AWS MFA devices. These modif
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Reactivate multi-factor authentication for the user.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/initial_access_console_login_root.toml
+++ b/rules/integrations/aws/initial_access_console_login_root.toml
@@ -27,7 +27,11 @@ note = """## Triage and analysis
 
 ### Investigating AWS Management Console Root Login
 
-The AWS root account is the one identity that has complete access to all AWS services and resources in the account, which is created when the AWS account is created. AWS strongly recommends that you do not use the root user for your everyday tasks, even the administrative ones. Instead, adhere to the best practice of using the root user only to create your first IAM user. Then securely lock away the root user credentials and use them to perform only a few account and service management tasks. AWS provides a [list of the tasks that require root user](https://docs.aws.amazon.com/general/latest/gr/root-vs-iam.html#aws_tasks-that-require-root).
+The AWS root account is the one identity that has complete access to all AWS services and resources in the account,
+which is created when the AWS account is created. AWS strongly recommends that you do not use the root user for your
+everyday tasks, even the administrative ones. Instead, adhere to the best practice of using the root user only to create
+your first IAM user. Then securely lock away the root user credentials and use them to perform only a few account and
+service management tasks. AWS provides a [list of the tasks that require root user](https://docs.aws.amazon.com/general/latest/gr/root-vs-iam.html#aws_tasks-that-require-root).
 
 This rule looks for attempts to log in to the AWS Management Console as the root user.
 
@@ -35,7 +39,8 @@ This rule looks for attempts to log in to the AWS Management Console as the root
 
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Examine whether this activity is common in the environment by looking for past occurrences on your logs.
-- Consider the source IP address and geolocation for the calling user who issued the command. Do they look normal for the calling user?
+- Consider the source IP address and geolocation for the calling user who issued the command. Do they look normal for the
+  calling user?
 - Examine the commands, API calls, and data management actions performed by the account in the last 24 hours.
 - Contact the account owner and confirm whether they are aware of this activity.
 - If you suspect the account has been compromised, scope potentially compromised assets by tracking access to servers,
@@ -43,7 +48,8 @@ services, and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- The alert can be dismissed if this operation is done under change management and approved according to the organization's policy for performing a task that needs this privilege level.
+- The alert can be dismissed if this operation is done under change management and approved according to the
+organization's policy for performing a task that needs this privilege level.
 
 ### Response and remediation
 
@@ -56,7 +62,8 @@ services, and data accessed by the account in the last 24 hours.
     - Identify if there are any regulatory or legal ramifications related to this activity.
 - Configure multi-factor authentication for the user.
 - Follow security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/initial_access_via_system_manager.toml
+++ b/rules/integrations/aws/initial_access_via_system_manager.toml
@@ -30,28 +30,35 @@ note = """## Triage and analysis
 
 ### Investigating AWS Execution via System Manager
 
-Amazon EC2 Systems Manager is a management service designed to help users automatically collect software inventory, apply operating system patches, create system images, and configure Windows and Linux operating systems.
+Amazon EC2 Systems Manager is a management service designed to help users automatically collect software inventory, apply
+operating system patches, create system images, and configure Windows and Linux operating systems.
 
-This rule looks for the execution of commands and scripts using System Manager. Note that the actual contents of these scripts and commands are not included in the event, so analysts must gain visibility using an host-level security product.
+This rule looks for the execution of commands and scripts using System Manager. Note that the actual contents of these
+scripts and commands are not included in the event, so analysts must gain visibility using an host-level security product.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user account during the past 48 hours.
-- Validate that the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Validate that the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Investigate the commands or scripts using host-level visibility.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences involving other users.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and IP address conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and IP address conditions.
 
 ### Response and remediation
 
@@ -63,14 +70,17 @@ This rule looks for the execution of commands and scripts using System Manager. 
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/ml_cloudtrail_error_message_spike.toml
+++ b/rules/integrations/aws/ml_cloudtrail_error_message_spike.toml
@@ -29,28 +29,39 @@ note = """## Triage and analysis
 
 ### Investigating Spike in AWS Error Messages
 
-CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity when deviations occur.
+CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and
+understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity
+when deviations occur.
 
-This rule uses a machine learning job to detect a significant spike in the rate of a particular error in the CloudTrail messages. Spikes in error messages may accompany attempts at privilege escalation, lateral movement, or discovery.
+This rule uses a machine learning job to detect a significant spike in the rate of a particular error in the CloudTrail
+messages. Spikes in error messages may accompany attempts at privilege escalation, lateral movement, or discovery.
 
 #### Possible investigation steps
 
-- Examine the history of the error. If the error only manifested recently, it might be related to recent changes in an automation module or script. You can find the error in the `aws.cloudtrail.error_code field` field.
+- Examine the history of the error. If the error only manifested recently, it might be related to recent changes in an
+automation module or script. You can find the error in the `aws.cloudtrail.error_code field` field.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Validate the activity is not related to planned patches, updates, or network administrator activity.
-- Examine the request parameters. These may indicate the source of the program or the nature of the task being performed when the error occurred.
+- Examine the request parameters. These may indicate the source of the program or the nature of the task being performed
+when the error occurred.
     - Check whether the error is related to unsuccessful attempts to enumerate or access objects, data, or secrets.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal time of day?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal
+time of day?
 - Contact the account owner and confirm whether they are aware of this activity if suspicious.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- Examine the history of the command. If the command only manifested recently, it might be part of a new automation module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence), it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
+- Examine the history of the command. If the command only manifested recently, it might be part of a new automation
+module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence),
+it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
 - The adoption of new services or the addition of new functionality to scripts may generate false positives.
 
 ### Related Rules
@@ -70,14 +81,17 @@ This rule uses a machine learning job to detect a significant spike in the rate 
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/ml_cloudtrail_rare_error_code.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_error_code.toml
@@ -29,30 +29,42 @@ note = """## Triage and analysis
 
 ### Investigating Rare AWS Error Code
 
-CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity when deviations occur.
+CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and
+understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity
+when deviations occur.
 
-This rule uses a machine learning job to detect an unusual error in a CloudTrail message. This can be byproducts of attempted or successful persistence, privilege escalation, defense evasion, discovery, lateral movement, or collection.
+This rule uses a machine learning job to detect an unusual error in a CloudTrail message. This can be byproducts of
+attempted or successful persistence, privilege escalation, defense evasion, discovery, lateral movement, or collection.
 
-Detection alerts from this rule indicate a rare and unusual error code that was associated with the response to an AWS API command or method call.
+Detection alerts from this rule indicate a rare and unusual error code that was associated with the response to an AWS
+API command or method call.
 
 #### Possible investigation steps
 
-- Examine the history of the error. If the error only manifested recently, it might be related to recent changes in an automation module or script. You can find the error in the `aws.cloudtrail.error_code field` field.
+- Examine the history of the error. If the error only manifested recently, it might be related to recent changes in an
+automation module or script. You can find the error in the `aws.cloudtrail.error_code field` field.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Validate the activity is not related to planned patches, updates, or network administrator activity.
-- Examine the request parameters. These may indicate the source of the program or the nature of the task being performed when the error occurred.
+- Examine the request parameters. These may indicate the source of the program or the nature of the task being performed
+when the error occurred.
     - Check whether the error is related to unsuccessful attempts to enumerate or access objects, data, or secrets.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal time of day?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal
+time of day?
 - Contact the account owner and confirm whether they are aware of this activity if suspicious.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- Examine the history of the command. If the command only manifested recently, it might be part of a new automation module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence), it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
+- Examine the history of the command. If the command only manifested recently, it might be part of a new automation
+module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence),
+it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
 - The adoption of new services or the addition of new functionality to scripts may generate false positives.
 
 ### Related Rules
@@ -72,14 +84,17 @@ Detection alerts from this rule indicate a rare and unusual error code that was 
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_city.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_city.toml
@@ -30,32 +30,44 @@ note = """## Triage and analysis
 
 ### Investigating Unusual City For an AWS Command
 
-CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity when deviations occur.
+CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and
+understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity
+when deviations occur.
 
-This rule uses a machine learning job to detect an AWS API command that while not inherently suspicious or abnormal, is sourcing from a geolocation (city) that is unusual for the command. This can be the result of compromised credentials or keys used by a threat actor in a different geography than the authorized user(s).
+This rule uses a machine learning job to detect an AWS API command that while not inherently suspicious or abnormal, is
+sourcing from a geolocation (city) that is unusual for the command. This can be the result of compromised credentials or
+keys used by a threat actor in a different geography than the authorized user(s).
 
-Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the geolocation of the source IP address.
+Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the geolocation
+of the source IP address.
 
 #### Possible investigation steps
 
 - Identify the user account involved and the action performed. Verify whether it should perform this kind of action.
-    - Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key ID in the `aws.cloudtrail.user_identity.access_key_id` field, which can help identify the precise user context.
+    - Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key ID in the
+    `aws.cloudtrail.user_identity.access_key_id` field, which can help identify the precise user context.
     - The user agent details in the `user_agent.original` field may also indicate what kind of a client made the request.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Validate the activity is not related to planned patches, updates, or network administrator activity.
 - Examine the request parameters. These might indicate the source of the program or the nature of its tasks.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal time of day?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal
+time of day?
 - Contact the account owner and confirm whether they are aware of this activity if suspicious.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
 - False positives can occur if activity is coming from new employees based in a city with no previous history in AWS.
-- Examine the history of the command. If the command only manifested recently, it might be part of a new automation module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence), it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
+- Examine the history of the command. If the command only manifested recently, it might be part of a new automation
+module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence),
+it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
 
 ### Related Rules
 
@@ -74,14 +86,17 @@ Detection alerts from this rule indicate an AWS API command or method call that 
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_country.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_country.toml
@@ -30,32 +30,44 @@ note = """## Triage and analysis
 
 ### Investigating Unusual Country For an AWS Command
 
-CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity when deviations occur.
+CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and
+understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity
+when deviations occur.
 
-This rule uses a machine learning job to detect an AWS API command that while not inherently suspicious or abnormal, is sourcing from a geolocation (country) that is unusual for the command. This can be the result of compromised credentials or keys used by a threat actor in a different geography than the authorized user(s).
+This rule uses a machine learning job to detect an AWS API command that while not inherently suspicious or abnormal, is
+sourcing from a geolocation (country) that is unusual for the command. This can be the result of compromised credentials
+or keys used by a threat actor in a different geography than the authorized user(s).
 
-Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the geolocation of the source IP address.
+Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the geolocation
+of the source IP address.
 
 #### Possible investigation steps
 
 - Identify the user account involved and the action performed. Verify whether it should perform this kind of action.
-    - Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key ID in the `aws.cloudtrail.user_identity.access_key_id` field, which can help identify the precise user context.
+    - Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key ID in the
+    `aws.cloudtrail.user_identity.access_key_id` field, which can help identify the precise user context.
     - The user agent details in the `user_agent.original` field may also indicate what kind of a client made the request.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Validate the activity is not related to planned patches, updates, or network administrator activity.
 - Examine the request parameters. These might indicate the source of the program or the nature of its tasks.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal time of day?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal
+time of day?
 - Contact the account owner and confirm whether they are aware of this activity if suspicious.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False Positive Analysis
 
 - False positives can occur if activity is coming from new employees based in a country with no previous history in AWS.
-- Examine the history of the command. If the command only manifested recently, it might be part of a new automation module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence), it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
+- Examine the history of the command. If the command only manifested recently, it might be part of a new automation
+module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence),
+it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
 
 ### Related Rules
 
@@ -74,14 +86,17 @@ Detection alerts from this rule indicate an AWS API command or method call that 
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_user.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_user.toml
@@ -29,31 +29,43 @@ note = """## Triage and analysis
 
 ### Investigating Unusual AWS Command for a User
 
-CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity when deviations occur.
+CloudTrail logging provides visibility on actions taken within an AWS environment. By monitoring these events and
+understanding what is considered normal behavior within an organization, you can spot suspicious or malicious activity
+when deviations occur.
 
-This rule uses a machine learning job to detect an AWS API command that while not inherently suspicious or abnormal, is being made by a user context that does not normally use the command. This can be the result of compromised credentials or keys as someone uses a valid account to persist, move laterally, or exfiltrate data.
+This rule uses a machine learning job to detect an AWS API command that while not inherently suspicious or abnormal, is
+being made by a user context that does not normally use the command. This can be the result of compromised credentials or
+keys as someone uses a valid account to persist, move laterally, or exfiltrate data.
 
-Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the calling IAM user.
+Detection alerts from this rule indicate an AWS API command or method call that is rare and unusual for the calling IAM
+user.
 
 #### Possible investigation steps
 
 - Identify the user account involved and the action performed. Verify whether it should perform this kind of action.
-    - Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key ID in the `aws.cloudtrail.user_identity.access_key_id` field, which can help identify the precise user context.
+    - Examine the user identity in the `aws.cloudtrail.user_identity.arn` field and the access key ID in the
+    `aws.cloudtrail.user_identity.access_key_id` field, which can help identify the precise user context.
     - The user agent details in the `user_agent.original` field may also indicate what kind of a client made the request.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Validate the activity is not related to planned patches, updates, or network administrator activity.
 - Examine the request parameters. These might indicate the source of the program or the nature of its tasks.
 - Considering the source IP address and geolocation of the user who issued the command:
     - Do they look normal for the calling user?
-    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
-    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
-- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal time of day?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source
+    IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles?
+    Are there any other alerts or signs of suspicious activity involving this instance?
+- Consider the time of day. If the user is a human (not a program or script), did the activity take place during a normal
+time of day?
 - Contact the account owner and confirm whether they are aware of this activity if suspicious.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- Examine the history of the command. If the command only manifested recently, it might be part of a new automation module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence), it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
+- Examine the history of the command. If the command only manifested recently, it might be part of a new automation
+module or script. If it has a consistent cadence (for example, it appears in small numbers on a weekly or monthly cadence),
+it might be part of a housekeeping or maintenance process. You can find the command in the `event.action field` field.
 
 ### Related Rules
 
@@ -72,14 +84,17 @@ Detection alerts from this rule indicate an AWS API command or method call that 
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/integrations/aws/privilege_escalation_root_login_without_mfa.toml
@@ -28,19 +28,28 @@ note = """## Triage and analysis
 
 ### Investigating AWS Root Login Without MFA
 
-Multi-factor authentication (MFA) in AWS is a simple best practice that adds an extra layer of protection on top of your user name and password. With MFA enabled, when a user signs in to an AWS Management Console, they will be prompted for their user name and password, as well as for an authentication code from their AWS MFA device. Taken together, these multiple factors provide increased security for your AWS account settings and resources.
+Multi-factor authentication (MFA) in AWS is a simple best practice that adds an extra layer of protection on top of your
+user name and password. With MFA enabled, when a user signs in to an AWS Management Console, they will be prompted for
+their user name and password, as well as for an authentication code from their AWS MFA device. Taken together, these
+multiple factors provide increased security for your AWS account settings and resources.
 
 For more information about using MFA in AWS, access the [official documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html).
 
-The AWS root account is the one identity that has complete access to all AWS services and resources in the account, which is created when the AWS account is created. AWS strongly recommends that you do not use the root user for your everyday tasks, even the administrative ones. Instead, adhere to the best practice of using the root user only to create your first IAM user. Then securely lock away the root user credentials and use them to perform only a few account and service management tasks. Amazon provides a [list of the tasks that require root user](https://docs.aws.amazon.com/general/latest/gr/root-vs-iam.html#aws_tasks-that-require-root).
+The AWS root account is the one identity that has complete access to all AWS services and resources in the account,
+which is created when the AWS account is created. AWS strongly recommends that you do not use the root user for your
+everyday tasks, even the administrative ones. Instead, adhere to the best practice of using the root user only to create
+your first IAM user. Then securely lock away the root user credentials and use them to perform only a few account and
+service management tasks. Amazon provides a [list of the tasks that require root user](https://docs.aws.amazon.com/general/latest/gr/root-vs-iam.html#aws_tasks-that-require-root).
 
-This rule looks for attempts to log in to AWS as the root user without using multi-factor authentication (MFA), meaning the account is not secured properly.
+This rule looks for attempts to log in to AWS as the root user without using multi-factor authentication (MFA), meaning
+the account is not secured properly.
 
 #### Possible investigation steps
 
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Examine whether this activity is common in the environment by looking for past occurrences on your logs.
-- Consider the source IP address and geolocation for the calling user who issued the command. Do they look normal for the calling user?
+- Consider the source IP address and geolocation for the calling user who issued the command. Do they look normal for the
+  calling user?
 - Examine the commands, API calls, and data management actions performed by the account in the last 24 hours.
 - Contact the account owner and confirm whether they are aware of this activity.
 - If you suspect the account has been compromised, scope potentially compromised assets by tracking access to servers,
@@ -48,7 +57,8 @@ services, and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- While this activity is not inherently malicious, the root account must use MFA. The security team should address any potential benign true positive (B-TP), as this configuration can risk the entire cloud environment.
+- While this activity is not inherently malicious, the root account must use MFA. The security team should address any
+potential benign true positive (B-TP), as this configuration can risk the entire cloud environment.
 
 ### Response and remediation
 
@@ -61,7 +71,8 @@ services, and data accessed by the account in the last 24 hours.
     - Identify if there are any regulatory or legal ramifications related to this activity.
 - Configure multi-factor authentication for the user.
 - Follow security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/integrations/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -29,9 +29,15 @@ note = """## Triage and analysis
 
 ### Investigating AWS IAM Assume Role Policy Update
 
-An IAM role is an IAM identity that you can create in your account that has specific permissions. An IAM role is similar to an IAM user, in that it is an AWS identity with permission policies that determine what the identity can and cannot do in AWS. However, instead of being uniquely associated with one person, a role is intended to be assumable by anyone who needs it. Also, a role does not have standard long-term credentials such as a password or access keys associated with it. Instead, when you assume a role, it provides you with temporary security credentials for your role session.
+An IAM role is an IAM identity that you can create in your account that has specific permissions. An IAM role is similar
+to an IAM user, in that it is an AWS identity with permission policies that determine what the identity can and cannot
+do in AWS. However, instead of being uniquely associated with one person, a role is intended to be assumable by anyone
+who needs it. Also, a role does not have standard long-term credentials such as a password or access keys associated
+with it. Instead, when you assume a role, it provides you with temporary security credentials for your role session.
 
-The role trust policy is a JSON document in which you define the principals you trust to assume the role. This policy is a required resource-based policy that is attached to a role in IAM. An attacker may attempt to modify this policy by using the `UpdateAssumeRolePolicy` API action to gain the privileges of that role.
+The role trust policy is a JSON document in which you define the principals you trust to assume the role. This policy is
+a required resource-based policy that is attached to a role in IAM. An attacker may attempt to modify this policy by
+using the `UpdateAssumeRolePolicy` API action to gain the privileges of that role.
 
 #### Possible investigation steps
 
@@ -39,11 +45,14 @@ The role trust policy is a JSON document in which you define the principals you 
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account and resource owners and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- False positives may occur due to the intended usage of the service. Tuning is needed in order to have higher confidence. Consider adding exceptions — preferably with a combination of the user agent and user ID conditions — to cover administrator activities and infrastructure as code tooling.
+- False positives may occur due to the intended usage of the service. Tuning is needed in order to have higher
+confidence. Consider adding exceptions — preferably with a combination of the user agent and user ID conditions — to
+cover administrator activities and infrastructure as code tooling.
 
 ### Response and remediation
 
@@ -56,13 +65,17 @@ The role trust policy is a JSON document in which you define the principals you 
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
 - Use AWS [policy versioning](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-versioning.html) to restore the trust policy to the desired state.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other
+IAM users.
 - Consider enabling multi-factor authentication for users.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/azure/defense_evasion_azure_service_principal_addition.toml
+++ b/rules/integrations/azure/defense_evasion_azure_service_principal_addition.toml
@@ -30,24 +30,31 @@ note = """## Triage and analysis
 
 ### Investigating Azure Service Principal Addition
 
-Service Principals are identities used by applications, services, and automation tools to access specific resources. They grant specific access based on the assigned API permissions. Most organizations that work a lot with Azure AD make use of service principals. Whenever an application is registered, it automatically creates an application object and a service principal in an Azure AD tenant.
+Service Principals are identities used by applications, services, and automation tools to access specific resources.
+They grant specific access based on the assigned API permissions. Most organizations that work a lot with Azure AD make
+use of service principals. Whenever an application is registered, it automatically creates an application object and a
+service principal in an Azure AD tenant.
 
-This rule looks for the addition of service principals. This behavior may enable attackers to impersonate legitimate service principals to camouflage their activities among noisy automations/apps.
+This rule looks for the addition of service principals. This behavior may enable attackers to impersonate legitimate
+service principals to camouflage their activities among noisy automations/apps.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Consider the source IP address and geolocation for the user who issued the command. Do they look normal for the user?
-- Consider the time of day. If the user is a human, not a program or script, did the activity take place during a normal time of day?
+- Consider the time of day. If the user is a human, not a program or script, did the activity take place during a normal
+time of day?
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Examine the account's commands, API calls, and data management actions in the last 24 hours.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and device conditions.
+If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and device conditions.
 
 ### Response and remediation
 
@@ -59,12 +66,16 @@ If this rule is noisy in your environment due to expected activity, consider add
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other
+IAM users.
 - Consider enabling multi-factor authentication for users.
 - Follow security best practices [outlined](https://docs.microsoft.com/en-us/azure/security/fundamentals/identity-management-best-practices) by Microsoft.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin.toml
+++ b/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin.toml
@@ -36,11 +36,13 @@ This rule identifies events produced by Microsoft Identity Protection with high 
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and device conditions.
+If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and device conditions.
 
 ### Response and remediation
 
@@ -52,12 +54,16 @@ If this rule is noisy in your environment due to expected activity, consider add
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other
+IAM users.
 - Consider enabling multi-factor authentication for users.
 - Follow security best practices [outlined](https://docs.microsoft.com/en-us/azure/security/fundamentals/identity-management-best-practices) by Microsoft.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin_atrisk_or_confirmed.toml
+++ b/rules/integrations/azure/initial_access_azure_active_directory_high_risk_signin_atrisk_or_confirmed.toml
@@ -23,7 +23,8 @@ note = """## Triage and analysis
 
 Microsoft Identity Protection is an Azure AD security tool that detects various types of identity risks and attacks.
 
-This rule identifies events produced by the Microsoft Identity Protection with a risk state equal to `confirmedCompromised` or `atRisk`.
+This rule identifies events produced by the Microsoft Identity Protection with a risk state equal to `confirmedCompromised`
+or `atRisk`.
 
 #### Possible investigation steps
 
@@ -34,11 +35,13 @@ This rule identifies events produced by the Microsoft Identity Protection with a
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and device conditions.
+If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a
+combination of user and device conditions.
 
 ### Response and remediation
 
@@ -50,12 +53,16 @@ If this rule is noisy in your environment due to expected activity, consider add
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other
+IAM users.
 - Consider enabling multi-factor authentication for users.
 - Follow security best practices [outlined](https://docs.microsoft.com/en-us/azure/security/fundamentals/identity-management-best-practices) by Microsoft.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/azure/initial_access_azure_active_directory_powershell_signin.toml
+++ b/rules/integrations/azure/initial_access_azure_active_directory_powershell_signin.toml
@@ -28,9 +28,13 @@ note = """## Triage and analysis
 
 ### Investigating Azure Active Directory PowerShell Sign-in
 
-Azure Active Directory PowerShell for Graph (Azure AD PowerShell) is a module IT professionals commonly use to manage their Azure Active Directory. The cmdlets in the Azure AD PowerShell module enable you to retrieve data from the directory, create new objects in the directory, update existing objects, remove objects, as well as configure the directory and its features.
+Azure Active Directory PowerShell for Graph (Azure AD PowerShell) is a module IT professionals commonly use to manage
+their Azure Active Directory. The cmdlets in the Azure AD PowerShell module enable you to retrieve data from the
+directory, create new objects in the directory, update existing objects, remove objects, as well as configure the
+directory and its features.
 
-This rule identifies sign-ins that use the Azure Active Directory PowerShell module, which can indicate unauthorized access if done outside of IT or engineering.
+This rule identifies sign-ins that use the Azure Active Directory PowerShell module, which can indicate unauthorized
+access if done outside of IT or engineering.
 
 #### Possible investigation steps
 
@@ -39,12 +43,15 @@ This rule identifies sign-ins that use the Azure Active Directory PowerShell mod
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Consider the source IP address and geolocation for the involved user account. Do they look normal?
 - Contact the account owner and confirm whether they are aware of this activity.
-- Investigate suspicious actions taken by the user using the module, for example, modifications in security settings that weakens the security policy, persistence-related tasks, and data access.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- Investigate suspicious actions taken by the user using the module, for example, modifications in security settings
+that weakens the security policy, persistence-related tasks, and data access.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- If this activity is expected and noisy in your environment, consider adding IT, Engineering, and other authorized users as exceptions — preferably with a combination of user and device conditions.
+- If this activity is expected and noisy in your environment, consider adding IT, Engineering, and other authorized users
+as exceptions — preferably with a combination of user and device conditions.
 
 ### Response and remediation
 
@@ -56,12 +63,16 @@ This rule identifies sign-ins that use the Azure Active Directory PowerShell mod
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other
+IAM users.
 - Consider enabling multi-factor authentication for users.
 - Follow security best practices [outlined](https://docs.microsoft.com/en-us/azure/security/fundamentals/identity-management-best-practices) by Microsoft.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -22,7 +22,13 @@ note = """## Triage and analysis
 
 ### Investigating Possible Consent Grant Attack via Azure-Registered Application
 
-In an illicit consent grant attack, the attacker creates an Azure-registered application that requests access to data such as contact information, email, or documents. The attacker then tricks an end user into granting that application consent to access their data either through a phishing attack, or by injecting illicit code into a trusted website. After the illicit application has been granted consent, it has account-level access to data without the need for an organizational account. Normal remediation steps like resetting passwords for breached accounts or requiring multi-factor authentication (MFA) on accounts are not effective against this type of attack, since these are third-party applications and are external to the organization.
+In an illicit consent grant attack, the attacker creates an Azure-registered application that requests access to data
+such as contact information, email, or documents. The attacker then tricks an end user into granting that application
+consent to access their data either through a phishing attack, or by injecting illicit code into a trusted website.
+After the illicit application has been granted consent, it has account-level access to data without the need for an
+organizational account. Normal remediation steps like resetting passwords for breached accounts or requiring multi-factor
+authentication (MFA) on accounts are not effective against this type of attack, since these are third-party applications
+and are external to the organization.
 
 Official Microsoft guidance for detecting and remediating this attack can be found [here](https://docs.microsoft.com/en-us/microsoft-365/security/office-365-security/detect-and-remediate-illicit-consent-grants).
 
@@ -41,7 +47,8 @@ Official Microsoft guidance for detecting and remediating this attack can be fou
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Malicious applications abuse the same workflow used by legitimate apps. Thus, analysts must review each app consent to ensure that only desired apps are granted access.
+- This mechanism can be used legitimately. Malicious applications abuse the same workflow used by legitimate apps.
+Thus, analysts must review each app consent to ensure that only desired apps are granted access.
 
 ### Response and remediation
 
@@ -53,15 +60,21 @@ Official Microsoft guidance for detecting and remediating this attack can be fou
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
 - Disable the malicious application to stop user access and the application access to your data.
-- Revoke the application Oauth consent grant. The `Remove-AzureADOAuth2PermissionGrant` cmdlet can be used to complete this task.
-- Remove the service principal application role assignment. The `Remove-AzureADServiceAppRoleAssignment` cmdlet can be used to complete this task.
+- Revoke the application Oauth consent grant. The `Remove-AzureADOAuth2PermissionGrant` cmdlet can be used to complete
+this task.
+- Remove the service principal application role assignment. The `Remove-AzureADServiceAppRoleAssignment` cmdlet can be
+used to complete this task.
 - Revoke the refresh token for all users assigned to the application. Azure provides a [playbook](https://github.com/Azure/Azure-Sentinel/tree/master/Playbooks/Revoke-AADSignInSessions) for this task.
 - [Report](https://docs.microsoft.com/en-us/defender-cloud-apps/manage-app-permissions#send-feedback) the application as malicious to Microsoft.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Investigate the potential for data compromise from the user's email and file sharing services. Activate your Data Loss incident response playbook.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Investigate the potential for data compromise from the user's email and file sharing services. Activate your Data Loss
+incident response playbook.
 - Disable the permission for a user to set consent permission on their behalf.
   - Enable the [Admin consent request](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/configure-admin-consent-workflow) feature.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/azure/persistence_azure_privileged_identity_management_role_modified.toml
+++ b/rules/integrations/azure/persistence_azure_privileged_identity_management_role_modified.toml
@@ -23,20 +23,25 @@ note = """## Triage and analysis
 
 ### Investigating Azure Privilege Identity Management Role Modified
 
-Azure Active Directory (AD) Privileged Identity Management (PIM) is a service that enables you to manage, control, and monitor access to important resources in an organization. PIM can be used to manage the built-in Azure resource roles such as Global Administrator and Application Administrator.
+Azure Active Directory (AD) Privileged Identity Management (PIM) is a service that enables you to manage, control, and
+monitor access to important resources in an organization. PIM can be used to manage the built-in Azure resource roles
+such as Global Administrator and Application Administrator.
 
-This rule identifies the update of PIM role settings, which can indicate that an attacker has already gained enough access to modify role assignment settings.
+This rule identifies the update of PIM role settings, which can indicate that an attacker has already gained enough
+access to modify role assignment settings.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Consider the source IP address and geolocation for the user who issued the command. Do they look normal for the user?
-- Consider the time of day. If the user is a human, not a program or script, did the activity take place during a normal time of day?
+- Consider the time of day. If the user is a human, not a program or script, did the activity take place during a normal
+time of day?
 - Check if this operation was approved and performed according to the organization's change management policy.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Examine the account's commands, API calls, and data management actions in the last 24 hours.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
@@ -52,13 +57,17 @@ This rule identifies the update of PIM role settings, which can indicate that an
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other
+IAM users.
 - Restore the PIM roles to the desired state.
 - Consider enabling multi-factor authentication for users.
 - Follow security best practices [outlined](https://docs.microsoft.com/en-us/azure/security/fundamentals/identity-management-best-practices) by Microsoft.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/azure/persistence_mfa_disabled_for_azure_user.toml
+++ b/rules/integrations/azure/persistence_mfa_disabled_for_azure_user.toml
@@ -21,13 +21,17 @@ note = """## Triage and analysis
 
 ### Investigating Multi-Factor Authentication Disabled for an Azure User
 
-Multi-factor authentication is a process in which users are prompted during the sign-in process for an additional form of identification, such as a code on their cellphone or a fingerprint scan.
+Multi-factor authentication is a process in which users are prompted during the sign-in process for an additional form
+of identification, such as a code on their cellphone or a fingerprint scan.
 
-If you only use a password to authenticate a user, it leaves an insecure vector for attack. If the password is weak or has been exposed elsewhere, an attacker could be using it to gain access. When you require a second form of authentication, security is increased because this additional factor isn't something that's easy for an attacker to obtain or duplicate.
+If you only use a password to authenticate a user, it leaves an insecure vector for attack. If the password is weak or
+has been exposed elsewhere, an attacker could be using it to gain access. When you require a second form of authentication,
+security is increased because this additional factor isn't something that's easy for an attacker to obtain or duplicate.
 
 For more information about using MFA in Azure AD, access the [official documentation](https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-mfa-howitworks#how-to-enable-and-use-azure-ad-multi-factor-authentication).
 
-This rule identifies the deactivation of MFA for an Azure user account. This modification weakens account security and can lead to the compromise of accounts and other assets.
+This rule identifies the deactivation of MFA for an Azure user account. This modification weakens account security
+and can lead to the compromise of accounts and other assets.
 
 #### Possible investigation steps
 
@@ -35,11 +39,13 @@ This rule identifies the deactivation of MFA for an Azure user account. This mod
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account and resource owners and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- While this activity can be done by administrators, all users must use MFA. The security team should address any potential benign true positive (B-TP), as this configuration can risk the user and domain.
+- While this activity can be done by administrators, all users must use MFA. The security team should address any
+potential benign true positive (B-TP), as this configuration can risk the user and domain.
 
 ### Response and remediation
 
@@ -51,12 +57,15 @@ This rule identifies the deactivation of MFA for an Azure user account. This mod
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Reactivate multi-factor authentication for the user.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security defaults [provided by Microsoft](https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/concept-fundamentals-security-defaults).
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/integrations/google_workspace/impact_google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/integrations/google_workspace/impact_google_workspace_mfa_enforcement_disabled.toml
@@ -28,13 +28,17 @@ note = """## Triage and analysis
 
 ### Investigating Google Workspace MFA Enforcement Disabled
 
-Multi-factor authentication is a process in which users are prompted during the sign-in process for an additional form of identification, such as a code on their cellphone or a fingerprint scan.
+Multi-factor authentication is a process in which users are prompted during the sign-in process for an additional form
+of identification, such as a code on their cellphone or a fingerprint scan.
 
-If you only use a password to authenticate a user, it leaves an insecure vector for attack. If the password is weak or has been exposed elsewhere, an attacker could be using it to gain access. When you require a second form of authentication, security is increased because this additional factor isn't something that's easy for an attacker to obtain or duplicate.
+If you only use a password to authenticate a user, it leaves an insecure vector for attack. If the password is weak or
+has been exposed elsewhere, an attacker could be using it to gain access. When you require a second form of authentication,
+security is increased because this additional factor isn't something that's easy for an attacker to obtain or duplicate.
 
 For more information about using MFA in Google Workspace, access the [official documentation](https://support.google.com/a/answer/175197).
 
-This rule identifies the disabling of MFA enforcement in Google Workspace. This modification weakens the security of the accounts and can lead to the compromise of accounts and other assets.
+This rule identifies the disabling of MFA enforcement in Google Workspace. This modification weakens the security of
+the accounts and can lead to the compromise of accounts and other assets.
 
 #### Possible investigation steps
 
@@ -42,11 +46,13 @@ This rule identifies the disabling of MFA enforcement in Google Workspace. This 
 - Investigate other alerts associated with the user account during the past 48 hours.
 - Contact the account and resource owners and confirm whether they are aware of this activity.
 - Check if this operation was approved and performed according to the organization's change management policy.
-- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services,
+and data accessed by the account in the last 24 hours.
 
 ### False positive analysis
 
-- While this activity can be done by administrators, all users must use MFA. The security team should address any potential benign true positive (B-TP), as this configuration can risk the user and domain.
+- While this activity can be done by administrators, all users must use MFA. The security team should address any
+potential benign true positive (B-TP), as this configuration can risk the user and domain.
 
 ### Response and remediation
 
@@ -58,19 +64,21 @@ This rule identifies the disabling of MFA enforcement in Google Workspace. This 
     - Work with your IT team to identify and minimize the impact on users.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with
+your IT teams to minimize the impact on business operations during these actions.
 - Reactivate the multi-factor authentication enforcement.
 - Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://support.google.com/a/answer/7587183) by Google.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
 
 ### Important Information Regarding Google Workspace Event Lag Times
-
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.

--- a/rules/linux/credential_access_bruteforce_password_guessing.toml
+++ b/rules/linux/credential_access_bruteforce_password_guessing.toml
@@ -3,7 +3,7 @@ creation_date = "2022/09/14"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/28"
+updated_date = "2022/09/23"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,8 @@ note = """## Triage and analysis
 
 ### Investigating Potential SSH Password Guessing Attack
 
-The rule identifies consecutive SSH login failures followed by a successful login from the same source IP address to the same target host indicating a successful attempt of brute force password guessing.
+The rule identifies consecutive SSH login failures followed by a successful login from the same source IP address to the
+same target host indicating a successful attempt of brute force password guessing.
 
 #### Possible investigation steps
 
@@ -38,12 +39,17 @@ The rule identifies consecutive SSH login failures followed by a successful logi
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
-- Ensure active session(s) on the host(s) are terminated as the attacker could have gained initial access to the system(s).
+- Ensure active session(s) on the host(s) are terminated as the attacker could have gained initial
+access to the system(s).
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified.
+- Reset passwords for these accounts and other potentially compromised credentials.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 """
 risk_score = 47

--- a/rules/linux/credential_access_potential_linux_ssh_bruteforce.toml
+++ b/rules/linux/credential_access_potential_linux_ssh_bruteforce.toml
@@ -3,7 +3,7 @@ creation_date = "2022/09/14"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/28"
+updated_date = "2022/09/23"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,8 @@ note = """## Triage and analysis
 
 ### Investigating Potential SSH Brute Force Attack
 
-The rule identifies consecutive SSH login failures targeting a user account from the same source IP address to the same target host indicating brute force login attempts.
+The rule identifies consecutive SSH login failures targeting a user account from the same source IP address to the
+same target host indicating brute force login attempts.
 
 #### Possible investigation steps
 
@@ -40,10 +41,14 @@ The rule identifies consecutive SSH login failures targeting a user account from
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified.
+- Reset passwords for these accounts and other potentially compromised credentials.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 """
 risk_score = 47

--- a/rules/linux/credential_access_potential_linux_ssh_bruteforce_root.toml
+++ b/rules/linux/credential_access_potential_linux_ssh_bruteforce_root.toml
@@ -3,7 +3,7 @@ creation_date = "2022/09/14"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/28"
+updated_date = "2022/09/23"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,8 @@ note = """## Triage and analysis
 
 ### Investigating Potential SSH Brute Force Attack on Privileged Account
 
-The rule identifies consecutive SSH login failures targeting a privileged (root) account from the same source IP address to the same target host indicating brute force login attempts.
+The rule identifies consecutive SSH login failures targeting a privileged (root) account from the same source IP
+address to the same target host indicating brute force login attempts.
 
 #### Possible investigation steps
 
@@ -31,19 +32,21 @@ The rule identifies consecutive SSH login failures targeting a privileged (root)
 - Identify the source and the target computer and their roles in the IT environment.
 
 ### False positive analysis
-
 - Authentication misconfiguration or obsolete credentials.
 - Service account password expired.
 - Infrastructure or availability issue.
 
 ### Response and remediation
-
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified.
+- Reset passwords for these accounts and other potentially compromised credentials.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 """
 risk_score = 73

--- a/rules/linux/execution_abnormal_process_id_file_created.toml
+++ b/rules/linux/execution_abnormal_process_id_file_created.toml
@@ -29,41 +29,54 @@ note = """## Triage and analysis
 
 ### Investigating Abnormal Process ID or Lock File Created
 
-Linux applications may need to save their process identification number (PID) for various purposes: from signaling that a program is running to serving as a signal that a previous instance of an application didn't exit successfully. PID files contain its creator process PID in an integer value.
+Linux applications may need to save their process identification number (PID) for various purposes: from signaling that
+a program is running to serving as a signal that a previous instance of an application didn't exit successfully. PID
+files contain its creator process PID in an integer value.
 
 Linux lock files are used to coordinate operations in files so that conflicts and race conditions are prevented.
 
-This rule identifies the creation of PID, lock, or reboot files in the /var/run/ directory. Attackers can masquerade malware, payloads, staged data for exfiltration, and more as legitimate PID files.
+This rule identifies the creation of PID, lock, or reboot files in the /var/run/ directory. Attackers can masquerade
+malware, payloads, staged data for exfiltration, and more as legitimate PID files.
 
 #### Possible investigation steps
 
 - Retrieve the file and determine if it is malicious:
     - Check the contents of the PID files. They should only contain integer strings.
-    - Check the file type of the lock and PID files to determine if they are executables. This is only observed in     malicious files.
+    - Check the file type of the lock and PID files to determine if they are executables. This is only observed in
+    malicious files.
     - Check the size of the subject file. Legitimate PID files should be under 10 bytes.
     - Check if the lock or PID file has high entropy. This typically indicates an encrypted payload.
         - Analysts can use tools like `ent` to measure entropy.
-    - Examine the reputation of the SHA-256 hash in the PID file. Use a database like VirusTotal to identify additional pivots and artifacts for investigation.
+    - Examine the reputation of the SHA-256 hash in the PID file. Use a database like VirusTotal to identify additional
+    pivots and artifacts for investigation.
 - Trace the file's creation to ensure it came from a legitimate or authorized process.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
-- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any spawned child processes.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
+- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any
+spawned child processes.
 
 ### False positive analysis
 
-- False positives can appear if the PID file is legitimate and holding a process ID as intended. If the PID file is an executable or has a file size that's larger than 10 bytes, it should be ruled suspicious.
-- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of file name and process executable conditions.
+- False positives can appear if the PID file is legitimate and holding a process ID as intended. If the PID file is
+an executable or has a file size that's larger than 10 bytes, it should be ruled suspicious.
+- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination
+of file name and process executable conditions.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Block the identified indicators of compromise (IoCs).
 - Take actions to terminate processes and connections used by the attacker.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "https://www.sandflysecurity.com/blog/linux-file-masquerading-and-malicious-pids-sandfly-1-2-6-update/",

--- a/rules/linux/execution_file_transfer_or_listener_established_via_netcat.toml
+++ b/rules/linux/execution_file_transfer_or_listener_established_via_netcat.toml
@@ -29,13 +29,19 @@ note = """## Triage and analysis
 
 ### Investigating Netcat Network Activity
 
-Netcat is a dual-use command line tool that can be used for various purposes, such as port scanning, file transfers, and connection tests. Attackers can abuse its functionality for malicious purposes such creating bind shells or reverse shells to gain access to the target system.
+Netcat is a dual-use command line tool that can be used for various purposes, such as port scanning, file transfers, and
+connection tests. Attackers can abuse its functionality for malicious purposes such creating bind shells or reverse
+shells to gain access to the target system.
 
-A reverse shell is a mechanism that's abused to connect back to an attacker-controlled system. It effectively redirects the system's input and output and delivers a fully functional remote shell to the attacker. Even private systems are vulnerable since the connection is outgoing.
+A reverse shell is a mechanism that's abused to connect back to an attacker-controlled system. It effectively redirects
+the system's input and output and delivers a fully functional remote shell to the attacker. Even private systems are
+vulnerable since the connection is outgoing.
 
-A bind shell is a type of backdoor that attackers set up on the target host and binds to a specific port to listen for an incoming connection from the attacker.
+A bind shell is a type of backdoor that attackers set up on the target host and binds to a specific port to listen for
+an incoming connection from the attacker.
 
-This rule identifies potential reverse shell or bind shell activity using Netcat by checking for the execution of Netcat followed by a network connection.
+This rule identifies potential reverse shell or bind shell activity using Netcat by checking for the execution of Netcat
+followed by a network connection.
 
 #### Possible investigation steps
 
@@ -43,25 +49,34 @@ This rule identifies potential reverse shell or bind shell activity using Netcat
 - Extract and examine the target domain or IP address.
   - Check if the domain is newly registered or unexpected.
   - Check the reputation of the domain or IP address.
-  - Scope other potentially compromised hosts in your environment by mapping hosts that also communicated with the domain or IP address.
+  - Scope other potentially compromised hosts in your environment by mapping hosts that also communicated with the
+  domain or IP address.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
-- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any spawned child processes.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
+- Investigate any abnormal behavior by the subject process such as network connections, file modifications, and any
+spawned child processes.
 
 ### False positive analysis
 
-- Netcat is a dual-use tool that can be used for benign or malicious activity. It is included in some Linux distributions, so its presence is not necessarily suspicious. Some normal use of this program, while uncommon, may originate from scripts, automation tools, and frameworks.
+- Netcat is a dual-use tool that can be used for benign or malicious activity. It is included in some Linux
+distributions, so its presence is not necessarily suspicious. Some normal use of this program, while uncommon, may
+originate from scripts, automation tools, and frameworks.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Block the identified indicators of compromise (IoCs).
 - Take actions to terminate processes and connections used by the attacker.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "http://pentestmonkey.net/cheat-sheet/shells/reverse-shell-cheat-sheet",

--- a/rules/linux/execution_shell_evasion_linux_binary.toml
+++ b/rules/linux/execution_shell_evasion_linux_binary.toml
@@ -48,7 +48,8 @@ Initiate the incident response process based on the outcome of the triage.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - If the triage revelaed defence evasion for imparing defenses
   - Isolate the involved host to prevent further post-compromise behavior.
   - Identified the disabled security guard components on the host and take necessary steps in renebaling the same.
@@ -61,7 +62,8 @@ Initiate the incident response process based on the outcome of the triage.
   - Intiate compromised credential deactivation and credential rotation process for all exposed crednetials.
   - Investiagte if any IPR data was accessed during the data crawling and take appropriate actions.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/linux/impact_process_kill_threshold.toml
+++ b/rules/linux/impact_process_kill_threshold.toml
@@ -18,19 +18,24 @@ note = """## Triage and analysis
 
 ### Investigating High Number of Process Terminations
 
-Attackers can kill processes for a variety of purposes. For example, they can kill process associated with business applications and databases to release the lock on files used by these applications so they may be encrypted,or stop security and backup solutions, etc.
+Attackers can kill processes for a variety of purposes. For example, they can kill process associated
+with business applications and databases to release the lock on files used by these applications so they may be
+encrypted,or stop security and backup solutions, etc.
 
-This rule identifies a high number (10) of process terminations via pkill from the same host within a short time period.
+This rule identifies a high number (10) of process terminations via pkill from the same
+host within a short time period.
 
 #### Possible investigation steps
 
+Detection alerts from this rule indicate High Number of Process Terminations from the same host
+Here are some possible avenues of investigation:
 - Examine the entry point to the host and user in action via the Analyse View.
-  - Identify the session entry leader and session user.
+  - Identify the session entry leader and session user
 - Examine the contents of session leading to the process termination(s) via the Session View.
-  - Examine the command execution pattern in the session, which may lead to suspricous activities.
+  - Examine the command execution pattern in the session, which may lead to suspricous activities
 - Examine the process killed during the malicious execution
-  - Identify imment threat to the system from the process killed.
-  - Take necessary incident response actions to respawn necessary process.
+  - Identify imment threat to the system from the process killed
+  - Take necessary incident response actions to respawn necessary process
 
 ### False positive analysis
 
@@ -40,17 +45,22 @@ This rule identifies a high number (10) of process terminations via pkill from t
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further destructive behavior, which is commonly associated with this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Reimage the host operating system or restore it to the operational state.
-- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look for ransomware preparation and execution activities.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look
+for ransomware preparation and execution activities.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 47
 rule_id = "67f8443a-4ff3-4a70-916d-3cfa3ae9f02b"
 severity = "medium"
-tags = ["Elastic", "Host", "Linux", "Threat Detection", "Impact"]
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Impact", "Investigation Guide"]
 type = "threshold"
 
 query = '''

--- a/rules/linux/persistence_shell_activity_by_web_server.toml
+++ b/rules/linux/persistence_shell_activity_by_web_server.toml
@@ -24,9 +24,13 @@ note = """## Triage and analysis
 
 ### Investigating Potential Shell via Web Server
 
-Adversaries may backdoor web servers with web shells to establish persistent access to systems. A web shell is a web script that is placed on an openly accessible web server to allow an adversary to use the web server as a gateway into a network. A web shell may provide a set of functions to execute or a command line interface on the system that hosts the web server.
+Adversaries may backdoor web servers with web shells to establish persistent access to systems. A web shell is a web
+script that is placed on an openly accessible web server to allow an adversary to use the web server as a gateway into a
+network. A web shell may provide a set of functions to execute or a command line interface on the system that hosts the
+web server.
 
-This rule detects a web server process spawning script and command line interface programs, potentially indicating attackers executing commands using the web shell.
+This rule detects a web server process spawning script and command line interface programs, potentially indicating
+attackers executing commands using the web shell.
 
 #### Possible investigation steps
 
@@ -45,7 +49,8 @@ any other spawned child processes.
 
 ### False positive analysis
 
-- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently malicious must be monitored by the security team.
+- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently
+malicious must be monitored by the security team.
 
 ### Response and remediation
 
@@ -55,12 +60,17 @@ any other spawned child processes.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "https://pentestlab.blog/tag/web-shell/",

--- a/rules/windows/collection_email_powershell_exchange_mailbox.toml
+++ b/rules/windows/collection_email_powershell_exchange_mailbox.toml
@@ -22,28 +22,34 @@ note = """## Triage and analysis
 
 ### Investigating Exporting Exchange Mailbox via PowerShell
 
-The `New-MailBoxExportRequest` cmdlet is used to begin the process of exporting contents of a primary mailbox or archive to a .pst file. Note that this is done on a per-mailbox basis and this cmdlet is available only in on-premises Exchange.
+The `New-MailBoxExportRequest` cmdlet is used to begin the process of exporting contents of a primary mailbox or archive
+to a .pst file. Note that this is done on a per-mailbox basis and this cmdlet is available only in on-premises Exchange.
 
-Attackers can abuse this functionality in preparation for exfiltrating contents, which is likely to contain sensitive and strategic data.
+Attackers can abuse this functionality in preparation for exfiltrating contents, which is likely to contain sensitive
+and strategic data.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Investigate the export operation:
   - Identify the user account that performed the action and whether it should perform this kind of action.
   - Contact the account owner and confirm whether they are aware of this activity.
   - Check if this operation was approved and performed according to the organization's change management policy.
   - Retrieve the operation status and use the `Get-MailboxExportRequest` cmdlet to review previous requests.
-  - By default, no group in Exchange has the privilege to import or export mailboxes. Investigate administrators that assigned the "Mailbox Import Export" privilege for abnormal activity.
-- Investigate if there is a significant quantity of export requests in the alert timeframe. This operation is done on a per-mailbox basis and can be part of a mass export.
+  - By default, no group in Exchange has the privilege to import or export mailboxes. Investigate administrators that
+  assigned the "Mailbox Import Export" privilege for abnormal activity.
+- Investigate if there is a significant quantity of export requests in the alert timeframe. This operation is done on
+a per-mailbox basis and can be part of a mass export.
 - If the operation was completed successfully:
   - Check if the file is on the path specified in the command.
   - Investigate if the file was compressed, archived, or retrieved by the attacker for exfiltration.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity and it is done with proper approval.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity
+and it is done with proper approval.
 
 ### Response and remediation
 
@@ -51,11 +57,16 @@ Attackers can abuse this functionality in preparation for exfiltrating contents,
 - If the involved host is not the Exchange server, isolate the host to prevent further post-compromise behavior.
 - Use the `Remove-MailboxExportRequest` cmdlet to remove fully or partially completed export requests.
 - Prioritize cases that involve personally identifiable information (PII) or other classified data.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Review the privileges of users with the "Mailbox Import Export" privilege to ensure that the least privilege principle is being followed.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Review the privileges of users with the "Mailbox Import Export" privilege to ensure that the least privilege principle
+is being followed.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/collection_posh_audio_capture.toml
+++ b/rules/windows/collection_posh_audio_capture.toml
@@ -18,14 +18,18 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell Suspicious Script with Audio Capture Capabilities
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can use PowerShell to interact with the Windows API with the intent of capturing audio from input devices connected to the victim's computer.
+Attackers can use PowerShell to interact with the Windows API with the intent of capturing audio from input devices
+connected to the victim's computer.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -35,7 +39,8 @@ Attackers can use PowerShell to interact with the Windows API with the intent of
 
 ### False positive analysis
 
-- Regular users should not need scripts to capture audio, which makes false positives unlikely. In the case of authorized benign true positives (B-TPs), exceptions can be added.
+- Regular users should not need scripts to capture audio, which makes false positives unlikely. In the case of
+authorized benign true positives (B-TPs), exceptions can be added.
 
 ### Related rules
 
@@ -47,11 +52,15 @@ Attackers can use PowerShell to interact with the Windows API with the intent of
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - The response must be prioritized if this alert involves key executives or potentially valuable targets for espionage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/collection_posh_keylogger.toml
+++ b/rules/windows/collection_posh_keylogger.toml
@@ -21,14 +21,18 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell Keylogging Script
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can abuse PowerShell capabilities to capture user keystrokes with the goal of stealing credentials and other valuable information as credit card data and confidential conversations.
+Attackers can abuse PowerShell capabilities to capture user keystrokes with the goal of stealing credentials and other
+valuable information as credit card data and confidential conversations.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -38,7 +42,8 @@ Attackers can abuse PowerShell capabilities to capture user keystrokes with the 
 
 ### False positive analysis
 
-- Regular users do not have a business justification for using scripting utilities to capture keystrokes, making false positives unlikely. In the case of authorized benign true positives (B-TPs), exceptions can be added.
+- Regular users do not have a business justification for using scripting utilities to capture keystrokes, making
+false positives unlikely. In the case of authorized benign true positives (B-TPs), exceptions can be added.
 
 ### Related rules
 
@@ -50,10 +55,14 @@ Attackers can abuse PowerShell capabilities to capture user keystrokes with the 
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - The response must be prioritized if this alert involves key executives or potentially valuable targets for espionage.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/collection_posh_screen_grabber.toml
+++ b/rules/windows/collection_posh_screen_grabber.toml
@@ -21,14 +21,18 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell Suspicious Script with Screenshot Capabilities
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks, which makes it available for use in various environments and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks, which makes
+it available for use in various environments and creates an attractive way for attackers to execute code.
 
-Attackers can abuse PowerShell capabilities and take screen captures of desktops to gather information over the course of an operation.
+Attackers can abuse PowerShell capabilities and take screen captures of desktops to gather information over the course
+of an operation.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -38,7 +42,8 @@ Attackers can abuse PowerShell capabilities and take screen captures of desktops
 
 ### False positive analysis
 
-- Regular users do not have a business justification for using scripting utilities to take screenshots, which makes false positives unlikely. In the case of authorized benign true positives (B-TPs), exceptions can be added.
+- Regular users do not have a business justification for using scripting utilities to take screenshots, which makes false
+positives unlikely. In the case of authorized benign true positives (B-TPs), exceptions can be added.
 
 ### Related rules
 
@@ -49,10 +54,14 @@ Attackers can abuse PowerShell capabilities and take screen captures of desktops
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/collection_winrar_encryption.toml
+++ b/rules/windows/collection_winrar_encryption.toml
@@ -21,33 +21,42 @@ note = """## Triage and analysis
 
 ### Investigating Encrypting Files with WinRar or 7z
 
-Attackers may compress and/or encrypt data collected before exfiltration. Compressing the data can help obfuscate the collected data and minimize the amount of data sent over the network. Encryption can be used to hide information that is being exfiltrated from detection or make exfiltration less apparent upon inspection by a defender.
+Attackers may compress and/or encrypt data collected before exfiltration. Compressing the data can help obfuscate the
+collected data and minimize the amount of data sent over the network. Encryption can be used to hide information that is
+being exfiltrated from detection or make exfiltration less apparent upon inspection by a defender.
 
 These steps are usually done in preparation for exfiltration, meaning the attack may be in its final stages.
 
 #### Possible investigation steps
 
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Retrieve the encrypted file.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Check if the password used in the encryption was included in the command line.
 - Decrypt the `.rar`/`.zip` and check if the information is sensitive.
-- If the password is not available, and the format is `.zip` or the option used in WinRAR is not the `-hp`, list the file names included in the encrypted file.
+- If the password is not available, and the format is `.zip` or the option used in WinRAR is not the `-hp`, list the
+file names included in the encrypted file.
 - Investigate if the file was transferred to an attacker-controlled server.
 
 ### False positive analysis
 
-- Backup software can use these utilities. Check the `process.parent.executable` and `process.parent.command_line` fields to determine what triggered the encryption.
+- Backup software can use these utilities. Check the `process.parent.executable` and
+`process.parent.command_line` fields to determine what triggered the encryption.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Prioritize cases that involve personally identifiable information (PII) or other classified data.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/command_and_control_certutil_network_connection.toml
+++ b/rules/windows/command_and_control_certutil_network_connection.toml
@@ -21,16 +21,19 @@ note = """## Triage and analysis
 
 ### Investigating Network Connection via Certutil
 
-Attackers can abuse `certutil.exe` to download malware, offensive security tools, and certificates from external sources in order to take the next steps in a compromised environment.
+Attackers can abuse `certutil.exe` to download malware, offensive security tools, and certificates from external sources
+in order to take the next steps in a compromised environment.
 
-This rule looks for network events where `certutil.exe` contacts IP ranges other than the ones specified in [IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml)
+This rule looks for network events where `certutil.exe` contacts IP ranges other than the ones specified in
+[IANA IPv4 Special-Purpose Address Registry](https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml)
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Investigate if the downloaded file was executed.
 - Determine the context in which `certutil.exe` and the file were run.
@@ -38,21 +41,25 @@ This rule looks for network events where `certutil.exe` contacts IP ranges other
   - Analyze the downloaded file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. If trusted software uses this command and the triage has not identified anything suspicious, this alert can be closed as a false positive.
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- This mechanism can be used legitimately. If trusted software uses this command and the triage has not identified
+anything suspicious, this alert can be closed as a false positive.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination
+of user and command line conditions.
 
 ### Response and remediation
 
@@ -62,11 +69,14 @@ This rule looks for network events where `certutil.exe` contacts IP ranges other
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml",

--- a/rules/windows/command_and_control_common_webservices.toml
+++ b/rules/windows/command_and_control_common_webservices.toml
@@ -23,16 +23,20 @@ note = """## Triage and analysis
 
 ### Investigating Connection to Commonly Abused Web Services
 
-Adversaries may use an existing, legitimate external Web service as a means for relaying data to/from a compromised system. Popular websites and social media acting as a mechanism for C2 may give a significant amount of cover due to the likelihood that hosts within a network are already communicating with them prior to a compromise.
+Adversaries may use an existing, legitimate external Web service as a means for relaying data to/from a compromised
+system. Popular websites and social media acting as a mechanism for C2 may give a significant amount of cover due to the
+likelihood that hosts within a network are already communicating with them prior to a compromise.
 
-This rule looks for processes outside known legitimate program locations communicating with a list of services that can be abused for exfiltration or command and control.
+This rule looks for processes outside known legitimate program locations communicating with a list of services that can
+be abused for exfiltration or command and control.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Verify whether the digital signature exists in the executable.
 - Identify the operation type (upload, download, tunneling, etc.).
@@ -40,20 +44,23 @@ This rule looks for processes outside known legitimate program locations communi
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This rule has a high chance to produce false positives because it detects communication with legitimate services. Noisy false positives can be added as exceptions.
+- This rule has a high chance to produce false positives because it detects communication with legitimate services. Noisy
+false positives can be added as exceptions.
 
 ### Response and remediation
 
@@ -63,11 +70,14 @@ This rule looks for processes outside known legitimate program locations communi
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 21
 rule_id = "66883649-f908-4a5b-a1e0-54090a1d3a32"

--- a/rules/windows/command_and_control_dns_tunneling_nslookup.toml
+++ b/rules/windows/command_and_control_dns_tunneling_nslookup.toml
@@ -21,22 +21,28 @@ note = """## Triage and analysis
 
 ### Investigating Potential DNS Tunneling via NsLookup
 
-Attackers can abuse existing network rules that allow DNS communication with external resources to use the protocol as their command and control and/or exfiltration channel.
+Attackers can abuse existing network rules that allow DNS communication with external resources to use the protocol as
+their command and control and/or exfiltration channel.
 
-DNS queries can be used to infiltrate data such as commands to be run, malicious files, etc., and also for exfiltration, since queries can be used to send data to the attacker-controlled DNS server. This process is commonly known as DNS tunneling.
+DNS queries can be used to infiltrate data such as commands to be run, malicious files, etc., and also for exfiltration,
+since queries can be used to send data to the attacker-controlled DNS server. This process is commonly known as DNS tunneling.
 
-More information on how tunneling works and how it can be abused can be found on [Palo Alto Unit42 Research](https://unit42.paloaltonetworks.com/dns-tunneling-how-dns-can-be-abused-by-malicious-actors).
+More information on how tunneling works and how it can be abused can be found on
+[Palo Alto Unit42 Research](https://unit42.paloaltonetworks.com/dns-tunneling-how-dns-can-be-abused-by-malicious-actors).
 
 #### Possible investigation steps
 
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the DNS query and identify the information sent.
-- Extract this communication's indicators of compromise (IoCs) and use traffic logs to search for other potentially compromised hosts.
+- Extract this communication's indicators of compromise (IoCs) and use traffic logs to search for other potentially
+compromised hosts.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. If the parent process is trusted and the data sent is not sensitive nor command and control related, this alert can be closed.
+- This mechanism can be used legitimately. If the parent process is trusted and the data sent is not sensitive nor
+command and control related, this alert can be closed.
 
 ### Response and remediation
 
@@ -44,12 +50,16 @@ More information on how tunneling works and how it can be abused can be found on
 - Isolate the involved host to prevent further post-compromise behavior.
 - Immediately block the identified indicators of compromise (IoCs).
 - Implement any temporary network rules, procedures, and segmentation required to contain the attack.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Update firewall rules to be more restrictive.
 - Reimage the host operating system or restore the compromised files to clean versions.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = ["https://unit42.paloaltonetworks.com/dns-tunneling-in-the-wild-overview-of-oilrigs-dns-tunneling/"]
 risk_score = 47

--- a/rules/windows/command_and_control_port_forwarding_added_registry.toml
+++ b/rules/windows/command_and_control_port_forwarding_added_registry.toml
@@ -21,26 +21,32 @@ note = """## Triage and analysis
 
 ### Investigating Port Forwarding Rule Addition
 
-Network port forwarding is a mechanism to redirect incoming TCP connections (IPv4 or IPv6) from the local TCP port to any other port number, or even to a port on a remote computer.
+Network port forwarding is a mechanism to redirect incoming TCP connections (IPv4 or IPv6) from the local TCP port to
+any other port number, or even to a port on a remote computer.
 
-Attackers may configure port forwarding rules to bypass network segmentation restrictions, using the host as a jump box to access previously unreachable systems.
+Attackers may configure port forwarding rules to bypass network segmentation restrictions, using the host as a jump box
+to access previously unreachable systems.
 
 This rule monitors the modifications to the `HKLM\\SYSTEM\\*ControlSet*\\Services\\PortProxy\\v4tov4\\` subkeys.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account and system owners and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
-- Identify the target host IP address, check the connections originating from the host where the modification occurred, and inspect the credentials used.
+- Identify the target host IP address, check the connections originating from the host where the modification occurred,
+and inspect the credentials used.
   - Investigate suspicious login activity, such as unauthorized access and logins from outside working hours and unusual locations.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the Administrator is aware of the activity and there are justifications for this configuration.
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the Administrator is aware of the activity
+and there are justifications for this configuration.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination
+of user and command line conditions.
 
 ### Response and remediation
 
@@ -51,12 +57,17 @@ This rule monitors the modifications to the `HKLM\\SYSTEM\\*ControlSet*\\Service
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/command_and_control_rdp_tunnel_plink.toml
+++ b/rules/windows/command_and_control_rdp_tunnel_plink.toml
@@ -21,15 +21,20 @@ note = """## Triage and analysis
 
 ### Investigating Potential Remote Desktop Tunneling Detected
 
-Protocol Tunneling is a mechanism that involves explicitly encapsulating a protocol within another for various use cases, ranging from providing an outer layer of encryption (similar to a VPN) to enabling traffic that network appliances would filter to reach their destination.
+Protocol Tunneling is a mechanism that involves explicitly encapsulating a protocol within another for various use cases,
+ranging from providing an outer layer of encryption (similar to a VPN) to enabling traffic that network appliances would
+filter to reach their destination.
 
-Attackers may tunnel Remote Desktop Protocol (RDP) traffic through other protocols like Secure Shell (SSH) to bypass network restrictions that block incoming RDP connections but may be more permissive to other protocols.
+Attackers may tunnel Remote Desktop Protocol (RDP) traffic through other protocols like Secure Shell (SSH) to bypass network restrictions that block incoming RDP
+connections but may be more permissive to other protocols.
 
-This rule looks for command lines involving the `3389` port, which RDP uses by default and options commonly associated with tools that perform tunneling.
+This rule looks for command lines involving the `3389` port, which RDP uses by default and options commonly associated
+with tools that perform tunneling.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account and system owners and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -45,11 +50,16 @@ This rule looks for command lines involving the `3389` port, which RDP uses by d
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Take the necessary actions to disable the tunneling, which can be a process kill, service deletion, registry key modification, etc. Inspect the host to learn which method was used and to determine a response for the case.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Take the necessary actions to disable the tunneling, which can be a process kill, service deletion, registry key
+modification, etc. Inspect the host to learn which method was used and to determine a response for the case.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
+++ b/rules/windows/command_and_control_remote_file_copy_desktopimgdownldr.toml
@@ -21,39 +21,46 @@ note = """## Triage and analysis
 
 ### Investigating Remote File Download via Desktopimgdownldr Utility
 
-Attackers commonly transfer tooling or malware from external systems into a compromised environment using the command and control channel. However, they can also abuse signed utilities to drop these files.
+Attackers commonly transfer tooling or malware from external systems into a compromised environment using the command
+and control channel. However, they can also abuse signed utilities to drop these files.
 
-The `Desktopimgdownldr.exe` utility is used to to configure lockscreen/desktop image, and can be abused with the `lockscreenurl` argument to download remote files and tools, this rule looks for this behavior.
+The `Desktopimgdownldr.exe` utility is used to to configure lockscreen/desktop image, and can be abused with the
+`lockscreenurl` argument to download remote files and tools, this rule looks for this behavior.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
-- Check the reputation of the domain or IP address used to host the downloaded file or if the user downloaded the file from an internal system.
+- Check the reputation of the domain or IP address used to host the downloaded file or if the user downloaded the file
+from an internal system.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This activity is unusual but can be done by administrators. Benign true positives (B-TPs) can be added as exceptions if necessary.
+- This activity is unusual but can be done by administrators. Benign true positives (B-TPs) can be added as exceptions
+if necessary.
 - Analysts can dismiss the alert if the downloaded file is a legitimate image.
 
 ### Response and remediation
@@ -64,12 +71,17 @@ The `Desktopimgdownldr.exe` utility is used to to configure lockscreen/desktop i
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
+++ b/rules/windows/command_and_control_remote_file_copy_mpcmdrun.toml
@@ -18,16 +18,20 @@ note = """## Triage and analysis
 
 ### Investigating Remote File Download via MpCmdRun
 
-Attackers commonly transfer tooling or malware from external systems into a compromised environment using the command and control channel. However, they can also abuse signed utilities to drop these files.
+Attackers commonly transfer tooling or malware from external systems into a compromised environment using the command
+and control channel. However, they can also abuse signed utilities to drop these files.
 
-The `MpCmdRun.exe` is a command-line tool part of Windows Defender and is used to manage various Microsoft Windows Defender Antivirus settings and perform certain tasks. It can also be abused by attackers to download remote files, including malware and offensive tooling. This rule looks for the patterns used to perform downloads using the utility.
+The `MpCmdRun.exe` is a command-line tool part of Windows Defender and is used to manage various Microsoft Windows
+Defender Antivirus settings and perform certain tasks. It can also be abused by attackers to download remote files,
+including malware and offensive tooling. This rule looks for the patterns used to perform downloads using the utility.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -36,16 +40,18 @@ The `MpCmdRun.exe` is a command-line tool part of Windows Defender and is used t
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -59,12 +65,17 @@ The `MpCmdRun.exe` is a command-line tool part of Windows Defender and is used t
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/command_and_control_remote_file_copy_powershell.toml
+++ b/rules/windows/command_and_control_remote_file_copy_powershell.toml
@@ -18,16 +18,21 @@ note = """## Triage and analysis
 
 ### Investigating Remote File Download via PowerShell
 
-Attackers commonly transfer tooling or malware from external systems into a compromised environment using the command and control channel. However, they can also abuse signed utilities to drop these files.
+Attackers commonly transfer tooling or malware from external systems into a compromised environment using the command
+and control channel. However, they can also abuse signed utilities to drop these files.
 
-PowerShell is one of system administrators' main tools for automation, report routines, and other tasks. This makes it available for use in various environments and creates an attractive way for attackers to execute code and perform actions. This rule correlates network and file events to detect downloads of executable and script files performed using PowerShell.
+PowerShell is one of system administrators' main tools for automation, report routines, and other tasks. This makes it
+available for use in various environments and creates an attractive way for attackers to execute code and perform
+actions. This rule correlates network and file events to detect downloads of executable and script files performed using
+PowerShell.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -36,20 +41,23 @@ PowerShell is one of system administrators' main tools for automation, report ro
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- Administrators can use PowerShell legitimately to download executable and script files. Analysts can dismiss the alert if the Administrator is aware of the activity and the triage has not identified suspicious or malicious files.
+- Administrators can use PowerShell legitimately to download executable and script files. Analysts can dismiss the alert
+if the Administrator is aware of the activity and the triage has not identified suspicious or malicious files.
 
 ### Response and remediation
 
@@ -59,12 +67,17 @@ PowerShell is one of system administrators' main tools for automation, report ro
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 47
 rule_id = "33f306e8-417c-411b-965c-c2812d6d3f4d"

--- a/rules/windows/command_and_control_remote_file_copy_scripts.toml
+++ b/rules/windows/command_and_control_remote_file_copy_scripts.toml
@@ -21,9 +21,11 @@ note = """## Triage and analysis
 
 ### Investigating Remote File Download via Script Interpreter
 
-The Windows Script Host (WSH) is a Windows automation technology, which is ideal for non-interactive scripting needs, such as logon scripting, administrative scripting, and machine automation.
+The Windows Script Host (WSH) is a Windows automation technology, which is ideal for non-interactive scripting needs,
+such as logon scripting, administrative scripting, and machine automation.
 
-Attackers commonly use WSH scripts as their initial access method, acting like droppers for second stage payloads, but can also use them to download tools and utilities needed to accomplish their goals.
+Attackers commonly use WSH scripts as their initial access method, acting like droppers for second stage payloads, but
+can also use them to download tools and utilities needed to accomplish their goals.
 
 This rule looks for DLLs and executables downloaded using `cscript.exe` or `wscript.exe`.
 
@@ -32,25 +34,29 @@ This rule looks for DLLs and executables downloaded using `cscript.exe` or `wscr
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze both the script and the executable involved using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- The usage of these script engines by regular users is unlikely. In the case of authorized benign true positives (B-TPs), exceptions can be added.
+- The usage of these script engines by regular users is unlikely. In the case of authorized benign true positives
+(B-TPs), exceptions can be added.
 
 ### Response and remediation
 
@@ -60,12 +66,17 @@ This rule looks for DLLs and executables downloaded using `cscript.exe` or `wscr
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 47
 rule_id = "1d276579-3380-4095-ad38-e596a01bc64f"

--- a/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
+++ b/rules/windows/command_and_control_sunburst_c2_activity_detected.toml
@@ -21,36 +21,48 @@ note = """## Triage and analysis
 
 ### Investigating SUNBURST Command and Control Activity
 
-SUNBURST is a trojanized version of a digitally signed SolarWinds Orion plugin called SolarWinds.Orion.Core.BusinessLayer.dll. The plugin contains a backdoor that communicates via HTTP to third-party servers. After an initial dormant period of up to two weeks, SUNBURST may retrieve and execute commands that instruct the backdoor to transfer files, execute files, profile the system, reboot the system, and disable system services. The malware's network traffic attempts to blend in with legitimate SolarWinds activity by imitating the Orion Improvement Program (OIP) protocol, and the malware stores persistent state data within legitimate plugin configuration files. The backdoor uses multiple obfuscated blocklists to identify processes, services, and drivers associated with forensic and anti-virus tools.
+SUNBURST is a trojanized version of a digitally signed SolarWinds Orion plugin called
+SolarWinds.Orion.Core.BusinessLayer.dll. The plugin contains a backdoor that communicates via HTTP to third-party
+servers. After an initial dormant period of up to two weeks, SUNBURST may retrieve and execute commands that instruct
+the backdoor to transfer files, execute files, profile the system, reboot the system, and disable system services.
+The malware's network traffic attempts to blend in with legitimate SolarWinds activity by imitating the Orion
+Improvement Program (OIP) protocol, and the malware stores persistent state data within legitimate plugin configuration files. The
+backdoor uses multiple obfuscated blocklists to identify processes, services, and drivers associated with forensic and
+anti-virus tools.
 
 More details on SUNBURST can be found on the [Mandiant Report](https://www.mandiant.com/resources/sunburst-additional-technical-details).
 
-This rule identifies suspicious network connections that attempt to blend in with legitimate SolarWinds activity by imitating the Orion Improvement Program (OIP) protocol behavior.
+This rule identifies suspicious network connections that attempt to blend in with legitimate SolarWinds activity
+by imitating the Orion Improvement Program (OIP) protocol behavior.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the executable involved using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This activity should not happen legitimately. The security team should address any potential benign true positive (B-TP), as this configuration can put the environment at risk.
+- This activity should not happen legitimately. The security team should address any potential benign true positive
+(B-TP), as this configuration can put the environment at risk.
 
 ### Response and remediation
 
@@ -60,12 +72,15 @@ This rule identifies suspicious network connections that attempt to blend in wit
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Reimage the host operating system and restore compromised files to clean versions.
 - Upgrade SolarWinds systems to the latest version to eradicate the chance of reinfection by abusing the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "https://www.fireeye.com/blog/threat-research/2020/12/evasive-attacker-leverages-solarwinds-supply-chain-compromises-with-sunburst-backdoor.html",

--- a/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
+++ b/rules/windows/command_and_control_teamviewer_remote_file_copy.toml
@@ -18,37 +18,45 @@ note = """## Triage and analysis
 
 ### Investigating Remote File Copy via TeamViewer
 
-Attackers commonly transfer tooling or malware from external systems into a compromised environment using the command and control channel. However, they can also abuse legitimate utilities to drop these files.
+Attackers commonly transfer tooling or malware from external systems into a compromised environment using the command
+and control channel. However, they can also abuse legitimate utilities to drop these files.
 
-TeamViewer is a remote access and remote control tool used by helpdesks and system administrators to perform various support activities. It is also frequently used by attackers and scammers to deploy malware interactively and other malicious activities. This rule looks for the TeamViewer process creating files with suspicious extensions.
+TeamViewer is a remote access and remote control tool used by helpdesks and system administrators to perform various
+support activities. It is also frequently used by attackers and scammers to deploy malware interactively and other
+malicious activities. This rule looks for the TeamViewer process creating files with suspicious extensions.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Contact the user to gather information about who and why was conducting the remote access.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Check whether the company uses TeamViewer for the support activities and if there is a support ticket related to this access.
+- Check whether the company uses TeamViewer for the support activities and if there is a support ticket related to this
+access.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the company relies on TeamViewer to conduct remote access and the triage has not identified suspicious or malicious files.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the company relies on TeamViewer to conduct
+remote access and the triage has not identified suspicious or malicious files.
 
 ### Response and remediation
 
@@ -58,11 +66,16 @@ TeamViewer is a remote access and remote control tool used by helpdesks and syst
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/credential_access_bruteforce_admin_account.toml
+++ b/rules/windows/credential_access_bruteforce_admin_account.toml
@@ -39,12 +39,17 @@ note = """## Triage and analysis
 - Initiate the incident response process based on the outcome of the triage.
 - If the host is a domain controller (DC):
   - Activate your incident response plan for total Active Directory compromise.
-  - Review the privileges assigned to users that can access the DCs, to ensure that the least privilege principle is being followed and to reduce the attack surface.
+  - Review the privileges assigned to users that can access the DCs, to ensure that the least privilege principle is
+  being followed and to reduce the attack surface.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
@@ -39,12 +39,17 @@ note = """## Triage and analysis
 - Initiate the incident response process based on the outcome of the triage.
 - If the host is a domain controller (DC):
   - Activate your incident response plan for total Active Directory compromise.
-  - Review the privileges assigned to users that can access the DCs, to ensure that the least privilege principle is being followed and to reduce the attack surface.
+  - Review the privileges assigned to users that can access the DCs, to ensure that the least privilege principle is
+  being followed and to reduce the attack surface.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
@@ -43,12 +43,17 @@ note = """## Triage and analysis
 - Initiate the incident response process based on the outcome of the triage.
 - If the host is a domain controller (DC):
   - Activate your incident response plan for total Active Directory compromise.
-  - Review the privileges assigned to users that can access the DCs, to ensure that the least privilege principle is being followed and to reduce the attack surface.
+  - Review the privileges assigned to users that can access the DCs, to ensure that the least privilege principle is
+  being followed and to reduce the attack surface.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_cmdline_dump_tool.toml
+++ b/rules/windows/credential_access_cmdline_dump_tool.toml
@@ -21,35 +21,47 @@ note = """## Triage and analysis
 
 ### Investigating Potential Credential Access via Windows Utilities
 
-Local Security Authority Server Service (LSASS) is a process in Microsoft Windows operating systems that is responsible for enforcing security policy on the system. It verifies users logging on to a Windows computer or server, handles password changes, and creates access tokens.
+Local Security Authority Server Service (LSASS) is a process in Microsoft Windows operating systems that is responsible
+for enforcing security policy on the system. It verifies users logging on to a Windows computer or server, handles
+password changes, and creates access tokens.
 
-The `Ntds.dit` file is a database that stores Active Directory data, including information about user objects, groups, and group membership.
+The `Ntds.dit` file is a database that stores Active Directory data, including information about user objects, groups, and
+group membership.
 
-This rule looks for the execution of utilities that can extract credential data from the LSASS memory and Active Directory `Ntds.dit` file.
+This rule looks for the execution of utilities that can extract credential data from the LSASS memory and Active
+Directory `Ntds.dit` file.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file
+modifications, and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Examine the command line to identify what information was targeted.
 - Identify the target computer and its role in the IT environment.
 
 ### False positive analysis
 
-- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently malicious must be monitored by the security team.
+- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently malicious
+must be monitored by the security team.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - If the host is a domain controller (DC):
   - Activate your incident response plan for total Active Directory compromise.
-  - Review the privileges assigned to users that can access the DCs, to ensure that the least privilege principle is being followed and to reduce the attack surface.
+  - Review the privileges assigned to users that can access the DCs, to ensure that the least privilege principle is
+  being followed and to reduce the attack surface.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_credential_dumping_msbuild.toml
+++ b/rules/windows/credential_access_credential_dumping_msbuild.toml
@@ -22,35 +22,46 @@ note = """## Triage and analysis
 
 ### Investigating Potential Credential Access via Trusted Developer Utility
 
-The Microsoft Build Engine is a platform for building applications. This engine, also known as MSBuild, provides an XML schema for a project file that controls how the build platform processes and builds software.
+The Microsoft Build Engine is a platform for building applications. This engine, also known as MSBuild, provides an XML
+schema for a project file that controls how the build platform processes and builds software.
 
-Adversaries can abuse MSBuild to proxy the execution of malicious code. The inline task capability of MSBuild that was introduced in .NET version 4 allows for C# or Visual Basic code to be inserted into an XML project file. MSBuild will compile and execute the inline task. `MSBuild.exe` is a signed Microsoft binary, and the execution of code using it can bypass application control defenses that are configured to allow `MSBuild.exe` execution.
+Adversaries can abuse MSBuild to proxy the execution of malicious code. The inline task capability of MSBuild that was
+introduced in .NET version 4 allows for C# or Visual Basic code to be inserted into an XML project file. MSBuild will
+compile and execute the inline task. `MSBuild.exe` is a signed Microsoft binary, and the execution of code using it can bypass
+application control defenses that are configured to allow `MSBuild.exe` execution.
 
-This rule looks for the MSBuild process loading `vaultcli.dll` or `SAMLib.DLL`, which indicates the execution of credential access activities.
+This rule looks for the MSBuild process loading `vaultcli.dll` or `SAMLib.DLL`, which indicates the execution of
+credential access activities.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file
+modifications, and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Examine the command line to identify the `.csproj` file location.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
+- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target
+host after the registry modification.
 
 ### False positive analysis
 
@@ -64,12 +75,17 @@ This rule looks for the MSBuild process loading `vaultcli.dll` or `SAMLib.DLL`, 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 73
 rule_id = "9d110cb3-5f4b-4c9a-b9f5-53f0a1707ae5"

--- a/rules/windows/credential_access_dcsync_replication_rights.toml
+++ b/rules/windows/credential_access_dcsync_replication_rights.toml
@@ -22,38 +22,60 @@ note = """## Triage and analysis
 
 ### Investigating Potential Credential Access via DCSync
 
-Active Directory replication is the process by which the changes that originate on one domain controller are automatically transferred to other domain controllers that store the same data.
+Active Directory replication is the process by which the changes that originate on one domain controller are
+automatically transferred to other domain controllers that store the same data.
 
-Active Directory data consists of objects that have properties, or attributes. Each object is an instance of an object class, and object classes and their respective attributes are defined in the Active Directory schema. Objects are defined by the values of their attributes, and changes to attribute values must be transferred from the domain controller on which they occur to every other domain controller that stores a replica of an affected object.
+Active Directory data consists of objects that have properties, or attributes. Each object is an instance of an object
+class, and object classes and their respective attributes are defined in the Active Directory schema. Objects are
+defined by the values of their attributes, and changes to attribute values must be transferred from the domain
+controller on which they occur to every other domain controller that stores a replica of an affected object.
 
-Adversaries can use the DCSync technique that uses Windows Domain Controller's API to simulate the replication process from a remote domain controller, compromising major credential material such as the Kerberos krbtgt keys used legitimately for tickets creation, but also tickets forging by attackers. This attack requires some extended privileges to succeed (DS-Replication-Get-Changes and DS-Replication-Get-Changes-All), which are granted by default to members of the Administrators, Domain Admins, Enterprise Admins, and Domain Controllers groups. Privileged accounts can be abused to grant controlled objects the right to DCsync/Replicate.
+Adversaries can use the DCSync technique that uses Windows Domain Controller's API to simulate the replication process
+from a remote domain controller, compromising major credential material such as the Kerberos krbtgt keys used
+legitimately for tickets creation, but also tickets forging by attackers. This attack requires some extended privileges
+to succeed (DS-Replication-Get-Changes and DS-Replication-Get-Changes-All), which are granted by default to members of
+the Administrators, Domain Admins, Enterprise Admins, and Domain Controllers groups. Privileged accounts can be abused
+to grant controlled objects the right to DCsync/Replicate.
 
 More details can be found on [Threat Hunter Playbook](https://threathunterplaybook.com/library/windows/active_directory_replication.html?highlight=dcsync#directory-replication-services-auditing) and [The Hacker Recipes](https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync).
 
-This rule monitors for Event ID 4662 (Operation was performed on an Active Directory object) and identifies events that use the access mask 0x100 (Control Access) and properties that contain at least one of the following or their equivalent: Schema-Id-GUID (DS-Replication-Get-Changes, DS-Replication-Get-Changes-All, DS-Replication-Get-Changes-In-Filtered-Set). It also filters out events that use computer accounts and also Azure AD Connect MSOL accounts (more details [here](https://techcommunity.microsoft.com/t5/microsoft-defender-for-identity/ad-connect-msol-user-suspected-dcsync-attack/m-p/788028)).
+This rule monitors for Event ID 4662 (Operation was performed on an Active Directory object) and identifies events that
+use the access mask 0x100 (Control Access) and properties that contain at least one of the following or their equivalent:
+Schema-Id-GUID (DS-Replication-Get-Changes, DS-Replication-Get-Changes-All, DS-Replication-Get-Changes-In-Filtered-Set).
+It also filters out events that use computer accounts and also Azure AD Connect MSOL accounts (more details [here](https://techcommunity.microsoft.com/t5/microsoft-defender-for-identity/ad-connect-msol-user-suspected-dcsync-attack/m-p/788028)).
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account and system owners and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Correlate security events 4662 and 4624 (Logon Type 3) by their Logon ID (`winlog.logon.id`) on the Domain Controller (DC) that received the replication request. This will tell you where the AD replication request came from, and if it came from another DC or not.
+- Correlate security events 4662 and 4624 (Logon Type 3) by their Logon ID (`winlog.logon.id`) on the Domain Controller
+(DC) that received the replication request. This will tell you where the AD replication request came from, and if it
+came from another DC or not.
 - Scope which credentials were compromised (for example, whether all accounts were replicated or specific ones).
 
 ### False positive analysis
 
-- This activity should not happen legitimately, since replication should be done by Domain Controllers only. Any potential benign true positive (B-TP) should be mapped and monitored by the security team. Any account that performs this activity can put the domain at risk for not having the same security standards as computer accounts (which have long, complex, random passwords that change frequently), exposing it to credential cracking attacks (Kerberoasting, brute force, etc.).
+- This activity should not happen legitimately, since replication should be done by Domain Controllers only. Any
+potential benign true positive (B-TP) should be mapped and monitored by the security team. Any account that performs
+this activity can put the domain at risk for not having the same security standards as computer accounts (which have
+long, complex, random passwords that change frequently), exposing it to credential cracking attacks (Kerberoasting,
+brute force, etc.).
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - If specific credentials were compromised:
-  - Reset the password for these accounts and other potentially compromised credentials, like email, business systems, and web services.
+  - Reset the password for these accounts and other potentially compromised credentials, like email, business systems,
+  and web services.
 - If the entire domain or the `krbtgt` user were compromised:
-  - Activate your incident response plan for total Active Directory compromise which should include, but not be limited to, a password reset (twice) of the `krbtgt` user.
-- Investigate how the attacker escalated privileges and identify systems they used to conduct lateral movement. Use this information to scope ways that the attacker could use to regain access to the environment.
+  - Activate your incident response plan for total Active Directory compromise which should include, but not be limited
+  to, a password reset (twice) of the `krbtgt` user.
+- Investigate how the attacker escalated privileges and identify systems they used to conduct lateral movement. Use this
+information to scope ways that the attacker could use to regain access to the environment.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_disable_kerberos_preauth.toml
+++ b/rules/windows/credential_access_disable_kerberos_preauth.toml
@@ -22,9 +22,16 @@ note = """## Triage and analysis
 
 ### Investigating Kerberos Pre-authentication Disabled for User
 
-Kerberos pre-authentication is an account protection against offline password cracking. When enabled, a user requesting access to a resource initiates communication with the Domain Controller (DC) by sending an Authentication Server Request (AS-REQ) message with a timestamp that is encrypted with the hash of their password. If and only if the DC is able to successfully decrypt the timestamp with the hash of the user’s password, it will then send an Authentication Server Response (AS-REP) message that contains the Ticket Granting Ticket (TGT) to the user. Part of the AS-REP message is signed with the user’s password. Microsoft's security monitoring [recommendations](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4738) state that `'Don't Require Preauth' – Enabled` should not be enabled for user accounts because it weakens security for the account’s Kerberos authentication.
+Kerberos pre-authentication is an account protection against offline password cracking. When enabled, a user requesting
+access to a resource initiates communication with the Domain Controller (DC) by sending an Authentication Server Request
+(AS-REQ) message with a timestamp that is encrypted with the hash of their password. If and only if the DC is able to
+successfully decrypt the timestamp with the hash of the user’s password, it will then send an Authentication Server
+Response (AS-REP) message that contains the Ticket Granting Ticket (TGT) to the user. Part of the AS-REP message is
+signed with the user’s password. Microsoft's security monitoring [recommendations](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4738) state that `'Don't Require Preauth' – Enabled` should not be enabled for user accounts because it weakens security for the account’s Kerberos authentication.
 
-AS-REP roasting is an attack against Kerberos for user accounts that do not require pre-authentication, which means that if the target user has pre-authentication disabled, an attacker can request authentication data for it and get a TGT that can be brute-forced offline, similarly to Kerberoasting.
+AS-REP roasting is an attack against Kerberos for user accounts that do not require pre-authentication, which means that
+if the target user has pre-authentication disabled, an attacker can request authentication data for it and get a TGT that
+can be brute-forced offline, similarly to Kerberoasting.
 
 #### Possible investigation steps
 
@@ -35,7 +42,8 @@ AS-REP roasting is an attack against Kerberos for user accounts that do not requ
 
 ### False positive analysis
 
-- Disabling pre-authentication is a bad security practice and should not be allowed in the domain. The security team should map and monitor any potential benign true positives (B-TPs), especially if the target account is privileged.
+- Disabling pre-authentication is a bad security practice and should not be allowed in the domain. The security team
+should map and monitor any potential benign true positives (B-TPs), especially if the target account is privileged.
 
 ### Response and remediation
 
@@ -43,8 +51,11 @@ AS-REP roasting is an attack against Kerberos for user accounts that do not requ
 - Reset the target account's password if there is any risk of TGTs having been retrieved.
 - Re-enable the preauthentication option or disable the target account.
 - Review the privileges assigned to the involved users to ensure that the least privilege principle is being followed.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_dump_registry_hives.toml
+++ b/rules/windows/credential_access_dump_registry_hives.toml
@@ -20,24 +20,29 @@ note = """## Triage and analysis
 
 Dumping registry hives is a common way to access credential information as some hives store credential material.
 
-For example, the SAM hive stores locally cached credentials (SAM Secrets), and the SECURITY hive stores domain cached credentials (LSA secrets).
+For example, the SAM hive stores locally cached credentials (SAM Secrets), and the SECURITY hive stores domain cached
+credentials (LSA secrets).
 
 Dumping these hives in combination with the SYSTEM hive enables the attacker to decrypt these secrets.
 
-This rule identifies the usage of `reg.exe` to dump SECURITY and/or SAM hives, which potentially indicates the compromise of the credentials stored in the host.
+This rule identifies the usage of `reg.exe` to dump SECURITY and/or SAM hives, which potentially indicates the
+compromise of the credentials stored in the host.
 
 #### Possible investigation steps
 
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Investigate if the credential material was exfiltrated or processed locally by other tools.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (e.g., 4624) to the target host.
+- Investigate potentially compromised accounts. Analysts can do this by searching for login events (e.g., 4624) to the target
+host.
 
 ### False positive analysis
 
-- Administrators can export registry hives for backup purposes using command line tools like `reg.exe`. Check whether the user is legitamitely performing this kind of activity.
+- Administrators can export registry hives for backup purposes using command line tools like `reg.exe`. Check whether
+the user is legitamitely performing this kind of activity.
 
 ### Related rules
 
@@ -47,11 +52,15 @@ This rule identifies the usage of `reg.exe` to dump SECURITY and/or SAM hives, w
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Reimage the host operating system and restore compromised files to clean versions.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_kerberoasting_unusual_process.toml
+++ b/rules/windows/credential_access_kerberoasting_unusual_process.toml
@@ -26,16 +26,20 @@ note = """## Triage and analysis
 
 ### Investigating Kerberos Traffic from Unusual Process
 
-Kerberos is the default authentication protocol in Active Directory, designed to provide strong authentication for client/server applications by using secret-key cryptography.
+Kerberos is the default authentication protocol in Active Directory, designed to provide strong authentication for
+client/server applications by using secret-key cryptography.
 
-Domain-joined hosts usually perform Kerberos traffic using the `lsass.exe` process. This rule detects the occurrence of traffic on the Kerberos port (88) by processes other than `lsass.exe` to detect the unusual request and usage of Kerberos tickets.
+Domain-joined hosts usually perform Kerberos traffic using the `lsass.exe` process. This rule detects the occurrence of
+traffic on the Kerberos port (88) by processes other than `lsass.exe` to detect the unusual request and usage of
+Kerberos tickets.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Check if the Destination IP is related to a Domain Controller.
 - Review event ID 4769 for suspicious ticket requests.
@@ -43,37 +47,45 @@ Domain-joined hosts usually perform Kerberos traffic using the `lsass.exe` proce
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This rule uses a Kerberos-related port but does not identify the protocol used on that port. HTTP traffic on a non-standard port or destination IP address unrelated to Domain controllers can create false positives.
+- This rule uses a Kerberos-related port but does not identify the protocol used on that port. HTTP traffic on a
+non-standard port or destination IP address unrelated to Domain controllers can create false positives.
 - Exceptions can be added for noisy/frequent connections.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
   - Ticket requests can be used to investigate potentially compromised accounts.
 - If the triage identified malware, search the environment for additional compromised hosts.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_lsass_memdump_handle_access.toml
+++ b/rules/windows/credential_access_lsass_memdump_handle_access.toml
@@ -23,37 +23,48 @@ note = """## Triage and analysis
 
 ### Investigating LSASS Memory Dump Handle Access
 
-Local Security Authority Server Service (LSASS) is a process in Microsoft Windows operating systems that is responsible for enforcing security policy on the system. It verifies users logging on to a Windows computer or server, handles password changes, and creates access tokens.
+Local Security Authority Server Service (LSASS) is a process in Microsoft Windows operating systems that is responsible
+for enforcing security policy on the system. It verifies users logging on to a Windows computer or server, handles
+password changes, and creates access tokens.
 
-Adversaries may attempt to access credential material stored in LSASS process memory. After a user logs on, the system generates and stores a variety of credential materials in LSASS process memory. This is meant to facilitate single sign-on (SSO) ensuring a user isn’t prompted each time resource access is requested. These credential materials can be harvested by an adversary using administrative user or SYSTEM privileges to conduct lateral movement using [alternate authentication material](https://attack.mitre.org/techniques/T1550/).
+Adversaries may attempt to access credential material stored in LSASS process memory. After a user logs on,the system
+generates and stores a variety of credential materials in LSASS process memory. This is meant to facilitate single
+sign-on (SSO) ensuring a user isn’t prompted each time resource access is requested. These credential materials can be
+harvested by an adversary using administrative user or SYSTEM privileges to conduct lateral movement using
+[alternate authentication material](https://attack.mitre.org/techniques/T1550/).
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
 
-- There should be very few or no false positives for this rule. If this activity is expected or noisy in your environment, consider adding exceptions — preferably with a combination of user and command line conditions.
-- If the process is related to antivirus or endpoint detection and response solutions, validate that it is installed on the correct path and signed with the company's valid digital signature.
+- There should be very few or no false positives for this rule. If this activity is expected or noisy in your environment,
+consider adding exceptions — preferably with a combination of user and command line conditions.
+- If the process is related to antivirus or endpoint detection and response solutions, validate that it is installed on
+the correct path and signed with the company's valid digital signature.
 
 ### Response and remediation
 
@@ -64,12 +75,17 @@ Adversaries may attempt to access credential material stored in LSASS process me
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -18,15 +18,22 @@ note = """## Triage and analysis
 
 ### Investigating Mimikatz Memssp Log File Detected
 
-[Mimikatz](https://github.com/gentilkiwi/mimikatz) is an open-source tool used to collect, decrypt, and/or use cached credentials. This tool is commonly abused by adversaries during the post-compromise stage where adversaries have gained an initial foothold on an endpoint and are looking to elevate privileges and seek out additional authentication objects such as tokens/hashes/credentials that can then be used to laterally move and pivot across a network.
+[Mimikatz](https://github.com/gentilkiwi/mimikatz) is an open-source tool used to collect, decrypt, and/or use cached
+credentials. This tool is commonly abused by adversaries during the post-compromise stage where adversaries have gained
+an initial foothold on an endpoint and are looking to elevate privileges and seek out additional authentication objects
+such as tokens/hashes/credentials that can then be used to laterally move and pivot across a network.
 
-This rule looks for the creation of a file named `mimilsa.log`, which is generated when using the Mimikatz misc::memssp module, which injects a malicious Windows SSP to collect locally authenticated credentials, which includes the computer account password, running service credentials, and any accounts that logon.
+This rule looks for the creation of a file named `mimilsa.log`, which is generated when using the Mimikatz misc::memssp
+module, which injects a malicious Windows SSP to collect locally authenticated credentials, which includes the computer
+account password, running service credentials, and any accounts that logon.
 
 #### Possible investigation steps
 
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (e.g., 4624) to the target host.
+- Investigate potentially compromised accounts. Analysts can do this by searching for login events (e.g., 4624) to the target
+host.
 - Retrieve and inspect the log file contents.
 - Search for DLL files created in the same location as the log file, and retrieve unsigned DLLs.
   - Use the PowerShell Get-FileHash cmdlet to get the SHA-256 hash value of these files.
@@ -47,13 +54,18 @@ This rule looks for the creation of a file named `mimilsa.log`, which is generat
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - If the host is a Domain Controller (DC):
   - Activate your incident response plan for total Active Directory compromise.
-  - Review the privileges assigned to users that can access the DCs to ensure that the least privilege principle is being followed and reduce the attack surface.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+  - Review the privileges assigned to users that can access the DCs to ensure that the least privilege principle is
+  being followed and reduce the attack surface.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Reboot the host to remove the injected SSP from memory.
 - Reimage the host operating system or restore compromised files to clean versions.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_mimikatz_powershell_module.toml
+++ b/rules/windows/credential_access_mimikatz_powershell_module.toml
@@ -22,21 +22,30 @@ note = """## Triage and analysis
 
 ### Investigating Mimikatz PowerShell Activity
 
-[Mimikatz](https://github.com/gentilkiwi/mimikatz) is an open-source tool used to collect, decrypt, and/or use cached credentials. This tool is commonly abused by adversaries during the post-compromise stage where adversaries have gained an initial foothold on an endpoint and are looking to elevate privileges and seek out additional authentication objects such as tokens/hashes/credentials that can then be used to move laterally and pivot across a network.
+[Mimikatz](https://github.com/gentilkiwi/mimikatz) is an open-source tool used to collect, decrypt, and/or use cached
+credentials. This tool is commonly abused by adversaries during the post-compromise stage where adversaries have gained
+an initial foothold on an endpoint and are looking to elevate privileges and seek out additional authentication objects
+such as tokens/hashes/credentials that can then be used to move laterally and pivot across a network.
 
-This rule looks for PowerShell scripts that load mimikatz in memory, like Invoke-Mimikataz, which are used to dump credentials from the Local Security Authority Subsystem Service (LSASS). Any activity triggered from this rule should be treated with high priority as it typically represents an active adversary.
+This rule looks for PowerShell scripts that load mimikatz in memory, like Invoke-Mimikataz, which are used to dump
+credentials from the Local Security Authority Subsystem Service (LSASS). Any activity triggered from this rule should be
+treated with high priority as it typically represents an active adversary.
 
 More information about Mimikatz components and how to detect/prevent them can be found on [ADSecurity](https://adsecurity.org/?page_id=1821).
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-  - Invoke-Mimitakz and alike scripts heavily use other capabilities covered by other detections described in the "Related Rules" section.
+  - Invoke-Mimitakz and alike scripts heavily use other capabilities covered by other detections described in the
+  "Related Rules" section.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host.
+- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the
+target host.
   - Examine network and security events in the environment to identify potential lateral movement using compromised credentials.
 
 ### False positive analysis
@@ -56,13 +65,18 @@ More information about Mimikatz components and how to detect/prevent them can be
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
 - Validate that cleartext passwords are disabled in memory for use with `WDigest`.
-- Look into preventing access to `LSASS` using capabilities such as LSA protection or antivirus/EDR tools that provide this capability.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Look into preventing access to `LSASS` using capabilities such as LSA protection or antivirus/EDR tools that provide
+this capability.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_mod_wdigest_security_provider.toml
+++ b/rules/windows/credential_access_mod_wdigest_security_provider.toml
@@ -23,14 +23,21 @@ note = """## Triage and analysis
 
 ### Investigating Modification of WDigest Security Provider
 
-In Windows XP, Microsoft added support for a protocol known as WDigest. The WDigest protocol allows clients to send cleartext credentials to Hypertext Transfer Protocol (HTTP) and Simple Authentication Security Layer (SASL) applications based on RFC 2617 and 2831. Windows versions up to 8 and 2012 store logon credentials in memory in plaintext by default, which is no longer the case with newer Windows versions.
+In Windows XP, Microsoft added support for a protocol known as WDigest. The WDigest protocol allows clients to send
+cleartext credentials to Hypertext Transfer Protocol (HTTP) and Simple Authentication Security Layer (SASL) applications
+based on RFC 2617 and 2831. Windows versions up to 8 and 2012 store logon credentials in memory in plaintext by default,
+which is no longer the case with newer Windows versions.
 
-Still, attackers can force WDigest to store the passwords insecurely on the memory by modifying the `HKLM\\SYSTEM\\*ControlSet*\\Control\\SecurityProviders\\WDigest\\UseLogonCredential` registry key. This activity is commonly related to the execution of credential dumping tools.
+Still, attackers can force WDigest to store the passwords insecurely on the memory by modifying the
+`HKLM\\SYSTEM\\*ControlSet*\\Control\\SecurityProviders\\WDigest\\UseLogonCredential` registry key. This activity is
+commonly related to the execution of credential dumping tools.
 
 #### Possible investigation steps
 
-- It is unlikely that the monitored registry key was modified legitimately in newer versions of Windows. Analysts should treat any activity triggered from this rule with high priority as it typically represents an active adversary.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- It is unlikely that the monitored registry key was modified legitimately in newer versions of Windows. Analysts should
+treat any activity triggered from this rule with high priority as it typically represents an active adversary.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Determine if credential dumping tools were run on the host, and retrieve and analyze suspicious executables:
   - Use a private sandboxed malware analysis system to perform analysis.
@@ -42,11 +49,14 @@ Still, attackers can force WDigest to store the passwords insecurely on the memo
   - Use the PowerShell Get-FileHash cmdlet to get the files' SHA-256 hash values.
     - Search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 - Use process name, command line, and file hash to search for occurrences on other hosts.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target
+host after the registry modification.
 
 ### False positive analysis
 
-- This modification should not happen legitimately. Any potential benign true positive (B-TP) should be mapped and monitored by the security team, as these modifications expose the entire domain to credential compromises and consequently unauthorized access.
+- This modification should not happen legitimately. Any potential benign true positive (B-TP) should be mapped and
+monitored by the security team, as these modifications expose the entire domain to credential compromises and
+consequently unauthorized access.
 
 ### Related rules
 
@@ -56,11 +66,15 @@ Still, attackers can force WDigest to store the passwords insecurely on the memo
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Reimage the host operating system and restore compromised files to clean versions.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_moving_registry_hive_via_smb.toml
+++ b/rules/windows/credential_access_moving_registry_hive_via_smb.toml
@@ -22,9 +22,14 @@ note = """## Triage and analysis
 
 ### Investigating Windows Registry File Creation in SMB Share
 
-Dumping registry hives is a common way to access credential information. Some hives store credential material, as is the case for the SAM hive, which stores locally cached credentials (SAM secrets), and the SECURITY hive, which stores domain cached credentials (LSA secrets). Dumping these hives in combination with the SYSTEM hive enables the attacker to decrypt these secrets.
+Dumping registry hives is a common way to access credential information. Some hives store credential material, as is the
+case for the SAM hive, which stores locally cached credentials (SAM secrets), and the SECURITY hive, which stores domain
+cached credentials (LSA secrets). Dumping these hives in combination with the SYSTEM hive enables the attacker to
+decrypt these secrets.
 
-Attackers can try to evade detection on the host by transferring this data to a system that is not monitored to be parsed and decrypted. This rule identifies the creation or modification of a medium-size registry hive file on an SMB share, which may indicate this kind of exfiltration attempt.
+Attackers can try to evade detection on the host by transferring this data to a system that is not
+monitored to be parsed and decrypted. This rule identifies the creation or modification of a medium-size registry hive
+file on an SMB share, which may indicate this kind of exfiltration attempt.
 
 #### Possible investigation steps
 
@@ -36,7 +41,8 @@ Attackers can try to evade detection on the host by transferring this data to a 
 
 ### False positive analysis
 
-- Administrators can export registry hives for backup purposes. Check whether the user should be performing this kind of activity and is aware of it.
+- Administrators can export registry hives for backup purposes. Check whether the user should be performing this kind of
+activity and is aware of it.
 
 ### Related rules
 
@@ -46,11 +52,15 @@ Attackers can try to evade detection on the host by transferring this data to a 
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Reimage the host operating system and restore compromised files to clean versions.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = ["https://www.elastic.co/security-labs/detect-credential-access"]
 risk_score = 47

--- a/rules/windows/credential_access_posh_minidump.toml
+++ b/rules/windows/credential_access_posh_minidump.toml
@@ -22,14 +22,18 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell MiniDump Script
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can abuse Process Memory Dump capabilities to extract credentials from LSASS or to obtain other privileged information stored in the process memory.
+Attackers can abuse Process Memory Dump capabilities to extract credentials from LSASS or to obtain other
+privileged information stored in the process memory.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -37,7 +41,8 @@ Attackers can abuse Process Memory Dump capabilities to extract credentials from
 
 ### False positive analysis
 
-- Regular users do not have a business justification for using scripting utilities to dump process memory, making false positives unlikely.
+- Regular users do not have a business justification for using scripting utilities to dump process memory, making false
+positives unlikely.
 
 ### Related rules
 
@@ -49,10 +54,14 @@ Attackers can abuse Process Memory Dump capabilities to extract credentials from
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_posh_request_ticket.toml
+++ b/rules/windows/credential_access_posh_request_ticket.toml
@@ -21,35 +21,46 @@ note = """## Triage and analysis
 
 ### Investigating Explicit PowerShell Kerberos Ticket Request
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks, making it available for use in various environments, creating an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks, making
+it available for use in various environments, creating an attractive way for attackers to execute code.
 
-Accounts associated with a service principal name (SPN) are viable targets for Kerberoasting attacks, which use brute force to crack the user password, which is used to encrypt a Kerberos TGS ticket.
+Accounts associated with a service principal name (SPN) are viable targets for Kerberoasting attacks, which use brute
+force to crack the user password, which is used to encrypt a Kerberos TGS ticket.
 
-Attackers can use PowerShell to request these Kerberos tickets, with the intent of extracting them from memory to perform Kerberoasting.
+Attackers can use PowerShell to request these Kerberos tickets, with the intent of extracting them from memory to
+perform Kerberoasting.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate if the script was executed, and if so, which account was targeted.
 - Validate if the account has an SPN associated with it.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Check if the script has any other functionality that can be potentially malicious.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Review event ID [4769](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4769) related to this account and service name for additional information.
+- Review event ID [4769](https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4769)
+related to this account and service name for additional information.
 
 ### False positive analysis
 
-- A possible false positive can be identified if the script content is not malicious/harmful or does not request Kerberos tickets for user accounts, as computer accounts are not vulnerable to Kerberoasting due to complex password requirements and policy.
+- A possible false positive can be identified if the script content is not malicious/harmful or does not request
+Kerberos tickets for user accounts, as computer accounts are not vulnerable to Kerberoasting due to complex password
+requirements and policy.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services. Prioritize privileged accounts.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services. Prioritize privileged accounts.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_remote_sam_secretsdump.toml
+++ b/rules/windows/credential_access_remote_sam_secretsdump.toml
@@ -21,9 +21,13 @@ note = """## Triage and analysis
 
 ### Investigating Potential Remote Credential Access via Registry
 
-Dumping registry hives is a common way to access credential information. Some hives store credential material, such as the SAM hive, which stores locally cached credentials (SAM secrets), and the SECURITY hive, which stores domain cached credentials (LSA secrets). Dumping these hives in combination with the SYSTEM hive enables the attacker to decrypt these secrets.
+Dumping registry hives is a common way to access credential information. Some hives store credential material,
+such as the SAM hive, which stores locally cached credentials (SAM secrets), and the SECURITY hive, which stores domain
+cached credentials (LSA secrets). Dumping these hives in combination with the SYSTEM hive enables the attacker to
+decrypt these secrets.
 
-Attackers can use tools like secretsdump.py or CrackMapExec to dump the registry hives remotely, and use dumped credentials to access other systems in the domain.
+Attackers can use tools like secretsdump.py or CrackMapExec to dump the registry hives remotely, and use dumped
+credentials to access other systems in the domain.
 
 #### Possible investigation steps
 
@@ -31,11 +35,13 @@ Attackers can use tools like secretsdump.py or CrackMapExec to dump the registry
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Determine the privileges of the compromised accounts.
 - Investigate other alerts associated with the user/source host during the past 48 hours.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (e.g., 4624) to the target host.
+- Investigate potentially compromised accounts. Analysts can do this by searching for login events (e.g., 4624) to the target
+host.
 
 ### False positive analysis
 
-- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently malicious must be monitored by the security team.
+- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently malicious
+must be monitored by the security team.
 
 ### Related rules
 
@@ -45,16 +51,21 @@ Attackers can use tools like secretsdump.py or CrackMapExec to dump the registry
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine if other hosts were compromised.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Reimage the host operating system or restore the compromised files to clean versions.
 - Ensure that the machine has the latest security updates and is not running unsupported Windows versions.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 
-This rule uses Elastic Endpoint file creation and system integration events for correlation. Both data should be collected from the host for this detection to work.
+This rule uses Elastic Endpoint file creation and system integration events for correlation. Both data should be
+collected from the host for this detection to work.
 
 If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2, events will not define `event.ingested` and default fallback for EQL rules was not added until 8.2, so you will need to add a custom pipeline to populate `event.ingested` to @timestamp for this rule to work.
 """

--- a/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
+++ b/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
@@ -22,23 +22,36 @@ note = """## Triage and analysis
 
 ### Investigating Sensitive Privilege SeEnableDelegationPrivilege assigned to a User
 
-Kerberos delegation is an Active Directory feature that allows user and computer accounts to impersonate other accounts, act on their behalf, and use their privileges. Delegation (constrained and unconstrained) can be configured for user and computer objects.
+Kerberos delegation is an Active Directory feature that allows user and computer accounts to impersonate other accounts,
+act on their behalf, and use their privileges. Delegation (constrained and unconstrained) can be configured
+for user and computer objects.
 
-Enabling unconstrained delegation for a computer causes the computer to store the ticket-granting ticket (TGT) in memory at any time an account connects to the computer, so it can be used by the computer for impersonation when needed. Risk is heightened if an attacker compromises computers with unconstrained delegation enabled, as they could extract TGTs from memory and then replay them to move laterally on the domain. If the attacker coerces a privileged user to connect to the server, or if the user does so routinely, the account will be compromised and the attacker will be able to pass-the-ticket to privileged assets.
+Enabling unconstrained delegation for a computer causes the computer to store the ticket-granting ticket
+(TGT) in memory at any time an account connects to the computer, so it can be used by the computer for impersonation
+when needed. Risk is heightened if an attacker compromises computers with unconstrained delegation enabled, as they
+could extract TGTs from memory and then replay them to move laterally on the domain. If the attacker coerces a privileged
+user to connect to the server, or if the user does so routinely, the account will be compromised and the attacker will
+be able to pass-the-ticket to privileged assets.
 
-SeEnableDelegationPrivilege is a user right that is controlled within the Local Security Policy of a domain controller and is managed through Group Policy. This setting is named **Enable computer and user accounts to be trusted for delegation**.
+SeEnableDelegationPrivilege is a user right that is controlled within the Local Security Policy of a domain controller
+and is managed through Group Policy. This setting is named **Enable computer and user accounts to be trusted for
+delegation**.
 
-It is critical to control the assignment of this privilege. A user with this privilege and write access to a computer can control delegation settings, perform the attacks described above, and harvest TGTs from any user that connects to the system.
+It is critical to control the assignment of this privilege. A user with this privilege and write access to a computer
+can control delegation settings, perform the attacks described above, and harvest TGTs from any user that connects to
+the system.
 
 #### Possible investigation steps
 
 - Investigate how the privilege was assigned to the user and who assigned it.
-- Investigate other potentially malicious activity that was performed by the user that assigned the privileges using the `user.id` and `winlog.activity_id` fields as a filter during the past 48 hours.
+- Investigate other potentially malicious activity that was performed by the user that assigned the privileges using the
+`user.id` and `winlog.activity_id` fields as a filter during the past 48 hours.
 - Investigate other alerts associated with the users/host during the past 48 hours.
 
 ### False positive analysis
 
-- The SeEnableDelegationPrivilege privilege should not be assigned to users. If this rule is triggered in your environment legitimately, the security team should notify the administrators about the risks of using it.
+- The SeEnableDelegationPrivilege privilege should not be assigned to users. If this rule is triggered in your
+environment legitimately, the security team should notify the administrators about the risks of using it.
 
 ### Related rules
 
@@ -50,7 +63,8 @@ It is critical to control the assignment of this privilege. A user with this pri
 - Remove the privilege from the account.
 - Review the privileges of the administrator account that performed the action.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_spn_attribute_modified.toml
+++ b/rules/windows/credential_access_spn_attribute_modified.toml
@@ -22,15 +22,24 @@ note = """## Triage and analysis
 
 ### Investigating User account exposed to Kerberoasting
 
-Service Principal Names (SPNs) are names by which Kerberos clients uniquely identify service instances for Kerberos target computers.
+Service Principal Names (SPNs) are names by which Kerberos clients uniquely identify service instances for Kerberos target
+computers.
 
-By default, only computer accounts have SPNs, which creates no significant risk, since machine accounts have a default domain policy that rotates their passwords every 30 days, and the password is composed of 120 random characters, making them invulnerable to Kerberoasting.
+By default, only computer accounts have SPNs, which creates no significant risk, since machine accounts have a default
+domain policy that rotates their passwords every 30 days, and the password is composed of 120 random characters, making
+them invulnerable to Kerberoasting.
 
-A user account with an SPN assigned is considered a service account, and is accessible to the entire domain. If any user in the directory requests a ticket-granting service (TGS), the domain controller will encrypt it with the secret key of the account executing the service. An attacker can potentially perform a Kerberoasting attack with this information, as the human-defined password is likely to be less complex.
+A user account with an SPN assigned is considered a service account, and is accessible to the entire domain. If any
+user in the directory requests a ticket-granting service (TGS), the domain controller will encrypt it with the secret
+key of the account executing the service. An attacker can potentially perform a Kerberoasting attack with this
+information, as the human-defined password is likely to be less complex.
 
-For scenarios where SPNs cannot be avoided on user accounts, Microsoft provides the Group Managed Service Accounts (gMSA) feature, which ensures that account passwords are robust and changed regularly and automatically. More information can be found [here](https://docs.microsoft.com/en-us/windows-server/security/group-managed-service-accounts/group-managed-service-accounts-overview).
+For scenarios where SPNs cannot be avoided on user accounts, Microsoft provides the Group Managed Service Accounts (gMSA)
+feature, which ensures that account passwords are robust and changed regularly and automatically. More information can
+be found [here](https://docs.microsoft.com/en-us/windows-server/security/group-managed-service-accounts/group-managed-service-accounts-overview).
 
-Attackers can also perform "Targeted Kerberoasting", which consists of adding fake SPNs to user accounts that they have write privileges to, making them potentially vulnerable to Kerberoasting.
+Attackers can also perform "Targeted Kerberoasting", which consists of adding fake SPNs to user accounts that they have
+write privileges to, making them potentially vulnerable to Kerberoasting.
 
 #### Possible investigation steps
 
@@ -42,15 +51,22 @@ Attackers can also perform "Targeted Kerberoasting", which consists of adding fa
 
 ### False positive analysis
 
-- The use of user accounts as service accounts is a bad security practice and should not be allowed in the domain. The security team should map and monitor any potential benign true positive (B-TP), especially if the account is privileged. Domain Administrators that define this kind of setting can put the domain at risk as user accounts don't have the same security standards as computer accounts (which have long, complex, random passwords that change frequently), exposing them to credential cracking attacks (Kerberoasting, brute force, etc.).
+- The use of user accounts as service accounts is a bad security practice and should not be allowed in the domain. The
+security team should map and monitor any potential benign true positive (B-TP), especially if the account is privileged.
+Domain Administrators that define this kind of setting can put the domain at risk as user accounts don't have the same
+security standards as computer accounts (which have long, complex, random passwords that change frequently), exposing
+them to credential cracking attacks (Kerberoasting, brute force, etc.).
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services. Prioritize privileged accounts.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services. Prioritize privileged accounts.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
+++ b/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
@@ -22,31 +22,42 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious Remote Registry Access via SeBackupPrivilege
 
-SeBackupPrivilege is a privilege that allows file content retrieval, designed to enable users to create backup copies of the system. Since it is impossible to make a backup of something you cannot read, this privilege comes at the cost of providing the user with full read access to the file system. This privilege must bypass any access control list (ACL) placed in the system.
+SeBackupPrivilege is a privilege that allows file content retrieval, designed to enable users to create backup copies of
+the system. Since it is impossible to make a backup of something you cannot read, this privilege comes at the cost of
+providing the user with full read access to the file system. This privilege must bypass any access control list (ACL) placed in the system.
 
-This rule identifies remote access to the registry using an account with Backup Operators group membership. This may indicate an attempt to exfiltrate credentials by dumping the Security Account Manager (SAM) registry hive in preparation for credential access and privileges elevation.
+This rule identifies remote access to the registry using an account with Backup Operators group membership. This may
+indicate an attempt to exfiltrate credentials by dumping the Security Account Manager (SAM) registry hive in preparation
+for credential access and privileges elevation.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
-- Investigate the activities done by the subject user the login session. The field `winlog.event_data.SubjectLogonId` can be used to get this data.
+- Investigate the activities done by the subject user the login session. The field `winlog.event_data.SubjectLogonId`
+can be used to get this data.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Contact the account owner and confirm whether they are aware of this activity.
-- Investigate abnormal behaviors observed by the subject user such as network connections, registry or file modifications, and processes created.
+- Investigate abnormal behaviors observed by the subject user such as network connections, registry or file
+modifications, and processes created.
 - Investigate if the registry file was retrieved or exfiltrated.
 
 ### False positive analysis
 
-- If this activity is expected and noisy in your environment, benign true positives (B-TPs) can be added as exceptions if necessary.
+- If this activity is expected and noisy in your environment, benign true positives (B-TPs) can be added as exceptions
+if necessary.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Limit or disable the involved user account to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/credential_access_symbolic_link_to_shadow_copy_created.toml
+++ b/rules/windows/credential_access_symbolic_link_to_shadow_copy_created.toml
@@ -22,12 +22,16 @@ note = """## Triage and analysis
 
 ### Investigating Symbolic Link to Shadow Copy Created
 
-Shadow copies are backups or snapshots of an endpoint's files or volumes while they are in use. Adversaries may attempt to discover and create symbolic links to these shadow copies in order to copy sensitive information offline. If Active Directory (AD) is in use, often the ntds.dit file is a target as it contains password hashes, but an offline copy is needed to extract these hashes and potentially conduct lateral movement.
+Shadow copies are backups or snapshots of an endpoint's files or volumes while they are in use. Adversaries may attempt
+to discover and create symbolic links to these shadow copies in order to copy sensitive information offline. If Active
+Directory (AD) is in use, often the ntds.dit file is a target as it contains password hashes, but an offline copy is
+needed to extract these hashes and potentially conduct lateral movement.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Determine if a volume shadow copy was recently created on this endpoint.
 - Review privileges of the end user as this requires administrative access.
@@ -47,14 +51,19 @@ Shadow copies are backups or snapshots of an endpoint's files or volumes while t
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - If the entire domain or the `krbtgt` user was compromised:
-  - Activate your incident response plan for total Active Directory compromise which should include, but not be limited to, a password reset (twice) of the `krbtgt` user.
+  - Activate your incident response plan for total Active Directory compromise which should include, but not be limited
+  to, a password reset (twice) of the `krbtgt` user.
 - Locate and remove static files copied from volume shadow copies.
 - Command-Line tool mklink should require administrative access by default unless in developer mode.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_amsienable_key_mod.toml
+++ b/rules/windows/defense_evasion_amsienable_key_mod.toml
@@ -21,16 +21,20 @@ note = """## Triage and analysis
 
 ### Investigating Modification of AmsiEnable Registry Key
 
-The Windows Antimalware Scan Interface (AMSI) is a versatile interface standard that allows your applications and services to integrate with any antimalware product that's present on a machine. AMSI provides integration with multiple Windows components, ranging from User Account Control (UAC) to VBA Macros.
+The Windows Antimalware Scan Interface (AMSI) is a versatile interface standard that allows your applications and
+services to integrate with any antimalware product that's present on a machine. AMSI provides integration with multiple
+Windows components, ranging from User Account Control (UAC) to VBA Macros.
 
-Since AMSI is widely used across security products for increased visibility, attackers can disable it to evade detections that rely on it.
+Since AMSI is widely used across security products for increased visibility, attackers can disable it to evade
+detections that rely on it.
 
 This rule monitors the modifications to the Software\\Microsoft\\Windows Script\\Settings\\AmsiEnable registry key.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Investigate the execution of scripts and macros after the registry modification.
 - Retrieve scripts or Microsoft Office files and determine if they are malicious:
@@ -46,7 +50,8 @@ This rule monitors the modifications to the Software\\Microsoft\\Windows Script\
 
 ### False positive analysis
 
-- This modification should not happen legitimately. Any potential benign true positive (B-TP) should be mapped and monitored by the security team, as these modifications expose the host to malware infections.
+- This modification should not happen legitimately. Any potential benign true positive (B-TP) should be mapped and
+monitored by the security team, as these modifications expose the host to malware infections.
 
 ### Related rules
 
@@ -60,12 +65,15 @@ This rule monitors the modifications to the Software\\Microsoft\\Windows Script\
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Delete or set the key to its default value.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_clearing_windows_console_history.toml
+++ b/rules/windows/defense_evasion_clearing_windows_console_history.toml
@@ -21,18 +21,23 @@ note = """## Triage and analysis
 
 ### Investigating Clearing Windows Console History
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can try to cover their tracks by clearing PowerShell console history. PowerShell has two different ways of logging commands: the built-in history and the command history managed by the PSReadLine module. This rule looks for the execution of commands that can clear the built-in PowerShell logs or delete the `ConsoleHost_history.txt` file.
+Attackers can try to cover their tracks by clearing PowerShell console history. PowerShell has two different ways of
+logging commands: the built-in history and the command history managed by the PSReadLine module. This rule looks for the
+execution of commands that can clear the built-in PowerShell logs or delete the `ConsoleHost_history.txt` file.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
   - Verify if any other anti-forensics behaviors were observed.
-- Investigate the PowerShell logs on the SIEM to determine if there was suspicious behavior that an attacker may be trying to cover up.
+- Investigate the PowerShell logs on the SIEM to determine if there was suspicious behavior that an attacker may be
+trying to cover up.
 
 ### False positive analysis
 
@@ -42,10 +47,14 @@ Attackers can try to cover their tracks by clearing PowerShell console history. 
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
   - Ensure that PowerShell auditing policies and log collection are in place to grant future visibility.
 
 ## Setup

--- a/rules/windows/defense_evasion_clearing_windows_event_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_event_logs.toml
@@ -21,13 +21,15 @@ note = """## Triage and analysis
 
 ### Investigating Clearing Windows Event Logs
 
-Windows event logs are a fundamental data source for security monitoring, forensics, and incident response. Adversaries can tamper, clear, and delete this data to break SIEM detections, cover their tracks, and slow down incident response.
+Windows event logs are a fundamental data source for security monitoring, forensics, and incident response. Adversaries
+can tamper, clear, and delete this data to break SIEM detections, cover their tracks, and slow down incident response.
 
 This rule looks for the execution of the `wevtutil.exe` utility or the `Clear-EventLog` cmdlet to clear event logs.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -36,18 +38,26 @@ This rule looks for the execution of the `wevtutil.exe` utility or the `Clear-Ev
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity and there are justifications for this action.
-- Analyze whether the cleared event log is pertinent to security and general monitoring. Administrators can clear non-relevant event logs using this mechanism. If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of user and command line conditions.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity
+and there are justifications for this action.
+- Analyze whether the cleared event log is pertinent to security and general monitoring. Administrators can clear
+non-relevant event logs using this mechanism. If this activity is expected and noisy in your environment, consider
+adding exceptions — preferably with a combination of user and command line conditions.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
-  - This activity is potentially done after the adversary achieves its objectives on the host. Ensure that previous actions, if any, are investigated accordingly with their response playbooks.
+  - This activity is potentially done after the adversary achieves its objectives on the host. Ensure that previous
+  actions, if any, are investigated accordingly with their response playbooks.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_clearing_windows_security_logs.toml
+++ b/rules/windows/defense_evasion_clearing_windows_security_logs.toml
@@ -21,13 +21,15 @@ note = """## Triage and analysis
 
 ### Investigating Windows Event Logs Cleared
 
-Windows event logs are a fundamental data source for security monitoring, forensics, and incident response. Adversaries can tamper, clear, and delete this data to break SIEM detections, cover their tracks, and slow down incident response.
+Windows event logs are a fundamental data source for security monitoring, forensics, and incident response. Adversaries
+can tamper, clear, and delete this data to break SIEM detections, cover their tracks, and slow down incident response.
 
 This rule looks for the occurrence of clear actions on the `security` event log.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -41,12 +43,17 @@ This rule looks for the occurrence of clear actions on the `security` event log.
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
-  - This activity is potentially done after the adversary achieves its objectives on the host. Ensure that previous actions, if any, are investigated accordingly with their response playbooks.
+  - This activity is potentially done after the adversary achieves its objectives on the host. Ensure that previous
+  actions, if any, are investigated accordingly with their response playbooks.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 21
 rule_id = "45ac4800-840f-414c-b221-53dd36a5aaf7"

--- a/rules/windows/defense_evasion_create_mod_root_certificate.toml
+++ b/rules/windows/defense_evasion_create_mod_root_certificate.toml
@@ -23,17 +23,23 @@ note = """## Triage and analysis
 
 ### Investigating Creation or Modification of Root Certificate
 
-Root certificates are the primary level of certifications that tell a browser that the communication is trusted and legitimate. This verification is based upon the identification of a certification authority. Windows adds several trusted root certificates so browsers can use them to communicate with websites.
+Root certificates are the primary level of certifications that tell a browser that the communication is trusted and
+legitimate. This verification is based upon the identification of a certification authority. Windows
+adds several trusted root certificates so browsers can use them to communicate with websites.
 
 [Check out this post](https://www.thewindowsclub.com/what-are-root-certificates-windows) for more details on root certificates and the involved cryptography.
 
-This rule identifies the creation or modification of a root certificate by monitoring registry modifications. The installation of a malicious root certificate would allow an attacker the ability to masquerade malicious files as valid signed components from any entity (for example, Microsoft). It could also allow an attacker to decrypt SSL traffic.
+This rule identifies the creation or modification of a root certificate by monitoring registry modifications. The
+installation of a malicious root certificate would allow an attacker the ability to masquerade malicious files as valid
+signed components from any entity (for example, Microsoft). It could also allow an attacker to decrypt SSL traffic.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate abnormal behaviors observed by the subject process such as network connections, other registry or file modifications, and any spawned child processes.
+- Investigate abnormal behaviors observed by the subject process such as network connections, other registry or file
+modifications, and any spawned child processes.
 - If one of the processes is suspicious, retrieve it and determine if it is malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
     - Observe and collect information about the following activities:
@@ -46,7 +52,8 @@ This rule identifies the creation or modification of a root certificate by monit
 
 ### False positive analysis
 
-- This detection may be triggered by certain applications that install root certificates for the purpose of inspecting SSL traffic. Benign true positives (B-TPs) can be added as exceptions if necessary.
+- This detection may be triggered by certain applications that install root certificates for the purpose of inspecting
+SSL traffic. Benign true positives (B-TPs) can be added as exceptions if necessary.
 
 ### Response and remediation
 
@@ -56,13 +63,18 @@ This rule identifies the creation or modification of a root certificate by monit
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove the malicious certificate from the root certificate store.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_defender_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_defender_disabled_via_registry.toml
@@ -21,14 +21,17 @@ note = """## Triage and analysis
 
 ### Investigating Windows Defender Disabled via Registry Modification
 
-Microsoft Windows Defender is an antivirus product built into Microsoft Windows, which makes it popular across multiple environments. Disabling it is a common step in threat actor playbooks.
+Microsoft Windows Defender is an antivirus product built into Microsoft Windows, which makes it popular across multiple
+environments. Disabling it is a common step in threat actor playbooks.
 
 This rule monitors the registry for configurations that disable Windows Defender or the start of its service.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -36,7 +39,9 @@ This rule monitors the registry for configurations that disable Windows Defender
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity, the configuration is justified (for example, it is being used to deploy other security solutions or troubleshooting), and no other suspicious activity has been observed.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity,
+the configuration is justified (for example, it is being used to deploy other security solutions or troubleshooting),
+and no other suspicious activity has been observed.
 
 ### Related rules
 
@@ -47,12 +52,16 @@ This rule monitors the registry for configurations that disable Windows Defender
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Re-enable Windows Defender and restore the service configurations to automatic start.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Review the privileges assigned to the user to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_defender_exclusion_via_powershell.toml
+++ b/rules/windows/defense_evasion_defender_exclusion_via_powershell.toml
@@ -21,11 +21,16 @@ note = """## Triage and analysis
 
 ### Investigating Windows Defender Exclusions Added via PowerShell
 
-Microsoft Windows Defender is an antivirus product built into Microsoft Windows. Since this software product is used to prevent and stop malware, it's important to monitor what specific exclusions are made to the product's configuration settings. These can often be signs of an adversary or malware trying to bypass Windows Defender's capabilities. One of the more notable [examples](https://www.cyberbit.com/blog/endpoint-security/latest-trickbot-variant-has-new-tricks-up-its-sleeve/) was observed in 2018 where Trickbot incorporated mechanisms to disable Windows Defender to avoid detection.
+Microsoft Windows Defender is an antivirus product built into Microsoft Windows. Since this software product is
+used to prevent and stop malware, it's important to monitor what specific exclusions are made to the product's configuration
+settings. These can often be signs of an adversary or malware trying to bypass Windows Defender's capabilities. One of
+the more notable [examples](https://www.cyberbit.com/blog/endpoint-security/latest-trickbot-variant-has-new-tricks-up-its-sleeve/)
+was observed in 2018 where Trickbot incorporated mechanisms to disable Windows Defender to avoid detection.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Examine the exclusion in order to determine the intent behind it.
@@ -42,7 +47,9 @@ Microsoft Windows Defender is an antivirus product built into Microsoft Windows.
 
 ### False positive analysis
 
-- This rule has a high chance to produce false positives due to how often network administrators legitimately configure exclusions. In order to validate the activity further, review the specific exclusion and its intent. There are many legitimate reasons for exclusions, so it's important to gain context.
+- This rule has a high chance to produce false positives due to how often network administrators legitimately configure
+exclusions. In order to validate the activity further, review the specific exclusion and its intent. There are many
+legitimate reasons for exclusions, so it's important to gain context.
 
 ### Related rules
 
@@ -57,12 +64,15 @@ Microsoft Windows Defender is an antivirus product built into Microsoft Windows.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Exclusion lists for antimalware capabilities should always be routinely monitored for review.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
+++ b/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
@@ -21,14 +21,17 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell Script Block Logging Disabled
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks, making it available in various environments and creating an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks, making
+it available in various environments and creating an attractive way for attackers to execute code.
 
-PowerShell Script Block Logging is a feature of PowerShell that records the content of all script blocks that it processes, giving defenders visibility of PowerShell scripts and sequences of executed commands.
+PowerShell Script Block Logging is a feature of PowerShell that records the content of all script blocks that it
+processes, giving defenders visibility of PowerShell scripts and sequences of executed commands.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Check whether it makes sense for the user to use PowerShell to complete tasks.
 - Investigate if PowerShell scripts were run after logging was disabled.
@@ -53,9 +56,11 @@ PowerShell Script Block Logging is a feature of PowerShell that records the cont
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Review the privileges assigned to the involved users to ensure that the least privilege principle is being followed.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
+++ b/rules/windows/defense_evasion_disable_windows_firewall_rules_with_netsh.toml
@@ -21,7 +21,8 @@ note = """## Triage and analysis
 
 ### Investigating Disable Windows Firewall Rules via Netsh
 
-The Windows Defender Firewall is a native component which provides host-based, two-way network traffic filtering for a device, and blocks unauthorized network traffic flowing into or out of the local device.
+The Windows Defender Firewall is a native component which provides host-based, two-way network traffic filtering for a
+device, and blocks unauthorized network traffic flowing into or out of the local device.
 
 Attackers can disable the Windows firewall or its rules to enable lateral movement and command and control activity.
 
@@ -31,12 +32,14 @@ This rule identifies patterns related to disabling the Windows firewall or its r
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the user to check if they are aware of the operation.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Check whether the user is an administrator and is legitimately performing troubleshooting.
+- This mechanism can be used legitimately. Check whether the user is an administrator and is legitimately performing
+troubleshooting.
 - In case of an allowed benign true positive (B-TP), assess adding rules to allow needed traffic and re-enable the firewall.
 
 ### Response and remediation
@@ -45,7 +48,8 @@ This rule identifies patterns related to disabling the Windows firewall or its r
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Review the privileges assigned to the involved users to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_disabling_windows_defender_powershell.toml
+++ b/rules/windows/defense_evasion_disabling_windows_defender_powershell.toml
@@ -19,22 +19,28 @@ note = """## Triage and analysis
 
 ### Investigating Disabling Windows Defender Security Settings via PowerShell
 
-Microsoft Windows Defender is an antivirus product built into Microsoft Windows, which makes it popular across multiple environments. Disabling it is a common step in threat actor playbooks.
+Microsoft Windows Defender is an antivirus product built into Microsoft Windows, which makes it popular across multiple
+environments. Disabling it is a common step in threat actor playbooks.
 
 This rule monitors the execution of commands that can tamper the Windows Defender antivirus features.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Examine the command line to determine which action was executed. Based on that, examine exceptions, antivirus state, sample submission, etc.
+- Examine the command line to determine which action was executed. Based on that, examine exceptions, antivirus state,
+sample submission, etc.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity, the configuration is justified (for example, it is being used to deploy other security solutions or troubleshooting), and no other suspicious activity has been observed.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity,
+the configuration is justified (for example, it is being used to deploy other security solutions or troubleshooting),
+and no other suspicious activity has been observed.
 
 ### Related rules
 
@@ -45,12 +51,16 @@ This rule monitors the execution of commands that can tamper the Windows Defende
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Based on the command line, take actions to restore the appropriate Windows Defender antivirus configurations.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Review the privileges assigned to the user to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_disabling_windows_logs.toml
+++ b/rules/windows/defense_evasion_disabling_windows_logs.toml
@@ -21,13 +21,15 @@ note = """## Triage and analysis
 
 ### Investigating Disable Windows Event and Security Logs Using Built-in Tools
 
-Windows event logs are a fundamental data source for security monitoring, forensics, and incident response. Adversaries can tamper, clear, and delete this data to break SIEM detections, cover their tracks, and slow down incident response.
+Windows event logs are a fundamental data source for security monitoring, forensics, and incident response. Adversaries
+can tamper, clear, and delete this data to break SIEM detections, cover their tracks, and slow down incident response.
 
 This rule looks for the usage of different utilities to disable the EventLog service or specific event logs.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -43,10 +45,14 @@ This rule looks for the usage of different utilities to disable the EventLog ser
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
 - Re-enable affected logging components, services, and security monitoring.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
+++ b/rules/windows/defense_evasion_enable_inbound_rdp_with_netsh.toml
@@ -21,17 +21,21 @@ note = """## Triage and analysis
 
 ### Investigating Remote Desktop Enabled in Windows Firewall by Netsh
 
-Microsoft Remote Desktop Protocol (RDP) is a proprietary Microsoft protocol that enables remote connections to other computers, typically over TCP port 3389.
+Microsoft Remote Desktop Protocol (RDP) is a proprietary Microsoft protocol that enables remote connections to other
+computers, typically over TCP port 3389.
 
-Attackers can use RDP to conduct their actions interactively. Ransomware operators frequently use RDP to access victim servers, often using privileged accounts.
+Attackers can use RDP to conduct their actions interactively. Ransomware operators frequently use RDP to access
+victim servers, often using privileged accounts.
 
-This rule detects the creation of a Windows Firewall inbound rule that would allow inbound RDP traffic using the `netsh.exe` utility.
+This rule detects the creation of a Windows Firewall inbound rule that would allow inbound RDP traffic using the
+`netsh.exe` utility.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the user to check if they are aware of the operation.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Check whether it makes sense to enable RDP to this host, given its role in the environment.
 - Check if the host is directly exposed to the internet.
@@ -40,7 +44,8 @@ This rule detects the creation of a Windows Firewall inbound rule that would all
 
 ### False positive analysis
 
-- The `netsh.exe` utility can be used legitimately. Check whether the user should be performing this kind of activity, whether the user is aware of it, whether RDP should be open, and whether the action exposes the environment to unnecessary risks.
+- The `netsh.exe` utility can be used legitimately. Check whether the user should be performing this kind of activity, whether the user is aware
+of it, whether RDP should be open, and whether the action exposes the environment to unnecessary risks.
 
 ### Response and remediation
 
@@ -51,7 +56,8 @@ This rule detects the creation of a Windows Firewall inbound rule that would all
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Review the privileges assigned to the involved users to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_enable_network_discovery_with_netsh.toml
+++ b/rules/windows/defense_evasion_enable_network_discovery_with_netsh.toml
@@ -22,13 +22,17 @@ note = """## Triage and analysis
 
 ### Investigating Enable Host Network Discovery via Netsh
 
-The Windows Defender Firewall is a native component that provides host-based, two-way network traffic filtering for a device and blocks unauthorized network traffic flowing into or out of the local device.
+The Windows Defender Firewall is a native component that provides host-based, two-way network traffic filtering for a
+device and blocks unauthorized network traffic flowing into or out of the local device.
 
-Attackers can enable Network Discovery on the Windows firewall to find other systems present in the same network. Systems with this setting enabled will communicate with other systems using broadcast messages, which can be used to identify targets for lateral movement. This rule looks for the setup of this setting using the netsh utility.
+Attackers can enable Network Discovery on the Windows firewall to find other systems present in the same network. Systems
+with this setting enabled will communicate with other systems using broadcast messages, which can be used to identify
+targets for lateral movement. This rule looks for the setup of this setting using the netsh utility.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -36,7 +40,8 @@ Attackers can enable Network Discovery on the Windows firewall to find other sys
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the Administrator is aware of the activity and there are justifications for this configuration.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity
+and there are justifications for this configuration.
 
 ### Response and remediation
 
@@ -44,10 +49,13 @@ Attackers can enable Network Discovery on the Windows firewall to find other sys
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Disable Network Discovery:
     - Using netsh: `netsh advfirewall firewall set rule group="Network Discovery" new enable=No`
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Review the privileges assigned to the involved users to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
+++ b/rules/windows/defense_evasion_execution_msbuild_started_by_office_app.toml
@@ -27,18 +27,27 @@ note = """## Triage and analysis
 
 ### Investigating Microsoft Build Engine Started by an Office Application
 
-Microsoft Office (MS Office) is a suite of applications designed to help with productivity and completing common tasks on a computer. You can create and edit documents containing text and images, work with data in spreadsheets and databases, and create presentations and posters. As it is some of the most-used software across companies, MS Office is frequently targeted for initial access. It also has a wide variety of capabilities that attackers can take advantage of.
+Microsoft Office (MS Office) is a suite of applications designed to help with productivity and completing common tasks on a computer.
+You can create and edit documents containing text and images, work with data in spreadsheets and databases, and create
+presentations and posters. As it is some of the most-used software across companies, MS Office is frequently targeted
+for initial access. It also has a wide variety of capabilities that attackers can take advantage of.
 
-The Microsoft Build Engine is a platform for building applications. This engine, also known as MSBuild, provides an XML schema for a project file that controls how the build platform processes and builds software, and can be abused to proxy execution of code.
+The Microsoft Build Engine is a platform for building applications. This engine, also known as MSBuild, provides an XML
+schema for a project file that controls how the build platform processes and builds software, and can be abused to proxy
+execution of code.
 
-This rule looks for the `Msbuild.exe` utility spawned by MS Office programs. This is generally the result of the execution of malicious documents.
+This rule looks for the `Msbuild.exe` utility spawned by MS Office programs. This is generally the result of the
+execution of malicious documents.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file
+modifications, and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Retrieve MS Office documents received and opened by the user that could cause this behavior. Common locations include, but are not limited to, the Downloads and Document folders and the folder configured at the email client.
+- Retrieve MS Office documents received and opened by the user that could cause this behavior. Common locations include,
+but are not limited to, the Downloads and Document folders and the folder configured at the email client.
 - Determine if the collected files are malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
     - Observe and collect information about the following activities:
@@ -57,21 +66,26 @@ This rule looks for the `Msbuild.exe` utility spawned by MS Office programs. Thi
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - If the triage identified malware, search the environment for additional compromised hosts.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
   - If the malicious file was delivered via phishing:
     - Block the email sender from sending future emails.
     - Block the malicious web pages.
     - Remove emails from the sender from mailboxes.
     - Consider improvements to the security awareness program.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_microsoft_defender_tampering.toml
+++ b/rules/windows/defense_evasion_microsoft_defender_tampering.toml
@@ -22,22 +22,28 @@ note = """## Triage and analysis
 
 ### Investigating Microsoft Windows Defender Tampering
 
-Microsoft Windows Defender is an antivirus product built into Microsoft Windows, which makes it popular across multiple environments. Disabling it is a common step in threat actor playbooks.
+Microsoft Windows Defender is an antivirus product built into Microsoft Windows, which makes it popular across multiple
+environments. Disabling it is a common step in threat actor playbooks.
 
 This rule monitors the registry for modifications that disable Windows Defender features.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Examine which features have been disabled, and check if this operation is done under change management and approved according to the organization's policy.
+- Examine which features have been disabled, and check if this operation is done under change management and approved
+according to the organization's policy.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity, the configuration is justified (for example, it is being used to deploy other security solutions or troubleshooting), and no other suspicious activity has been observed.
+- This mechanism can be used legitimately. Analysts can dismiss the alert if the administrator is aware of the activity,
+the configuration is justified (for example, it is being used to deploy other security solutions or troubleshooting),
+and no other suspicious activity has been observed.
 
 ### Related rules
 
@@ -48,12 +54,16 @@ This rule monitors the registry for modifications that disable Windows Defender 
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Take actions to restore the appropriate Windows Defender antivirus configurations.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Review the privileges assigned to the user to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
+++ b/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
@@ -22,20 +22,30 @@ note = """## Triage and analysis
 
 ### Investigating MS Office Macro Security Registry Modifications
 
-Macros are small programs that are used to automate repetitive tasks in Microsoft Office applications. Historically, macros have been used for a variety of reasons -- from automating part of a job, to building entire processes and data flows. Macros are written in Visual Basic for Applications (VBA) and are saved as part of Microsoft Office files.
+Macros are small programs that are used to automate repetitive tasks in Microsoft Office applications.
+Historically, macros have been used for a variety of reasons -- from automating part of a job, to
+building entire processes and data flows. Macros are written in Visual Basic for Applications (VBA) and are saved as
+part of Microsoft Office files.
 
-Macros are often created for legitimate reasons, but they can also be written by attackers to gain access, harm a system, or bypass other security controls such as application allow listing. In fact, exploitation from malicious macros is one of the top ways that organizations are compromised today. These attacks are often conducted through phishing or spear phishing campaigns.
+Macros are often created for legitimate reasons, but they can also be written by attackers to gain access, harm a
+system, or bypass other security controls such as application allow listing. In fact, exploitation from malicious macros
+is one of the top ways that organizations are compromised today. These attacks are often conducted through phishing or
+spear phishing campaigns.
 
-Attackers can convince victims to modify Microsoft Office security settings, so their macros are trusted by default and no warnings are displayed when they are executed. These settings include:
+Attackers can convince victims to modify Microsoft Office security settings, so their macros are trusted by default and
+no warnings are displayed when they are executed. These settings include:
 
-- *Trust access to the VBA project object model* - When enabled, Microsoft Office will trust all macros and run any code without showing a security warning or requiring user permission.
-- *VbaWarnings* - When set to 1, Microsoft Office will trust all macros and run any code without showing a security warning or requiring user permission.
+* *Trust access to the VBA project object model* - When enabled, Microsoft Office will trust all macros and run any code
+without showing a security warning or requiring user permission.
+* *VbaWarnings* - When set to 1, Microsoft Office will trust all macros and run any code without showing a security
+warning or requiring user permission.
 
 This rule looks for registry changes affecting the conditions above.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the user and check if the change was done manually.
 - Verify whether malicious macros were executed after the registry change.
@@ -52,18 +62,23 @@ This rule looks for registry changes affecting the conditions above.
 
 ### False positive analysis
 
-- This activity should not happen legitimately. The security team should address any potential benign true positive (B-TP), as this configuration can put the user and the domain at risk.
+- This activity should not happen legitimately. The security team should address any potential benign true
+positives (B-TPs), as this configuration can put the user and the domain at risk.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Reset the registry key value.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Explore using GPOs to manage security settings for Microsoft Office macros.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/defense_evasion_posh_assembly_load.toml
+++ b/rules/windows/defense_evasion_posh_assembly_load.toml
@@ -21,17 +21,21 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious .NET Reflection via PowerShell
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can use .NET reflection to load PEs and DLLs in memory. These payloads are commonly embedded in the script, which can circumvent file-based security protections.
+Attackers can use .NET reflection to load PEs and DLLs in memory. These payloads are commonly embedded in the script,
+which can circumvent file-based security protections.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -39,20 +43,23 @@ Attackers can use .NET reflection to load PEs and DLLs in memory. These payloads
   - Analyze the script using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This activity is unlikely to happen legitimately outside engineering or IT business units. As long as the analyst did not identify malware or suspicious activity related to the user or host, this alert can be dismissed.
+- This activity is unlikely to happen legitimately outside engineering or IT business units. As long as the analyst did
+not identify malware or suspicious activity related to the user or host, this alert can be dismissed.
 
 ### Related rules
 
@@ -68,13 +75,18 @@ Attackers can use .NET reflection to load PEs and DLLs in memory. These payloads
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_posh_compressed.toml
+++ b/rules/windows/defense_evasion_posh_compressed.toml
@@ -22,17 +22,21 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell Suspicious Payload Encoded and Compressed
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can embed compressed and encoded payloads in scripts to load directly into the memory without touching the disk. This strategy can circumvent string and file-based security protections.
+Attackers can embed compressed and encoded payloads in scripts to load directly into the memory without touching the
+disk. This strategy can circumvent string and file-based security protections.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -40,20 +44,23 @@ Attackers can embed compressed and encoded payloads in scripts to load directly 
   - Analyze the script using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This activity is unlikely to happen legitimately outside engineering or IT business units. As long as the analyst did not identify malware or suspicious activity related to the user or host, this alert can be dismissed.
+- This activity is unlikely to happen legitimately outside engineering or IT business units. As long as the analyst did
+not identify malware or suspicious activity related to the user or host, this alert can be dismissed.
 
 ### Related rules
 
@@ -69,13 +76,18 @@ Attackers can embed compressed and encoded payloads in scripts to load directly 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_posh_process_injection.toml
+++ b/rules/windows/defense_evasion_posh_process_injection.toml
@@ -22,16 +22,21 @@ note = """## Triage and analysis
 
 ### Investigating Potential Process Injection via PowerShell
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-PowerShell also has solid capabilities to make the interaction with the Win32 API in an uncomplicated and reliable way, like the execution of inline C# code, PSReflect, Get-ProcAddress, etc.
+PowerShell also has solid capabilities to make the interaction with the Win32 API in an uncomplicated and reliable way,
+like the execution of inline C# code, PSReflect, Get-ProcAddress, etc.
 
-Red Team tooling and malware developers take advantage of these capabilities to develop stagers and loaders that inject payloads directly into the memory without touching the disk to circumvent file-based security protections.
+Red Team tooling and malware developers take advantage of these capabilities to develop stagers and loaders that inject
+payloads directly into the memory without touching the disk to circumvent file-based security protections.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -51,10 +56,14 @@ Red Team tooling and malware developers take advantage of these capabilities to 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_powershell_windows_firewall_disabled.toml
+++ b/rules/windows/defense_evasion_powershell_windows_firewall_disabled.toml
@@ -28,15 +28,18 @@ note = """## Triage and analysis
 
 ### Investigating Windows Firewall Disabled via PowerShell
 
-Windows Defender Firewall is a native component that provides host-based, two-way network traffic filtering for a device and blocks unauthorized network traffic flowing into or out of the local device.
+Windows Defender Firewall is a native component that provides host-based, two-way network traffic filtering for a
+device and blocks unauthorized network traffic flowing into or out of the local device.
 
 Attackers can disable the Windows firewall or its rules to enable lateral movement and command and control activity.
 
-This rule identifies patterns related to disabling the Windows firewall or its rules using the `Set-NetFirewallProfile` PowerShell cmdlet.
+This rule identifies patterns related to disabling the Windows firewall or its rules using the `Set-NetFirewallProfile`
+PowerShell cmdlet.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -44,7 +47,8 @@ This rule identifies patterns related to disabling the Windows firewall or its r
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Check whether the user is an administrator and is legitimately performing troubleshooting.
+- This mechanism can be used legitimately. Check whether the user is an administrator and is legitimately performing
+troubleshooting.
 - In case of an allowed benign true positive (B-TP), assess adding rules to allow needed traffic and re-enable the firewall.
 
 ### Response and remediation
@@ -52,10 +56,13 @@ This rule identifies patterns related to disabling the Windows firewall or its r
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Re-enable the firewall with its desired configurations.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Review the privileges assigned to the involved users to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_suspicious_process_access_direct_syscall.toml
+++ b/rules/windows/defense_evasion_suspicious_process_access_direct_syscall.toml
@@ -22,39 +22,46 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious Process Access via Direct System Call
 
-Endpoint security solutions usually hook userland Windows APIs in order to decide if the code that is being executed is malicious or not. It's possible to bypass hooked functions by writing malicious functions that call syscalls directly.
+Endpoint security solutions usually hook userland Windows APIs in order to decide if the code that is being executed is
+malicious or not. It's possible to bypass hooked functions by writing malicious functions that call syscalls directly.
 
 More context and technical details can be found in this [research blog](https://outflank.nl/blog/2019/06/19/red-team-tactics-combining-direct-system-calls-and-srdi-to-bypass-av-edr/).
 
-This rule identifies suspicious process access events from an unknown memory region. Attackers can use direct system calls to bypass security solutions that rely on hooks.
+This rule identifies suspicious process access events from an unknown memory region. Attackers can use direct system
+calls to bypass security solutions that rely on hooks.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
 
-- This detection may be triggered by certain applications that install root certificates for the purpose of inspecting SSL traffic. Benign true positives (B-TPs) can be added as exceptions if necessary.
+- This detection may be triggered by certain applications that install root certificates for the purpose of inspecting
+SSL traffic. Benign true positives (B-TPs) can be added as exceptions if necessary.
 
 ### Response and remediation
 
@@ -64,13 +71,18 @@ This rule identifies suspicious process access events from an unknown memory reg
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove the malicious certificate from the root certificate store.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_suspicious_process_creation_calltrace.toml
+++ b/rules/windows/defense_evasion_suspicious_process_creation_calltrace.toml
@@ -21,12 +21,17 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious Process Creation CallTrace
 
-Attackers may inject code into child processes' memory to hide their actual activity, evade detection mechanisms, and decrease discoverability during forensics. This rule looks for a spawned process by Microsoft Office, scripting, and command line applications, followed by a process access event for an unknown memory region by the parent process, which can indicate a code injection attempt.
+Attackers may inject code into child processes' memory to hide their actual activity, evade detection mechanisms, and
+decrease discoverability during forensics. This rule looks for a spawned process by Microsoft Office, scripting, and
+command line applications, followed by a process access event for an unknown memory region by the parent process, which
+can indicate a code injection attempt.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate abnormal behavior observed by the subject process such as network connections, registry or file
+modifications, and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
 - Create a memory dump of the child process for analysis.
@@ -40,10 +45,14 @@ Attackers may inject code into child processes' memory to hide their actual acti
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 47
 rule_id = "3ed032b2-45d8-4406-bc79-7ad1eabb2c72"

--- a/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
+++ b/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
@@ -21,32 +21,38 @@ note = """## Triage and analysis
 
 ### Investigating Unusual Executable File Creation by a System Critical Process
 
-Windows internal/system processes have some characteristics that can be used to spot suspicious activities. One of these characteristics is file operations.
+Windows internal/system processes have some characteristics that can be used to spot suspicious activities. One of these
+characteristics is file operations.
 
-This rule looks for the creation of executable files done by system-critical processes. This can indicate the exploitation of a vulnerability or a malicious process masquerading as a system-critical process.
+This rule looks for the creation of executable files done by system-critical processes. This can indicate the exploitation
+of a vulnerability or a malicious process masquerading as a system-critical process.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
@@ -61,11 +67,14 @@ This rule looks for the creation of executable files done by system-critical pro
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_unusual_ads_file_creation.toml
+++ b/rules/windows/defense_evasion_unusual_ads_file_creation.toml
@@ -21,42 +21,51 @@ note = """## Triage and analysis
 
 ### Investigating Unusual File Creation - Alternate Data Stream
 
-Alternate Data Streams (ADS) are file attributes only found on the NTFS file system. In this file system, files are built up from a couple of attributes; one of them is $Data, also known as the data attribute.
+Alternate Data Streams (ADS) are file attributes only found on the NTFS file system. In this file system, files are
+built up from a couple of attributes; one of them is $Data, also known as the data attribute.
 
-The regular data stream, also referred to as the unnamed data stream since the name string of this attribute is empty, contains the data inside the file. So any data stream that has a name is considered an alternate data stream.
+The regular data stream, also referred to as the unnamed data stream since the name string of this attribute is empty,
+contains the data inside the file. So any data stream that has a name is considered an alternate data stream.
 
-Attackers can abuse these alternate data streams to hide malicious files, string payloads, etc. This rule detects the creation of alternate data streams on highly targeted file types.
+Attackers can abuse these alternate data streams to hide malicious files, string payloads, etc. This rule detects the
+creation of alternate data streams on highly targeted file types.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Retrieve the contents of the alternate data stream, and analyze it for potential maliciousness. Analysts can use the following PowerShell cmdlet to accomplish this:
+- Retrieve the contents of the alternate data stream, and analyze it for potential maliciousness. Analysts can use the
+following PowerShell cmdlet to accomplish this:
   - `Get-Content -file C:\\Path\\To\\file.exe -stream ADSname`
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
 
-- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of process executable and file conditions.
+- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination
+of process executable and file conditions.
 
 ### Response and remediation
 
@@ -66,12 +75,17 @@ Attackers can abuse these alternate data streams to hide malicious files, string
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/defense_evasion_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/defense_evasion_unusual_network_connection_via_rundll32.toml
@@ -21,13 +21,17 @@ note = """## Triage and analysis
 
 ### Investigating Unusual Network Connection via RunDLL32
 
-RunDLL32 is a built-in Windows utility and also a vital component used by the operating system itself. The functionality provided by RunDLL32 to execute Dynamic Link Libraries (DLLs) is widely abused by attackers, because it makes it hard to differentiate malicious activity from normal operations.
+RunDLL32 is a built-in Windows utility and also a vital component used by the operating system itself. The functionality
+provided by RunDLL32 to execute Dynamic Link Libraries (DLLs) is widely abused by attackers, because it makes it hard to
+differentiate malicious activity from normal operations.
 
-This rule looks for external network connections established using RunDLL32 when the utility is being executed with no arguments, which can potentially indicate command and control activity.
+This rule looks for external network connections established using RunDLL32 when the utility is being executed with no
+arguments, which can potentially indicate command and control activity.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Investigate the target host that RunDLL32 is communicating with.
   - Check if the domain is newly registered or unexpected.
@@ -43,11 +47,15 @@ This rule looks for external network connections established using RunDLL32 when
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
 - Review the privileges assigned to the user to ensure that the least privilege principle is being followed.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml",

--- a/rules/windows/defense_evasion_unusual_process_network_connection.toml
+++ b/rules/windows/defense_evasion_unusual_process_network_connection.toml
@@ -21,11 +21,13 @@ note = """## Triage and analysis
 
 ### Investigating Unusual Process Network Connection
 
-This rule identifies network activity from unexpected system utilities and applications. These applications are commonly abused by attackers to execute code, evade detections, and bypass security protections.
+This rule identifies network activity from unexpected system utilities and applications. These applications are commonly
+abused by attackers to execute code, evade detections, and bypass security protections.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Investigate the target host that the process is communicating with.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
@@ -38,11 +40,15 @@ This rule identifies network activity from unexpected system utilities and appli
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
 - Review the privileges assigned to the user to ensure that the least privilege principle is being followed.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 21
 rule_id = "610949a1-312f-4e04-bb55-3a79b8c95267"

--- a/rules/windows/defense_evasion_workfolders_control_execution.toml
+++ b/rules/windows/defense_evasion_workfolders_control_execution.toml
@@ -21,31 +21,41 @@ note = """## Triage and analysis
 
 ### Investigating Signed Proxy Execution via MS Work Folders
 
-Work Folders is a role service for file servers running Windows Server that provides a consistent way for users to access their work files from their PCs and devices. This allows users to store work files and access them from anywhere. When called, Work Folders will automatically execute any Portable Executable (PE) named control.exe as an argument before accessing the synced share.
+Work Folders is a role service for file servers running Windows Server that provides a consistent way for users to access
+their work files from their PCs and devices. This allows users to store work files and access them from anywhere. When
+called, Work Folders will automatically execute any Portable Executable (PE) named control.exe as an argument before
+accessing the synced share.
 
-Using Work Folders to execute a masqueraded control.exe could allow an adversary to bypass application controls and increase privileges.
+Using Work Folders to execute a masqueraded control.exe could allow an adversary to bypass application controls and
+increase privileges.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-    - Examine the location of the WorkFolders.exe binary to determine if it was copied to the location of the control.exe binary. It resides in the System32 directory by default.
+- Investigate the process tree starting with parent process WorkFolders.exe and child process control.exe to determine
+if other child processes spawned during execution.
 - Trace the activity related to the control.exe binary to identify any continuing intrusion activity on the host.
-- Review the control.exe binary executed with Work Folders to determine maliciousness such as additional host activity or network traffic.
+- Examine the location of the WorkFolders.exe binary to determine if it was copied to the location of the control.exe
+binary. It resides in the System32 directory by default.
+- Review the control.exe binary executed with Work Folders to determine maliciousness such as additional host activity
+or network traffic.
 - Determine if control.exe was synced to sync share, indicating potential lateral movement.
 - Review how control.exe was originally delivered on the host, such as emailed, downloaded from the web, or written to
 disk from a separate binary.
 
 ### False positive analysis
 
-- Windows Work Folders are used legitimately by end users and administrators for file sharing and syncing but not in the instance where a suspicious control.exe is passed as an argument.
+- Windows Work Folders are used legitimately by end users and administrators for file sharing and syncing but not in the
+instance where a suspicious control.exe is passed as an argument.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
 - Review the Work Folders synced share to determine if the control.exe was shared and if so remove it.
-- If no lateral movement was identified during investigation, take the affected host offline if possible and remove the control.exe binary as well as any additional artifacts identified during investigation.
-- Review integrating Windows Information Protection (WIP) to enforce data protection by encrypting the data on PCs using Work Folders.
+- If no lateral movement was identified during investigation, take the affected host offline if possible and remove the
+control.exe binary as well as any additional artifacts identified during investigation.
+- Review integrating Windows Information Protection (WIP) to enforce data protection by encrypting the data on PCs using
+Work Folders.
 - Confirm with the user whether this was expected or not, and reset their password.
 
 ## Setup

--- a/rules/windows/discovery_adfind_command_activity.toml
+++ b/rules/windows/discovery_adfind_command_activity.toml
@@ -22,11 +22,16 @@ note = """## Triage and analysis
 
 ### Investigating AdFind Command Activity
 
-[AdFind](http://www.joeware.net/freetools/tools/adfind/) is a freely available command-line tool used to retrieve information from Active Directory (AD). Network discovery and enumeration tools like `AdFind` are useful to adversaries in the same ways they are effective for network administrators. This tool provides quick ability to scope AD person/computer objects and understand subnets and domain information. There are many [examples](https://thedfirreport.com/category/adfind/) of this tool being adopted by ransomware and criminal groups and used in compromises.
+[AdFind](http://www.joeware.net/freetools/tools/adfind/) is a freely available command-line tool used to retrieve information
+from Active Directory (AD). Network discovery and enumeration tools like `AdFind` are useful to adversaries in the same
+ways they are effective for network administrators. This tool provides quick ability to scope AD person/computer objects
+and understand subnets and domain information. There are many [examples](https://thedfirreport.com/category/adfind/) of
+this tool being adopted by ransomware and criminal groups and used in compromises.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Examine the command line to determine what information was retrieved by the tool.
 - Contact the account owner and confirm whether they are aware of this activity.
@@ -35,8 +40,10 @@ note = """## Triage and analysis
 ### False positive analysis
 
 - This rule has a high chance to produce false positives as it is a legitimate tool used by network administrators.
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and command line conditions.
-- Malicious behavior with `AdFind` should be investigated as part of a step within an attack chain. It doesn't happen in isolation, so reviewing previous logs/activity from impacted machines can be very telling.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination
+of user and command line conditions.
+- Malicious behavior with `AdFind` should be investigated as part of a step within an attack chain. It doesn't happen in
+isolation, so reviewing previous logs/activity from impacted machines can be very telling.
 
 ### Related rules
 
@@ -48,10 +55,14 @@ note = """## Triage and analysis
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_admin_recon.toml
+++ b/rules/windows/discovery_admin_recon.toml
@@ -21,20 +21,27 @@ note = """## Triage and analysis
 
 ### Investigating Enumeration of Administrator Accounts
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the execution of the `net` and `wmic` utilities to enumerate administrator-related users or groups in the domain and local machine scope. Attackers can use this information to plan their next steps of the attack, such as mapping targets for credential compromise and other post-exploitation activities.
+This rule looks for the execution of the `net` and `wmic` utilities to enumerate administrator-related users or groups
+in the domain and local machine scope. Attackers can use this information to plan their next steps of the attack, such
+as mapping targets for credential compromise and other post-exploitation activities.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Related rules
 
@@ -44,10 +51,14 @@ This rule looks for the execution of the `net` and `wmic` utilities to enumerate
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_command_system_account.toml
+++ b/rules/windows/discovery_command_system_account.toml
@@ -21,29 +21,41 @@ note = """## Triage and analysis
 
 ### Investigating Account Discovery Command via SYSTEM Account
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the execution of account discovery utilities using the SYSTEM account, which is commonly observed after attackers successfully perform privilege escalation or exploit web applications.
+This rule looks for the execution of account discovery utilities using the SYSTEM account, which is commonly observed
+after attackers successfully perform privilege escalation or exploit web applications.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-  - If the process tree includes a web-application server process such as w3wp, httpd.exe, nginx.exe and alike, investigate any suspicious file creation or modification in the last 48 hours to assess the presence of any potential webshell backdoor.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+  - If the process tree includes a web-application server process such as w3wp, httpd.exe, nginx.exe and alike,
+  investigate any suspicious file creation or modification in the last 48 hours to assess the presence of any potential
+  webshell backdoor.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Determine how the SYSTEM account is being used. For example, users with administrator privileges can spawn a system shell using Windows services, scheduled tasks or other third party utilities.
+- Determine how the SYSTEM account is being used. For example, users with administrator privileges can spawn a system
+shell using Windows services, scheduled tasks or other third party utilities.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 - Use the data collected through the analysis to investigate other machines affected in the environment.
 
 ## Setup

--- a/rules/windows/discovery_net_view.toml
+++ b/rules/windows/discovery_net_view.toml
@@ -18,29 +18,40 @@ note = """## Triage and analysis
 
 ### Investigating Windows Network Enumeration
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the execution of the `net` utility to enumerate servers in the environment that hosts shared drives or printers. This information is useful to attackers as they can identify targets for lateral movements and search for valuable shared data.
+This rule looks for the execution of the `net` utility to enumerate servers in the environment that hosts shared drives
+or printers. This information is useful to attackers as they can identify targets for lateral movements and search for
+valuable shared data.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_peripheral_device.toml
+++ b/rules/windows/discovery_peripheral_device.toml
@@ -21,30 +21,42 @@ note = """## Triage and analysis
 
 ### Investigating Peripheral Device Discovery
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the execution of the `fsutil` utility with the `fsinfo` subcommand to enumerate drives attached to the computer, which can be used to identify secondary drives used for backups, mapped network drives, and removable media. These devices can contain valuable information for attackers.
+This rule looks for the execution of the `fsutil` utility with the `fsinfo` subcommand to enumerate drives attached to
+the computer, which can be used to identify secondary drives used for backups, mapped network drives, and removable
+media. These devices can contain valuable information for attackers.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
-- Determine whether this activity was followed by suspicious file access/copy operations or uploads to file storage services.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
+- Determine whether this activity was followed by suspicious file access/copy operations or uploads to file storage
+services.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_posh_invoke_sharefinder.toml
+++ b/rules/windows/discovery_posh_invoke_sharefinder.toml
@@ -22,14 +22,18 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell Share Enumeration Script
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can use PowerShell to enumerate shares to search for sensitive data like documents, scripts, and other kinds of valuable data for encryption, exfiltration, and lateral movement.
+Attackers can use PowerShell to enumerate shares to search for sensitive data like documents, scripts, and other kinds
+of valuable data for encryption, exfiltration, and lateral movement.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -44,11 +48,15 @@ Attackers can use PowerShell to enumerate shares to search for sensitive data li
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_posh_suspicious_api_functions.toml
+++ b/rules/windows/discovery_posh_suspicious_api_functions.toml
@@ -23,14 +23,18 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell Suspicious Discovery Related Windows API Functions
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can use PowerShell to interact with the Win32 API to bypass command line based detections, using libraries like PSReflect or Get-ProcAddress Cmdlet.
+Attackers can use PowerShell to interact with the Win32 API to bypass command line based detections, using libraries
+like PSReflect or Get-ProcAddress Cmdlet.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Examine file or network events from the involved PowerShell process for suspicious behavior.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -38,7 +42,9 @@ Attackers can use PowerShell to interact with the Win32 API to bypass command li
 
 ### False positive analysis
 
-- Discovery activities themselves are not inherently malicious if occurring in isolation, as long as the script does not contain other capabilities, and there are no other alerts related to the user or host; such alerts can be dismissed. However, analysts should keep in mind that this is not a common way of getting information, making it suspicious.
+- Discovery activities themselves are not inherently malicious if occurring in isolation, as long as the script does not
+contain other capabilities, and there are no other alerts related to the user or host; such alerts can be dismissed.
+However, analysts should keep in mind that this is not a common way of getting information, making it suspicious.
 
 ### Related rules
 
@@ -50,8 +56,10 @@ Attackers can use PowerShell to interact with the Win32 API to bypass command li
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_post_exploitation_external_ip_lookup.toml
+++ b/rules/windows/discovery_post_exploitation_external_ip_lookup.toml
@@ -28,32 +28,44 @@ note = """## Triage and analysis
 
 ### Investigating External IP Lookup from Non-Browser Process
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for connections to known IP lookup services through non-browser processes or non-installed programs. Using only the IP address of the compromised system, attackers can obtain valuable information such as the system's geographic location, the company that owns the IP, whether the system is cloud-hosted, and more.
+This rule looks for connections to known IP lookup services through non-browser processes or non-installed programs.
+Using only the IP address of the compromised system, attackers can obtain valuable information such as the system's
+geographic location, the company that owns the IP, whether the system is cloud-hosted, and more.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file
+modifications, and any spawned child processes.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination
+of user and command line conditions.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Use the data collected through the analysis to investigate other machines affected in the environment.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "https://community.jisc.ac.uk/blogs/csirt/article/trickbot-analysis-and-mitigation",

--- a/rules/windows/discovery_privileged_localgroup_membership.toml
+++ b/rules/windows/discovery_privileged_localgroup_membership.toml
@@ -21,9 +21,13 @@ note = """## Triage and analysis
 
 ### Investigating Enumeration of Privileged Local Groups Membership
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the enumeration of privileged local groups' membership by suspicious processes, and excludes known legitimate utilities and programs installed. Attackers can use this information to decide the next steps of the attack, such as mapping targets for credential compromise and other post-exploitation activities.
+This rule looks for the enumeration of privileged local groups' membership by suspicious processes, and excludes known
+legitimate utilities and programs installed. Attackers can use this information to decide the next steps of the attack,
+such as mapping targets for credential compromise and other post-exploitation activities.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
@@ -31,37 +35,47 @@ This rule looks for the enumeration of privileged local groups' membership by su
 #### Possible investigation steps
 
 - Identify the process, host and user involved on the event.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination
+of user and command line conditions.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_remote_system_discovery_commands_windows.toml
+++ b/rules/windows/discovery_remote_system_discovery_commands_windows.toml
@@ -18,29 +18,39 @@ note = """## Triage and analysis
 
 ### Investigating Remote System Discovery Commands
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the execution of the `arp` or `nbstat` utilities to enumerate remote systems in the environment, which is useful for attackers to identify lateral movement targets.
+This rule looks for the execution of the `arp` or `nbstat` utilities to enumerate remote systems in the environment,
+which is useful for attackers to identify lateral movement targets.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_security_software_wmic.toml
+++ b/rules/windows/discovery_security_software_wmic.toml
@@ -21,29 +21,40 @@ note = """## Triage and analysis
 
 ### Investigating Security Software Discovery using WMIC
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the execution of the `wmic` utility with arguments compatible to the enumeration of the security software installed on the host. Attackers can use this information to decide whether or not to infect a system, disable protections, use bypasses, etc.
+This rule looks for the execution of the `wmic` utility with arguments compatible to the enumeration of the security
+software installed on the host. Attackers can use this information to decide whether or not to infect a system, disable
+protections, use bypasses, etc.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -27,20 +27,26 @@ note = """## Triage and analysis
 
 ### Investigating Whoami Process Activity
 
-After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps. This can happen by running commands to enumerate network resources, users, connections, files, and installed security software.
+After successfully compromising an environment, attackers may try to gain situational awareness to plan their next steps.
+This can happen by running commands to enumerate network resources, users, connections, files, and installed security
+software.
 
-This rule looks for the execution of the `whoami` utility. Attackers commonly use this utility to measure their current privileges, discover the current user, determine if a privilege escalation was successful, etc.
+This rule looks for the execution of the `whoami` utility. Attackers commonly use this utility to measure their current
+privileges, discover the current user, determine if a privilege escalation was successful, etc.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
 
 ### False positive analysis
 
-- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify suspicious activity related to the user or host, such alerts can be dismissed.
+- Discovery activities are not inherently malicious if they occur in isolation. As long as the analyst did not identify
+suspicious activity related to the user or host, such alerts can be dismissed.
 
 ### Related rules
 
@@ -50,10 +56,14 @@ This rule looks for the execution of the `whoami` utility. Attackers commonly us
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/execution_command_shell_started_by_svchost.toml
+++ b/rules/windows/execution_command_shell_started_by_svchost.toml
@@ -18,32 +18,40 @@ note = """## Triage and analysis
 
 ### Investigating Svchost spawning Cmd
 
-The Service Host process (SvcHost) is a system process that can host one, or multiple, Windows services in the Windows NT family of operating systems. Note that `Svchost.exe` is reserved for use by the operating system and should not be used by non-Windows services.
+The Service Host process (SvcHost) is a system process that can host one, or multiple, Windows services in the Windows
+NT family of operating systems. Note that `Svchost.exe` is reserved for use by the operating system and should not be
+used by non-Windows services.
 
-This rule looks for the creation of the `cmd.exe` process with `svchost.exe` as its parent process. This is an unusual behavior that can indicate the masquerading of a malicious process as `svchost.exe` or exploitation for privilege escalation.
+This rule looks for the creation of the `cmd.exe` process with `svchost.exe` as its parent process. This is an unusual
+behavior that can indicate the masquerading of a malicious process as `svchost.exe` or exploitation for privilege
+escalation.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
@@ -58,11 +66,14 @@ This rule looks for the creation of the `cmd.exe` process with `svchost.exe` as 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/execution_from_unusual_path_cmdline.toml
+++ b/rules/windows/execution_from_unusual_path_cmdline.toml
@@ -21,38 +21,39 @@ note = """## Triage and analysis
 
 ### Investigating Execution from Unusual Directory - Command Line
 
-This rule looks for the execution of scripts from unusual directories. Attackers can use system or application paths to hide malware and make the execution less suspicious.
+This rule looks for the execution of scripts from unusual directories. Attackers can use system or application paths to
+hide malware and make the execution less suspicious.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Examine the command line to determine which commands or scripts were executed.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the script using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of parent process executable and command line conditions.
-
-### Related rules
-
-- Process Execution from an Unusual Directory - ebfe1448-7fac-4d59-acea-181bd89b1f7f
+- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination
+of parent process executable and command line conditions.
 
 ### Response and remediation
 
@@ -62,11 +63,17 @@ This rule looks for the execution of scripts from unusual directories. Attackers
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
+
+
+This is related to the `Process Execution from an Unusual Directory rule`.
 
 ## Setup
 

--- a/rules/windows/execution_ms_office_written_file.toml
+++ b/rules/windows/execution_ms_office_written_file.toml
@@ -22,15 +22,22 @@ note = """## Triage and analysis
 
 ### Investigating Execution of File Written or Modified by Microsoft Office
 
-Microsoft Office is a suite of applications designed to help with productivity and completing common tasks on a computer. You can create and edit documents containing text and images, work with data in spreadsheets and databases, and create presentations and posters. As it is some of the most-used software across companies, MS Office is frequently targeted for initial access. It also has a wide variety of capabilities that attackers can take advantage of.
+Microsoft Office is a suite of applications designed to help with productivity and completing common tasks on a computer.
+You can create and edit documents containing text and images, work with data in spreadsheets and databases, and create
+presentations and posters. As it is some of the most-used software across companies, MS Office is frequently
+targeted for initial access. It also has a wide variety of capabilities that attackers can take advantage of.
 
-This rule searches for executable files written by MS Office applications executed in sequence. This is most likely the result of the execution of malicious documents or exploitation for initial access or privilege escalation. This rule can also detect suspicious processes masquerading as the MS Office applications.
+This rule searches for executable files written by MS Office applications executed in sequence. This is most likely the result
+of the execution of malicious documents or exploitation for initial access or privilege escalation. This rule can also detect
+suspicious processes masquerading as the MS Office applications.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Retrieve MS Office documents received and opened by the user that could cause this behavior. Common locations include, but are not limited to, the Downloads and Document folders and the folder configured at the email client.
+- Retrieve MS Office documents received and opened by the user that could cause this behavior. Common locations include,
+but are not limited to, the Downloads and Document folders and the folder configured at the email client.
 - Determine if the collected files are malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
     - Observe and collect information about the following activities:
@@ -49,21 +56,26 @@ This rule searches for executable files written by MS Office applications execut
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - If the triage identified malware, search the environment for additional compromised hosts.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
   - If the malicious file was delivered via phishing:
     - Block the email sender from sending future emails.
     - Block the malicious web pages.
     - Remove emails from the sender from mailboxes.
     - Consider improvements to the security awareness program.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 73
 rule_id = "0d8ad79f-9025-45d8-80c1-4f0cd3c5e8e5"

--- a/rules/windows/execution_pdf_written_file.toml
+++ b/rules/windows/execution_pdf_written_file.toml
@@ -22,15 +22,21 @@ note = """## Triage and analysis
 
 ### Investigating Execution of File Written or Modified by PDF Reader
 
-PDF is a common file type used in corporate environments and most machines have software to handle these files. This creates a vector where attackers can exploit the engines and technology behind this class of software for initial access or privilege escalation.
+PDF is a common file type used in corporate environments and most machines have software to
+handle these files. This creates a vector where attackers can exploit the engines and technology behind this class of
+software for initial access or privilege escalation.
 
-This rule searches for executable files written by PDF reader software and executed in sequence. This is most likely the result of exploitation for privilege escalation or initial access. This rule can also detect suspicious processes masquerading as PDF readers.
+This rule searches for executable files written by PDF reader software and executed in sequence. This is most likely the
+result of exploitation for privilege escalation or initial access. This rule can also detect suspicious processes masquerading as
+PDF readers.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Retrieve the PDF documents received and opened by the user that could cause this behavior. Common locations include, but are not limited to, the Downloads and Document folders and the folder configured at the email client.
+- Retrieve the PDF documents received and opened by the user that could cause this behavior. Common locations include,
+but are not limited to, the Downloads and Document folders and the folder configured at the email client.
 - Determine if the collected files are malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
     - Observe and collect information about the following activities:
@@ -49,21 +55,26 @@ This rule searches for executable files written by PDF reader software and execu
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - If the triage identified malware, search the environment for additional compromised hosts.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
   - If the malicious file was delivered via phishing:
     - Block the email sender from sending future emails.
     - Block the malicious web pages.
     - Remove emails from the sender from mailboxes.
     - Consider improvements to the security awareness program.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 73
 rule_id = "1defdd62-cd8d-426e-a246-81a37751bb2b"

--- a/rules/windows/execution_posh_portable_executable.toml
+++ b/rules/windows/execution_posh_portable_executable.toml
@@ -21,33 +21,39 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious Portable Executable Encoded in Powershell Script
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can abuse PowerShell in-memory capabilities to inject executables into memory without touching the disk, bypassing file-based security protections. These executables are generally base64 encoded.
+Attackers can abuse PowerShell in-memory capabilities to inject executables into memory without touching the disk,
+bypassing file-based security protections. These executables are generally base64 encoded.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the script using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -67,13 +73,16 @@ Attackers can abuse PowerShell in-memory capabilities to inject executables into
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - Reimage the host operating system or restore the compromised files to clean versions.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/execution_posh_psreflect.toml
+++ b/rules/windows/execution_posh_psreflect.toml
@@ -22,21 +22,29 @@ note = """## Triage and analysis
 
 ### Investigating PowerShell PSReflect Script
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-PSReflect is a library that enables PowerShell to access win32 API functions in an uncomplicated way. It also helps to create enums and structs easily—all without touching the disk.
+PSReflect is a library that enables PowerShell to access win32 API functions in an uncomplicated way. It also helps to
+create enums and structs easily—all without touching the disk.
 
-Although this is an interesting project for every developer and admin out there, it is mainly used in the red team and malware tooling for its capabilities.
+Although this is an interesting project for every developer and admin out there, it is mainly used in the red team and
+malware tooling for its capabilities.
 
-Detecting the core implementation of PSReflect means detecting most of the tooling that uses Windows API through PowerShell, enabling defenders to discover tools being dropped in the environment.
+Detecting the core implementation of PSReflect means detecting most of the tooling that uses Windows API through
+PowerShell, enabling defenders to discover tools being dropped in the environment.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics. The script content that may be split into multiple script blocks (you can use the field `powershell.file.script_block_id` for filtering).
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration
+capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics. The
+script content that may be split into multiple script blocks (you can use the field `powershell.file.script_block_id`
+for filtering).
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Check for additional PowerShell and command-line logs that indicate that imported functions were run.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Evaluate whether the user needs to use PowerShell to complete tasks.
@@ -44,16 +52,18 @@ Detecting the core implementation of PSReflect means detecting most of the tooli
   - Analyze the script using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -77,12 +87,15 @@ Detecting the core implementation of PSReflect means detecting most of the tooli
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/execution_psexec_lateral_movement_command.toml
+++ b/rules/windows/execution_psexec_lateral_movement_command.toml
@@ -27,33 +27,44 @@ note = """## Triage and analysis
 
 ### Investigating PsExec Network Connection
 
-PsExec is a remote administration tool that enables the execution of commands with both regular and SYSTEM privileges on Windows systems. Microsoft develops it as part of the Sysinternals Suite. Although commonly used by administrators, PsExec is frequently used by attackers to enable lateral movement and execute commands as SYSTEM to disable defenses and bypass security protections.
+PsExec is a remote administration tool that enables the execution of commands with both regular and SYSTEM privileges
+on Windows systems. Microsoft develops it as part of the Sysinternals Suite. Although commonly used by administrators,
+PsExec is frequently used by attackers to enable lateral movement and execute commands as SYSTEM to disable defenses and
+bypass security protections.
 
-This rule identifies PsExec execution by looking for the creation of `PsExec.exe`, the default name for the utility, followed by a network connection done by the process.
+This rule identifies PsExec execution by looking for the creation of `PsExec.exe`, the default name for the
+utility, followed by a network connection done by the process.
 
 #### Possible investigation steps
 
 - Check if the usage of this tool complies with the organization's administration policy.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Identify the target computer and its role in the IT environment.
-- Investigate what commands were run, and assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
+- Investigate what commands were run, and assess whether this behavior is prevalent in the environment by looking for
+similar occurrences across hosts.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. As long as the analyst did not identify suspicious activity related to the user or involved hosts, and the tool is allowed by the organization's policy, such alerts can be dismissed.
+- This mechanism can be used legitimately. As long as the analyst did not identify suspicious activity related to the
+user or involved hosts, and the tool is allowed by the organization's policy, such alerts can be dismissed.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
   - Prioritize accordingly with the role of the servers and users involved.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
 - Review the privileges assigned to the user to ensure that the least privilege principle is being followed.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 21
 rule_id = "55d551c6-333b-4665-ab7e-5d14a59715ce"

--- a/rules/windows/execution_suspicious_pdf_reader.toml
+++ b/rules/windows/execution_suspicious_pdf_reader.toml
@@ -21,15 +21,19 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious PDF Reader Child Process
 
-PDF is a common file type used in corporate environments and most machines have software to handle these files. This creates a vector where attackers can exploit the engines and technology behind this class of software for initial access or privilege escalation.
+PDF is a common file type used in corporate environments and most machines have software to handle these files. This
+creates a vector where attackers can exploit the engines and technology behind this class of software for initial access
+or privilege escalation.
 
 This rule looks for commonly abused built-in utilities spawned by a PDF reader process, which is likely a malicious behavior.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Retrieve PDF documents received and opened by the user that could cause this behavior. Common locations include, but are not limited to, the Downloads and Document folders and the folder configured at the email client.
+- Retrieve PDF documents received and opened by the user that could cause this behavior. Common locations include, but
+are not limited to, the Downloads and Document folders and the folder configured at the email client.
 - Determine if the collected files are malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
     - Observe and collect information about the following activities:
@@ -49,21 +53,26 @@ This rule looks for commonly abused built-in utilities spawned by a PDF reader p
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - If the triage identified malware, search the environment for additional compromised hosts.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
   - If the malicious file was delivered via phishing:
     - Block the email sender from sending future emails.
     - Block the malicious web pages.
     - Remove emails from the sender from mailboxes.
     - Consider improvements to the security awareness program.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/execution_suspicious_powershell_imgload.toml
+++ b/rules/windows/execution_suspicious_powershell_imgload.toml
@@ -21,14 +21,19 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious PowerShell Engine ImageLoad
 
-PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This makes it available for use in various environments, and creates an attractive way for attackers to execute code.
+PowerShell is one of the main tools system administrators use for automation, report routines, and other tasks. This
+makes it available for use in various environments, and creates an attractive way for attackers to execute code.
 
-Attackers can use PowerShell without having to execute `PowerShell.exe` directly. This technique, often called "PowerShell without PowerShell," works by using the underlying System.Management.Automation namespace and can bypass application allowlisting and PowerShell security features.
+Attackers can use PowerShell without having to execute `PowerShell.exe` directly. This technique, often called
+"PowerShell without PowerShell," works by using the underlying System.Management.Automation namespace and can bypass
+application allowlisting and PowerShell security features.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file
+modifications, and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
 - Retrieve the implementation (DLL, executable, etc.) and determine if it is malicious:
@@ -43,7 +48,8 @@ Attackers can use PowerShell without having to execute `PowerShell.exe` directly
 
 ### False positive analysis
 
-- This activity can happen legitimately. Some vendors have their own PowerShell implementations that are shipped with some products. These benign true positives (B-TPs) can be added as exceptions if necessary after analysis.
+- This activity can happen legitimately. Some vendors have their own PowerShell implementations that are shipped with
+some products. These benign true positives (B-TPs) can be added as exceptions if necessary after analysis.
 
 ### Response and remediation
 
@@ -53,12 +59,17 @@ Attackers can use PowerShell without having to execute `PowerShell.exe` directly
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/execution_via_hidden_shell_conhost.toml
+++ b/rules/windows/execution_via_hidden_shell_conhost.toml
@@ -21,14 +21,19 @@ note = """## Triage and analysis
 
 ### Investigating Conhost Spawned By Suspicious Parent Process
 
-The Windows Console Host, or `conhost.exe`, is both the server application for all of the Windows Console APIs as well as the classic Windows user interface for working with command-line applications.
+The Windows Console Host, or `conhost.exe`, is both the server application for all of the Windows Console APIs as well as
+the classic Windows user interface for working with command-line applications.
 
-Attackers often rely on custom shell implementations to avoid using built-in command interpreters like `cmd.exe` and `PowerShell.exe` and bypass application allowlisting and security features. Attackers commonly inject these implementations into legitimate system processes.
+Attackers often rely on custom shell implementations to avoid using built-in command interpreters like `cmd.exe` and
+`PowerShell.exe` and bypass application allowlisting and security features. Attackers commonly inject these implementations into
+legitimate system processes.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate abnormal behaviors observed by the subject process, such as network connections, registry or file
+modifications, and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
 - Retrieve the parent process executable and determine if it is malicious:
@@ -58,12 +63,17 @@ Attackers often rely on custom shell implementations to avoid using built-in com
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
+++ b/rules/windows/execution_via_xp_cmdshell_mssql_stored_procedure.toml
@@ -21,34 +21,48 @@ note = """## Triage and analysis
 
 ### Investigating Execution via MSSQL xp_cmdshell Stored Procedure
 
-Microsoft SQL Server (MSSQL) has procedures meant to extend its functionality, the Extended Stored Procedures. These procedures are external functions written in C/C++; some provide interfaces for external programs. This is the case for xp_cmdshell, which spawns a Windows command shell and passes in a string for execution. Attackers can use this to execute commands on the system running the SQL server, commonly to escalate their privileges and establish persistence.
+Microsoft SQL Server (MSSQL) has procedures meant to extend its functionality, the Extended Stored Procedures. These
+procedures are external functions written in C/C++; some provide interfaces for external programs. This is the case for
+xp_cmdshell, which spawns a Windows command shell and passes in a string for execution. Attackers can use this to
+execute commands on the system running the SQL server, commonly to escalate their privileges and establish persistence.
 
-The xp_cmdshell procedure is disabled by default, but when used, it has the same security context as the MSSQL Server service account, which is often privileged.
+The xp_cmdshell procedure is disabled by default, but when used, it has the same security context as the MSSQL Server
+service account, which is often privileged.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network connections.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal account behavior, such as command executions, file creations or modifications, and network
+connections.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the command line to determine if the command executed is potentially harmful or malicious.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
 
 ### False positive analysis
 
-- This mechanism can be used legitimately, but it brings inherent risk. The security team must monitor any activity of it. If recurrent tasks are being executed using this mechanism, consider adding exceptions — preferably with a full command line.
+- This mechanism can be used legitimately, but it brings inherent risk. The security team must monitor any activity of
+it. If recurrent tasks are being executed using this mechanism, consider adding exceptions — preferably with a full
+command line.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Ensure that SQL servers are not directly exposed to the internet. If there is a business justification for such, use an allowlist to allow only connections from known legitimate sources.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Ensure that SQL servers are not directly exposed to the internet. If there is a business justification for such, use
+an allowlist to allow only connections from known legitimate sources.
 - Disable the xp_cmdshell stored procedure.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/impact_backup_file_deletion.toml
+++ b/rules/windows/impact_backup_file_deletion.toml
@@ -24,15 +24,19 @@ note = """## Triage and analysis
 
 ### Investigating Third-party Backup Files Deleted via Unexpected Process
 
-Backups are a significant obstacle for any ransomware operation. They allow the victim to resume business by performing data recovery, making them a valuable target.
+Backups are a significant obstacle for any ransomware operation. They allow the victim to resume business by performing
+data recovery, making them a valuable target.
 
-Attackers can delete backups from the host and gain access to backup servers to remove centralized backups for the environment, ensuring that victims have no alternatives to paying the ransom.
+Attackers can delete backups from the host and gain access to backup servers to remove centralized backups for the
+environment, ensuring that victims have no alternatives to paying the ransom.
 
-This rule identifies file deletions performed by a process that does not belong to the backup suite and aims to delete Veritas or Veeam backups.
+This rule identifies file deletions performed by a process that does not belong to the backup suite and aims to delete
+Veritas or Veeam backups.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -40,7 +44,8 @@ This rule identifies file deletions performed by a process that does not belong 
 
 ### False positive analysis
 
-- This rule can be triggered by the manual removal of backup files and by removal using other third-party tools that are not from the backup suite. Exceptions can be added for specific accounts and executables, preferably tied together.
+- This rule can be triggered by the manual removal of backup files and by removal using other third-party tools that are
+not from the backup suite. Exceptions can be added for specific accounts and executables, preferably tied together.
 
 ### Related rules
 
@@ -52,12 +57,16 @@ This rule identifies file deletions performed by a process that does not belong 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Consider isolating the involved host to prevent destructive behavior, which is commonly associated with this activity.
 - Perform data recovery locally or restore the backups from replicated copies (Cloud, other servers, etc.).
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/impact_deleting_backup_catalogs_with_wbadmin.toml
+++ b/rules/windows/impact_deleting_backup_catalogs_with_wbadmin.toml
@@ -21,13 +21,16 @@ note = """## Triage and analysis
 
 ### Investigating Deleting Backup Catalogs with Wbadmin
 
-Windows Server Backup stores the details about your backups (what volumes are backed up and where the backups are located) in a file called a backup catalog, which ransomware victims can use to recover corrupted backup files. Deleting these files is a common step in threat actor playbooks.
+Windows Server Backup stores the details about your backups (what volumes are backed up and where the backups are
+located) in a file called a backup catalog, which ransomware victims can use to recover corrupted backup files.
+Deleting these files is a common step in threat actor playbooks.
 
 This rule identifies the deletion of the backup catalog using the `wbadmin.exe` utility.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -49,12 +52,16 @@ This rule identifies the deletion of the backup catalog using the `wbadmin.exe` 
 
 - Initiate the incident response process based on the outcome of the triage.
 - Consider isolating the involved host to prevent destructive behavior, which is commonly associated with this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look for ransomware preparation and execution activities.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look
+for ransomware preparation and execution activities.
 - If any backups were affected:
   - Perform data recovery locally or restore the backups from replicated copies (cloud, other servers, etc.).
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/impact_modification_of_boot_config.toml
+++ b/rules/windows/impact_modification_of_boot_config.toml
@@ -21,7 +21,9 @@ note = """## Triage and analysis
 
 ### Investigating Modification of Boot Configuration
 
-Boot entry parameters, or boot parameters, are optional, system-specific settings that represent configuration options. These are stored in a boot configuration data (BCD) store, and administrators can use utilities like `bcdedit.exe` to configure these.
+Boot entry parameters, or boot parameters, are optional, system-specific settings that represent configuration options.
+These are stored in a boot configuration data (BCD) store, and administrators can use utilities like `bcdedit.exe` to
+configure these.
 
 This rule identifies the usage of `bcdedit.exe` to:
 
@@ -32,7 +34,8 @@ These are common steps in destructive attacks by adversaries leveraging ransomwa
 
 #### Possible investigation steps
 
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -41,7 +44,8 @@ These are common steps in destructive attacks by adversaries leveraging ransomwa
 
 ### False positive analysis
 
-- The usage of these options is not inherently malicious. Administrators can modify these configurations to force a machine to boot for troubleshooting or data recovery purposes.
+- The usage of these options is not inherently malicious. Administrators can modify these configurations to force a
+machine to boot for troubleshooting or data recovery purposes.
 
 ### Related rules
 
@@ -51,10 +55,14 @@ These are common steps in destructive attacks by adversaries leveraging ransomwa
 
 - Initiate the incident response process based on the outcome of the triage.
 - Consider isolating the involved host to prevent destructive behavior, which is commonly associated with this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look for ransomware preparation and execution activities.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look
+for ransomware preparation and execution activities.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/impact_stop_process_service_threshold.toml
+++ b/rules/windows/impact_stop_process_service_threshold.toml
@@ -21,13 +21,17 @@ note = """## Triage and analysis
 
 ### Investigating High Number of Process and/or Service Terminations
 
-Attackers can stop services and kill processes for a variety of purposes. For example, they can stop services associated with business applications and databases to release the lock on files used by these applications so they may be encrypted, or stop security and backup solutions, etc.
+Attackers can stop services and kill processes for a variety of purposes. For example, they can stop services associated
+with business applications and databases to release the lock on files used by these applications so they may be encrypted,
+or stop security and backup solutions, etc.
 
-This rule identifies a high number (10) of service and/or process terminations (stop, delete, or suspend) from the same host within a short time period.
+This rule identifies a high number (10) of service and/or process terminations (stop, delete, or suspend) from the same
+host within a short time period.
 
 #### Possible investigation steps
 
-- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -41,12 +45,17 @@ This rule identifies a high number (10) of service and/or process terminations (
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further destructive behavior, which is commonly associated with this activity.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Reimage the host operating system or restore it to the operational state.
-- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look for ransomware preparation and execution activities.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- If any other destructive action was identified on the host, it is recommended to prioritize the investigation and look
+for ransomware preparation and execution activities.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = ["https://www.elastic.co/security-labs/luna-ransomware-attack-pattern"]
 risk_score = 47

--- a/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_or_resized_via_vssadmin.toml
@@ -21,15 +21,19 @@ note = """## Triage and analysis
 
 ### Investigating Volume Shadow Copy Deleted or Resized via VssAdmin
 
-The Volume Shadow Copy Service (VSS) is a Windows feature that enables system administrators to take snapshots of volumes that can later be restored or mounted to recover specific files or folders.
+The Volume Shadow Copy Service (VSS) is a Windows feature that enables system administrators to take snapshots of volumes
+that can later be restored or mounted to recover specific files or folders.
 
-A typical step in the playbook of an attacker attempting to deploy ransomware is to delete Volume Shadow Copies to ensure that victims have no alternative to paying the ransom, making any action that deletes shadow copies worth monitoring.
+A typical step in the playbook of an attacker attempting to deploy ransomware is to delete Volume Shadow
+Copies to ensure that victims have no alternative to paying the ransom, making any action that deletes shadow
+copies worth monitoring.
 
 This rule monitors the execution of Vssadmin.exe to either delete or resize shadow copies.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - In the case of a resize operation, check if the resize value is equal to suspicious values, like 401MB.
@@ -49,7 +53,8 @@ This rule monitors the execution of Vssadmin.exe to either delete or resize shad
 
 ### False positive analysis
 
-- This rule may produce benign true positives (B-TPs). If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of user and command line conditions.
+- This rule may produce benign true positives (B-TPs). If this activity is expected and noisy in your
+environment, consider adding exceptions — preferably with a combination of user and command line conditions.
 
 ### Related rules
 
@@ -65,14 +70,19 @@ This rule monitors the execution of Vssadmin.exe to either delete or resize shad
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - If data was encrypted, deleted, or modified, activate your data recovery plan.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Perform data recovery locally or restore the backups from replicated copies (cloud, other servers, etc.).
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_powershell.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_powershell.toml
@@ -21,11 +21,15 @@ note = """## Triage and analysis
 
 ### Investigating Volume Shadow Copy Deletion via PowerShell
 
-The Volume Shadow Copy Service (VSS) is a Windows feature that enables system administrators to take snapshots of volumes that can later be restored or mounted to recover specific files or folders.
+The Volume Shadow Copy Service (VSS) is a Windows feature that enables system administrators to take snapshots of volumes
+that can later be restored or mounted to recover specific files or folders.
 
-A typical step in the playbook of an attacker attempting to deploy ransomware is to delete Volume Shadow Copies to ensure that victims have no alternative to paying the ransom, making any action that deletes shadow copies worth monitoring.
+A typical step in the playbook of an attacker attempting to deploy ransomware is to delete Volume Shadow
+Copies to ensure that victims have no alternative to paying the ransom, making any action that deletes shadow
+copies worth monitoring.
 
-This rule monitors the execution of PowerShell cmdlets to interact with the Win32_ShadowCopy WMI class, retrieve shadow copy objects, and delete them.
+This rule monitors the execution of PowerShell cmdlets to interact with the Win32_ShadowCopy WMI class, retrieve shadow
+copy objects, and delete them.
 
 #### Possible investigation steps
 
@@ -48,7 +52,8 @@ This rule monitors the execution of PowerShell cmdlets to interact with the Win3
 
 ### False positive analysis
 
-- This rule has chances of producing benign true positives (B-TPs). If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of user and command line conditions.
+- This rule has chances of producing benign true positives (B-TPs). If this activity is expected and noisy in your
+environment, consider adding exceptions — preferably with a combination of user and command line conditions.
 
 ### Related rules
 
@@ -64,14 +69,19 @@ This rule monitors the execution of PowerShell cmdlets to interact with the Win3
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - If data was encrypted, deleted, or modified, activate your data recovery plan.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Perform data recovery locally or restore the backups from replicated copies (cloud, other servers, etc.).
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/impact_volume_shadow_copy_deletion_via_wmic.toml
+++ b/rules/windows/impact_volume_shadow_copy_deletion_via_wmic.toml
@@ -21,9 +21,12 @@ note = """## Triage and analysis
 
 ### Investigating Volume Shadow Copy Deletion via WMIC
 
-The Volume Shadow Copy Service (VSS) is a Windows feature that enables system administrators to take snapshots of volumes that can later be restored or mounted to recover specific files or folders.
+The Volume Shadow Copy Service (VSS) is a Windows feature that enables system administrators to take snapshots of volumes
+that can later be restored or mounted to recover specific files or folders.
 
-A typical step in the playbook of an attacker attempting to deploy ransomware is to delete Volume Shadow Copies to ensure that victims have no alternative to paying the ransom, making any action that deletes shadow copies worth monitoring.
+A typical step in the playbook of an attacker attempting to deploy ransomware is to delete Volume Shadow
+Copies to ensure that victims have no alternative to paying the ransom, making any action that deletes shadow
+copies worth monitoring.
 
 This rule monitors the execution of `wmic.exe` to interact with VSS via the `shadowcopy` alias and delete parameter.
 
@@ -49,7 +52,8 @@ This rule monitors the execution of `wmic.exe` to interact with VSS via the `sha
 
 ### False positive analysis
 
-- This rule has chances of producing benign true positives (B-TPs). If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of user and command line conditions.
+- This rule has chances of producing benign true positives (B-TPs). If this activity is expected and noisy in your
+environment, consider adding exceptions — preferably with a combination of user and command line conditions.
 
 ### Related rules
 
@@ -65,14 +69,19 @@ This rule monitors the execution of `wmic.exe` to interact with VSS via the `sha
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - If data was encrypted, deleted, or modified, activate your data recovery plan.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Perform data recovery locally or restore the backups from replicated copies (cloud, other servers, etc.).
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/initial_access_script_executing_powershell.toml
+++ b/rules/windows/initial_access_script_executing_powershell.toml
@@ -21,15 +21,18 @@ note = """## Triage and analysis
 
 ### Investigating Windows Script Executing PowerShell
 
-The Windows Script Host (WSH) is an Windows automation technology, which is ideal for non-interactive scripting needs, such as logon scripting, administrative scripting, and machine automation.
+The Windows Script Host (WSH) is an Windows automation technology, which is ideal for non-interactive scripting needs,
+such as logon scripting, administrative scripting, and machine automation.
 
-Attackers commonly use WSH scripts as their initial access method, acting like droppers for second stage payloads, but can also use them to download tools and utilities needed to accomplish their goals.
+Attackers commonly use WSH scripts as their initial access method, acting like droppers for second stage payloads, but
+can also use them to download tools and utilities needed to accomplish their goals.
 
 This rule looks for the spawn of the `powershell.exe` process with `cscript.exe` or `wscript.exe` as its parent process.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate commands executed by the spawned PowerShell process.
 - If unsigned files are found on the process tree, retrieve them and determine if they are malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
@@ -45,7 +48,8 @@ This rule looks for the spawn of the `powershell.exe` process with `cscript.exe`
 
 ### False positive analysis
 
-- The usage of these script engines by regular users is unlikely. In the case of authorized benign true positives (B-TPs), exceptions can be added.
+- The usage of these script engines by regular users is unlikely. In the case of authorized benign true positives
+(B-TPs), exceptions can be added.
 
 ### Response and remediation
 
@@ -55,7 +59,8 @@ This rule looks for the spawn of the `powershell.exe` process with `cscript.exe`
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - If the malicious file was delivered via phishing:
   - Block the email sender from sending future emails.
@@ -63,9 +68,11 @@ This rule looks for the spawn of the `powershell.exe` process with `cscript.exe`
   - Remove emails from the sender from mailboxes.
   - Consider improvements to the security awareness program.
 - Reimage the host operating system and restore compromised files to clean versions.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/initial_access_suspicious_ms_office_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_office_child_process.toml
@@ -22,15 +22,21 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious MS Office Child Process
 
-Microsoft Office (MS Office) is a suite of applications designed to help with productivity and completing common tasks on a computer. You can create and edit documents containing text and images, work with data in spreadsheets and databases, and create presentations and posters. As it is some of the most-used software across companies, MS Office is frequently targeted for initial access. It also has a wide variety of capabilities that attackers can take advantage of.
+Microsoft Office (MS Office) is a suite of applications designed to help with productivity and completing common tasks on a computer.
+You can create and edit documents containing text and images, work with data in spreadsheets and databases, and create
+presentations and posters. As it is some of the most-used software across companies, MS Office is frequently targeted
+for initial access. It also has a wide variety of capabilities that attackers can take advantage of.
 
-This rule looks for suspicious processes spawned by MS Office programs. This is generally the result of the execution of malicious documents.
+This rule looks for suspicious processes spawned by MS Office programs. This is generally the result of the execution of
+malicious documents.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Retrieve MS Office documents received and opened by the user that could cause this behavior. Common locations include, but are not limited to, the Downloads and Document folders and the folder configured at the email client.
+- Retrieve MS Office documents received and opened by the user that could cause this behavior. Common locations include,
+but are not limited to, the Downloads and Document folders and the folder configured at the email client.
 - Determine if the collected files are malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
     - Observe and collect information about the following activities:
@@ -49,21 +55,26 @@ This rule looks for suspicious processes spawned by MS Office programs. This is 
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - If the triage identified malware, search the environment for additional compromised hosts.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
   - If the malicious file was delivered via phishing:
     - Block the email sender from sending future emails.
     - Block the malicious web pages.
     - Remove emails from the sender from mailboxes.
     - Consider improvements to the security awareness program.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
@@ -21,15 +21,19 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious MS Outlook Child Process
 
-Microsoft Outlook is an email client that provides contact, email calendar, and task management features. Outlook is widely used, either standalone or as part of the Office suite.
+Microsoft Outlook is an email client that provides contact, email calendar, and task management features. Outlook is
+widely used, either standalone or as part of the Office suite.
 
-This rule looks for suspicious processes spawned by MS Outlook, which can be the result of the execution of malicious documents and/or exploitation for initial access.
+This rule looks for suspicious processes spawned by MS Outlook, which can be the result of the execution of malicious
+documents and/or exploitation for initial access.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Retrieve recently opened files received via email and opened by the user that could cause this behavior. Common locations include but are not limited to, the Downloads and Document folders and the folder configured at the email client.
+- Retrieve recently opened files received via email and opened by the user that could cause this behavior. Common
+locations include but are not limited to, the Downloads and Document folders and the folder configured at the email client.
 - Determine if the collected files are malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
     - Observe and collect information about the following activities:
@@ -48,21 +52,26 @@ This rule looks for suspicious processes spawned by MS Outlook, which can be the
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - If the triage identified malware, search the environment for additional compromised hosts.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
   - If the malicious file was delivered via phishing:
     - Block the email sender from sending future emails.
     - Block the malicious web pages.
     - Remove emails from the sender from mailboxes.
     - Consider improvements to the security awareness program.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/initial_access_unusual_dns_service_children.toml
+++ b/rules/windows/initial_access_unusual_dns_service_children.toml
@@ -28,17 +28,27 @@ note = """## Triage and analysis
 
 ### Investigating Unusual Child Process of dns.exe
 
-SIGRed (CVE-2020-1350) is a wormable, critical vulnerability in the Windows DNS server that affects Windows Server versions 2003 to 2019 and can be triggered by a malicious DNS response. Because the service is running in elevated privileges (SYSTEM), an attacker that successfully exploits it is granted Domain Administrator rights. This can effectively compromise the entire corporate infrastructure.
+SIGRed (CVE-2020-1350) is a wormable, critical vulnerability in the Windows DNS server that affects Windows Server
+versions 2003 to 2019 and can be triggered by a malicious DNS response. Because the service is running in elevated
+privileges (SYSTEM), an attacker that successfully exploits it is granted Domain Administrator rights. This can
+effectively compromise the entire corporate infrastructure.
 
-This rule looks for unusual children of the `dns.exe` process, which can indicate the exploitation of the SIGRed or a similar remote code execution vulnerability in the DNS server.
+This rule looks for unusual children of the `dns.exe` process, which can indicate the exploitation of the SIGRed or a
+similar remote code execution vulnerability in the DNS server.
 
 #### Possible investigation steps
 
 - Investigate the process execution chain (parent process tree) for unknown processes.
-  - Any suspicious or abnormal child process spawned from dns.exe should be carefully reviewed and investigated. It's impossible to predict what an adversary may deploy as the follow-on process after the exploit, but built-in discovery/enumeration utilities should be top of mind (`whoami.exe`, `netstat.exe`, `systeminfo.exe`, `tasklist.exe`).
-  - Built-in Windows programs that contain capabilities used to download and execute additional payloads should also be considered. This is not an exhaustive list, but ideal candidates to start out would be: `mshta.exe`, `powershell.exe`, `regsvr32.exe`, `rundll32.exe`, `wscript.exe`, `wmic.exe`.
-  - If a denial-of-service (DoS) exploit is successful and DNS Server service crashes, be mindful of potential child processes related to `werfault.exe` occurring.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+  - Any suspicious or abnormal child process spawned from dns.exe should be carefully reviewed and investigated. It's
+  impossible to predict what an adversary may deploy as the follow-on process after the exploit, but built-in
+  discovery/enumeration utilities should be top of mind (`whoami.exe`, `netstat.exe`, `systeminfo.exe`, `tasklist.exe`).
+  - Built-in Windows programs that contain capabilities used to download and execute additional payloads should also be
+  considered. This is not an exhaustive list, but ideal candidates to start out would be: `mshta.exe`, `powershell.exe`,
+  `regsvr32.exe`, `rundll32.exe`, `wscript.exe`, `wmic.exe`.
+  - If a denial-of-service (DoS) exploit is successful and DNS Server service crashes, be mindful of potential child processes related to
+  `werfault.exe` occurring.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Investigate other alerts associated with the host during the past 48 hours.
 - Check whether the server is vulnerable to CVE-2020-1350.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
@@ -51,14 +61,18 @@ This rule looks for unusual children of the `dns.exe` process, which can indicat
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved hosts to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Reimage the host operating system or restore the compromised server to a clean state.
 - Install the latest patches on systems that run Microsoft DNS Server.
 - Consider the implementation of a patch management system, such as the Windows Server Update Services (WSUS).
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full scan using the antimalware tool in place. This scan can reveal additional artifacts left in the system,
+persistence mechanisms, and malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
 - Review the privileges assigned to the user to ensure that the least privilege principle is being followed.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -23,36 +23,44 @@ note = """## Triage and analysis
 
 ### Investigating Direct Outbound SMB Connection
 
-This rule looks for unexpected processes making network connections over port 445. Windows file sharing is typically implemented over Server Message Block (SMB), which communicates between hosts using port 445. When legitimate, these network connections are established by the kernel (PID 4). Occurrences of non-system processes using this port can indicate port scanners, exploits, and tools used to move laterally on the environment.
+This rule looks for unexpected processes making network connections over port 445. Windows file sharing is typically
+implemented over Server Message Block (SMB), which communicates between hosts using port 445. When legitimate, these
+network connections are established by the kernel (PID 4). Occurrences of non-system processes using this port can indicate
+port scanners, exploits, and tools used to move laterally on the environment.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Contact the account owner and confirm whether they are aware of this activity.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
 
-- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- If this rule is noisy in your environment due to expected activity, consider adding exceptions — preferably with a combination
+of user and command line conditions.
 
 ### Response and remediation
 
@@ -62,11 +70,14 @@ This rule looks for unexpected processes making network connections over port 44
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 47
 rule_id = "c82c7d8f-fb9e-4874-a4bd-fd9e3f9becf1"

--- a/rules/windows/lateral_movement_dns_server_overflow.toml
+++ b/rules/windows/lateral_movement_dns_server_overflow.toml
@@ -3,7 +3,7 @@ creation_date = "2020/07/16"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/11/28"
+updated_date = "2022/11/07"
 
 [rule]
 author = ["Elastic"]
@@ -26,20 +26,28 @@ note = """## Triage and analysis
 
 ### Investigating Abnormally Large DNS Response
 
-Detection alerts from this rule indicate possible anomalous activity around large byte DNS responses from a Windows DNS server. This detection rule was created based on activity represented in exploitation of vulnerability (CVE-2020-1350) also known as [SigRed](https://www.elastic.co/blog/detection-rules-for-sigred-vulnerability) during July 2020.
+Detection alerts from this rule indicate possible anomalous activity around large byte DNS responses from a Windows DNS
+server. This detection rule was created based on activity represented in exploitation of vulnerability (CVE-2020-1350)
+also known as [SigRed](https://www.elastic.co/blog/detection-rules-for-sigred-vulnerability) during July 2020.
 
 #### Possible investigation steps
 
-- This specific rule is sourced from network log activity such as DNS or network level data. It's important to validate the source of the incoming traffic and determine if this activity has been observed previously within an environment.
+- This specific rule is sourced from network log activity such as DNS or network level data. It's important to validate
+the source of the incoming traffic and determine if this activity has been observed previously within an environment.
 - Activity can be further investigated and validated by reviewing any associated Intrusion Detection Signatures (IDS) alerts.
-- Further examination can include a review of the `dns.question_type` network fieldset with a protocol analyzer, such as Zeek, Packetbeat, or Suricata, for `SIG` or `RRSIG` data.
-- Validate the patch level and OS of the targeted DNS server to validate the observed activity was not large-scale internet vulnerability scanning.
+- Further examination can include a review of the `dns.question_type` network fieldset with a protocol analyzer, such as
+Zeek, Packetbeat, or Suricata, for `SIG` or `RRSIG` data.
+- Validate the patch level and OS of the targeted DNS server to validate the observed activity was not large-scale
+internet vulnerability scanning.
 - Validate that the source of the network activity was not from an authorized vulnerability scan or compromise assessment.
 
 #### False positive analysis
 
-- Based on this rule, which looks for a threshold of 60k bytes, it is possible for activity to be generated under 65k bytes and related to legitimate behavior. In packet capture files received by the [SANS Internet Storm Center](https://isc.sans.edu/forums/diary/PATCH+NOW+SIGRed+CVE20201350+Microsoft+DNS+Server+Vulnerability/26356/), byte responses were all observed as greater than 65k bytes.
-- This activity can be triggered by compliance/vulnerability scanning or compromise assessment; it's important to determine the source of the activity and potentially allowlist the source host.
+- Based on this rule, which looks for a threshold of 60k bytes, it is possible for activity to be generated under 65k bytes
+and related to legitimate behavior.  In packet capture files received by the [SANS Internet Storm Center](https://isc.sans.edu/forums/diary/PATCH+NOW+SIGRed+CVE20201350+Microsoft+DNS+Server+Vulnerability/26356/), byte responses
+were all observed as greater than 65k bytes.
+- This activity can be triggered by compliance/vulnerability scanning or compromise assessment; it's important to
+determine the source of the activity and potentially allowlist the source host.
 
 ### Related rules
 
@@ -49,7 +57,9 @@ Detection alerts from this rule indicate possible anomalous activity around larg
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
-- Ensure that you have deployed the latest Microsoft [Security Update](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1350) (Monthly Rollup or Security Only) and restarted the patched machines. If unable to patch immediately, Microsoft [released](https://support.microsoft.com/en-us/help/4569509/windows-dns-server-remote-code-execution-vulnerability) a registry-based workaround that doesn’t require a restart. This can be used as a temporary solution before the patch is applied.
+- Ensure that you have deployed the latest Microsoft [Security Update](https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2020-1350)
+(Monthly Rollup or Security Only) and restarted the patched machines. If unable to patch immediately, Microsoft [released](https://support.microsoft.com/en-us/help/4569509/windows-dns-server-remote-code-execution-vulnerability)
+a registry-based workaround that doesn’t require a restart. This can be used as a temporary solution before the patch is applied.
 - Maintain backups of your critical systems to aid in quick recovery.
 - Perform routine vulnerability scans of your systems, monitor [CISA advisories](https://us-cert.cisa.gov/ncas/current-activity) and patch identified vulnerabilities.
 - If you observe a true positive, implement a remediation plan and monitor host-based artifacts for additional post-exploitation behavior.

--- a/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
+++ b/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
@@ -21,11 +21,14 @@ note = """## Triage and analysis
 
 ### Investigating Potential Lateral Tool Transfer via SMB Share
 
-Adversaries can use network shares to host tooling to support the compromise of other hosts in the environment. These tools can include discovery utilities, credential dumpers, malware, etc. Attackers can also leverage file shares that employees frequently access to host malicious files to gain a foothold in other machines.
+Adversaries can use network shares to host tooling to support the compromise of other hosts in the environment. These tools
+can include discovery utilities, credential dumpers, malware, etc. Attackers can also leverage file shares that employees
+frequently access to host malicious files to gain a foothold in other machines.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -51,12 +54,15 @@ Adversaries can use network shares to host tooling to support the compromise of 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - Review the privileges needed to write to the network share and restrict write access as needed.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 47
 rule_id = "58bc134c-e8d2-4291-a552-b4b3e537c60b"

--- a/rules/windows/lateral_movement_execution_via_file_shares_sequence.toml
+++ b/rules/windows/lateral_movement_execution_via_file_shares_sequence.toml
@@ -21,30 +21,34 @@ note = """## Triage and analysis
 
 ### Investigating Remote Execution via File Shares
 
-Adversaries can use network shares to host tooling to support the compromise of other hosts in the environment. These tools can include discovery utilities, credential dumpers, malware, etc.
+Adversaries can use network shares to host tooling to support the compromise of other hosts in the environment. These
+tools can include discovery utilities, credential dumpers, malware, etc.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Review adjacent login events (e.g., 4624) in the alert timeframe to identify the account used to perform this action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -58,12 +62,15 @@ Adversaries can use network shares to host tooling to support the compromise of 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - Review the privileges needed to write to the network share and restrict write access as needed.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = ["https://blog.menasec.net/2020/08/new-trick-to-detect-lateral-movement.html"]
 risk_score = 47

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -21,17 +21,21 @@ note = """## Triage and analysis
 
 ### Investigating RDP Enabled via Registry
 
-Microsoft Remote Desktop Protocol (RDP) is a proprietary Microsoft protocol that enables remote connections to other computers, typically over TCP port 3389.
+Microsoft Remote Desktop Protocol (RDP) is a proprietary Microsoft protocol that enables remote connections to other
+computers, typically over TCP port 3389.
 
-Attackers can use RDP to conduct their actions interactively. Ransomware operators frequently use RDP to access victim servers, often using privileged accounts.
+Attackers can use RDP to conduct their actions interactively. Ransomware operators frequently use RDP to access
+victim servers, often using privileged accounts.
 
-This rule detects modification of the fDenyTSConnections registry key to the value `0`, which specifies that remote desktop connections are enabled. Attackers can abuse remote registry, use psexec, etc., to enable RDP and move laterally.
+This rule detects modification of the fDenyTSConnections registry key to the value `0`, which specifies that remote
+desktop connections are enabled. Attackers can abuse remote registry, use psexec, etc., to enable RDP and move laterally.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the user to check if they are aware of the operation.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Check whether it makes sense to enable RDP to this host, given its role in the environment.
 - Check if the host is directly exposed to the internet.
@@ -40,7 +44,8 @@ This rule detects modification of the fDenyTSConnections registry key to the val
 
 ### False positive analysis
 
-- This mechanism can be used legitimately. Check whether the user should be performing this kind of activity, whether they are aware of it, whether RDP should be open, and whether the action exposes the environment to unnecessary risks.
+- This mechanism can be used legitimately. Check whether the user should be performing this kind of activity, whether
+they are aware of it, whether RDP should be open, and whether the action exposes the environment to unnecessary risks.
 
 ### Response and remediation
 
@@ -51,7 +56,8 @@ This rule detects modification of the fDenyTSConnections registry key to the val
 - Isolate the involved hosts to prevent further post-compromise behavior.
 - Review the privileges assigned to the involved users to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/lateral_movement_remote_services.toml
+++ b/rules/windows/lateral_movement_remote_services.toml
@@ -21,35 +21,47 @@ note = """## Triage and analysis
 
 ### Investigating Remotely Started Services via RPC
 
-The Service Control Manager Remote Protocol is a client/server protocol used for configuring and controlling service programs running on a remote computer. A remote service management session begins with the client initiating the connection request to the server. If the server grants the request, the connection is established. The client can then make multiple requests to modify, query the configuration, or start and stop services on the server by using the same session until the session is terminated.
+The Service Control Manager Remote Protocol is a client/server protocol used for configuring and controlling service
+programs running on a remote computer. A remote service management session begins with the client initiating the
+connection request to the server. If the server grants the request, the connection is established. The client can then
+make multiple requests to modify, query the configuration, or start and stop services on the server by using the same
+session until the session is terminated.
 
-This rule detects the remote creation or start of a service by correlating a `services.exe` network connection and the spawn of a child process.
+This rule detects the remote creation or start of a service by correlating a `services.exe` network connection and the
+spawn of a child process.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Review login events (e.g., 4624) in the alert timeframe to identify the account used to perform this action. Use the `source.address` field to help identify the source system.
-- Review network events from the source system using the source port identified on the alert and try to identify the program used to initiate the action.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Review login events (e.g., 4624) in the alert timeframe to identify the account used to perform this action. Use the
+`source.address` field to help identify the source system.
+- Review network events from the source system using the source port identified on the alert and try to identify the
+program used to initiate the action.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
@@ -64,12 +76,17 @@ This rule detects the remote creation or start of a service by correlating a `se
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-scmr/705b624a-13de-43cc-b8a2-99573da3635f",

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -21,17 +21,27 @@ note = """## Triage and analysis
 
 ### Investigating Remote Scheduled Task Creation
 
-[Scheduled tasks](https://docs.microsoft.com/en-us/windows/win32/taskschd/about-the-task-scheduler) are a great mechanism for persistence and program execution. These features can be used remotely for a variety of legitimate reasons, but at the same time used by malware and adversaries. When investigating scheduled tasks that were set up remotely, one of the first steps should be to determine the original intent behind the configuration and to verify if the activity is tied to benign behavior such as software installation or any kind of network administrator work. One objective for these alerts is to understand the configured action within the scheduled task. This is captured within the registry event data for this rule and can be base64 decoded to view the value.
+[Scheduled tasks](https://docs.microsoft.com/en-us/windows/win32/taskschd/about-the-task-scheduler) are a great mechanism
+for persistence and program execution. These features can be used remotely for a variety of legitimate reasons, but at
+the same time used by malware and adversaries. When investigating scheduled tasks that were set up remotely, one of the
+first steps should be to determine the original intent behind the configuration and to verify if the activity is tied to
+benign behavior such as software installation or any kind of network administrator work. One objective for these alerts
+is to understand the configured action within the scheduled task. This is captured within the registry event data for
+this rule and can be base64 decoded to view the value.
 
 #### Possible investigation steps
 
 - Review the TaskContent value to investigate the task configured action.
-- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
-- Further examination should include review of host-based artifacts and network logs from around when the scheduled task was created, on both the source and target machines.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software
+installations.
+- Further examination should include review of host-based artifacts and network logs from around when the scheduled task
+was created, on both the source and target machines.
 
 ### False positive analysis
 
-- There is a high possibility of benign activity tied to the creation of remote scheduled tasks as it is a general feature within Windows and used for legitimate purposes for a wide range of activity. Any kind of context should be found to further understand the source of the activity and determine the intent based on the scheduled task's contents.
+- There is a high possibility of benign activity tied to the creation of remote scheduled tasks as it is a general feature
+within Windows and used for legitimate purposes for a wide range of activity. Any kind of context should be found to
+further understand the source of the activity and determine the intent based on the scheduled task's contents.
 
 ### Related rules
 
@@ -44,7 +54,8 @@ note = """## Triage and analysis
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
 - Remove scheduled task and any other related artifacts.
-- Review privileged account management and user account management settings. Consider implementing group policy object (GPO) policies to further restrict activity, or configuring settings that only allow administrators to create remote scheduled tasks.
+- Review privileged account management and user account management settings. Consider implementing group policy object (GPO) policies to further
+restrict activity, or configuring settings that only allow administrators to create remote scheduled tasks.
 """
 risk_score = 47
 rule_id = "9c865691-5599-447a-bac9-b3f2df5f9a9d"

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -18,17 +18,27 @@ note = """## Triage and analysis
 
 ### Investigating Remote Scheduled Task Creation
 
-[Scheduled tasks](https://docs.microsoft.com/en-us/windows/win32/taskschd/about-the-task-scheduler) are a great mechanism for persistence and program execution. These features can be used remotely for a variety of legitimate reasons, but at the same time used by malware and adversaries. When investigating scheduled tasks that were set up remotely, one of the first steps should be to determine the original intent behind the configuration and to verify if the activity is tied to benign behavior such as software installation or any kind of network administrator work. One objective for these alerts is to understand the configured action within the scheduled task. This is captured within the registry event data for this rule and can be base64 decoded to view the value.
+[Scheduled tasks](https://docs.microsoft.com/en-us/windows/win32/taskschd/about-the-task-scheduler) are a great mechanism
+for persistence and program execution. These features can be used remotely for a variety of legitimate reasons, but at
+the same time used by malware and adversaries. When investigating scheduled tasks that were set up remotely, one of the
+first steps should be to determine the original intent behind the configuration and to verify if the activity is tied to
+benign behavior such as software installation or any kind of network administrator work. One objective for these alerts
+is to understand the configured action within the scheduled task. This is captured within the registry event data for
+this rule and can be base64 decoded to view the value.
 
 #### Possible investigation steps
 
 - Review the base64 encoded tasks actions registry value to investigate the task configured action.
-- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
-- Further examination should include review of host-based artifacts and network logs from around when the scheduled task was created, on both the source and target machines.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software
+installations.
+- Further examination should include review of host-based artifacts and network logs from around when the scheduled task
+was created, on both the source and target machines.
 
 ### False positive analysis
 
-- There is a high possibility of benign activity tied to the creation of remote scheduled tasks as it is a general feature within Windows and used for legitimate purposes for a wide range of activity. Any kind of context should be found to further understand the source of the activity and determine the intent based on the scheduled task's contents.
+- There is a high possibility of benign activity tied to the creation of remote scheduled tasks as it is a general feature
+within Windows and used for legitimate purposes for a wide range of activity. Any kind of context should be found to
+further understand the source of the activity and determine the intent based on the scheduled task's contents.
 
 ### Related rules
 
@@ -40,7 +50,8 @@ note = """## Triage and analysis
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
 - Remove scheduled task and any other related artifacts.
-- Review privileged account management and user account management settings. Consider implementing group policy object (GPO) policies to further restrict activity, or configuring settings that only allow administrators to create remote scheduled tasks.
+- Review privileged account management and user account management settings. Consider implementing group policy object (GPO) policies to further
+restrict activity, or configuring settings that only allow administrators to create remote scheduled tasks.
 """
 risk_score = 47
 rule_id = "954ee7c8-5437-49ae-b2d6-2960883898e9"

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -18,14 +18,16 @@ note = """## Triage and analysis
 
 ### Investigating Adobe Hijack Persistence
 
-Attackers can replace the `RdrCEF.exe` executable with their own to maintain their access, which will be launched whenever Adobe Acrobat Reader is executed.
+Attackers can replace the `RdrCEF.exe` executable with their own to maintain their access, which will be launched
+whenever Adobe Acrobat Reader is executed.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
@@ -33,16 +35,18 @@ Attackers can replace the `RdrCEF.exe` executable with their own to maintain the
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -56,12 +60,17 @@ Attackers can replace the `RdrCEF.exe` executable with their own to maintain the
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/persistence_dontexpirepasswd_account.toml
+++ b/rules/windows/persistence_dontexpirepasswd_account.toml
@@ -30,9 +30,11 @@ note = """## Triage and analysis
 
 ### Investigating Account Configured with Never-Expiring Password
 
-Active Directory provides a setting that prevents users' passwords from expiring. Enabling this setting is bad practice and can expose environments to vulnerabilities that weaken security posture, especially when these accounts are privileged.
+Active Directory provides a setting that prevents users' passwords from expiring. Enabling this setting is bad practice and can expose
+environments to vulnerabilities that weaken security posture, especially when these accounts are privileged.
 
-The setting is usually configured so a user account can act as a service account. Attackers can abuse these accounts to persist in the domain and maintain long-term access using compromised accounts with a never-expiring password set.
+The setting is usually configured so a user account can act as a service account. Attackers can abuse these accounts to
+persist in the domain and maintain long-term access using compromised accounts with a never-expiring password set.
 
 #### Possible investigation steps
 
@@ -43,8 +45,12 @@ The setting is usually configured so a user account can act as a service account
 
 ### False positive analysis
 
-- This activity should not happen legitimately. The security team should address any potential benign true positive (B-TP), as this configuration can put the user and the domain at risk.
-- Using user accounts as service accounts is a bad security practice and should not be allowed in the domain. The security team should map and monitor potential benign true positives (B-TPs), especially if the account is privileged. For cases in which user accounts cannot be avoided, Microsoft provides the Group Managed Service Accounts (gMSA) feature, which ensures that the account password is robust and changed regularly and automatically.
+- This activity should not happen legitimately. The security team should address any potential benign true positive
+(B-TP), as this configuration can put the user and the domain at risk.
+- Using user accounts as service accounts is a bad security practice and should not be allowed in the domain. The
+security team should map and monitor potential benign true positives (B-TPs), especially if the account is privileged.
+For cases in which user accounts cannot be avoided, Microsoft provides the Group Managed Service Accounts (gMSA) feature,
+which ensures that the account password is robust and changed regularly and automatically.
 
 ### Response and remediation
 
@@ -54,8 +60,11 @@ The setting is usually configured so a user account can act as a service account
 - Search for other occurrences on the domain.
     - Using the [Active Directory PowerShell module](https://docs.microsoft.com/en-us/powershell/module/activedirectory/get-aduser):
         - `get-aduser -filter { passwordNeverExpires -eq $true  -and enabled -eq $true } | ft`
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts, if
+any, are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email,
+business systems, and web services.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 references = [
     "https://www.cert.ssi.gouv.fr/uploads/guide-ad.html#dont_expire",

--- a/rules/windows/persistence_evasion_hidden_local_account_creation.toml
+++ b/rules/windows/persistence_evasion_hidden_local_account_creation.toml
@@ -22,14 +22,16 @@ note = """## Triage and analysis
 
 ### Investigating Creation of a Hidden Local User Account
 
-Attackers can create accounts ending with a `$` symbol to make the account hidden to user enumeration utilities and bypass detections that identify computer accounts by this pattern to apply filters.
+Attackers can create accounts ending with a `$` symbol to make the account hidden to user enumeration utilities and
+bypass detections that identify computer accounts by this pattern to apply filters.
 
 This rule uses registry events to identify the creation of local hidden accounts.
 
 #### Possible investigation steps
 
 - Identify the user account that performed the action and whether it should perform this kind of action.
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for
+prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 
 ### False positive analysis
@@ -43,7 +45,8 @@ This rule uses registry events to identify the creation of local hidden accounts
 - Delete the hidden account.
 - Review the privileges assigned to the involved users to ensure that the least privilege principle is being followed.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
+++ b/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
@@ -21,35 +21,44 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious Startup Shell Folder Modification
 
-Techniques used within malware and by adversaries often leverage the Windows registry to store malicious programs for persistence. Startup shell folders are often targeted as they are not as prevalent as normal Startup folder paths so this behavior may evade existing AV/EDR solutions. These programs may also run with higher privileges which can be ideal for an attacker.
+Techniques used within malware and by adversaries often leverage the Windows registry to store malicious programs for
+persistence. Startup shell folders are often targeted as they are not as prevalent as normal Startup folder paths so this
+behavior may evade existing AV/EDR solutions. These programs may also run with higher privileges which can be ideal for
+an attacker.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Review the source process and related file tied to the Windows Registry entry.
-- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Validate the activity is not related to planned patches, updates, network administrator activity or legitimate software
+installations.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- There is a high possibility of benign legitimate programs being added to shell folders. This activity could be based on new software installations, patches, or other network administrator activity. Before undertaking further investigation, it should be verified that this activity is not benign.
+- There is a high possibility of benign legitimate programs being added to shell folders. This activity could be based
+on new software installations, patches, or other network administrator activity. Before undertaking further investigation,
+it should be verified that this activity is not benign.
 
 ### Related rules
 
@@ -66,8 +75,10 @@ Techniques used within malware and by adversaries often leverage the Windows reg
   - Block the malicious web pages.
   - Remove emails from the sender from mailboxes.
   - Consider improvements to the security awareness program.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 73
 rule_id = "c8b150f0-0164-475b-a75e-74b47800a9ff"

--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -22,18 +22,23 @@ note = """## Triage and analysis
 
 ### Investigating Potential Modification of Accessibility Binaries
 
-Adversaries may establish persistence and/or elevate privileges by executing malicious content triggered by accessibility features. Windows contains accessibility features that may be launched with a key combination before a user has logged in (ex: when the user is on the Windows logon screen). An adversary can modify the way these programs are launched to get a command prompt or backdoor without logging in to the system.
+Adversaries may establish persistence and/or elevate privileges by executing malicious content triggered by
+accessibility features. Windows contains accessibility features that may be launched with a key combination before a
+user has logged in (ex: when the user is on the Windows logon screen). An adversary can modify the way these programs
+are launched to get a command prompt or backdoor without logging in to the system.
 
 More details can be found [here](https://attack.mitre.org/techniques/T1546/008/).
 
-This rule looks for the execution of supposed accessibility binaries that don't match any of the accessibility features binaries' original file names, which is likely a custom binary deployed by the attacker.
+This rule looks for the execution of supposed accessibility binaries that don't match any of the accessibility features
+binaries' original file names, which is likely a custom binary deployed by the attacker.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account and system owners and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -42,20 +47,23 @@ This rule looks for the execution of supposed accessibility binaries that don't 
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- This activity should not happen legitimately. The security team should address any potential benign true positive (B-TP), as this configuration can put the user and the domain at risk.
+- This activity should not happen legitimately. The security team should address any potential benign true positive
+(B-TP), as this configuration can put the user and the domain at risk.
 
 ### Response and remediation
 
@@ -65,12 +73,17 @@ This rule looks for the execution of supposed accessibility binaries that don't 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/persistence_run_key_and_startup_broad.toml
+++ b/rules/windows/persistence_run_key_and_startup_broad.toml
@@ -21,36 +21,45 @@ note = """## Triage and analysis
 
 ### Investigating Startup or Run Key Registry Modification
 
-Adversaries may achieve persistence by referencing a program with a registry run key. Adding an entry to the run keys in the registry will cause the program referenced to be executed when a user logs in. These programs will executed under the context of the user and will have the account's permissions. This rule looks for this behavior by monitoring a range of registry run keys.
+Adversaries may achieve persistence by referencing a program with a registry run key. Adding an entry to the run keys
+in the registry will cause the program referenced to be executed when a user logs in. These programs will executed
+under the context of the user and will have the account's permissions. This rule looks for this behavior by monitoring
+a range of registry run keys.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
 
-- There is a high possibility of benign legitimate programs being added to registry run keys. This activity could be based on new software installations, patches, or any kind of network administrator related activity. Before undertaking further investigation, verify that this activity is not benign.
+- There is a high possibility of benign legitimate programs being added to registry run keys. This activity could be
+based on new software installations, patches, or any kind of network administrator related activity. Before undertaking
+further investigation, verify that this activity is not benign.
 
 ### Related rules
 
@@ -67,12 +76,17 @@ Adversaries may achieve persistence by referencing a program with a registry run
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 21
 rule_id = "97fc44d3-8dae-4019-ae83-298c3015600f"

--- a/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
+++ b/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
@@ -25,15 +25,22 @@ note = """## Triage and analysis
 
 ### Investigating AdminSDHolder SDProp Exclusion Added
 
-The SDProp process compares the permissions on protected objects with those defined on the AdminSDHolder object. If the permissions on any of the protected accounts and groups do not match, it resets the permissions on the protected accounts and groups to match those defined in the domain AdminSDHolder object.
+The SDProp process compares the permissions on protected objects with those defined on the AdminSDHolder object. If the
+permissions on any of the protected accounts and groups do not match, it resets the permissions on the protected
+accounts and groups to match those defined in the domain AdminSDHolder object.
 
-The dSHeuristics is a Unicode string attribute, in which each character in the string represents a heuristic that is used to determine the behavior of Active Directory.
+The dSHeuristics is a Unicode string attribute, in which each character in the string represents a heuristic that is
+used to determine the behavior of Active Directory.
 
-Administrators can use the dSHeuristics attribute to exclude privilege groups from the SDProp process by setting the 16th bit (dwAdminSDExMask) of the string to a certain value, which represents the group(s):
+Administrators can use the dSHeuristics attribute to exclude privilege groups from the SDProp process by setting the
+16th bit (dwAdminSDExMask) of the string to a certain value, which represents the group(s):
 
-- For example, to exclude the Account Operators group, an administrator would modify the string, so the 16th character is set to 1 (i.e., 0000000001000001).
+* For example, to exclude the Account Operators group, an administrator would modify the string, so the 16th character
+is set to 1 (i.e., 0000000001000001).
 
-The usage of this exclusion can leave the accounts unprotected and facilitate the misconfiguration of privileges for the excluded groups, enabling attackers to add accounts to these groups to maintain long-term persistence with high privileges.
+The usage of this exclusion can leave the accounts unprotected and facilitate the misconfiguration of privileges for the
+excluded groups, enabling attackers to add accounts to these groups to maintain long-term persistence with high
+privileges.
 
 This rule matches changes of the dsHeuristics object where the 16th bit is set to a value other than zero.
 
@@ -47,16 +54,19 @@ This rule matches changes of the dsHeuristics object where the 16th bit is set t
     - Server Operators eq 2
     - Print Operators eq 4
     - Backup Operators eq 8
-    The field value can range from 0 to f (15). If more than one group is specified, the values will be summed together; for example, Backup Operators and Print Operators will set the `c` value on the bit.
+    The field value can range from 0 to f (15). If more than one group is specified, the values will be summed together;
+    for example, Backup Operators and Print Operators will set the `c` value on the bit.
 
 ### False positive analysis
 
-- While this modification can be done legitimately, it is not a best practice. Any potential benign true positive (B-TP) should be mapped and reviewed by the security team for alternatives as this weakens the security of the privileged group.
+- While this modification can be done legitimately, it is not a best practice. Any potential benign true positive (B-TP)
+should be mapped and reviewed by the security team for alternatives as this weakens the security of the privileged group.
 
 ### Response and remediation
 
 - The change can be reverted by setting the dwAdminSDExMask (16th bit) to 0 in dSHeuristics.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_service_windows_service_winlog.toml
+++ b/rules/windows/persistence_service_windows_service_winlog.toml
@@ -21,8 +21,10 @@ note = """## Triage and analysis
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Identify how the service was created or modified. Look for registry changes events or Windows events related to service activities (for example, 4697 and/or 7045).
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Identify how the service was created or modified. Look for registry changes events or Windows events related to
+service activities (for example, 4697 and/or 7045).
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -31,17 +33,22 @@ note = """## Triage and analysis
 
 ### False positive analysis
 
-- Certain services such as PSEXECSVC may happen legitimately. The security team should address any potential benign true positive (B-TP) by excluding the relevant FP by pattern.
+- Certain services such as PSEXECSVC may happen legitimately. The security team should address any potential benign true
+positive (B-TP) by excluding the relevant FP by pattern.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Delete the service or restore it to the original configuration.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
+++ b/rules/windows/persistence_startup_folder_file_written_by_suspicious_process.toml
@@ -21,7 +21,8 @@ note = """## Triage and analysis
 
 ### Investigating Startup Persistence by a Suspicious Process
 
-The Windows Startup folder is a special folder in Windows. Programs added to this folder are executed during account logon, without user interaction, providing an excellent way for attackers to maintain persistence.
+The Windows Startup folder is a special folder in Windows. Programs added to this folder are executed during account
+logon, without user interaction, providing an excellent way for attackers to maintain persistence.
 
 This rule monitors for commonly abused processes writing to the Startup folder locations.
 
@@ -30,28 +31,33 @@ This rule monitors for commonly abused processes writing to the Startup folder l
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- Administrators may add programs to this mechanism via command-line shells. Before the further investigation, verify that this activity is not benign.
+- Administrators may add programs to this mechanism via command-line shells. Before the further investigation,
+verify that this activity is not benign.
 
 ### Related rules
 
@@ -66,12 +72,17 @@ This rule monitors for commonly abused processes writing to the Startup folder l
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_startup_folder_file_written_by_unsigned_process.toml
+++ b/rules/windows/persistence_startup_folder_file_written_by_unsigned_process.toml
@@ -21,7 +21,8 @@ note = """## Triage and analysis
 
 ### Investigating Startup Folder Persistence via Unsigned Process
 
-The Windows Startup folder is a special folder in Windows. Programs added to this folder are executed during account logon, without user interaction, providing an excellent way for attackers to maintain persistence.
+The Windows Startup folder is a special folder in Windows. Programs added to this folder are executed during account
+logon, without user interaction, providing an excellent way for attackers to maintain persistence.
 
 This rule looks for unsigned processes writing to the Startup folder locations.
 
@@ -30,28 +31,34 @@ This rule looks for unsigned processes writing to the Startup folder locations.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
-- There is a high possibility of benign legitimate programs being added to Startup folders. This activity could be based on new software installations, patches, or any kind of network administrator related activity. Before undertaking further investigation, verify that this activity is not benign.
+- There is a high possibility of benign legitimate programs being added to Startup folders. This activity could be based
+on new software installations, patches, or any kind of network administrator related activity. Before undertaking further
+investigation, verify that this activity is not benign.
 
 ### Related rules
 
@@ -66,12 +73,17 @@ This rule looks for unsigned processes writing to the Startup folder locations.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 """
 risk_score = 47
 rule_id = "2fba96c0-ade5-4bce-b92f-a5df2509da3f"

--- a/rules/windows/persistence_startup_folder_scripts.toml
+++ b/rules/windows/persistence_startup_folder_scripts.toml
@@ -21,7 +21,8 @@ note = """## Triage and analysis
 
 ### Investigating Persistent Scripts in the Startup Directory
 
-The Windows Startup folder is a special folder in Windows. Programs added to this folder are executed during account logon, without user interaction, providing an excellent way for attackers to maintain persistence.
+The Windows Startup folder is a special folder in Windows. Programs added to this folder are executed during account
+logon, without user interaction, providing an excellent way for attackers to maintain persistence.
 
 This rule looks for shortcuts created by wscript.exe or cscript.exe, or js/vbs scripts created by any process.
 
@@ -30,24 +31,28 @@ This rule looks for shortcuts created by wscript.exe or cscript.exe, or js/vbs s
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Validate if the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate
+software installations.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -66,12 +71,17 @@ This rule looks for shortcuts created by wscript.exe or cscript.exe, or js/vbs s
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_suspicious_com_hijack_registry.toml
+++ b/rules/windows/persistence_suspicious_com_hijack_registry.toml
@@ -25,7 +25,8 @@ Adversaries can insert malicious code that can be executed in place of legitimat
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
@@ -51,12 +52,17 @@ Adversaries can insert malicious code that can be executed in place of legitimat
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 
 ## Setup

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -21,14 +21,17 @@ note = """## Triage and analysis
 
 ### Investigating System Shells via Services
 
-Attackers may configure existing services or create new ones to execute system shells to elevate their privileges from administrator to SYSTEM. They can also configure services to execute these shells with persistence payloads.
+Attackers may configure existing services or create new ones to execute system shells to elevate their privileges from
+administrator to SYSTEM. They can also configure services to execute these shells with persistence payloads.
 
 This rule looks for system shells being spawned by `services.exe`, which is compatible with the above behavior.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Identify how the service was created or modified. Look for registry changes events or Windows events related to service activities (for example, 4697 and/or 7045).
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Identify how the service was created or modified. Look for registry changes events or Windows events related to
+service activities (for example, 4697 and/or 7045).
   - Identify the user account that performed the action and whether it should perform this kind of action.
 - Contact the account owner and confirm whether they are aware of this activity.
 - Investigate other alerts associated with the user/host during the past 48 hours.
@@ -37,17 +40,22 @@ This rule looks for system shells being spawned by `services.exe`, which is comp
 
 ### False positive analysis
 
-- This activity should not happen legitimately. The security team should address any potential benign true positive (B-TP), as this configuration can put the user and the domain at risk.
+- This activity should not happen legitimately. The security team should address any potential benign true positive
+(B-TP), as this configuration can put the user and the domain at risk.
 
 ### Response and remediation
 
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Delete the service or restore it to the original configuration.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
+++ b/rules/windows/persistence_user_account_added_to_privileged_group_ad.toml
@@ -22,9 +22,11 @@ note = """## Triage and analysis
 
 ### Investigating User Added to Privileged Group in Active Directory
 
-Privileged accounts and groups in Active Directory are those to which powerful rights, privileges, and permissions are granted that allow them to perform nearly any action in Active Directory and on domain-joined systems.
+Privileged accounts and groups in Active Directory are those to which powerful rights, privileges, and permissions are
+granted that allow them to perform nearly any action in Active Directory and on domain-joined systems.
 
-Attackers can add users to privileged groups to maintain a level of access if their other privileged accounts are uncovered by the security team. This allows them to keep operating after the security team discovers abused accounts.
+Attackers can add users to privileged groups to maintain a level of access if their other privileged accounts are
+uncovered by the security team. This allows them to keep operating after the security team discovers abused accounts.
 
 This rule monitors events related to a user being added to a privileged group.
 
@@ -36,7 +38,9 @@ This rule monitors events related to a user being added to a privileged group.
 
 ### False positive analysis
 
-- This attack abuses a legitimate Active Directory mechanism, so it is important to determine whether the activity is legitimate, if the administrator is authorized to perform this operation, and if there is a need to grant the account this level of privilege.
+- This attack abuses a legitimate Active Directory mechanism, so it is important to determine whether the activity is
+legitimate, if the administrator is authorized to perform this operation, and if there is a need to grant the account
+this level of privilege.
 
 ### Response and remediation
 
@@ -45,7 +49,8 @@ This rule monitors events related to a user being added to a privileged group.
 - If the user does not need the administrator privileges, remove the account from the privileged group.
 - Review the privileges of the administrator account that performed the action.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_user_account_creation.toml
+++ b/rules/windows/persistence_user_account_creation.toml
@@ -27,14 +27,16 @@ This rule identifies the usage of `net.exe` to create new accounts.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Identify the user account that performed the action and whether it should perform this kind of action.
 - Identify if the account was added to privileged groups or assigned special privileges after creation.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 
 ### False positive analysis
 
-- Account creation is a common administrative task, so there is a high chance of the activity being legitimate. Before investigating further, verify that this activity is not benign.
+- Account creation is a common administrative task, so there is a high chance of the activity being legitimate. Before
+investigating further, verify that this activity is not benign.
 
 ### Related rules
 
@@ -46,9 +48,12 @@ This rule identifies the usage of `net.exe` to create new accounts.
 - Initiate the incident response process based on the outcome of the triage.
 - Isolate the involved host to prevent further post-compromise behavior.
 - Delete the created account.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
+++ b/rules/windows/persistence_via_update_orchestrator_service_hijack.toml
@@ -21,33 +21,41 @@ note = """## Triage and analysis
 
 ### Investigating Persistence via Update Orchestrator Service Hijack
 
-Windows Update Orchestrator Service is a DCOM service used by other components to install Windows updates that are already downloaded. Windows Update Orchestrator Service was vulnerable to elevation of privileges (any user to local system) due to an improper authorization of the callers. The vulnerability affected the Windows 10 and Windows Server Core products. Fixed by Microsoft on Patch Tuesday June 2020.
+Windows Update Orchestrator Service is a DCOM service used by other components to install Windows updates that are
+already downloaded. Windows Update Orchestrator Service was vulnerable to elevation of privileges (any user to local
+system) due to an improper authorization of the callers. The vulnerability affected the Windows 10 and Windows Server
+Core products. Fixed by Microsoft on Patch Tuesday June 2020.
 
-This rule will detect uncommon processes spawned by `svchost.exe` with `UsoSvc` as the command line parameters. Attackers can leverage this technique to elevate privileges or maintain persistence.
+This rule will detect uncommon processes spawned by `svchost.exe` with `UsoSvc` as the command line parameters.
+Attackers can leverage this technique to elevate privileges or maintain persistence.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
@@ -62,12 +70,17 @@ This rule will detect uncommon processes spawned by `svchost.exe` with `UsoSvc` 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/persistence_webshell_detection.toml
+++ b/rules/windows/persistence_webshell_detection.toml
@@ -24,13 +24,18 @@ note = """## Triage and analysis
 
 ### Investigating Web Shell Detection: Script Process Child of Common Web Processes
 
-Adversaries may backdoor web servers with web shells to establish persistent access to systems. A web shell is a web script that is placed on an openly accessible web server to allow an adversary to use the web server as a gateway into a network. A web shell may provide a set of functions to execute or a command-line interface on the system that hosts the web server.
+Adversaries may backdoor web servers with web shells to establish persistent access to systems. A web shell is a web
+script that is placed on an openly accessible web server to allow an adversary to use the web server as a gateway into a
+network. A web shell may provide a set of functions to execute or a command-line interface on the system that hosts the
+web server.
 
-This rule detects a web server process spawning script and command-line interface programs, potentially indicating attackers executing commands using the web shell.
+This rule detects a web server process spawning script and command-line interface programs, potentially indicating
+attackers executing commands using the web shell.
 
 #### Possible investigation steps
 
-- Investigate abnormal behaviors observed by the subject process such as network connections, registry or file modifications, and any other spawned child processes.
+- Investigate abnormal behaviors observed by the subject process such as network connections, registry or file
+modifications, and any other spawned child processes.
 - Examine the command line to determine which commands or scripts were executed.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
@@ -46,7 +51,8 @@ This rule detects a web server process spawning script and command-line interfac
 
 ### False positive analysis
 
-- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently malicious must be monitored by the security team.
+- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently
+malicious must be monitored by the security team.
 
 ### Response and remediation
 
@@ -56,12 +62,17 @@ This rule detects a web server process spawning script and command-line interfac
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_disable_uac_registry.toml
+++ b/rules/windows/privilege_escalation_disable_uac_registry.toml
@@ -23,18 +23,24 @@ note = """## Triage and analysis
 
 ### Investigating Disabling User Account Control via Registry Modification
 
-Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as low to high integrity levels) to perform a task under administrator-level permissions, possibly by prompting the user for confirmation. UAC can deny an operation under high-integrity enforcement, or allow the user to perform the action if they are in the local administrators group and enter an administrator password when prompted.
+Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as low to high integrity levels)
+to perform a task under administrator-level permissions, possibly by prompting the user for confirmation.
+UAC can deny an operation under high-integrity enforcement, or allow the user to perform the action if they are in the
+local administrators group and enter an administrator password when prompted.
 
 For more information about the UAC and how it works, check the [official Microsoft docs page](https://docs.microsoft.com/en-us/windows/security/identity-protection/user-account-control/how-user-account-control-works).
 
-Attackers may disable UAC to execute code directly in high integrity. This rule identifies registry value changes to bypass the UAC protection.
+Attackers may disable UAC to execute code directly in high integrity. This rule identifies registry value changes to
+bypass the UAC protection.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behaviors in the alert timeframe.
-- Investigate abnormal behaviors observed by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate abnormal behaviors observed by the subject process such as network connections, registry or file
+modifications, and any spawned child processes.
 - Analyze non-system processes executed with high integrity after UAC was disabled for unknown or suspicious processes.
 - Retrieve the suspicious processes' executables and determine if they are malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
@@ -58,13 +64,18 @@ Attackers may disable UAC to execute code directly in high integrity. This rule 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
 - Restore UAC settings to the desired state.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_group_policy_iniscript.toml
+++ b/rules/windows/privilege_escalation_group_policy_iniscript.toml
@@ -18,14 +18,17 @@ note = """## Triage and analysis
 
 ### Investigating Scheduled Task Execution at Scale via GPO
 
-Group Policy Objects (GPOs) can be used by attackers to instruct arbitrarily large groups of clients to execute specified commands at startup, logon, shutdown, and logoff. This is done by creating or modifying the `scripts.ini` or `psscripts.ini` files. The scripts are stored in the following paths: 
-  - `<GPOPath>\\Machine\\Scripts\\`
-  - `<GPOPath>\\User\\Scripts\\`
+Group Policy Objects (GPOs) can be used by attackers to instruct arbitrarily large groups of
+clients to execute specified commands at startup, logon, shutdown, and logoff. This is done by creating or modifying the
+`scripts.ini` or `psscripts.ini` files. The scripts are stored in the following path: `<GPOPath>\\Machine\\Scripts\\`,
+`<GPOPath>\\User\\Scripts\\`
 
 #### Possible investigation steps
 
-- This attack abuses a legitimate mechanism of Active Directory, so it is important to determine whether the activity is legitimate and the administrator is authorized to perform this operation.
-- Retrieve the contents of the `ScheduledTasks.xml` file, and check the `<Command>` and `<Arguments>` XML tags for any potentially malicious commands or binaries.
+- This attack abuses a legitimate mechanism of Active Directory, so it is important to determine whether the activity
+is legitimate and the administrator is authorized to perform this operation.
+- Retrieve the contents of the `ScheduledTasks.xml` file, and check the `<Command>` and `<Arguments>` XML tags for any
+potentially malicious commands or binaries.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Scope which objects may be compromised by retrieving information about which objects are controlled by the GPO.
 
@@ -45,7 +48,8 @@ Group Policy Objects (GPOs) can be used by attackers to instruct arbitrarily lar
 - Remove the script from the GPO.
 - Check if other GPOs have suspicious scripts attached.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_group_policy_privileged_groups.toml
+++ b/rules/windows/privilege_escalation_group_policy_privileged_groups.toml
@@ -20,17 +20,23 @@ note = """## Triage and analysis
 
 ### Investigating Group Policy Abuse for Privilege Addition
 
-Group Policy Objects (GPOs) can be used to add rights and/or modify Group Membership on GPOs by changing the contents of an INF file named GptTmpl.inf, which is responsible for storing every setting under the Security Settings container in the GPO. This file is unique for each GPO, and only exists if the GPO contains security settings. Example Path: "\\\\DC.com\\SysVol\\DC.com\\Policies\\{PolicyGUID}\\Machine\\Microsoft\\Windows NT\\SecEdit\\GptTmpl.inf"
+Group Policy Objects (GPOs) can be used to add rights and/or modify Group Membership on GPOs by changing the contents of an INF
+file named GptTmpl.inf, which is responsible for storing every setting under the Security Settings container in the GPO.
+This file is unique for each GPO, and only exists if the GPO contains security settings.
+Example Path: "\\DC.com\\SysVol\\DC.com\\Policies\\{PolicyGUID}\\Machine\\Microsoft\\Windows NT\\SecEdit\\GptTmpl.inf"
 
 #### Possible investigation steps
 
-- This attack abuses a legitimate mechanism of Active Directory, so it is important to determine whether the activity is legitimate and the administrator is authorized to perform this operation.
-- Retrieve the contents of the `GptTmpl.inf` file, and under the `Privilege Rights` section, look for potentially dangerous high privileges, for example: SeTakeOwnershipPrivilege, SeEnableDelegationPrivilege, etc.
+- This attack abuses a legitimate mechanism of Active Directory, so it is important to determine whether the activity
+is legitimate and the administrator is authorized to perform this operation.
+- Retrieve the contents of the `GptTmpl.inf` file, and under the `Privilege Rights` section, look for potentially
+dangerous high privileges, for example: SeTakeOwnershipPrivilege, SeEnableDelegationPrivilege, etc.
 - Inspect the user security identifiers (SIDs) associated with these privileges, and if they should have these privileges.
 
 ### False positive analysis
 
-- Inspect whether the user that has done the modifications should be allowed to. The user name can be found in the `winlog.event_data.SubjectUserName` field.
+- Inspect whether the user that has done the modifications should be allowed to. The user name can be found in the
+`winlog.event_data.SubjectUserName` field.
 
 ### Related rules
 

--- a/rules/windows/privilege_escalation_group_policy_scheduled_task.toml
+++ b/rules/windows/privilege_escalation_group_policy_scheduled_task.toml
@@ -20,12 +20,16 @@ note = """## Triage and analysis
 
 ### Investigating Scheduled Task Execution at Scale via GPO
 
-Group Policy Objects (GPOs) can be used by attackers to execute scheduled tasks at scale to compromise objects controlled by a given GPO. This is done by changing the contents of the `<GPOPath>\\Machine\\Preferences\\ScheduledTasks\\ScheduledTasks.xml` file.
+Group Policy Objects (GPOs) can be used by attackers to execute scheduled tasks at scale to compromise objects controlled
+by a given GPO. This is done by changing the contents of the `<GPOPath>\\Machine\\Preferences\\ScheduledTasks\\ScheduledTasks.xml`
+file.
 
 #### Possible investigation steps
 
-- This attack abuses a legitimate mechanism of Active Directory, so it is important to determine whether the activity is legitimate and the administrator is authorized to perform this operation.
-- Retrieve the contents of the `ScheduledTasks.xml` file, and check the `<Command>` and `<Arguments>` XML tags for any potentially malicious commands or binaries.
+- This attack abuses a legitimate mechanism of Active Directory, so it is important to determine whether the activity
+is legitimate and the administrator is authorized to perform this operation.
+- Retrieve the contents of the `ScheduledTasks.xml` file, and check the `<Command>` and `<Arguments>` XML tags for any
+potentially malicious commands or binaries.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Scope which objects may be compromised by retrieving information about which objects are controlled by the GPO.
 
@@ -45,7 +49,8 @@ Group Policy Objects (GPOs) can be used by attackers to execute scheduled tasks 
 - Remove the script from the GPO.
 - Check if other GPOs have suspicious scheduled tasks attached.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_installertakeover.toml
+++ b/rules/windows/privilege_escalation_installertakeover.toml
@@ -21,16 +21,20 @@ note = """## Triage and analysis
 
 ### Investigating Potential Privilege Escalation via InstallerFileTakeOver
 
-InstallerFileTakeOver is a weaponized escalation of privilege proof of concept (EoP PoC) to the CVE-2021-41379 vulnerability. Upon successful exploitation, an unprivileged user will escalate privileges to SYSTEM/NT AUTHORITY.
+InstallerFileTakeOver is a weaponized escalation of privilege proof of concept (EoP PoC) to the CVE-2021-41379 vulnerability. Upon successful exploitation, an
+unprivileged user will escalate privileges to SYSTEM/NT AUTHORITY.
 
-This rule detects the default execution of the PoC, which overwrites the `elevation_service.exe` DACL and copies itself to the location to escalate privileges. An attacker is able to still take over any file that is not in use (locked), which is outside the scope of this rule.
+This rule detects the default execution of the PoC, which overwrites the `elevation_service.exe` DACL and copies itself
+to the location to escalate privileges. An attacker is able to still take over any file that is not in use (locked),
+which is outside the scope of this rule.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Look for additional processes spawned by the process, command lines, and network communications.
 - Assess whether this behavior is prevalent in the environment by looking for similar occurrences across hosts.
@@ -38,16 +42,18 @@ This rule detects the default execution of the PoC, which overwrites the `elevat
   - Analyze the file using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -65,12 +71,17 @@ This rule detects the default execution of the PoC, which overwrites the `elevat
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_persistence_phantom_dll.toml
+++ b/rules/windows/privilege_escalation_persistence_phantom_dll.toml
@@ -22,12 +22,15 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious DLL Loaded for Persistence or Privilege Escalation
 
-Attackers can execute malicious code by abusing missing modules that processes try to load, enabling them to escalate privileges or gain persistence. This rule identifies the loading of a non-Microsoft-signed DLL that is missing on a default Windows installation or one that can be loaded from a different location by a native Windows process.
+Attackers can execute malicious code by abusing missing modules that processes try to load, enabling them to escalate
+privileges or gain persistence. This rule identifies the loading of a non-Microsoft-signed DLL that is missing on a
+default Windows installation or one that can be loaded from a different location by a native Windows process.
 
 #### Possible investigation steps
 
 - Examine the DLL signature and identify the process that created it.
-  - Investigate any abnormal behaviors by the process such as network connections, registry or file modifications, and any spawned child processes.
+  - Investigate any abnormal behaviors by the process such as network connections, registry or file modifications, and
+  any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Retrieve the DLL and determine if it is malicious:
   - Use a private sandboxed malware analysis system to perform analysis.
@@ -41,7 +44,8 @@ Attackers can execute malicious code by abusing missing modules that processes t
 
 ### False positive analysis
 
-- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently malicious must be monitored by the security team.
+- This activity is unlikely to happen legitimately. Any activity that triggered the alert and is not inherently
+malicious must be monitored by the security team.
 
 ### Response and remediation
 
@@ -51,12 +55,17 @@ Attackers can execute malicious code by abusing missing modules that processes t
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_suspicious_spl_file.toml
@@ -21,38 +21,46 @@ note = """## Triage and analysis
 
 ### Investigating Suspicious Print Spooler SPL File Created
 
-Print Spooler is a Windows service enabled by default in all Windows clients and servers. The service manages print jobs by loading printer drivers, receiving files to be printed, queuing them, scheduling, etc.
+Print Spooler is a Windows service enabled by default in all Windows clients and servers. The service manages print jobs
+by loading printer drivers, receiving files to be printed, queuing them, scheduling, etc.
 
-The Print Spooler service has some known vulnerabilities that attackers can abuse to escalate privileges to SYSTEM, like CVE-2020-1048 and CVE-2020-1337. This rule looks for unusual processes writing SPL files to the location `?:\\Windows\\System32\\spool\\PRINTERS\\`, which is an essential step in exploiting these vulnerabilities.
+The Print Spooler service has some known vulnerabilities that attackers can abuse to escalate privileges to SYSTEM, like
+CVE-2020-1048 and CVE-2020-1337. This rule looks for unusual processes writing SPL files to the location
+`?:\\Windows\\System32\\spool\\PRINTERS\\`, which is an essential step in exploiting these vulnerabilities.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
 
-- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination of process executable and file conditions.
+- If this activity is expected and noisy in your environment, consider adding exceptions — preferably with a combination
+of process executable and file conditions.
 
 ### Response and remediation
 
@@ -62,13 +70,18 @@ The Print Spooler service has some known vulnerabilities that attackers can abus
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Ensure that the machine has the latest security updates and is not running legacy Windows versions.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_event_viewer.toml
@@ -21,35 +21,46 @@ note = """## Triage and analysis
 
 ### Investigating Bypass UAC via Event Viewer
 
-Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as low to high integrity levels) to perform a task under administrator-level permissions, possibly by prompting the user for confirmation. UAC can deny an operation under high-integrity enforcement, or allow the user to perform the action if they are in the local administrators group and enter an administrator password when prompted.
+Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as low to high integrity levels)
+to perform a task under administrator-level permissions, possibly by prompting the user for confirmation.
+UAC can deny an operation under high-integrity enforcement, or allow the user to perform the action if they are in the
+local administrators group and enter an administrator password when prompted.
 
 For more information about the UAC and how it works, check the [official Microsoft docs page](https://docs.microsoft.com/en-us/windows/security/identity-protection/user-account-control/how-user-account-control-works).
 
-During startup, `eventvwr.exe` checks the registry value of the `HKCU\\Software\\Classes\\mscfile\\shell\\open\\command` registry key for the location of `mmc.exe`, which is used to open the `eventvwr.msc` saved console file. If the location of another binary or script is added to this registry value, it will be executed as a high-integrity process without a UAC prompt being displayed to the user. This rule detects this UAC bypass by monitoring processes spawned by `eventvwr.exe` other than `mmc.exe` and `werfault.exe`.
+During startup, `eventvwr.exe` checks the registry value of the `HKCU\\Software\\Classes\\mscfile\\shell\\open\\command`
+registry key for the location of `mmc.exe`, which is used to open the `eventvwr.msc` saved console file. If the location
+of another binary or script is added to this registry value, it will be executed as a high-integrity process without a
+UAC prompt being displayed to the user. This rule detects this UAC bypass by monitoring processes spawned by
+`eventvwr.exe` other than `mmc.exe` and `werfault.exe`.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
@@ -64,12 +75,17 @@ During startup, `eventvwr.exe` checks the registry value of the `HKCU\\Software\
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_mock_windir.toml
@@ -21,35 +21,43 @@ note = """## Triage and analysis
 
 ### Investigating UAC Bypass Attempt via Windows Directory Masquerading
 
-Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as low to high integrity levels) to perform a task under administrator-level permissions, possibly by prompting the user for confirmation. UAC can deny an operation under high-integrity enforcement, or allow the user to perform the action if they are in the local administrators group and enter an administrator password when prompted.
+Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as low to high integrity levels)
+to perform a task under administrator-level permissions, possibly by prompting the user for confirmation.
+UAC can deny an operation under high-integrity enforcement, or allow the user to perform the action if they are in the
+local administrators group and enter an administrator password when prompted.
 
 For more information about the UAC and how it works, check the [official Microsoft docs page](https://docs.microsoft.com/en-us/windows/security/identity-protection/user-account-control/how-user-account-control-works).
 
-This rule identifies an attempt to bypass User Account Control (UAC) by masquerading as a Microsoft trusted Windows directory. Attackers may bypass UAC to stealthily execute code with elevated permissions.
+This rule identifies an attempt to bypass User Account Control (UAC) by masquerading as a Microsoft trusted Windows
+directory. Attackers may bypass UAC to stealthily execute code with elevated permissions.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze any suspicious spawned processes using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -63,12 +71,17 @@ This rule identifies an attempt to bypass User Account Control (UAC) by masquera
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
+++ b/rules/windows/privilege_escalation_uac_bypass_winfw_mmc_hijack.toml
@@ -21,35 +21,43 @@ note = """## Triage and analysis
 
 ### Investigating UAC Bypass via Windows Firewall Snap-In Hijack
 
-Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as low to high integrity levels) to perform a task under administrator-level permissions, possibly by prompting the user for confirmation. UAC can deny an operation under high-integrity enforcement, or allow the user to perform the action if they are in the local administrators group and enter an administrator password when prompted.
+Windows User Account Control (UAC) allows a program to elevate its privileges (tracked as low to high integrity levels)
+to perform a task under administrator-level permissions, possibly by prompting the user for confirmation.
+UAC can deny an operation under high-integrity enforcement, or allow the user to perform the action if they are in the
+local administrators group and enter an administrator password when prompted.
 
 For more information about the UAC and how it works, check the [official Microsoft docs page](https://docs.microsoft.com/en-us/windows/security/identity-protection/user-account-control/how-user-account-control-works).
 
-This rule identifies attempts to bypass User Account Control (UAC) by hijacking the Microsoft Management Console (MMC) Windows Firewall snap-in. Attackers bypass UAC to stealthily execute code with elevated permissions.
+This rule identifies attempts to bypass User Account Control (UAC) by hijacking the Microsoft Management Console (MMC)
+Windows Firewall snap-in. Attackers bypass UAC to stealthily execute code with elevated permissions.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic stack version 8.5.0. Older Elastic stacks versions will see unrendered markdown in this guide.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
 - Inspect the host for suspicious or abnormal behavior in the alert timeframe.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze any suspicious spawned processes using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False positive analysis
 
@@ -63,12 +71,17 @@ This rule identifies attempts to bypass User Account Control (UAC) by hijacking 
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
-- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are
+identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business
+systems, and web services.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -21,7 +21,9 @@ note = """## Triage and analysis
 
 ### Investigating Unusual Parent-Child Relationship
 
-Windows internal/system processes have some characteristics that can be used to spot suspicious activities. One of these characteristics is parent-child relationships. These relationships can be used to baseline the typical behavior of the system and then alert on occurrences that don't comply with the baseline.
+Windows internal/system processes have some characteristics that can be used to spot suspicious activities. One of these
+characteristics is parent-child relationships. These relationships can be used to baseline the typical behavior of the
+system and then alert on occurrences that don't comply with the baseline.
 
 This rule uses this information to spot suspicious parent and child processes.
 
@@ -30,23 +32,27 @@ This rule uses this information to spot suspicious parent and child processes.
 
 #### Possible investigation steps
 
-- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files
+for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate other alerts associated with the user/host during the past 48 hours.
-- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
+- Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications,
+and any spawned child processes.
 - Examine the host for derived artifacts that indicates suspicious activities:
   - Analyze the process executable using a private sandboxed analysis system.
   - Observe and collect information about the following activities in both the sandbox and the alert subject host:
     - Attempts to contact external domains and addresses.
-      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process' `process.entity_id`.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by
+      filtering by the process' `process.entity_id`.
       - Examine the DNS cache for suspicious or anomalous entries.
         - !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}
-    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related
+    processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
-  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
-- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE "%LocalSystem" OR user_account LIKE "%LocalService" OR user_account LIKE "%NetworkService" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != "trusted"","label":"Osquery - Retrieve Service Unsigned Executables with Virustotal Link"}}
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and
+  reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 
 ### False positive analysis
@@ -61,11 +67,14 @@ This rule uses this information to spot suspicious parent and child processes.
   - Implement temporary network rules, procedures, and segmentation to contain the malware.
   - Stop suspicious processes.
   - Immediately block the identified indicators of compromise (IoCs).
-  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that
+  attackers could use to reinfect the system.
 - Remove and block malicious artifacts identified during triage.
-- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and
+malware components.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
-- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the
+mean time to respond (MTTR).
 
 ## Setup
 


### PR DESCRIPTION
Reverts elastic/detection-rules#2412

## Summary
Deprecated rules received changes and were merged into #2412. The [Threat Intel Filebeat 7.x](https://github.com/elastic/detection-rules/blob/7.16/rules/cross-platform/threat_intel_filebeat7x.toml) rule is not deprecated in the 7.16 branch, but is deprecated in main. As a result, changes to the file were out of sync when attempting to backport, causing a Git issue shown below.

```sql
Run set -x
+ echo 'Switch to the target branch and keep the staged changes'
Switch to the target branch and keep the staged changes
+ git checkout 7.16
error: Your local changes to the following files would be overwritten by checkout:
	rules/_deprecated/threat_intel_filebeat7x.toml
Please commit your changes or stash them before you switch branches.
Aborting
Error: Process completed with exit code 1.
```

Solution:
1. Revert PR changes and merge into main. Backporting should not take place as the changes only exist in main at the moment because of the failed backport attempts to 7.16.
3. Create new PR but without deprecated rule changes and merge
4. Confirm backporting issue has been resolved