### PR TITLE
Check integrations cross major versions for older release support

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -32,7 +32,7 @@
         "RelativeTargetName": "keyword",
         "ShareName": "keyword",
         "SubjectLogonId": "keyword",
-        "SubjectUserName": "keyword", 
+        "SubjectUserName": "keyword",
         "SubjectUserSid": "keyword",
         "TargetUserName": "keyword",
         "TargetImage": "keyword",
@@ -45,16 +45,16 @@
         "AuthenticationPackageName" : "keyword",
         "TargetUserSid" : "keyword",
         "LogonProcessName": "keyword",
-        "DnsHostName" : "keyword", 
-        "ServiceFileName": "keyword", 
-        "ImagePath": "keyword", 
-        "TaskName": "keyword", 
+        "DnsHostName" : "keyword",
+        "ServiceFileName": "keyword",
+        "ImagePath": "keyword",
+        "TaskName": "keyword",
         "Status": "keyword",
-        "EnabledPrivilegeList": "keyword", 
+        "EnabledPrivilegeList": "keyword",
         "OperationType": "keyword"
       }
     },
-    "winlog.logon.type": "keyword", 
+    "winlog.logon.type": "keyword",
     "winlog.logon.id": "keyword",
     "powershell.file.script_block_text": "text"
   },
@@ -63,14 +63,14 @@
   },
   "logs-endpoint.events.*": {
     "process.Ext.token.integrity_level_name": "keyword",
-    "process.parent.Ext.real.pid": "long", 
-    "process.Ext.effective_parent.executable": "keyword", 
+    "process.parent.Ext.real.pid": "long",
+    "process.Ext.effective_parent.executable": "keyword",
     "process.Ext.effective_parent.name": "keyword",
-    "file.Ext.header_bytes": "keyword", 
+    "file.Ext.header_bytes": "keyword",
     "file.Ext.entropy": "long",
     "file.size": "long",
     "file.Ext.original.name": "keyword",
-    "dll.Ext.relative_file_creation_time": "double", 
+    "dll.Ext.relative_file_creation_time": "double",
     "dll.Ext.relative_file_name_modify_time": "double",
     "process.Ext.relative_file_name_modify_time": "double",
     "process.Ext.relative_file_creation_time": "double"
@@ -102,11 +102,16 @@
     "kubernetes.audit.objectRef.serviceAccountName": "keyword",
     "kubernetes.audit.requestObject.spec.serviceAccountName": "keyword",
     "kubernetes.audit.responseStatus.reason": "keyword",
-    "kubernetes.audit.requestObject.spec.containers.securityContext.capabilities.add": "keyword", 
+    "kubernetes.audit.requestObject.spec.containers.securityContext.capabilities.add": "keyword",
     "kubernetes.audit.requestObject.spec.containers.image": "text"
   },
   ".alerts-security.*": {
     "signal.rule.name": "keyword",
     "kibana.alert.rule.threat.tactic.id": "keyword"
+  },
+  "logs-google_workspace*": {
+    "gsuite.admin": "keyword",
+    "gsuite.admin.new_value": "keyword",
+    "gsuite.admin.setting.name": "keyword"
   }
 }

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -197,8 +197,14 @@ def find_latest_compatible_version(package: str, integration: str,
                       f"Update the rule min_stack version from {rule_stack_version} to "
                       f"{highest_compatible_version} if using new features in this latest version.")
 
-        elif int(highest_compatible_version[0]) == int(rule_stack_version[0]):
+        if int(highest_compatible_version[0]) == int(rule_stack_version[0]):
             return version, notice
+
+        else:
+            # Check for rules that cross majors
+            for compatible_version in compatible_versions:
+                if Version(compatible_version) <= Version(rule_stack_version):
+                    return version, notice
 
     raise ValueError(f"no compatible version for integration {package}:{integration}")
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Backport checks failed after merging in https://github.com/elastic/detection-rules/pull/2470

## Summary

- Some rules used fields from integrations that have been renamed/no longer exist. This modification updates the non-ecs-schema-file to catch the edge case simply to support older rule versions.
- To support older rule branches that cross major releases, we also have to support those edge cases.

