### PR TITLE
[Bug] Patch fix for #2503

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -678,7 +678,7 @@ class BaseRuleContents(ABC):
     @property
     def is_dirty(self) -> Optional[bool]:
         """Determine if the rule has changed since its version was locked."""
-        min_stack = Version.parse(self.get_supported_version())
+        min_stack = Version.parse(self.get_supported_version(), optional_minor_and_patch=True)
         existing_sha256 = self.version_lock.get_locked_hash(self.id, str(min_stack).rstrip(".0"))
 
         if existing_sha256 is not None:
@@ -743,7 +743,7 @@ class BaseRuleContents(ABC):
         """Get the lowest stack version for the rule that is currently supported in the form major.minor."""
         rule_min_stack = self.metadata.get('min_stack_version')
         min_stack = self.convert_supported_version(rule_min_stack)
-        return str(min_stack)
+        return f"{min_stack.major}.{min_stack.minor}"
 
     def _post_dict_transform(self, obj: dict) -> dict:
         """Transform the converted API in place before sending to Kibana."""

--- a/detection_rules/version_lock.py
+++ b/detection_rules/version_lock.py
@@ -202,7 +202,8 @@ class VersionLock:
         for rule in rules:
             if rule.contents.metadata.maturity == "production" or rule.id in newly_deprecated:
                 # assume that older stacks are always locked first
-                min_stack = Version.parse(rule.contents.get_supported_version())
+                min_stack = Version.parse(rule.contents.get_supported_version(),
+                                          optional_minor_and_patch=True)
 
                 lock_from_rule = rule.contents.lock_info(bump=not exclude_version_update)
                 lock_from_file: dict = lock_file_contents.setdefault(rule.id, {})


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Related
* https://github.com/elastic/detection-rules/pull/2503

## Summary
This PR contains a bug fix related to #2503 where version lock file references were being pulled incorrectly and thus version collisions were occurring as the result of the latest version referenced by default.

## Solution
Adjust `rule.get_supported_version` return to be a string of `major.minor` rather than a full semantic version string.

Code was modified on the 7.16 branch after the bug was resolved and then unit tests were ran again, which then all passed. The code changes were then exported to a git diff file and then checked out of each branch that the unit tests failed to then test the unit testing in each branch.
