### PR TITLE
[New Rule] PowerShell Suspicious Script with Clipboard Retrieval Capabilities

### DIFF
--- a/rules/windows/collection_posh_clipboard_capture.toml
+++ b/rules/windows/collection_posh_clipboard_capture.toml
@@ -20,7 +20,6 @@ name = "PowerShell Suspicious Script with Clipboard Retrieval Capabilities"
 references = [
   "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-clipboard",
   "https://github.com/EmpireProject/Empire/blob/master/data/module_source/collection/Get-ClipboardContents.ps1",
-  ""
 ]
 risk_score = 47
 rule_id = "92984446-aefb-4d5e-ad12-598042ca80ba"

--- a/rules/windows/collection_posh_clipboard_capture.toml
+++ b/rules/windows/collection_posh_clipboard_capture.toml
@@ -22,9 +22,9 @@ references = [
   "https://github.com/EmpireProject/Empire/blob/master/data/module_source/collection/Get-ClipboardContents.ps1",
   ""
 ]
-risk_score = 21
+risk_score = 47
 rule_id = "92984446-aefb-4d5e-ad12-598042ca80ba"
-severity = "low"
+severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Collection", "PowerShell"]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/windows/collection_posh_clipboard_capture.toml
+++ b/rules/windows/collection_posh_clipboard_capture.toml
@@ -1,0 +1,76 @@
+[metadata]
+creation_date = "2023/01/12"
+integration = ["windows"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/01/12"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects PowerShell scripts that can get the contents of the clipboard, which attackers can abuse to retrieve sensitive
+information like credentials, messages, etc.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-windows.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "PowerShell Suspicious Script with Clipboard Retrieval Capabilities"
+references = [
+  "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-clipboard",
+  "https://github.com/EmpireProject/Empire/blob/master/data/module_source/collection/Get-ClipboardContents.ps1",
+  ""
+]
+risk_score = 21
+rule_id = "92984446-aefb-4d5e-ad12-598042ca80ba"
+severity = "low"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Collection", "PowerShell"]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+event.category:process and
+  (powershell.file.script_block_text : (
+    "Windows.Clipboard" or
+    "Windows.Forms.Clipboard" or
+    "Windows.Forms.TextBox"
+   ) and
+   powershell.file.script_block_text : (
+    "]::GetText" or
+    ".Paste()"
+  )) or powershell.file.script_block_text : "Get-Clipboard"
+  and not user.id : "S-1-5-18"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1115"
+name = "Clipboard Data"
+reference = "https://attack.mitre.org/techniques/T1115/"
+
+
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.001"
+name = "PowerShell"
+reference = "https://attack.mitre.org/techniques/T1059/001/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+


### PR DESCRIPTION
## Summary

Detects PowerShell scripts that can get the contents of the clipboard, which attackers can abuse to retrieve sensitive
information like credentials, messages, etc.