### PR TITLE
New Rule to identify potential linux credential dumping

### DIFF
--- a/rules/linux/credential_access_credential_dumping.toml
+++ b/rules/linux/credential_access_credential_dumping.toml
@@ -30,7 +30,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where process.name == "unshadow" and
-event.type == "start" and event.action =="exec" and process.args_count >= 2
+  event.type == "start" and event.action == "exec" and process.args_count >= 2
 '''
 
 

--- a/rules/linux/credential_access_credential_dumping.toml
+++ b/rules/linux/credential_access_credential_dumping.toml
@@ -9,11 +9,12 @@ updated_date = "2023/02/27"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the execution of the unshadow utility on the host machine.
-Malicious actors can use the utility to retrieve the combined contents of the '/etc/shadow' and '/etc/password' files.
-Using the combined file generated from the utility, the malicious threat actors can prepare
-themselves for reconnaissance attacks by gathering credential information of the victim which can be used
-to plan future operations or use them as input for password-cracking utilities.
+Identifies the execution of the unshadow utility which is part of John the Ripper,
+a password-cracking tool on the host machine. Malicious actors can use the utility to retrieve
+the combined contents of the '/etc/shadow' and '/etc/password' files.
+Using the combined file generated from the utility, the malicious threat actors can use them as input
+for password-cracking utilities or prepare themselves for reconnaissance attacks by gathering credential information
+of the victim to plan future operations.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "endgame-*"]

--- a/rules/linux/credential_access_credential_dumping.toml
+++ b/rules/linux/credential_access_credential_dumping.toml
@@ -13,8 +13,8 @@ Identifies the execution of the unshadow utility which is part of John the Rippe
 a password-cracking tool on the host machine. Malicious actors can use the utility to retrieve
 the combined contents of the '/etc/shadow' and '/etc/password' files.
 Using the combined file generated from the utility, the malicious threat actors can use them as input
-for password-cracking utilities or prepare themselves for reconnaissance attacks by gathering credential information
-of the victim to plan future operations.
+for password-cracking utilities or prepare themselves for future operations by gathering
+credential information of the victim.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "endgame-*"]

--- a/rules/linux/credential_access_credential_dumping.toml
+++ b/rules/linux/credential_access_credential_dumping.toml
@@ -19,6 +19,9 @@ index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Linux Credential Dumping"
+references = [
+    "https://www.cyberciti.biz/faq/unix-linux-password-cracking-john-the-ripper/",
+]
 risk_score = 47
 rule_id = "e7cb3cfd-aaa3-4d7b-af18-23b89955062c"
 severity = "medium"

--- a/rules/linux/credential_access_credential_dumping.toml
+++ b/rules/linux/credential_access_credential_dumping.toml
@@ -9,23 +9,24 @@ updated_date = "2023/02/27"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the use of the Linux utility 'unshadow' being executed with the right set of parameters.
-This technique could be used by malicious actors to retrieve the contents of the '/etc/shadow' and
-'/etc/password' files.Using these files the malicious threat actors can prepare
-themselves for password-cracking utilities.
+Identifies the execution of the unshadow utility on the host machine.
+Malicious actors can use the utility to retrieve the combined contents of the '/etc/shadow' and '/etc/password' files.
+Using the combined file generated from the utility, the malicious threat actors can prepare
+themselves for reconnaissance attacks by gathering credential information of the victim which can be used
+to plan future operations or use them as input for password-cracking utilities.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
-name = "Potential Linux Credential Dumping"
+name = "Potential Linux Credential Dumping via Unshadow"
 references = [
     "https://www.cyberciti.biz/faq/unix-linux-password-cracking-john-the-ripper/",
 ]
 risk_score = 47
 rule_id = "e7cb3cfd-aaa3-4d7b-af18-23b89955062c"
 severity = "medium"
-tags = ["Elastic", "Host", "Linux", "Threat Detection", "Credential Access"]
+tags = ["Elastic", "Elastic Endgame", "Host", "Linux", "Threat Detection", "Credential Access"]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''

--- a/rules/linux/credential_access_credential_dumping.toml
+++ b/rules/linux/credential_access_credential_dumping.toml
@@ -1,0 +1,51 @@
+[metadata]
+creation_date = "2023/02/27"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/02/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies the use of the Linux utility 'unshadow' being executed with the right set of parameters.
+This technique could be used by malicious actors to retrieve the contents of the '/etc/shadow' and
+'/etc/password' files.Using these files the malicious threat actors can prepare
+themselves for password-cracking utilities.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Linux Credential Dumping"
+risk_score = 47
+rule_id = "e7cb3cfd-aaa3-4d7b-af18-23b89955062c"
+severity = "medium"
+tags = ["Elastic", "Host", "Linux", "Threat Detection", "Credential Access"]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where process.name == "unshadow" and
+event.type == "start" and event.action =="exec" and process.args_count >= 2
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1003"
+name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
+[[rule.threat.technique.subtechnique]]
+id = "T1003.008"
+name = "/etc/passwd and /etc/shadow"
+reference = "https://attack.mitre.org/techniques/T1003/008/"
+
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+


### PR DESCRIPTION

## Issues
#2603 

## Summary
This detection identifies the use of the Linux utility 'unshadow' being executed with the right set of parameters.
This technique could be used by malicious actors to retrieve the contents of the '/etc/shadow' and '/etc/password' files.
Using these files the malicious threat actors can prepare themselves for password-cracking utilities.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
