### PR TITLE
[Rule Tuning] Unusual File Modification by dns.exe

### DIFF
--- a/rules/windows/initial_access_unusual_dns_service_file_writes.toml
+++ b/rules/windows/initial_access_unusual_dns_service_file_writes.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/30"
 
 [rule]
 author = ["Elastic"]
@@ -42,7 +42,8 @@ type = "eql"
 
 query = '''
 file where process.name : "dns.exe" and event.type in ("creation", "deletion", "change") and
-  not file.name : "dns.log"
+  not file.name : "dns.log" and not
+  (file.extension : ("old", "temp", "bak", "dns", "arpa") and file.path : "C:\\Windows\\System32\\dns\\*")
 '''
 
 


### PR DESCRIPTION
## Summary

Exclude noisy file extensions related to DNS Backup processes, temporary DNS files, etc. This reduces the number of alerts by ~98%.