### PR TITLE
[Investigation Guide] Update defense_evasion_unusual_ads_file_creation.toml

### DIFF
--- a/rules/windows/defense_evasion_unusual_ads_file_creation.toml
+++ b/rules/windows/defense_evasion_unusual_ads_file_creation.toml
@@ -33,7 +33,7 @@ Attackers can abuse these alternate data streams to hide malicious files, string
 #### Possible investigation steps
 
 - Retrieve the contents of the alternate data stream, and analyze it for potential maliciousness. Analysts can use the following PowerShell cmdlet to accomplish this:
-  - `Get-Content -file C:\\Path\\To\\file.exe -stream ADSname`
+  - `Get-Content C:\\Path\\To\\file.exe -stream SampleAlternateDataStreamName`
 - Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
 - Investigate any abnormal behavior by the subject process such as network connections, registry or file modifications, and any spawned child processes.
 - Investigate other alerts associated with the user/host during the past 48 hours.


### PR DESCRIPTION
## Summary
The current Powershell command includes -file which is not a valid parameter for this module. The "-file" must be removed to be effective. Also, I changed the sample ADSname to something a little more obvious to the end user that it is a value that they need to change.

If a user runs the following sample command, they will get an error:
```
PS C:\Program Files\Test> Get-Content -file .\SpecialFile.ps1 -stream PatchVersion
Get-Content: Could not open the alternate data stream 'PatchVersion' of the file 'C:\Program Files\Test\SpecialFile.ps1'.
```

Instead, they should run:

```
PS C:\Program Files\Test> Get-Content .\SpecialFile.ps1 -stream PatchVersion
2.4
```