### PR TITLE
[Rule Tuning] Potential Shadow File Read via CLI

### DIFF
--- a/rules/linux/privilege_escalation_shadow_file_read.toml
+++ b/rules/linux/privilege_escalation_shadow_file_read.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/02/23"
 
 [rule]
 author = ["Elastic"]
@@ -49,8 +49,12 @@ process where event.type == "start" and event.action == "exec" and user.name == 
     "/usr/bin/uniq",
     "/bin/uniq",
     "/usr/bin/unzip",
-    "/bin/unzip")
-  and not process.parent.executable: "/bin/dracut"
+    "/bin/unzip",
+    "/usr/sbin/restorecon",
+    "/sbin/restorecon")
+  and not process.parent.executable: "/bin/dracut" and
+  not (process.executable : ("/bin/chown", "/usr/bin/chown") and process.args : "root:shadow") and
+  not (process.executable : ("/bin/chmod", "/usr/bin/chmod") and process.args : "640")
 '''
 
 


### PR DESCRIPTION
## Summary
After excluding the true positives such as grep, egrep, sed, awk and cat, several false positives remained. This tuning request excludes the following three false positives:
- chown root:shadow --> which is benign behavior, as these permissions are default for the /etc/shadow file
- chmod 640 --> which is benign behavior, as these permissions are default for the /etc/shadow file
- process.executable restorecon --> which is used by SELinux to restore files to their proper permission state.

The query was tested in my test environment, and runs correctly. 

After excluding these false positives from the rule, the total number of hits will be reduced from 2856 to 2712. 

This is still a large number, however these alerts are true positives.

<img width="1312" alt="image" src="https://user-images.githubusercontent.com/78494512/220875727-297fa935-41f5-43ef-8864-01a4828d4908.png">