### PR TITLE
[Rule Tuning] Process Created with an Elevated Token (TiWorker.exe)

### DIFF
--- a/rules/windows/privilege_escalation_via_token_theft.toml
+++ b/rules/windows/privilege_escalation_via_token_theft.toml
@@ -46,6 +46,9 @@ process where host.os.type == "windows" and event.action == "start" and
  not (process.Ext.effective_parent.executable : "?:\\Windows\\System32\\Utilman.exe" and
       process.parent.executable : "?:\\Windows\\System32\\Utilman.exe" and process.parent.args : "/debug") and
 
+not (parent.process.executable: "?\\Windows\\System32\\spoolsv.exe" and
+     process.executable: "?:\\Program Files (x86)\\Access\\Intelligent Form\\Win32Bin\\LaunchCreate.exe")
+
  not process.executable : ("?:\\Windows\\System32\\WerFault.exe",
                            "?:\\Windows\\SysWOW64\\WerFault.exe",
                            "?:\\Windows\\System32\\WerFaultSecure.exe",
@@ -55,16 +58,15 @@ process where host.os.type == "windows" and event.action == "start" and
 
  /* Ignores windows updates from TiWorker.exe that runs with elevated privileges */
  not (process.parent.executable : "?:\\Windows\\WinSxS\\*\\TiWorker.exe" and
-         process.executable :
-             ("?:\\Windows\\Microsoft.NET\\Framework*.exe",
-              "?:\\Windows\\WinSxS\\*.exe",
-              "?:\\Windows\\System32\\inetsrv\\iissetup.exe",
-              "?:\\Windows\\SysWOW64\\inetsrv\\iissetup.exe"
-              "?:\\Windows\\System32\\inetsrv\\aspnetca.exe"
-              "?:\\Windows\\SysWOW64\\inetsrv\\aspnetca.exe",
-              "?:\\Windows\\System32\\lodctr.exe",
-			  "?:\\Windows\\SysWOW64\\lodctr.exe",
-			  "?:\\Windows\\System32\\netcfg.exe")) and
+      process.executable : ("?:\\Windows\\Microsoft.NET\\Framework*.exe",
+                            "?:\\Windows\\WinSxS\\*.exe",
+                            "?:\\Windows\\System32\\inetsrv\\iissetup.exe",
+                            "?:\\Windows\\SysWOW64\\inetsrv\\iissetup.exe",
+                            "?:\\Windows\\System32\\inetsrv\\aspnetca.exe",
+                            "?:\\Windows\\SysWOW64\\inetsrv\\aspnetca.exe",
+                            "?:\\Windows\\System32\\lodctr.exe",
+                            "?:\\Windows\\SysWOW64\\lodctr.exe",
+                            "?:\\Windows\\System32\\netcfg.exe")) and
 
 
  not process.parent.executable : ("?:\\Windows\\System32\\AtBroker.exe", "?:\\Windows\\system32\\svchost.exe", "?:\\Program Files (x86)\\*.exe", "?:\\Program Files\\*.exe", "?:\\Windows\\System32\\msiexec.exe",

--- a/rules/windows/privilege_escalation_via_token_theft.toml
+++ b/rules/windows/privilege_escalation_via_token_theft.toml
@@ -49,7 +49,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 /* Ignores Windows print spooler service with correlation to Access Intelligent Form */
 not (parent.process.executable: "?\\Windows\\System32\\spoolsv.exe" and
-     process.executable: "?:\\Program Files*\\Access\\Intelligent Form\\*\\LaunchCreate.exe")
+     process.executable: "?:\\Program Files*\\Access\\Intelligent Form\\*\\LaunchCreate.exe") and 
 
 /* Ignores Windows error reporting executables */
  not process.executable : ("?:\\Windows\\System32\\WerFault.exe",

--- a/rules/windows/privilege_escalation_via_token_theft.toml
+++ b/rules/windows/privilege_escalation_via_token_theft.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup, process.Ext.effective_parent.executable"
 min_stack_version = "8.4.0"
-updated_date = "2023/02/22"
+updated_date = "2023/03/07"
 
 [rule]
 author = ["Elastic"]
@@ -52,6 +52,20 @@ process where host.os.type == "windows" and event.action == "start" and
                            "?:\\Windows\\SysWOW64\\WerFaultSecure.exe",
                            "?:\\windows\\system32\\WerMgr.exe",
                            "?:\\Windows\\SoftwareDistribution\\Download\\Install\\securityhealthsetup.exe")  and
+
+ /* Ignores windows updates from TiWorker.exe that runs with elevated privileges */
+ not (process.parent.executable : "?:\\Windows\\WinSxS\\*\\TiWorker.exe" and
+         process.executable :
+             ("?:\\Windows\\Microsoft.NET\\Framework*.exe",
+              "?:\\Windows\\WinSxS\\*.exe",
+              "?:\\Windows\\System32\\inetsrv\\iissetup.exe",
+              "?:\\Windows\\SysWOW64\\inetsrv\\iissetup.exe"
+              "?:\\Windows\\System32\\inetsrv\\aspnetca.exe"
+              "?:\\Windows\\SysWOW64\\inetsrv\\aspnetca.exe",
+              "?:\\Windows\\System32\\lodctr.exe",
+			  "?:\\Windows\\SysWOW64\\lodctr.exe",
+			  "?:\\Windows\\System32\\netcfg.exe")) and
+
 
  not process.parent.executable : ("?:\\Windows\\System32\\AtBroker.exe", "?:\\Windows\\system32\\svchost.exe", "?:\\Program Files (x86)\\*.exe", "?:\\Program Files\\*.exe", "?:\\Windows\\System32\\msiexec.exe",
  "C:\\Windows\\System32\\DriverStore\\*") and

--- a/rules/windows/privilege_escalation_via_token_theft.toml
+++ b/rules/windows/privilege_escalation_via_token_theft.toml
@@ -48,7 +48,7 @@ process where host.os.type == "windows" and event.action == "start" and
       process.parent.executable : "?:\\Windows\\System32\\Utilman.exe" and process.parent.args : "/debug") and
 
 /* Ignores Windows print spooler service with correlation to Access Intelligent Form */
-not (parent.process.executable: "?\\Windows\\System32\\spoolsv.exe" and
+not (process.parent.executable : "?\\Windows\\System32\\spoolsv.exe" and
      process.executable: "?:\\Program Files*\\Access\\Intelligent Form\\*\\LaunchCreate.exe") and 
 
 /* Ignores Windows error reporting executables */
@@ -75,12 +75,24 @@ not (parent.process.executable: "?\\Windows\\System32\\spoolsv.exe" and
 
 
 /* Ignores additional parent executables that run with elevated privileges */
- not process.parent.executable : ("?:\\Windows\\System32\\AtBroker.exe", "?:\\Windows\\system32\\svchost.exe", "?:\\Program Files (x86)\\*.exe", "?:\\Program Files\\*.exe", "?:\\Windows\\System32\\msiexec.exe",
- "C:\\Windows\\System32\\DriverStore\\*") and
+ not process.parent.executable : 
+               ("?:\\Windows\\System32\\AtBroker.exe", 
+                "?:\\Windows\\system32\\svchost.exe", 
+                "?:\\Program Files (x86)\\*.exe", 
+                "?:\\Program Files\\*.exe", 
+                "?:\\Windows\\System32\\msiexec.exe",
+                "?:\\Windows\\System32\\DriverStore\\*") and
 
 /* Ignores Windows binaries with a trusted signature and specific signature name */
  not (process.code_signature.trusted == true and
-      process.code_signature.subject_name in ("philandro Software GmbH", "Freedom Scientific Inc.", "TeamViewer Germany GmbH", "Projector.is, Inc.", "TeamViewer GmbH", "Cisco WebEx LLC", "Dell Inc"))
+      process.code_signature.subject_name : 
+                ("philandro Software GmbH", 
+                 "Freedom Scientific Inc.", 
+                 "TeamViewer Germany GmbH", 
+                 "Projector.is, Inc.", 
+                 "TeamViewer GmbH", 
+                 "Cisco WebEx LLC", 
+                 "Dell Inc"))
 '''
 
 

--- a/rules/windows/privilege_escalation_via_token_theft.toml
+++ b/rules/windows/privilege_escalation_via_token_theft.toml
@@ -43,12 +43,15 @@ process where host.os.type == "windows" and event.action == "start" and
                  "?:\\Program Files (x86)\\*.exe",
                  "?:\\ProgramData\\*") and
 
+/* Ignores Utility Manager in Windows running in debug mode */
  not (process.Ext.effective_parent.executable : "?:\\Windows\\System32\\Utilman.exe" and
       process.parent.executable : "?:\\Windows\\System32\\Utilman.exe" and process.parent.args : "/debug") and
 
+/* Ignores Windows print spooler service with correlation to Access Intelligent Form */
 not (parent.process.executable: "?\\Windows\\System32\\spoolsv.exe" and
-     process.executable: "?:\\Program Files (x86)\\Access\\Intelligent Form\\Win32Bin\\LaunchCreate.exe")
+     process.executable: "?:\\Program Files*\\Access\\Intelligent Form\\*\\LaunchCreate.exe")
 
+/* Ignores Windows error reporting executables */
  not process.executable : ("?:\\Windows\\System32\\WerFault.exe",
                            "?:\\Windows\\SysWOW64\\WerFault.exe",
                            "?:\\Windows\\System32\\WerFaultSecure.exe",
@@ -56,7 +59,7 @@ not (parent.process.executable: "?\\Windows\\System32\\spoolsv.exe" and
                            "?:\\windows\\system32\\WerMgr.exe",
                            "?:\\Windows\\SoftwareDistribution\\Download\\Install\\securityhealthsetup.exe")  and
 
- /* Ignores windows updates from TiWorker.exe that runs with elevated privileges */
+ /* Ignores Windows updates from TiWorker.exe that runs with elevated privileges */
  not (process.parent.executable : "?:\\Windows\\WinSxS\\*\\TiWorker.exe" and
       process.executable : ("?:\\Windows\\Microsoft.NET\\Framework*.exe",
                             "?:\\Windows\\WinSxS\\*.exe",
@@ -66,13 +69,16 @@ not (parent.process.executable: "?\\Windows\\System32\\spoolsv.exe" and
                             "?:\\Windows\\SysWOW64\\inetsrv\\aspnetca.exe",
                             "?:\\Windows\\System32\\lodctr.exe",
                             "?:\\Windows\\SysWOW64\\lodctr.exe",
-                            "?:\\Windows\\System32\\netcfg.exe")) and
+                            "?:\\Windows\\System32\\netcfg.exe",
+                            "?:\\Windows\\Microsoft.NET\\Framework*\\*\\ngen.exe",
+                            "?:\\Windows\\Microsoft.NET\\Framework*\\*\\aspnet_regiis.exe")) and
 
 
+/* Ignores additional parent executables that run with elevated privileges */
  not process.parent.executable : ("?:\\Windows\\System32\\AtBroker.exe", "?:\\Windows\\system32\\svchost.exe", "?:\\Program Files (x86)\\*.exe", "?:\\Program Files\\*.exe", "?:\\Windows\\System32\\msiexec.exe",
  "C:\\Windows\\System32\\DriverStore\\*") and
 
-
+/* Ignores Windows binaries with a trusted signature and specific signature name */
  not (process.code_signature.trusted == true and
       process.code_signature.subject_name in ("philandro Software GmbH", "Freedom Scientific Inc.", "TeamViewer Germany GmbH", "Projector.is, Inc.", "TeamViewer GmbH", "Cisco WebEx LLC", "Dell Inc"))
 '''


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/2620
* https://github.com/elastic/detection-rules/issues/2578

## Summary
A couple community issues were created regarding potential False-Positive (FP) alerts for Process Created with an Elevated Token. Specifically, a Windows update executable, `TiWorker.exe` where child processes were for `iissetup.exe` and `ngen.exe`. 

This PR adds these as an exception, focusing on the parent and child executables, as well as some other FP alerts we observed from global telemetry.

Screenshots:
<img width="1648" alt="Screenshot 2023-03-07 at 10 20 24 AM" src="https://user-images.githubusercontent.com/99630311/223472368-7a3b804e-2abc-44cd-b773-cb26ed12b2e5.png">


