### PR TITLE
[Test] Restrict host.os.type unit test to 8.3+

### DIFF
--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -820,6 +820,8 @@ class TestOsqueryPluginNote(BaseRuleTest):
 class TestEndpointQuery(BaseRuleTest):
     """Test endpoint-specific rules."""
 
+    @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.3.0"),
+                     "Test only applicable to 8.3+ stacks since query updates are min_stacked at 8.3.0")
     def test_os_and_platform_in_query(self):
         """Test that all endpoint rules have an os defined and linux includes platform."""
         for rule in self.production_rules:


### PR DESCRIPTION
## Issues
related to #2286

## Summary

Since all rules are min_stacked to 8.3, rule updates did not backport prior to that, but the unit test did. This change skips the test for <8.3 branches

<img width="1643" alt="image" src="https://user-images.githubusercontent.com/16747370/222980086-5a8625f7-28f1-404f-aa7a-622ffb3d6316.png">
