### PR TITLE
[Rule Tuning] Potential Credential Access via DCSync

### DIFF
--- a/rules/windows/credential_access_dcsync_replication_rights.toml
+++ b/rules/windows/credential_access_dcsync_replication_rights.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/21"
+updated_date = "2023/01/27"
 
 [rule]
 author = ["Elastic"]
@@ -42,7 +42,8 @@ This rule monitors for Event ID 4662 (Operation was performed on an Active Direc
 
 ### False positive analysis
 
-- This activity should not happen legitimately, since replication should be done by Domain Controllers only. Any potential benign true positive (B-TP) should be mapped and monitored by the security team. Any account that performs this activity can put the domain at risk for not having the same security standards as computer accounts (which have long, complex, random passwords that change frequently), exposing it to credential cracking attacks (Kerberoasting, brute force, etc.).
+- Administrators may use custom accounts on Azure AD Connect, investigate if it is the case, and if it is properly secured. If noisy in your environment due to expected activity, consider adding the corresponding account as a exception.
+- Although replicating Active Directory (AD) data to non-Domain Controllers is not a common practice and is generally not recommended from a security perspective, some software vendors may require it for their products to function correctly. If this rule is noisy in your environment due to expected activity, consider adding the corresponding account as a exception.
 
 ### Response and remediation
 
@@ -115,7 +116,9 @@ any where event.action == "Directory Service Access" and
     /* The right to perform an operation controlled by an extended access right. */
 
     and winlog.event_data.AccessMask : "0x100" and
-    not winlog.event_data.SubjectUserName : ("*$", "MSOL_*")
+    not winlog.event_data.SubjectUserName : ("*$", "MSOL_*", "OpenDNS_Connector")
+
+    /* The Umbrella AD Connector uses the OpenDNS_Connector account to perform replication */
 '''
 
 


### PR DESCRIPTION
## Summary

- Adds the service account used by default by the Cisco Umbrella AD Connector, which accounts for ~16% of the alerts, as a exception.
- Adds information on the false positive analysis section of the investigation guides, as most of the FPs come from custom-named Azure AD accounts.