### PR TITLE
[Rule Tuning & Addition] Potential Linux SSH Brute Force

### DIFF
--- a/rules/linux/credential_access_potential_linux_ssh_bruteforce_external.toml
+++ b/rules/linux/credential_access_potential_linux_ssh_bruteforce_external.toml
@@ -1,0 +1,90 @@
+[metadata]
+creation_date = "2022/09/14"
+integration = ["system"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/02/21"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies multiple external consecutive login failures targeting a user account from the same source address within 
+a short time interval. Adversaries will often brute force login attempts across multiple users with a common or known
+password, in an attempt to gain access to these accounts.
+"""
+from = "now-9m"
+index = ["auditbeat-*", "logs-system.auth-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential External Linux SSH Brute Force Detected"
+note = """## Triage and analysis
+
+### Investigating Potential SSH Brute Force Attack
+
+The rule identifies consecutive SSH login failures targeting a user account from the same source IP address to the same target host indicating brute force login attempts.
+
+This rule will generate a lot of noise for systems with a front-facing SSH service. 
+Adversaries scan the whole internet for remotely accessible SSH services, and try to brute force them in order to gain unauthorized access. 
+In case this rule generates too much noise, and external brute forcing is of not much interest, consider turning this rule off and enabling "Potential Internal Linux SSH Brute Force Detected" to detect internal brute force attempts.
+
+#### Possible investigation steps
+
+- Investigate the login failure user name(s).
+- Investigate the source IP address of the failed ssh login attempt(s).
+- Investigate other alerts associated with the user/host during the past 48 hours.
+- Identify the source and the target computer and their roles in the IT environment.
+
+### False positive analysis
+
+- Authentication misconfiguration or obsolete credentials.
+- Service account password expired.
+- Infrastructure or availability issue.
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- Isolate the involved hosts to prevent further post-compromise behavior.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+
+"""
+risk_score = 21
+rule_id = "fa210b61-b627-4e5e-86f4-17e8270656ab"
+severity = "low"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Credential Access"]
+type = "eql"
+query = '''
+sequence by host.id, source.ip, user.name with maxspan = 5s
+  [authentication where event.action  in ("ssh_login", "user_login") and
+   event.outcome == "failure" and not
+   cidrmatch(source.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+  ] with runs = 3
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+[[rule.threat.technique.subtechnique]]
+id = "T1110.001"
+name = "Password Guessing"
+reference = "https://attack.mitre.org/techniques/T1110/001/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.003"
+name = "Password Spraying"
+reference = "https://attack.mitre.org/techniques/T1110/003/"
+
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/linux/credential_access_potential_linux_ssh_bruteforce_internal.toml
+++ b/rules/linux/credential_access_potential_linux_ssh_bruteforce_internal.toml
@@ -1,28 +1,28 @@
 [metadata]
-creation_date = "2022/09/14"
+creation_date = "2023/02/21"
 integration = ["system"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/02/01"
+updated_date = "2023/02/21"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies multiple consecutive login failures targeting an user account from the same source address and within a
-short time interval. Adversaries will often brute force login attempts across multiple users with a common or known
-password, in an attempt to gain access to accounts.
+Identifies multiple internal consecutive login failures targeting a user account from the same source address within 
+a short time interval. Adversaries will often brute force login attempts across multiple users with a common or known
+password, in an attempt to gain access to these accounts.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-system.auth-*"]
 language = "eql"
 license = "Elastic License v2"
-name = "Potential Linux SSH Brute Force Detected"
+name = "Potential Internal Linux SSH Brute Force Detected"
 note = """## Triage and analysis
 
 ### Investigating Potential SSH Brute Force Attack
 
-The rule identifies consecutive SSH login failures targeting a user account from the same source IP address to the same target host indicating brute force login attempts.
+The rule identifies consecutive internal SSH login failures targeting a user account from the same source IP address to the same target host indicating brute force login attempts.
 
 #### Possible investigation steps
 
@@ -48,14 +48,16 @@ The rule identifies consecutive SSH login failures targeting a user account from
 
 """
 risk_score = 47
-rule_id = "1c27fa22-7727-4dd3-81c0-de6da5555feb"
+rule_id = "a8fb5071-c071-4ec0-9ecd-85b45244ddfc"
 severity = "medium"
 tags = ["Elastic", "Host", "Linux", "Threat Detection", "Credential Access"]
 type = "eql"
 query = '''
-sequence by host.id, source.ip, user.name with maxspan=10s
+sequence by host.id, source.ip, user.name with maxspan = 5s
   [authentication where event.action  in ("ssh_login", "user_login") and
-   event.outcome == "failure" and source.ip != null and source.ip != "0.0.0.0" and source.ip != "::" ] with runs=10
+   event.outcome == "failure" and
+   cidrmatch(source.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+  ] with runs = 3
 '''
 
 


### PR DESCRIPTION
## Summary
Tuned the current SSH brute force rule (Potential External Linux SSH Brute Force Detected) to only detect external brute force attempts, and created an additional rule (Potential Internal Linux SSH Brute Force Detected) to account for internal brute force attempts. This will allow our users to disable the external rule in case they find it too noisy, without losing the internal visibility which is much less prone to false positives.

### Potential External Linux SSH Brute Force Detected
<img width="1593" alt="image" src="https://user-images.githubusercontent.com/78494512/220316915-d4263fec-3af8-419e-a9ec-9b6864f25860.png">

### Potential Internal Linux SSH Brute Force Detected
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/78494512/220317404-a5dd8f33-0a72-46d4-8345-cd3134f73dee.png">
