### PR TITLE
[Rule Tuning] T1069 and T1087 - admin wildcard and missing techniques

### DIFF
--- a/rules/windows/discovery_admin_recon.toml
+++ b/rules/windows/discovery_admin_recon.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/18"
 
 [rule]
 author = ["Elastic"]
@@ -66,7 +66,7 @@ process where event.type == "start" and
     ((process.name : "net1.exe" or process.pe.original_file_name == "net1.exe") and
         not process.parent.name : "net.exe")) and
    process.args : ("group", "user", "localgroup") and
-   process.args : ("admin", "Domain Admins", "Remote Desktop Users", "Enterprise Admins", "Organization Management") and
+   process.args : ("*admin*", "Domain Admins", "Remote Desktop Users", "Enterprise Admins", "Organization Management") and
    not process.args : "/add")
 
    or
@@ -83,6 +83,10 @@ id = "T1069"
 name = "Permission Groups Discovery"
 reference = "https://attack.mitre.org/techniques/T1069/"
 [[rule.threat.technique.subtechnique]]
+id = "T1069.001"
+name = "Local Groups"
+reference = "https://attack.mitre.org/techniques/T1069/001/"
+[[rule.threat.technique.subtechnique]]
 id = "T1069.002"
 name = "Domain Groups"
 reference = "https://attack.mitre.org/techniques/T1069/002/"
@@ -92,6 +96,14 @@ reference = "https://attack.mitre.org/techniques/T1069/002/"
 id = "T1087"
 name = "Account Discovery"
 reference = "https://attack.mitre.org/techniques/T1087/"
+[[rule.threat.technique.subtechnique]]
+id = "T1087.001"
+name = "Local Account"
+reference = "https://attack.mitre.org/techniques/T1087/001/"
+[[rule.threat.technique.subtechnique]]
+id = "T1087.002"
+name = "Domain Account"
+reference = "https://attack.mitre.org/techniques/T1087/002/"
 
 
 [rule.threat.tactic]

--- a/rules/windows/discovery_privileged_localgroup_membership.toml
+++ b/rules/windows/discovery_privileged_localgroup_membership.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/10/15"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2023/01/03"
+updated_date = "2023/01/18"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -135,7 +135,7 @@ iam where event.action == "user-member-enumerated" and
                 "?:\\Windows\\System32\\SystemPropertiesComputerName.exe") and
 
   /* privileged local groups */
-  (group.name:("admin*","RemoteDesktopUsers") or
+  (group.name:("*admin*","RemoteDesktopUsers") or
    winlog.event_data.TargetSid:("S-1-5-32-544","S-1-5-32-555"))
 '''
 


### PR DESCRIPTION
Tuned 2 rules:
- relax the conditions by using wildcard ```*admin*```
- added missing techniques

(relaxed condition captures "administrator" and "Administrator" args)
![image](https://user-images.githubusercontent.com/59296946/213289138-41692844-28dc-4d50-8f30-aa4f1b224feb.png)

(working query: no test data)
![image](https://user-images.githubusercontent.com/59296946/213289372-bfbf1acc-e1d3-41e0-a99b-71373d6bb151.png)

<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

## Summary



## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
