### PR TITLE
[Rule Tuning] Promote Guided Onboarding Rule to Production for 8.7 Release

### DIFF
--- a/rules/cross-platform/guided_onboarding_sample_rule.toml
+++ b/rules/cross-platform/guided_onboarding_sample_rule.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2022/09/22"
-maturity = "development"
-updated_date = "2022/12/21"
+maturity = "production"
 min_stack_comments = "Guided Onboarding will be available in Elastic 8.6+"
-min_stack_version = "8.6.0"
+min_stack_version = "8.7.0"
+updated_date = "2023/01/24"
 
 [rule]
 author = ["Elastic"]
@@ -32,8 +32,7 @@ language = "kuery"
 license = "Elastic License v2"
 max_signals = 1
 name = "My First Rule"
-note = """
-This is a test alert.
+note = """This is a test alert.
 
 This alert does not show threat activity. Elastic created this alert to help you understand how alerts work.
 


### PR DESCRIPTION
## Summary
This rule is being promoted to production and the min-stack bumped to 8.7 as it is only compatible with 8.7+ stacks. There is no rule tuning necessary for this regarding promotion. This rule should first be available in the v8.7.1 prebuilt rules integration package.
