### PR TITLE
[FR] Add validation for insight and osquery entries

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -277,6 +277,11 @@ class Osquery:
     @classmethod
     def from_string(cls, entry: str) -> 'Osquery':
         match = re.match(r'!{osquery({.*})}', entry)
+
+        if not entry.startswith('!{osquery{') and not match:
+            # found a non-osquery entry, return None
+            return
+
         if not match:
             raise ValidationError("Osquery entry should start with '!{osquery{'")
 
@@ -303,6 +308,11 @@ class Insight:
     @classmethod
     def from_string(cls, entry: str) -> 'Insight':
         match = re.match(r'!{insight({.*})}', entry)
+
+        if not entry.startswith('!{insight{') and not match:
+            # found a non-insight entry, return None
+            return
+
         if not match:
             raise ValidationError("Insight entry should start with '!{insight{'")
         try:

--- a/rules/ml/persistence_ml_rare_process_by_host_windows.toml
+++ b/rules/ml/persistence_ml_rare_process_by_host_windows.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2023/01/31"
+updated_date = "2023/02/23"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -55,8 +55,8 @@ This rule uses a machine learning job to detect a Windows process that is rare a
     - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Retrieve Service Unisgned Executables with Virustotal Link"}}
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE '%LocalSystem' OR user_account LIKE '%LocalService' OR user_account LIKE '%NetworkService' OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != 'trusted'","label":"Retrieve Service Unisgned Executables with Virustotal Link"}}
   - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False Positive Analysis

--- a/rules/ml/persistence_ml_windows_anomalous_process_all_hosts.toml
+++ b/rules/ml/persistence_ml_windows_anomalous_process_all_hosts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2023/02/22"
+updated_date = "2023/02/23"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -55,8 +55,8 @@ This rule uses a machine learning job to detect a Windows process that is rare a
     - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Retrieve Service Unisgned Executables with Virustotal Link"}}
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE '%LocalSystem' OR user_account LIKE '%LocalService' OR user_account LIKE '%NetworkService' OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != 'trusted'","label":"Retrieve Service Unisgned Executables with Virustotal Link"}}
   - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False Positive Analysis

--- a/rules/ml/persistence_ml_windows_anomalous_process_creation.toml
+++ b/rules/ml/persistence_ml_windows_anomalous_process_creation.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/03/25"
 maturity = "production"
-updated_date = "2023/01/31"
+updated_date = "2023/02/23"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -58,8 +58,8 @@ This rule uses a machine learning job to detect an anomalous Windows process wit
     - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
     - Examine the host services for suspicious or anomalous entries.
       - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services","label":"Osquery - Retrieve All Services"}}
-      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE \"%LocalSystem\" OR user_account LIKE \"%LocalService\" OR user_account LIKE \"%NetworkService\" OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
-      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != \"trusted\"","label":"Retrieve Service Unisgned Executables with Virustotal Link"}}
+      - !{osquery{"query":"SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE NOT (user_account LIKE '%LocalSystem' OR user_account LIKE '%LocalService' OR user_account LIKE '%NetworkService' OR user_account == null)","label":"Osquery - Retrieve Services Running on User Accounts"}}
+      - !{osquery{"query":"SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid, services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path = authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != 'trusted'","label":"Retrieve Service Unisgned Executables with Virustotal Link"}}
   - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
 
 ### False Positive Analysis


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
#2584 

## Summary

Adds schema validation for `osquery` and `insight` entries in the `note` toml rule field. This validation ensures that the entries match the expected format by loading the singleline node from the MarkoDocument and validating against the appropriate dataclass (osquery or insight). The entries are initially identified keyword `osquery` and by regex, json loaded, and then finally dataclass loaded which implicitly validates the entry.

A few rules are also tuned to pass validation (change quotes from double to single) and be consistent with the other rules.

## Testing

- Run unit tests
- Add a few valid osquery and insight entries to a toml file to test they pass validation (no errors).
  ```bash

  !{insight{"label":"Investigate activities done by the subject process", "providers": [[{"field": "process.entity_id", "value": "process.entity_id", "type":  "parameter"}]]}} 

    ```
    ```bash

  !{osquery{"query":"SELECT * FROM dns_cache", "label":"Osquery - Retrieve DNS Cache"}}

    ```
- Add the keywords `osquery` and `insight` in a few places in the note markdown field to ensure they do not attempt to validate (should skip validation with no errors)
- Add a few invalid insight and osquery entries (should see validation errors). Note: There is a gap in coverage where if there's a typo in `!{osquery{` or `!{insight{` in a valid entry, the validation will be skipped.



