### PR TITLE
[Rule Tuning] Potential Shadow Credentials added to AD Object

### DIFF
--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/21"
+updated_date = "2023/01/27"
 
 [rule]
 author = ["Elastic"]
@@ -62,7 +62,7 @@ type = "query"
 
 query = '''
 event.action:"Directory Service Changes" and event.code:"5136" and
- winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and winlog.event_data.AttributeValue :B\:828*
+ winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and winlog.event_data.AttributeValue :B\:828* and not winlog.event_data.SubjectUserName: MSOL_*
 '''
 
 


### PR DESCRIPTION
## Summary

Excludes the default azure connect AD synchronization account, which reduces the noise by ~45%