### PR TITLE
[Rule Tuning] Unusual Network Activity from a Windows System Binary

### DIFF
--- a/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+++ b/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/01/31"
 
 [rule]
 author = ["Elastic"]
@@ -63,7 +63,13 @@ sequence by process.entity_id with maxspan=5m
       process.name : "MSBuild.exe" or
       process.name : "msdt.exe" or
       process.name : "mshta.exe" or
-      process.name : "msiexec.exe" or
+      (
+         process.name : "msiexec.exe" and not
+         dns.question.name : (
+            "ocsp.digicert.com", "ocsp.verisign.com", "ocsp.comodoca.com", "ocsp.entrust.net", "ocsp.usertrust.com",
+            "ocsp.godaddy.com", "ocsp.camerfirma.com", "ocsp.globalsign.com", "ocsp.sectigo.com"
+         )
+      ) or
       process.name : "msxsl.exe" or
       process.name : "odbcconf.exe" or
       process.name : "rcsi.exe" or

--- a/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
+++ b/rules/windows/defense_evasion_network_connection_from_windows_binary.toml
@@ -67,7 +67,7 @@ sequence by process.entity_id with maxspan=5m
          process.name : "msiexec.exe" and not
          dns.question.name : (
             "ocsp.digicert.com", "ocsp.verisign.com", "ocsp.comodoca.com", "ocsp.entrust.net", "ocsp.usertrust.com",
-            "ocsp.godaddy.com", "ocsp.camerfirma.com", "ocsp.globalsign.com", "ocsp.sectigo.com"
+            "ocsp.godaddy.com", "ocsp.camerfirma.com", "ocsp.globalsign.com", "ocsp.sectigo.com", "*.local"
          )
       ) or
       process.name : "msxsl.exe" or


### PR DESCRIPTION
## Summary

Exclude common OCSP (Online Certificate Status Protocol) sites contacted by MSIEXEC and *.local domains, ~12% alert count reduction