### PR TITLE
[New Rule] System Service Discovery through built-in Windows Utilities

### DIFF
--- a/rules/windows/discovery_system_service_discovery.toml
+++ b/rules/windows/discovery_system_service_discovery.toml
@@ -28,7 +28,7 @@ query = '''
 process where event.type: "start" and
   ((process.name: "net.exe" or process.pe.original_file_name == "net.exe" or (process.name : "net1.exe" and not process.parent.name : "net.exe")) and process.args : ("start", "use")) or
   (process.name: "sc.exe" or process.pe.original_file_name == "sc.exe") and process.args: ("query", "q*") or
-  (process.name: "tasklist.exe" or process.pe.original_file_name == "tasklist.exe") and process.args: ("/svc")
+  (process.name: "tasklist.exe" or process.pe.original_file_name == "tasklist.exe") and process.args: "/svc"
 '''
 
 [[rule.threat]]

--- a/rules/windows/discovery_system_service_discovery.toml
+++ b/rules/windows/discovery_system_service_discovery.toml
@@ -26,9 +26,11 @@ type = "eql"
 
 query = '''
 process where event.type: "start" and
+  (
   ((process.name: "net.exe" or process.pe.original_file_name == "net.exe" or (process.name : "net1.exe" and not process.parent.name : "net.exe")) and process.args : ("start", "use")) or
-  (process.name: "sc.exe" or process.pe.original_file_name == "sc.exe") and process.args: ("query", "q*") or
-  (process.name: "tasklist.exe" or process.pe.original_file_name == "tasklist.exe") and process.args: "/svc"
+  ((process.name: "sc.exe" or process.pe.original_file_name == "sc.exe") and process.args: ("query", "q*")) or
+  ((process.name: "tasklist.exe" or process.pe.original_file_name == "tasklist.exe") and process.args: "/svc")
+  )
 '''
 
 [[rule.threat]]

--- a/rules/windows/discovery_system_service_discovery.toml
+++ b/rules/windows/discovery_system_service_discovery.toml
@@ -27,7 +27,7 @@ type = "eql"
 query = '''
 process where event.type == "start" and
   (
-  ((process.name: "net.exe" or process.pe.original_file_name == "net.exe" or (process.name : "net1.exe" and not process.parent.name : "net.exe")) and process.args : ("start", "use")) or
+  ((process.name: "net.exe" or process.pe.original_file_name == "net.exe" or (process.name : "net1.exe" and not process.parent.name : "net.exe")) and process.args : ("start", "use") and process.args_count == 2) or
   ((process.name: "sc.exe" or process.pe.original_file_name == "sc.exe") and process.args: ("query", "q*")) or
   ((process.name: "tasklist.exe" or process.pe.original_file_name == "tasklist.exe") and process.args: "/svc")
   )

--- a/rules/windows/discovery_system_service_discovery.toml
+++ b/rules/windows/discovery_system_service_discovery.toml
@@ -1,0 +1,44 @@
+[metadata]
+creation_date = "2023/01/24"
+integration = ["windows", "endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/01/24"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects the usage of commonly used system service discovery techniques, which attackers may use during the reconnaissance phase 
+after compromising a system in order to gain a better understanding of the environment and/or escalate privileges. 
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*", "endgame-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "System Service Discovery through built-in Windows Utilities"
+risk_score = 21
+rule_id = "e0881d20-54ac-457f-8733-fe0bc5d44c55"
+severity = "low"
+tags = ["Elastic", "Host", "Windows", "Threat Detection", "Discovery", "Elastic Endgame"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where event.type: "start" and
+  ((process.name: "net.exe" or (process.name : "net1.exe" and not process.parent.name : "net.exe")) and process.args : ("start", "use")) or
+  (process.name: "sc.exe" or process.pe.original_file_name == "sc.exe") and process.args: ("query", "q*") or
+  (process.name: "tasklist.exe" or process.pe.original_file_name == "tasklist.exe") and process.args: ("/svc")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1007"
+name = "System Service Discovery"
+reference = "https://attack.mitre.org/techniques/T1007/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"

--- a/rules/windows/discovery_system_service_discovery.toml
+++ b/rules/windows/discovery_system_service_discovery.toml
@@ -26,7 +26,7 @@ type = "eql"
 
 query = '''
 process where event.type: "start" and
-  ((process.name: "net.exe" or (process.name : "net1.exe" and not process.parent.name : "net.exe")) and process.args : ("start", "use")) or
+  ((process.name: "net.exe" or process.pe.original_file_name == "net.exe" or (process.name : "net1.exe" and not process.parent.name : "net.exe")) and process.args : ("start", "use")) or
   (process.name: "sc.exe" or process.pe.original_file_name == "sc.exe") and process.args: ("query", "q*") or
   (process.name: "tasklist.exe" or process.pe.original_file_name == "tasklist.exe") and process.args: ("/svc")
 '''

--- a/rules/windows/discovery_system_service_discovery.toml
+++ b/rules/windows/discovery_system_service_discovery.toml
@@ -25,7 +25,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.type: "start" and
+process where event.type == "start" and
   (
   ((process.name: "net.exe" or process.pe.original_file_name == "net.exe" or (process.name : "net1.exe" and not process.parent.name : "net.exe")) and process.args : ("start", "use")) or
   ((process.name: "sc.exe" or process.pe.original_file_name == "sc.exe") and process.args: ("query", "q*")) or


### PR DESCRIPTION
## Summary
Detects the usage of commonly used system service discovery techniques, which attackers may use during the reconnaissance phase after compromising a system in order to gain a better understanding of the environment and/or escalate privileges.

### Query
<img width="965" alt="image" src="https://user-images.githubusercontent.com/78494512/214303508-cda5457a-acca-4940-806f-49ab9bc89f04.png">

### Results
<img width="2129" alt="image" src="https://user-images.githubusercontent.com/78494512/214303772-b4c947a1-298c-4ab7-b718-47b074493f03.png">