### PR TITLE
[New Rule] Potential PowerShell HackTool Script by Function Names

### DIFF
--- a/rules/windows/execution_posh_hacktool_functions.toml
+++ b/rules/windows/execution_posh_hacktool_functions.toml
@@ -136,10 +136,9 @@ event.category:process and
     "Invoke-PrivescAudit" or "Invoke-ReflectivePEInjection" or
     "Invoke-ReverseDnsLookup" or "Invoke-RevertToSelf" or
     "Invoke-ServiceAbuse" or "Invoke-Shellcode" or
-    "Invoke-TokenManipulation" or
-    "Invoke-UserImpersonation" or "Invoke-WmiCommand" or
-    "Mount-VolumeShadowCopy" or "New-ADObjectAccessControlEntry" or
-    "New-DomainGroup" or
+    "Invoke-TokenManipulation" or "Invoke-UserImpersonation" or
+    "Invoke-WmiCommand" or "Mount-VolumeShadowCopy" or
+    "New-ADObjectAccessControlEntry" or "New-DomainGroup" or
     "New-DomainUser" or "New-DynamicParameter" or
     "New-InMemoryModule" or "New-ScriptBlockCallback" or
     "New-ThreadedFunction" or "New-VolumeShadowCopy" or

--- a/rules/windows/execution_posh_hacktool_functions.toml
+++ b/rules/windows/execution_posh_hacktool_functions.toml
@@ -157,7 +157,12 @@ event.category:process and
     "Update-MemoryAddresses" or "Update-MemoryProtectionFlags" or
     "Write-BytesToMemory" or "Write-HijackDll" or
     "Write-PortscanOut" or "Write-ServiceBinary" or
-    "Write-UserAddMSI"
+    "Write-UserAddMSI" or "Invoke-Privesc" or
+    "func_get_proc_address" or "Invoke-BloodHound" or
+    "Invoke-HostEnum" or "Get-BrowserInformation" or
+    "Get-DomainAccountPolicy" or "Get-DomainAdmins" or
+    "Get-AVProcesses" or "Get-AVInfo" or
+    "Get-RecycleBin"
   )
 '''
 

--- a/rules/windows/execution_posh_hacktool_functions.toml
+++ b/rules/windows/execution_posh_hacktool_functions.toml
@@ -1,0 +1,182 @@
+[metadata]
+creation_date = "2023/01/17"
+integration = ["windows"]
+maturity = "production"
+updated_date = "2023/01/17"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects known PowerShell offensive tooling functions names in PowerShell scripts. Attackers commonly use out-of-the-box
+offensive tools without modifying the code. This rule aim is to take advantage of that.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-windows.*", "logs-system.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Potential PowerShell HackTool Script by Function Names"
+note = """## Setup
+
+The 'PowerShell Script Block Logging' logging policy must be enabled.
+Steps to implement the logging policy with with Advanced Audit Configuration:
+
+```
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
+Turn on PowerShell Script Block Logging (Enable)
+```
+
+Steps to implement the logging policy via registry:
+
+```
+reg add "hklm\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging" /v EnableScriptBlockLogging /t REG_DWORD /d 1
+```
+"""
+references = [
+    "https://github.com/atc-project/atc-data/blob/master/docs/Logging_Policies/LP_0109_windows_powershell_script_block_log.md",
+    "https://github.com/BC-SECURITY/Empire"
+]
+risk_score = 47
+rule_id = "ad84d445-b1ce-4377-82d9-7c633f28bf9a"
+severity = "medium"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution", "PowerShell"]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+event.category:process and
+  powershell.file.script_block_text : (
+    "Add-DomainGroupMember" or "Add-DomainObjectAcl" or
+    "Add-RemoteConnection" or "Add-ServiceDacl" or
+    "Add-Win32Type" or "Convert-ADName" or
+    "Convert-LDAPProperty" or "ConvertFrom-LDAPLogonHours" or
+    "ConvertFrom-SID" or "ConvertFrom-UACValue" or
+    "ConvertTo-SID" or "Copy-ArrayOfMemAddresses" or
+    "Create-NamedPipe" or "Create-ProcessWithToken" or
+    "Create-RemoteThread" or "Create-SuspendedWinLogon" or
+    "Create-WinLogonProcess" or "Emit-CallThreadStub" or
+    "Enable-SeAssignPrimaryTokenPrivilege" or "Enable-SeDebugPrivilege" or
+    "Enum-AllTokens" or "Export-PowerViewCSV" or
+    "Find-AVSignature" or "Find-AppLockerLog" or
+    "Find-DomainLocalGroupMember" or "Find-DomainObjectPropertyOutlier" or
+    "Find-DomainProcess" or "Find-DomainShare" or
+    "Find-DomainUserEvent" or "Find-DomainUserLocation" or
+    "Find-InterestingDomainAcl" or "Find-InterestingDomainShareFile" or
+    "Find-InterestingFile" or "Find-LocalAdminAccess" or
+    "Find-PSScriptsInPSAppLog" or "Find-PathDLLHijack" or
+    "Find-ProcessDLLHijack" or "Find-RDPClientConnection" or
+    "Get-AllAttributesForClass" or "Get-CachedGPPPassword" or
+    "Get-DecryptedCpassword" or "Get-DecryptedSitelistPassword" or
+    "Get-DelegateType" or "Get-DomainController" or
+    "Get-DomainDFSShare" or "Get-DomainDFSShareV1" or
+    "Get-DomainDFSShareV2" or "Get-DomainDNSRecord" or
+    "Get-DomainDNSZone" or "Get-DomainFileServer" or
+    "Get-DomainForeignGroupMember" or "Get-DomainForeignUser" or
+    "Get-DomainGPO" or "Get-DomainGPOComputerLocalGroupMapping" or
+    "Get-DomainGPOLocalGroup" or "Get-DomainGPOUserLocalGroupMapping" or
+    "Get-DomainGUIDMap" or "Get-DomainGroup" or
+    "Get-DomainGroupMember" or "Get-DomainGroupMemberDeleted" or
+    "Get-DomainManagedSecurityGroup" or "Get-DomainOU" or
+    "Get-DomainObject" or "Get-DomainObjectAcl" or
+    "Get-DomainObjectAttributeHistory" or "Get-DomainObjectLinkedAttributeHistory" or
+    "Get-DomainPolicyData" or "Get-DomainSID" or
+    "Get-DomainSPNTicket" or "Get-DomainSearcher" or
+    "Get-DomainSite" or "Get-DomainSubnet" or
+    "Get-DomainTrust" or "Get-DomainTrustMapping" or
+    "Get-DomainUser" or "Get-DomainUserEvent" or
+    "Get-Forest" or "Get-ForestDomain" or
+    "Get-ForestGlobalCatalog" or "Get-ForestSchemaClass" or
+    "Get-ForestTrust" or "Get-GPODelegation" or
+    "Get-GPPAutologon" or "Get-GPPInnerField" or
+    "Get-GPPInnerFields" or "Get-GPPPassword" or
+    "Get-GptTmpl" or "Get-GroupsXML" or
+    "Get-HttpStatus" or "Get-ImageNtHeaders" or
+    "Get-IniContent" or "Get-Keystrokes" or
+    "Get-MemoryProcAddress" or "Get-MicrophoneAudio" or
+    "Get-ModifiablePath" or "Get-ModifiableRegistryAutoRun" or
+    "Get-ModifiableScheduledTaskFile" or "Get-ModifiableService" or
+    "Get-ModifiableServiceFile" or "Get-Name" or
+    "Get-NetComputerSiteName" or "Get-NetLocalGroup" or
+    "Get-NetLocalGroupMember" or "Get-NetLoggedon" or
+    "Get-NetRDPSession" or "Get-NetSession" or
+    "Get-NetShare" or "Get-PEArchitecture" or
+    "Get-PEBasicInfo" or "Get-PEDetailedInfo" or
+    "Get-PathAcl" or "Get-PrimaryToken" or
+    "Get-PrincipalContext" or "Get-ProcAddress" or
+    "Get-ProcessTokenGroup" or "Get-ProcessTokenPrivilege" or
+    "Get-ProcessTokenType" or "Get-Property" or
+    "Get-RegLoggedOn" or "Get-RegistryAlwaysInstallElevated" or
+    "Get-RegistryAutoLogon" or "Get-RemoteProcAddress" or
+    "Get-Screenshot" or "Get-ServiceDetail" or
+    "Get-SiteListPassword" or "Get-SitelistField" or
+    "Get-System" or "Get-SystemNamedPipe" or
+    "Get-SystemToken" or "Get-ThreadToken" or
+    "Get-TimedScreenshot" or "Get-TokenInformation" or
+    "Get-TopPort" or "Get-UnattendedInstallFile" or
+    "Get-UniqueTokens" or "Get-UnquotedService" or
+    "Get-VaultCredential" or "Get-VaultElementValue" or
+    "Get-VirtualProtectValue" or "Get-VolumeShadowCopy" or
+    "Get-WMIProcess" or "Get-WMIRegCachedRDPConnection" or
+    "Get-WMIRegLastLoggedOn" or "Get-WMIRegMountedDrive" or
+    "Get-WMIRegProxy" or "Get-WebConfig" or
+    "Get-Win32Constants" or "Get-Win32Functions" or
+    "Get-Win32Types" or "Import-DllImports" or
+    "Import-DllInRemoteProcess" or "Inject-LocalShellcode" or
+    "Inject-RemoteShellcode" or "Install-ServiceBinary" or
+    "Invoke-CompareAttributesForClass" or "Invoke-CreateRemoteThread" or
+    "Invoke-CredentialInjection" or "Invoke-DllInjection" or
+    "Invoke-EventVwrBypass" or "Invoke-ImpersonateUser" or
+    "Invoke-Kerberoast" or "Invoke-MemoryFreeLibrary" or
+    "Invoke-MemoryLoadLibrary" or "Invoke-Method" or
+    "Invoke-Mimikatz" or "Invoke-NinjaCopy" or
+    "Invoke-PatchDll" or "Invoke-Portscan" or
+    "Invoke-PrivescAudit" or "Invoke-ReflectivePEInjection" or
+    "Invoke-ReverseDnsLookup" or "Invoke-RevertToSelf" or
+    "Invoke-ServiceAbuse" or "Invoke-Shellcode" or
+    "Invoke-TokenManipulation" or
+    "Invoke-UserImpersonation" or "Invoke-WmiCommand" or
+    "Mount-VolumeShadowCopy" or "New-ADObjectAccessControlEntry" or
+    "New-DomainGroup" or
+    "New-DomainUser" or "New-DynamicParameter" or
+    "New-InMemoryModule" or "New-ScriptBlockCallback" or
+    "New-ThreadedFunction" or "New-VolumeShadowCopy" or
+    "Out-CompressedDll" or "Out-EncodedCommand" or
+    "Out-EncryptedScript" or "Out-Minidump" or
+    "PortScan-Alive" or "Portscan-Port" or
+    "Remove-DomainGroupMember" or "Remove-DomainObjectAcl" or
+    "Remove-RemoteConnection" or "Remove-VolumeShadowCopy" or
+    "Restore-ServiceBinary" or "Set-DesktopACLToAllowEveryone" or
+    "Set-DesktopACLs" or "Set-DomainObject" or
+    "Set-DomainObjectOwner" or "Set-DomainUserPassword" or
+    "Set-ServiceBinaryPath" or "Sub-SignedIntAsUnsigned" or
+    "Test-AdminAccess" or "Test-MemoryRangeValid" or
+    "Test-ServiceDaclPermission" or"Update-ExeFunctions" or
+    "Update-MemoryAddresses" or "Update-MemoryProtectionFlags" or
+    "Write-BytesToMemory" or "Write-HijackDll" or
+    "Write-PortscanOut" or "Write-ServiceBinary" or
+    "Write-UserAddMSI"
+  )
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.001"
+name = "PowerShell"
+reference = "https://attack.mitre.org/techniques/T1059/001/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/windows/execution_posh_hacktool_functions.toml
+++ b/rules/windows/execution_posh_hacktool_functions.toml
@@ -40,7 +40,7 @@ references = [
     "https://github.com/BC-SECURITY/Empire"
 ]
 risk_score = 47
-rule_id = "ad84d445-b1ce-4377-82d9-7c633f28bf9a"
+rule_id = "cde1bafa-9f01-4f43-a872-605b678968b0"
 severity = "medium"
 tags = ["Elastic", "Host", "Windows", "Threat Detection", "Execution", "PowerShell"]
 timestamp_override = "event.ingested"


### PR DESCRIPTION
## Summary

Detects known PowerShell offensive tooling functions names in PowerShell scripts. Attackers commonly use out-of-the-box offensive tools without modifying the code. This rule aim is to take advantage of that.