### PR TITLE
Resolve backport checks on 2470 by checking Version min_stack

### DIFF
--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -253,8 +253,11 @@ def get_integration_schema_data(data, meta, package_integrations: dict) -> Gener
                 integration = pk_int["integration"]
 
                 # Use the minimum stack version from the package not the rule
+                min_stack = meta.min_stack_version or load_current_package_version()
+
                 # Prior to 8.3, some rules had a min_stack_version with only major.minor
-                min_stack = meta.min_stack_version or Version(Version(load_current_package_version()) + (0,))
+                if Version(min_stack) != 3:
+                    min_stack = Version(Version(load_current_package_version()) + (0,))
 
                 package_version, notice = find_latest_compatible_version(package=package,
                                                                          integration=integration,

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -20,6 +20,7 @@ import kql
 
 from . import ecs
 from .beats import flatten_ecs_schema
+from .misc import load_current_package_version
 from .semver import Version
 from .utils import cached, get_etc_path, read_gzip, unzip
 
@@ -251,9 +252,16 @@ def get_integration_schema_data(data, meta, package_integrations: dict) -> Gener
                 package = pk_int["package"]
                 integration = pk_int["integration"]
 
+                # Use the minimum stack version from the package not the rule
+                min_stack = meta.min_stack_version or load_current_package_version()
+
+                # Prior to 8.3, some rules had a min_stack_version with only major.minor
+                if Version(min_stack) != 3:
+                    min_stack = f"{min_stack}.0"
+
                 package_version, notice = find_latest_compatible_version(package=package,
                                                                          integration=integration,
-                                                                         rule_stack_version=meta.min_stack_version,
+                                                                         rule_stack_version=min_stack,
                                                                          packages_manifest=packages_manifest)
 
                 if notify_update_available and notice and data.get("notify", False):

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -253,11 +253,8 @@ def get_integration_schema_data(data, meta, package_integrations: dict) -> Gener
                 integration = pk_int["integration"]
 
                 # Use the minimum stack version from the package not the rule
-                min_stack = meta.min_stack_version or load_current_package_version()
-
                 # Prior to 8.3, some rules had a min_stack_version with only major.minor
-                if Version(min_stack) != 3:
-                    min_stack = f"{min_stack}.0"
+                min_stack = meta.min_stack_version or Version(Version(load_current_package_version()) + (0,))
 
                 package_version, notice = find_latest_compatible_version(package=package,
                                                                          integration=integration,


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
None

Backport checks failed after merging in #2470

## Summary

- Prior to 8.3 where we min_stacked the rules, some of the rules did not include a min_stack. 
- Additionally some of the rules min_stack version only contained the major.minor vs full semantic versioning. 

This additional logic now defaults the min_stack version to the package version to address rules without a min_stack within the toml file.