### PR TITLE
[Rule Tuning] Exporting Exchange Mailbox via PowerShell

### DIFF
--- a/rules/windows/collection_email_powershell_exchange_mailbox.toml
+++ b/rules/windows/collection_email_powershell_exchange_mailbox.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/11"
 
 [rule]
 author = ["Elastic"]
@@ -74,7 +74,8 @@ type = "eql"
 
 query = '''
 process where event.type == "start" and
-  process.name: ("powershell.exe", "pwsh.exe", "powershell_ise.exe") and process.args : "New-MailboxExportRequest*"
+  process.name: ("powershell.exe", "pwsh.exe", "powershell_ise.exe") and 
+  process.command_line : ("*MailboxExportRequest*", "*-Mailbox*-ContentFilter*")
 '''
 
 


### PR DESCRIPTION
Tuned rule adding wildcard to powershell `process.command_line` to account for matches like : 


```
"process": {
      "args": [
        "powershell.exe",
        "-PSConsoleFile",
        "exshell.psc1",
        "-Command",
        "New-MailboxExportRequest -Mailbox foobar@corp.here -ContentFilter {(Received -ge '01/01/2023')} -FilePath '\\\\<MAILSERVER>\\c$\\temp\\b.pst'"
      ]
```