### PR TITLE
[New Rule] PowerShell Invoke-NinjaCopy script

### DIFF
--- a/rules/windows/credential_access_posh_invoke_ninjacopy.toml
+++ b/rules/windows/credential_access_posh_invoke_ninjacopy.toml
@@ -9,8 +9,8 @@ updated_date = "2023/01/23"
 [rule]
 author = ["Elastic"]
 description = """
-Detects PowerShell scripts that contains the default exported functions used on Invoke-NinjaCopy. Attackers can use
-Invoke-NinjaCopy to read SYSTEM files which are normally locked, such as the NTDS.dit file or registry hives.
+Detects PowerShell scripts that contain the default exported functions used on Invoke-NinjaCopy. Attackers can use
+Invoke-NinjaCopy to read SYSTEM files that are normally locked, such as the NTDS.dit file or registry hives.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-windows.*"]

--- a/rules/windows/credential_access_posh_invoke_ninjacopy.toml
+++ b/rules/windows/credential_access_posh_invoke_ninjacopy.toml
@@ -50,14 +50,14 @@ name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
 
     [[rule.threat.technique.subtechnique]]
-    id = "T1003.001"
-    name = "LSASS Memory"
-    reference = "https://attack.mitre.org/techniques/T1003/001/"
-
-    [[rule.threat.technique.subtechnique]]
     id = "T1003.002"
     name = "Security Account Manager"
     reference = "https://attack.mitre.org/techniques/T1003/002/"
+
+    [[rule.threat.technique.subtechnique]]
+    id = "T1003.003"
+    name = "NTDS"
+    reference = "https://attack.mitre.org/techniques/T1003/003/"
 
 
 

--- a/rules/windows/credential_access_posh_invoke_ninjacopy.toml
+++ b/rules/windows/credential_access_posh_invoke_ninjacopy.toml
@@ -1,0 +1,87 @@
+[metadata]
+creation_date = "2023/01/23"
+integration = ["windows"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/01/23"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects PowerShell scripts that contains the default exported functions used on Invoke-NinjaCopy. Attackers can use
+Invoke-NinjaCopy to read SYSTEM files which are normally locked, such as the NTDS.dit file or registry hives.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-windows.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "PowerShell Invoke-NinjaCopy script"
+references = [
+  "https://github.com/BC-SECURITY/Empire/blob/main/empire/server/data/module_source/collection/Invoke-NinjaCopy.ps1"
+]
+risk_score = 47
+rule_id = "b8386923-b02c-4b94-986a-d223d9b01f88"
+severity = "medium"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Credential Access", "PowerShell"]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+event.category:process and
+  powershell.file.script_block_text : (
+    "StealthReadFile" or
+    "StealthReadFileAddr" or
+    "StealthCloseFileDelegate" or
+    "StealthOpenFile" or
+    "StealthCloseFile" or
+    "StealthReadFile" or
+    "Invoke-NinjaCopy"
+   )
+  and not user.id : "S-1-5-18"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1003"
+name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
+
+    [[rule.threat.technique.subtechnique]]
+    id = "T1003.001"
+    name = "LSASS Memory"
+    reference = "https://attack.mitre.org/techniques/T1003/001/"
+
+    [[rule.threat.technique.subtechnique]]
+    id = "T1003.002"
+    name = "Security Account Manager"
+    reference = "https://attack.mitre.org/techniques/T1003/002/"
+
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+
+    [[rule.threat.technique.subtechnique]]
+    id = "T1059.001"
+    name = "PowerShell"
+    reference = "https://attack.mitre.org/techniques/T1059/001/"
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+


### PR DESCRIPTION
## Summary

Detects PowerShell scripts that contain the default exported functions used on Invoke-NinjaCopy. Attackers can use
Invoke-NinjaCopy to read SYSTEM files that are normally locked, such as the NTDS.dit file or registry hives.
