### PR TITLE
[Bug] Removed Strip Calls in Favor of F-Strings with Major and Minor Versions

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -169,11 +169,13 @@ def bump_versions(major_release: bool, minor_release: bool, patch_release: bool,
     pkg_ver = Version.parse(pkg_data["registry_data"]["version"])
     pkg_kibana_ver = Version.parse(pkg_data["registry_data"]["conditions"]["kibana.version"].lstrip("^"))
     if major_release:
-        pkg_data["name"] = str(kibana_ver.bump_major()).rstrip(".0")
+        major_bump = kibana_ver.bump_major()
+        pkg_data["name"] = f"{major_bump.major}.{major_bump.minor}"
         pkg_data["registry_data"]["conditions"]["kibana.version"] = f"^{pkg_kibana_ver.bump_major()}"
         pkg_data["registry_data"]["version"] = str(pkg_ver.bump_major().bump_prerelease("beta"))
     if minor_release:
-        pkg_data["name"] = str(kibana_ver.bump_minor()).rstrip(".0")
+        minor_bump = kibana_ver.bump_minor()
+        pkg_data["name"] = f"{major_bump.major}.{major_bump.minor}"
         pkg_data["registry_data"]["conditions"]["kibana.version"] = f"^{pkg_kibana_ver.bump_minor()}"
         pkg_data["registry_data"]["version"] = str(pkg_ver.bump_minor().bump_prerelease("beta"))
         pkg_data["registry_data"]["release"] = maturity

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -175,7 +175,7 @@ def bump_versions(major_release: bool, minor_release: bool, patch_release: bool,
         pkg_data["registry_data"]["version"] = str(pkg_ver.bump_major().bump_prerelease("beta"))
     if minor_release:
         minor_bump = kibana_ver.bump_minor()
-        pkg_data["name"] = f"{major_bump.major}.{major_bump.minor}"
+        pkg_data["name"] = f"{minor_bump.major}.{minor_bump.minor}"
         pkg_data["registry_data"]["conditions"]["kibana.version"] = f"^{pkg_kibana_ver.bump_minor()}"
         pkg_data["registry_data"]["version"] = str(pkg_ver.bump_minor().bump_prerelease("beta"))
         pkg_data["registry_data"]["release"] = maturity

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -679,7 +679,7 @@ class BaseRuleContents(ABC):
     def is_dirty(self) -> Optional[bool]:
         """Determine if the rule has changed since its version was locked."""
         min_stack = Version.parse(self.get_supported_version(), optional_minor_and_patch=True)
-        existing_sha256 = self.version_lock.get_locked_hash(self.id, str(min_stack).rstrip(".0"))
+        existing_sha256 = self.version_lock.get_locked_hash(self.id, f"{min_stack.major}.{min_stack.minor}")
 
         if existing_sha256 is not None:
             return existing_sha256 != self.sha256()

--- a/tests/test_version_locking.py
+++ b/tests/test_version_locking.py
@@ -23,7 +23,7 @@ class TestVersionLock(unittest.TestCase):
         for rule_id, lock in default_version_lock.version_lock.to_dict().items():
             if 'previous' in lock:
                 prev_vers = [Version.parse(v, optional_minor_and_patch=True) for v in list(lock['previous'])]
-                outdated = [str(v).lstrip(".0") for v in prev_vers if v < min_version]
+                outdated = [f"{v.major}.{v.minor}" for v in prev_vers if v < min_version]
                 if outdated:
                     errors[rule_id] = outdated
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/pull/2535

## Summary
Based on #2535 comments, we had triple bumps when forked rule versions were being compared to the current version in the `rule.BaseRuleContents.is_dirty` method. Since `rstrip(".0")` was being used on string versions, `8.0.0` became `8` and thus could not properly access the correct nested JSON object in the version-lock dictionary as the key was `8.0`.

## Solution
Use `f"{version.major}.{version.minor}"` instead of `rstrip` to ensure the correct key is being used for the version lock file in `rule.BaseRuleContents.is_dirty`.

The changes have been tested on the 7.16->8.7 branch to ensure unit tests pass and the version lock triple bumps do not occur.
