### PR TITLE
[FR] Use Read token on branch status checks

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           token: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
           ref: main
+          fetch-depth: 100
 
       - name: Set github config
         run: |
@@ -77,7 +78,6 @@ jobs:
 
       - name: Get branch histories
         run: |
-          git fetch origin main --depth 100
           git fetch origin ${{matrix.target_branch}} --depth 1
           git status
           git log -1 --format='%H'

--- a/.github/workflows/branch-status-checks.yml
+++ b/.github/workflows/branch-status-checks.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         url: "https://api.github.com/repos/elastic/detection-rules/actions/workflows/pythonpackage.yml/runs?per_page=1&branch=${{matrix.target_branch}}"
         method: 'GET'
+        bearerToken: ${{ secrets.READ_ORG_TOKEN }}
 
     - name: Check Backport Status
       uses: actions/github-script@v6


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

We've been hitting a lot of `API rate limit exceeded` errors in our [branch-status-checks](https://github.com/elastic/detection-rules/actions/workflows/branch-status-checks.yml). We additionally ran into a new issue were we hit `too many requests` when trying to fetch the git history. 


![image (11)](https://user-images.githubusercontent.com/1636709/221036065-1d5975df-d46a-408f-85e5-34f6a8cc521a.png)

![Screenshot 2023-02-23 at 4 38 02 PM](https://user-images.githubusercontent.com/1636709/221036129-391453b1-d3c4-428c-81bf-376adef4a80e.png)


## Summary

This PR adds the READ token to the branch-status-check which should resolve the daily issues that we observe, as the call will now be authenticated. The 100 depth fetch in the `backport.yml` workflow is moved to the checkout step which already uses a token.

## Testing

Testing this workflow while it's not on main is a bit tricky, so I forked the repo and made small modifications to the workflow to test the PAT was passed correctly to the workflow. I also ran the workflow to confirm it ran authenticated. 

<details>
<summary> Testing on Forked Repo</summary>

https://github.com/Mikaayenson/detection-rules/actions/runs/4256374716/jobs/7405180985

![Screenshot 2023-02-23 at 4 42 40 PM](https://user-images.githubusercontent.com/1636709/221036952-2955abfe-fa16-42ce-b531-f3dc1c6906af.png)

</details>

