### PR TITLE
[Rule Tuning] Potential Antimalware Scan Interface Bypass via PowerShell

### DIFF
--- a/rules/windows/defense_evasion_amsi_bypass_powershell.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_powershell.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/02/06"
+updated_date = "2023/03/02"
 
 [rule]
 author = ["Elastic"]
@@ -80,7 +80,7 @@ query = '''
 event.category :"process" and 
  (
   powershell.file.script_block_text : 
-        (System.Management.Automation.AmsiUtils or 
+        ("System.Management.Automation.AmsiUtils" or 
 				 amsiInitFailed or 
 				 Invoke-AmsiBypass or 
 				 Bypass.AMSI or 
@@ -88,7 +88,7 @@ event.category :"process" and
 				 AntimalwareProvider  or 
 				 amsiSession or 
 				 amsiContext or 
-				 System.Management.Automation.ScriptBlock or 
+				 "System.Management.Automation.ScriptBlock" or 
 				 AmsiInitialize or 
 				 unloadobfuscated or 
 				 unloadsilent or 


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/sdh-protections/issues/389

## Summary

Tune the rule to not have FPs due to partial match.

Due to the nature of the `powershell.file.script_block_text` field (Some context can be found [here](https://github.com/elastic/integrations/pull/1931)), we need to double quote any field value that contains non-alphanumerical chars, because KQL will use them as delimiters and treat the text as separated keywords instead of a full text. For example:

![image](https://user-images.githubusercontent.com/26856693/222544527-54dce0ec-667f-4c49-a7a0-3b60a754eb4b.png)
