### PR TITLE
[Rule Tuning] Bumping min-stack version for Google Workspace to 8.4

### DIFF
--- a/rules/integrations/google_workspace/collection_google_drive_ownership_transferred_via_google_workspace.toml
+++ b/rules/integrations/google_workspace/collection_google_drive_ownership_transferred_via_google_workspace.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/24"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/collection_google_drive_ownership_transferred_via_google_workspace.toml
+++ b/rules/integrations/google_workspace/collection_google_drive_ownership_transferred_via_google_workspace.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/collection_google_workspace_custom_gmail_route_created_or_modified.toml
+++ b/rules/integrations/google_workspace/collection_google_workspace_custom_gmail_route_created_or_modified.toml
@@ -3,7 +3,7 @@ creation_date = "2022/09/13"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/collection_google_workspace_custom_gmail_route_created_or_modified.toml
+++ b/rules/integrations/google_workspace/collection_google_workspace_custom_gmail_route_created_or_modified.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/defense_evasion_application_removed_from_blocklist_in_google_workspace.toml
+++ b/rules/integrations/google_workspace/defense_evasion_application_removed_from_blocklist_in_google_workspace.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/25"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/defense_evasion_application_removed_from_blocklist_in_google_workspace.toml
+++ b/rules/integrations/google_workspace/defense_evasion_application_removed_from_blocklist_in_google_workspace.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/defense_evasion_domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/integrations/google_workspace/defense_evasion_domain_added_to_google_workspace_trusted_domains.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/defense_evasion_domain_added_to_google_workspace_trusted_domains.toml
+++ b/rules/integrations/google_workspace/defense_evasion_domain_added_to_google_workspace_trusted_domains.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/defense_evasion_google_workspace_bitlocker_setting_disabled.toml
+++ b/rules/integrations/google_workspace/defense_evasion_google_workspace_bitlocker_setting_disabled.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/defense_evasion_google_workspace_bitlocker_setting_disabled.toml
+++ b/rules/integrations/google_workspace/defense_evasion_google_workspace_bitlocker_setting_disabled.toml
@@ -3,7 +3,7 @@ creation_date = "2022/09/06"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/defense_evasion_google_workspace_restrictions_for_google_marketplace_changed_to_allow_any_app.toml
+++ b/rules/integrations/google_workspace/defense_evasion_google_workspace_restrictions_for_google_marketplace_changed_to_allow_any_app.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/25"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/defense_evasion_google_workspace_restrictions_for_google_marketplace_changed_to_allow_any_app.toml
+++ b/rules/integrations/google_workspace/defense_evasion_google_workspace_restrictions_for_google_marketplace_changed_to_allow_any_app.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/impact_google_workspace_admin_role_deletion.toml
+++ b/rules/integrations/google_workspace/impact_google_workspace_admin_role_deletion.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/impact_google_workspace_admin_role_deletion.toml
+++ b/rules/integrations/google_workspace/impact_google_workspace_admin_role_deletion.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/impact_google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/integrations/google_workspace/impact_google_workspace_mfa_enforcement_disabled.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/impact_google_workspace_mfa_enforcement_disabled.toml
+++ b/rules/integrations/google_workspace/impact_google_workspace_mfa_enforcement_disabled.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_application_added_to_google_workspace_domain.toml
+++ b/rules/integrations/google_workspace/persistence_application_added_to_google_workspace_domain.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_application_added_to_google_workspace_domain.toml
+++ b/rules/integrations/google_workspace/persistence_application_added_to_google_workspace_domain.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_2sv_policy_disabled.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_2sv_policy_disabled.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/26"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_google_workspace_2sv_policy_disabled.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_2sv_policy_disabled.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_admin_role_assigned_to_user.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/12"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_domain_wide_delegation_of_authority.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_custom_admin_role_created.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_custom_admin_role_created.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_google_workspace_custom_admin_role_created.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_custom_admin_role_created.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_policy_modified.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_policy_modified.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_google_workspace_policy_modified.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_policy_modified.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_role_modified.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_role_modified.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_google_workspace_role_modified.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_role_modified.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_user_group_access_modified_to_allow_external_access.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_user_group_access_modified_to_allow_external_access.toml
@@ -3,7 +3,7 @@ creation_date = "2022/08/24"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_google_workspace_user_group_access_modified_to_allow_external_access.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_user_group_access_modified_to_allow_external_access.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_user_organizational_unit_changed.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_user_organizational_unit_changed.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_user_organizational_unit_changed.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_user_organizational_unit_changed.toml
@@ -3,7 +3,7 @@ creation_date = "2022/09/06"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/integrations/google_workspace/persistence_mfa_disabled_for_google_workspace_organization.toml
@@ -3,7 +3,7 @@ creation_date = "2020/11/17"
 integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_version = "8.4.0"
 updated_date = "2022/12/14"
 
 [rule]

--- a/rules/integrations/google_workspace/persistence_mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/integrations/google_workspace/persistence_mfa_disabled_for_google_workspace_organization.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.4.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/13"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues
https://github.com/elastic/detection-rules/pull/2464
https://github.com/elastic/integrations/pull/3430

## Summary
While updating and locking rule versions for the v8.3.4 and v8.4.2 release, we noticed that Google Workspace rule versions were double bumped. [Analysis](https://github.com/elastic/detection-rules/pull/2464/files#r1068332494) revealed this to be a result of build-time fields, specifically `related_integrations`. At the Detection Rules 8.3 branch, the build-time `version` value for `related_integrations` is 1.2.0, whereas for the 8.4 branch the value is 2.0.0 and thus the versions double bumped.

We have had a discussion with @spong about potentially adjusting this build-time value being determined via Fleet instead as we would supply the package and integration. While this is a long-term solution, a stop-gap solution is necessary to ensure we do not continue to double bump these versions, but continue our release process.

Bumping the min-stack rule to 8.4 would fork the Google Workspace rules and thus prior to 8.4 stacks they would receive the 1.2.0 package whereas 8.4+ would receive the 2.0.0 package. In regards to versioning, this would allow the rule to be in a diverged state and thus the SHA256 sum remain the same for the 8.3 forked version and 8.4+ separately.

Additionally, the Google Workspace integration received an [update](https://github.com/elastic/integrations/pull/3430) which may confirm the changes were necessary to change the Kibana stack version to 8.4.0.

<img width="581" alt="Screen Shot 2023-01-13 at 1 10 02 PM" src="https://user-images.githubusercontent.com/99630311/212390219-0182e525-0bbc-4492-af70-8f903c820dec.png">
