### PR TITLE
[Deprecate] Noisy Network rules

### DIFF
--- a/rules/_deprecated/command_and_control_nat_traversal_port_activity.toml
+++ b/rules/_deprecated/command_and_control_nat_traversal_port_activity.toml
@@ -1,10 +1,11 @@
 [metadata]
 creation_date = "2020/02/18"
+deprecation_date = "2023/01/24"
 integration = ["endpoint"]
-maturity = "production"
+maturity = "deprecated"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/command_and_control_port_26_activity.toml
+++ b/rules/_deprecated/command_and_control_port_26_activity.toml
@@ -1,10 +1,11 @@
 [metadata]
 creation_date = "2020/02/18"
+deprecation_date = "2023/01/24"
 integration = ["endpoint"]
-maturity = "production"
+maturity = "deprecated"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/initial_access_rpc_remote_procedure_call_to_the_internet.toml
+++ b/rules/_deprecated/initial_access_rpc_remote_procedure_call_to_the_internet.toml
@@ -1,10 +1,11 @@
 [metadata]
 creation_date = "2020/02/18"
+deprecation_date = "2023/01/24"
 integration = ["endpoint"]
-maturity = "production"
+maturity = "deprecated"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/24"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Summary

Deprecates the following rules, which alert mostly on traffic on the specified ports, not considering the traffic content, generating a low TP rate:
* IPSEC NAT Traversal Port Activity
* SMTP on Port 26/TCP
* RPC (Remote Procedure Call) to the Internet