### PR TITLE
[Bug] Patch fix for 2503 update addressing separate bugs

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1022,7 +1022,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         """Check for compatibility between restricted fields and the min_stack_version of the rule."""
         default_min_stack = get_min_supported_stack_version()
         if self.metadata.min_stack_version is not None:
-            min_stack = Version.parse(self.metadata.min_stack_version)
+            min_stack = Version.parse(self.metadata.min_stack_version, optional_minor_and_patch=True)
         else:
             min_stack = default_min_stack
         restricted = self.data.get_restricted_fields

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -617,8 +617,8 @@ class TestRuleTiming(BaseRuleTest):
             has_event_ingested = rule.contents.data.timestamp_override == 'event.ingested'
             indexes = rule.contents.data.get('index', [])
             beats_indexes = parse_beats_from_index(indexes)
-            min_stack_is_less_than_82 = Version.parse(rule.contents.metadata.min_stack_version or '7.13.0') \
-                < Version.parse("8.2.0")
+            min_stack_is_less_than_82 = Version.parse(rule.contents.metadata.min_stack_version or '7.13.0',
+                                                      optional_minor_and_patch=True) < Version.parse("8.2.0")
             config = rule.contents.data.get('note') or ''
             rule_str = self.rule_str(rule, trailer=None)
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
* https://github.com/elastic/detection-rules/pull/2503

## Summary
Added `optional_minor_and_patch` flag to `TestRuleTiming` unit test for valid full semantic version parsing prior to comparison logic. Flag was also added to `check_restricted_fields_compatibility` because `major.minor` was being passed in and failed semantic version parsing.

After addressing bugs, the a git diff file was created and then applied at every branch from 7.16-8.6 to ensure that unit testing passes for each branch.
