### PR TITLE
New Rule to identify iptables or firewall disabling.

### DIFF
--- a/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -24,20 +24,20 @@ tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where event.action == "exec" and
+process where event.type == "start" and event.action == "exec" and
  (
    /* disable FW */
    (
-     (process.name == "ufw" and process.args : "disable") or
-     (process.name == "iptables" and process.args : "-F" and process.args_count <= 2)
+     (process.name == "ufw" and process.args == "disable") or
+     (process.name == "iptables" and process.args == "-F" and process.args_count == 2)
    ) or
 
    /* stop FW service */
    (
      ((process.name == "service" and process.args == "stop") or
        (process.name == "chkconfig" and process.args == "off") or
-       (process.name=="systemctl" and process.args in ("disable","stop","kill"))) and
-    process.args in ("firewalld","ip6tables","iptables")
+       (process.name == "systemctl" and process.args in ("disable", "stop", "kill"))) and
+    process.args in ("firewalld", "ip6tables", "iptables")
     )
   )
 '''

--- a/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_iptables_or_firewall.toml
@@ -1,0 +1,63 @@
+[metadata]
+creation_date = "2023/02/22"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/02/22"
+
+[rule]
+author = ["Elastic"]
+description = """
+Adversaries may attempt to disable the iptables or firewall service in an attempt to affect how a host is allowed to
+receive or send network traffic.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Attempt to Disable IPTables or Firewall"
+risk_score = 21
+rule_id = "83e9c2b3-24ef-4c1d-a8cd-5ebafb5dfa2f"
+severity = "low"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Defense Evasion"]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where event.action == "exec" and
+ (
+   /* disable FW */
+   (
+     (process.name == "ufw" and process.args : "disable") or
+     (process.name == "iptables" and process.args : "-F" and process.args_count <= 2)
+   ) or
+
+   /* stop FW service */
+   (
+     ((process.name == "service" and process.args == "stop") or
+       (process.name == "chkconfig" and process.args == "off") or
+       (process.name=="systemctl" and process.args in ("disable","stop","kill"))) and
+    process.args in ("firewalld","ip6tables","iptables")
+    )
+  )
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+name = "Impair Defenses"
+id = "T1562"
+reference = "https://attack.mitre.org/techniques/T1562/"
+[[rule.threat.technique.subtechnique]]
+name = "Disable or Modify Tools"
+id = "T1562.001"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+
+
+[rule.threat.tactic]
+name = "Defense Evasion"
+id = "TA0005"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+


### PR DESCRIPTION
## Issues
#2590 

## Summary
The rule was in endpoint and is being moved to detection mode as part of elastic/endpoint-rules/issues/1817
No additional testing is required. Tested as part of elastic/endpoint-rules/pull/1297


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
