### PR TITLE
[Bug] Change YAML Dump Parameters for Integrations Changelog

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -527,8 +527,7 @@ def integrations_pr(ctx: click.Context, local_repo: str, token: str, draft: bool
             # add a note for other maintainers of elastic/integrations to be careful with versions
             f.write("# newer versions go on top\n")
             f.write("# NOTE: please use pre-release versions (e.g. -dev.0) until a package is ready for production\n")
-
-            yaml.dump(changelog_entries, f, allow_unicode=True, default_flow_style=False, indent=2)
+            yaml.dump(changelog_entries, f, allow_unicode=True, default_flow_style=False, indent=2, sort_keys=False)
 
     save_changelog()
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/2351

## Summary
The following changes will dump the Integrations changelog contents correctly where `version` is the root key followed by `changes`. 

<img width="1023" alt="Screenshot 2023-02-13 at 10 24 48 AM" src="https://user-images.githubusercontent.com/99630311/218500243-4cf5e0f5-7384-4e57-a39d-1e0feea10e08.png">

## Additional Information
While this fixes the export in Detection Rules when using the `integrations-pr` CLI command in `devtools.py` we must manually reconcile the changelog file in the Integrations repository. This has been done in https://github.com/elastic/integrations/pull/5238. 
