### PR TITLE
[FR] Remove Build-Time Fields from Rule SHA256 Generation

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -761,7 +761,11 @@ class BaseRuleContents(ABC):
     def sha256(self, include_version=False) -> str:
         # get the hash of the API dict without the version by default, otherwise it'll always be dirty.
         hashable_contents = self.to_api_format(include_version=include_version)
-        return utils.dict_hash(hashable_contents)
+        # removes build time fields from SHA256 hash generation
+        # build-time fields are dependant on other Elastic integrations factors we cannot control
+        _hashable_contents = dict([(k, v) for k,v in hashable_contents.items() if k
+                                    not in BUILD_FIELD_VERSIONS.keys()])
+        return utils.dict_hash(_hashable_contents)
 
 
 @dataclass(frozen=True)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -763,8 +763,8 @@ class BaseRuleContents(ABC):
         hashable_contents = self.to_api_format(include_version=include_version)
         # removes build time fields from SHA256 hash generation
         # build-time fields are dependant on other Elastic integrations factors we cannot control
-        _hashable_contents = dict([(k, v) for k,v in hashable_contents.items() if k
-                                    not in BUILD_FIELD_VERSIONS.keys()])
+        _hashable_contents = dict([(k, v) for k, v in hashable_contents.items() if k
+                                  not in BUILD_FIELD_VERSIONS.keys()])
         return utils.dict_hash(_hashable_contents)
 
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/2496

## Summary
When rule versions are determined, the contents (-metadata) are SHA256 hashed and compared with the version in the `version.lock.json` file. If found to be different, rules are considered "dirty" and the rule version is autobumped +1. This action is typically only observed during the lock-versions workflow.

### Issue
Since the introduction of build-time fields in rules and specifically `related_integrations` we are dynamically determining values based on stack versions, query objects and tags. As a result, often these values are not consistent as integration packages are bound to receive updates and integration developers could restrict stack version compatibility at any time.

As a result, the `related_integrations` build-time fields may have different values depending on the stack version which references our branch versions and thus the rule contents will be considered "dirty" and rule versions be bumped.

A good example of this is the [endpoint integration](https://epr.elastic.co/search?package=endpoint&prerelease=true&all=true&include_policy_templates=true) where the following happens from the `lock-versions` workflow.

```
8.3 branch -> Endpoint Rule: SHA256=123 & endpoint integration=8.3 -> Rule Version 100
8.4 branch -> Endpoint Rule: SHA256=124 & endpoint integration=8.4 -> Rule Version 101
8.5 branch -> Endpoint Rule: SHA256=125 & endpoint integration=8.5 -> Rule Version 102
```

## Solution
To avoid unnecessary rule version bumps and allow the value of these build time fields to be naturally dynamic and different depending on Elastic stack version, we should remove them from the rule dictionary object as the SHA256 is calculated.

While we could hard fork the rules meaning bump the min-stacks and lock, thus separating rule versions to specific stack versions the endpoint integration would require us to lock rules at each stack based on their release process.

Related to #2496, we will be able to move rule versions to semantic versioning and have a better way to determine what in the rule contents is considered major, minor and patch bumps.

## Additional Information
Come time for the next minor release, all rules will have a version bump since the build-time fields are not included in the SHA256 sum calculation. We have the choice to either manually reconcile this file to avoid unnecessary version bumps or we can leave it as-is and the following release (8.8) we will have no more version bumps from build-time fields.

The potential drawback to this is since rule versions allow the Kibana to know which rules need updates, we may have a different related_integration least compatible integration version than when the rules were initially loaded and thus this new value would not be present in the rule.