### PR TITLE
Speed up unit tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -5,12 +5,22 @@
 
 """Shared resources for tests."""
 
-import os
 import unittest
+from functools import lru_cache
 from typing import Union
 
 from detection_rules.rule import TOMLRule
 from detection_rules.rule_loader import DeprecatedCollection, DeprecatedRule, RuleCollection, production_filter
+
+
+RULE_LOADER_FAIL = False
+RULE_LOADER_FAIL_MSG = None
+RULE_LOADER_FAIL_RAISED = False
+
+
+@lru_cache
+def default_rules() -> RuleCollection:
+    return RuleCollection.default()
 
 
 class BaseRuleTest(unittest.TestCase):
@@ -18,13 +28,37 @@ class BaseRuleTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        os.environ["DR_NOTIFY_INTEGRATION_UPDATE_AVAILABLE"] = "1"
-        rc = RuleCollection.default()
-        cls.all_rules = rc.rules
-        cls.rule_lookup = rc.id_map
-        cls.production_rules = rc.filter(production_filter)
-        cls.deprecated_rules: DeprecatedCollection = rc.deprecated
+        global RULE_LOADER_FAIL, RULE_LOADER_FAIL_MSG
+
+        # too noisy; refactor
+        # os.environ["DR_NOTIFY_INTEGRATION_UPDATE_AVAILABLE"] = "1"
+
+        if not RULE_LOADER_FAIL:
+            try:
+                rc = default_rules()
+                cls.all_rules = rc.rules
+                cls.rule_lookup = rc.id_map
+                cls.production_rules = rc.filter(production_filter)
+                cls.deprecated_rules: DeprecatedCollection = rc.deprecated
+            except Exception as e:
+                RULE_LOADER_FAIL = True
+                RULE_LOADER_FAIL_MSG = str(e)
 
     @staticmethod
     def rule_str(rule: Union[DeprecatedRule, TOMLRule], trailer=' ->'):
         return f'{rule.id} - {rule.name}{trailer or ""}'
+
+    def setUp(self) -> None:
+        global RULE_LOADER_FAIL, RULE_LOADER_FAIL_MSG, RULE_LOADER_FAIL_RAISED
+
+        if RULE_LOADER_FAIL:
+            # limit the loader failure to just one run
+            # raise a dedicated test failure for the loader
+            if not RULE_LOADER_FAIL_RAISED:
+                RULE_LOADER_FAIL_RAISED = True
+                with self.subTest('Test that the rule loader loaded with no validation or other failures.'):
+                    self.fail(f'Rule loader failure: \n{RULE_LOADER_FAIL_MSG}')
+
+            self.skipTest('Rule loader failure')
+        else:
+            super(BaseRuleTest, self).setUp()

--- a/tests/base.py
+++ b/tests/base.py
@@ -13,11 +13,6 @@ from detection_rules.rule import TOMLRule
 from detection_rules.rule_loader import DeprecatedCollection, DeprecatedRule, RuleCollection, production_filter
 
 
-RULE_LOADER_FAIL = False
-RULE_LOADER_FAIL_MSG = None
-RULE_LOADER_FAIL_RAISED = False
-
-
 @lru_cache
 def default_rules() -> RuleCollection:
     return RuleCollection.default()
@@ -26,14 +21,16 @@ def default_rules() -> RuleCollection:
 class BaseRuleTest(unittest.TestCase):
     """Base class for shared test cases which need to load rules"""
 
+    RULE_LOADER_FAIL = False
+    RULE_LOADER_FAIL_MSG = None
+    RULE_LOADER_FAIL_RAISED = False
+
     @classmethod
     def setUpClass(cls):
-        global RULE_LOADER_FAIL, RULE_LOADER_FAIL_MSG
-
         # too noisy; refactor
         # os.environ["DR_NOTIFY_INTEGRATION_UPDATE_AVAILABLE"] = "1"
 
-        if not RULE_LOADER_FAIL:
+        if not cls.RULE_LOADER_FAIL:
             try:
                 rc = default_rules()
                 cls.all_rules = rc.rules
@@ -41,24 +38,22 @@ class BaseRuleTest(unittest.TestCase):
                 cls.production_rules = rc.filter(production_filter)
                 cls.deprecated_rules: DeprecatedCollection = rc.deprecated
             except Exception as e:
-                RULE_LOADER_FAIL = True
-                RULE_LOADER_FAIL_MSG = str(e)
+                cls.RULE_LOADER_FAIL = True
+                cls.RULE_LOADER_FAIL_MSG = str(e)
 
     @staticmethod
-    def rule_str(rule: Union[DeprecatedRule, TOMLRule], trailer=' ->'):
+    def rule_str(rule: Union[DeprecatedRule, TOMLRule], trailer=' ->') -> str:
         return f'{rule.id} - {rule.name}{trailer or ""}'
 
     def setUp(self) -> None:
-        global RULE_LOADER_FAIL, RULE_LOADER_FAIL_MSG, RULE_LOADER_FAIL_RAISED
-
-        if RULE_LOADER_FAIL:
+        if self.RULE_LOADER_FAIL:
             # limit the loader failure to just one run
             # raise a dedicated test failure for the loader
-            if not RULE_LOADER_FAIL_RAISED:
-                RULE_LOADER_FAIL_RAISED = True
+            if not self.RULE_LOADER_FAIL_RAISED:
+                self.RULE_LOADER_FAIL_RAISED = True
                 with self.subTest('Test that the rule loader loaded with no validation or other failures.'):
-                    self.fail(f'Rule loader failure: \n{RULE_LOADER_FAIL_MSG}')
+                    self.fail(f'Rule loader failure: \n{self.RULE_LOADER_FAIL_MSG}')
 
             self.skipTest('Rule loader failure')
         else:
-            super(BaseRuleTest, self).setUp()
+            super().setUp()


### PR DESCRIPTION
## Issues
resolves #1869 
resolves #2623 

## Summary
This PR caches the rule loader default rules for unit tests. It also skips rule based-test when the rule loader fails.


## Details

To test, change any rule `author` to `authorz` and run unit tests

Duration before:

```
passing: make test  165.21s user 11.06s system 96% cpu 3:03.31 total
failing: make test  478.26s user 14.04s system 97% cpu 8:23.70 total
# these are local; GH test took up to ~16+m
```

Duration after:

```
passing: make test  96.66s user 6.64s system 96% cpu 1:47.22 total
failing: make test  49.61s user 5.81s system 93% cpu 59.209 total
```



### Speeding up passing
Each unittest class in `test_all_rules` loads the `BaseRuleTest.setUp` method when setting up unit tests. This meant that the rule loader was run multiple times. It now caches that load to limit it to a single load.

### Speeding up failures
Now, if the loader fails, it will skip all rule based test dependent on the leader

<details>

```
tests/test_all_rules.py::TestValidRules::test_all_rule_queries_optimized FAILED                                                                                                                    [  0%]
tests/test_all_rules.py::TestValidRules::test_duplicate_file_names SKIPPED (Rule loader failure)                                                                                                   [  1%]
tests/test_all_rules.py::TestValidRules::test_file_names SKIPPED (Rule loader failure)                                                                                                             [  2%]
tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta SKIPPED (Rule loader failure)                                                                                              [  3%]
tests/test_all_rules.py::TestValidRules::test_rule_type_changes SKIPPED (Rule loader failure)                                                                                                      [  4%]
tests/test_all_rules.py::TestValidRules::test_schema_and_dupes SKIPPED (Rule loader failure)                                                                                                       [  5%]
tests/test_all_rules.py::TestThreatMappings::test_duplicated_tactics SKIPPED (Rule loader failure)                                                                                                 [  5%]
tests/test_all_rules.py::TestThreatMappings::test_tactic_to_technique_correlations SKIPPED (Rule loader failure)                                                                                   [  6%]
tests/test_all_rules.py::TestThreatMappings::test_technique_deprecations SKIPPED (Rule loader failure)                                                                                             [  7%]
tests/test_all_rules.py::TestRuleTags::test_casing_and_spacing SKIPPED (Rule loader failure)                                                                                                       [  8%]
tests/test_all_rules.py::TestRuleTags::test_primary_tactic_as_tag SKIPPED (Rule loader failure)                                                                                                    [  9%]
tests/test_all_rules.py::TestRuleTags::test_required_tags SKIPPED (Rule loader failure)                                                                                                            [ 10%]
tests/test_all_rules.py::TestRuleTimelines::test_timeline_has_title SKIPPED (Rule loader failure)                                                                                                  [ 11%]
tests/test_all_rules.py::TestRuleFiles::test_rule_file_name_tactic SKIPPED (Rule loader failure)                                                                                                   [ 11%]
tests/test_all_rules.py::TestRuleMetadata::test_deprecated_rules SKIPPED (Rule loader failure)                                                                                                     [ 12%]
tests/test_all_rules.py::TestRuleMetadata::test_integration_tag SKIPPED (Rule loader failure)                                                                                                      [ 13%]
tests/test_all_rules.py::TestRuleMetadata::test_updated_date_newer_than_creation SKIPPED (Rule loader failure)                                                                                     [ 14%]
tests/test_all_rules.py::TestIntegrationRules::test_all_min_stack_rules_have_comment SKIPPED (Rule loader failure)                                                                                 [ 15%]
tests/test_all_rules.py::TestIntegrationRules::test_integration_guide SKIPPED (8.3+ Stacks Have Related Integrations Feature)                                                                      [ 16%]
tests/test_all_rules.py::TestIntegrationRules::test_rule_demotions SKIPPED (Rule loader failure)                                                                                                   [ 16%]
tests/test_all_rules.py::TestRuleTiming::test_eql_interval_to_maxspan SKIPPED (Rule loader failure)                                                                                                [ 17%]
tests/test_all_rules.py::TestRuleTiming::test_eql_lookback SKIPPED (Rule loader failure)                                                                                                           [ 18%]
tests/test_all_rules.py::TestRuleTiming::test_event_override SKIPPED (Rule loader failure)                                                                                                         [ 19%]
tests/test_all_rules.py::TestRuleTiming::test_required_lookback SKIPPED (Rule loader failure)                                                                                                      [ 20%]
tests/test_all_rules.py::TestLicense::test_elastic_license_only_v2 SKIPPED (Rule loader failure)                                                                                                   [ 21%]
tests/test_all_rules.py::TestIncompatibleFields::test_rule_backports_for_restricted_fields SKIPPED (Rule loader failure)                                                                           [ 22%]
tests/test_all_rules.py::TestBuildTimeFields::test_build_fields_min_stack SKIPPED (Rule loader failure)                                                                                            [ 22%]
tests/test_all_rules.py::TestRiskScoreMismatch::test_rule_risk_score_severity_mismatch SKIPPED (Rule loader failure)                                                                               [ 23%]
tests/test_all_rules.py::TestOsqueryPluginNote::test_note_guide SKIPPED (Rule loader failure)                                                                                                      [ 24%]
tests/test_all_rules.py::TestEndpointQuery::test_os_and_platform_in_query SKIPPED (Rule loader failure)                                                                                            [ 25%]
tests/test_gh_workflows.py::TestWorkflows::test_matrix_to_lock_version_defaults PASSED                                                                                                             [ 26%]
tests/test_mappings.py::TestMappings::test_false_positives SKIPPED (Rule loader failure)                                                                                                           [ 27%]
tests/test_mappings.py::TestMappings::test_true_positives SKIPPED (Rule loader failure)                                                                                                            [ 27%]
tests/test_mappings.py::TestRTAs::test_rtas_with_triggered_rules_have_uuid PASSED                                                                                                                  [ 28%]
tests/test_packages.py::TestPackages::test_package_loader_default_configs SKIPPED (Rule loader failure)                                                                                            [ 29%]
tests/test_packages.py::TestPackages::test_package_loader_production_config SKIPPED (Rule loader failure)                                                                                          [ 30%]
tests/test_packages.py::TestPackages::test_package_summary SKIPPED (Rule loader failure)                                                                                                           [ 31%]
tests/test_packages.py::TestPackages::test_rule_versioning SKIPPED (Rule loader failure)                                                                                                           [ 32%]
tests/test_packages.py::TestRegistryPackage::test_registry_package_config PASSED                                                                                                                   [ 33%]
tests/test_schemas.py::TestSchemas::test_eql_validation PASSED                                                                                                                                     [ 33%]
tests/test_schemas.py::TestSchemas::test_query_downgrade_7_x PASSED                                                                                                                                [ 34%]
tests/test_schemas.py::TestSchemas::test_query_downgrade_8_x PASSED                                                                                                                                [ 35%]
tests/test_schemas.py::TestSchemas::test_threshold_downgrade_7_x PASSED                                                                                                                            [ 36%]
tests/test_schemas.py::TestSchemas::test_threshold_downgrade_8_x PASSED                                                                                                                            [ 37%]
tests/test_schemas.py::TestSchemas::test_versioned_downgrade_7_x PASSED                                                                                                                            [ 38%]
tests/test_schemas.py::TestSchemas::test_versioned_downgrade_8_x PASSED                                                                                                                            [ 38%]
tests/test_schemas.py::TestVersionLockSchema::test_version_lock_has_nested_previous PASSED                                                                                                         [ 39%]
tests/test_schemas.py::TestVersionLockSchema::test_version_lock_no_previous PASSED                                                                                                                 [ 40%]
tests/test_schemas.py::TestVersions::test_stack_schema_map PASSED                                                                                                                                  [ 41%]
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_formatter_deep PASSED                                                                                                                    [ 42%]
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_formatter_rule PASSED                                                                                                                    [ 43%]
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_normalization PASSED                                                                                                                     [ 44%]
tests/test_utils.py::TestTimeUtils::test_caching PASSED                                                                                                                                            [ 44%]
tests/test_utils.py::TestTimeUtils::test_event_class_normalization PASSED                                                                                                                          [ 45%]
tests/test_utils.py::TestTimeUtils::test_schema_multifields PASSED                                                                                                                                 [ 46%]
tests/test_utils.py::TestTimeUtils::test_time_normalize PASSED                                                                                                                                     [ 47%]
tests/test_version_locking.py::TestVersionLock::test_previous_entries_gte_current_min_stack PASSED                                                                                                 [ 48%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_and_query PASSED                                                                                                                                       [ 49%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_exists PASSED                                                                                                                                    [ 50%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_inequality PASSED                                                                                                                                [ 50%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_match PASSED                                                                                                                                     [ 51%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_not_query PASSED                                                                                                                                       [ 52%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_optimizations PASSED                                                                                                                                   [ 53%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_or_query PASSED                                                                                                                                        [ 54%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_and_query PASSED                                                                                                                                    [ 55%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_boolean_precedence PASSED                                                                                                                           [ 55%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_field_equals PASSED                                                                                                                                 [ 56%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_field_inequality PASSED                                                                                                                             [ 57%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_ip_checks PASSED                                                                                                                                    [ 58%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_list_of_values PASSED                                                                                                                               [ 59%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_not_query PASSED                                                                                                                                    [ 60%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_or_query PASSED                                                                                                                                     [ 61%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_wildcard_field PASSED                                                                                                                               [ 61%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_and_expr PASSED                                                                                                                                [ 62%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_and_values PASSED                                                                                                                              [ 63%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_cidr_match PASSED                                                                                                                              [ 64%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_field_exists PASSED                                                                                                                            [ 65%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_flattening PASSED                                                                                                                              [ 66%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_list_value PASSED                                                                                                                              [ 66%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_not_value PASSED                                                                                                                               [ 67%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_or_expr PASSED                                                                                                                                 [ 68%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_or_values PASSED                                                                                                                               [ 69%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_quoted_wildcard PASSED                                                                                                                         [ 70%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_range PASSED                                                                                                                                   [ 71%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_single_value PASSED                                                                                                                            [ 72%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_wildcard PASSED                                                                                                                                [ 72%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_and_query PASSED                                                                                                                                    [ 73%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_boolean_precedence PASSED                                                                                                                           [ 74%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_field_equals PASSED                                                                                                                                 [ 75%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_field_inequality PASSED                                                                                                                             [ 76%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_list_of_values PASSED                                                                                                                               [ 77%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_lone_value PASSED                                                                                                                                   [ 77%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_nested_query PASSED                                                                                                                                 [ 78%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_not_query PASSED                                                                                                                                    [ 79%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_or_query PASSED                                                                                                                                     [ 80%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_schema PASSED                                                                                                                                       [ 81%]
tests/kuery/test_lint.py::LintTests::test_and_not PASSED                                                                                                                                           [ 82%]
tests/kuery/test_lint.py::LintTests::test_compound PASSED                                                                                                                                          [ 83%]
tests/kuery/test_lint.py::LintTests::test_double_negate PASSED                                                                                                                                     [ 83%]
tests/kuery/test_lint.py::LintTests::test_extract_not PASSED                                                                                                                                       [ 84%]
tests/kuery/test_lint.py::LintTests::test_ip PASSED                                                                                                                                                [ 85%]
tests/kuery/test_lint.py::LintTests::test_lint_field PASSED                                                                                                                                        [ 86%]
tests/kuery/test_lint.py::LintTests::test_lint_precedence PASSED                                                                                                                                   [ 87%]
tests/kuery/test_lint.py::LintTests::test_merge_fields PASSED                                                                                                                                      [ 88%]
tests/kuery/test_lint.py::LintTests::test_mixed_demorgans PASSED                                                                                                                                   [ 88%]
tests/kuery/test_lint.py::LintTests::test_not_demorgans PASSED                                                                                                                                     [ 89%]
tests/kuery/test_lint.py::LintTests::test_not_or PASSED                                                                                                                                            [ 90%]
tests/kuery/test_lint.py::LintTests::test_upper_tokens PASSED                                                                                                                                      [ 91%]
tests/kuery/test_parser.py::ParserTests::test_conversion PASSED                                                                                                                                    [ 92%]
tests/kuery/test_parser.py::ParserTests::test_date PASSED                                                                                                                                          [ 93%]
tests/kuery/test_parser.py::ParserTests::test_keyword PASSED                                                                                                                                       [ 94%]
tests/kuery/test_parser.py::ParserTests::test_list_equals PASSED                                                                                                                                   [ 94%]
tests/kuery/test_parser.py::ParserTests::test_multiple_types_fail PASSED                                                                                                                           [ 95%]
tests/kuery/test_parser.py::ParserTests::test_multiple_types_success PASSED                                                                                                                        [ 96%]
tests/kuery/test_parser.py::ParserTests::test_number_exists PASSED                                                                                                                                 [ 97%]
tests/kuery/test_parser.py::ParserTests::test_number_wildcard_fail PASSED                                                                                                                          [ 98%]
tests/kuery/test_parser.py::ParserTests::test_type_family_fail PASSED                                                                                                                              [ 99%]
tests/kuery/test_parser.py::ParserTests::test_type_family_success PASSED                                                                                                                           [100%]

================================================================================================ FAILURES ================================================================================================
_____________________________________________________________________________ TestValidRules.test_all_rule_queries_optimized _____________________________________________________________________________
tests/base.py:60: in setUp
    self.fail(f'Rule loader failure: \n{RULE_LOADER_FAIL_MSG}')
E   AssertionError: Rule loader failure: 
E   {'rule': [ValidationError({'author': ['Missing data for required field.'], 'authorz': ['Unknown field.']}), ValidationError({'type': ['Must be equal to threshold.'], 'language': ['Must be one of: kuery, lucene.'], 'threshold': ['Missing data for required field.'], 'author': ['Missing data for required field.'], 'authorz': ['Unknown field.']}), ValidationError({'type': ['Must be equal to threat_match.'], 'threat_mapping': ['Missing data for required field.'], 'threat_index': ['Missing data for required field.'], 'language': ['Must be one of: kuery, lucene.'], 'author': ['Missing data for required field.'], 'authorz': ['Unknown field.']}), ValidationError({'type': ['Must be equal to machine_learning.'], 'anomaly_threshold': ['Missing data for required field.'], 'machine_learning_job_id': ['Missing data for required field.'], 'author': ['Missing data for required field.'], 'authorz': ['Unknown field.'], 'index': ['Unknown field.'], 'query': ['Unknown field.'], 'language': ['Unknown field.']}), ValidationError({'type': ['Must be equal to query.'], 'language': ['Must be one of: kuery, lucene.'], 'author': ['Missing data for required field.'], 'authorz': ['Unknown field.']}), ValidationError({'type': ['Must be equal to new_terms.'], 'language': ['Must be one of: kuery, lucene.'], 'author': ['Missing data for required field.'], 'new_terms': ['Missing data for required field.'], 'authorz': ['Unknown field.']})]}
----------------------------------------------------------------------------------------- Captured stdout setup ------------------------------------------------------------------------------------------
Error loading rule in /Users/jibarra/PycharmProjects/detection-rules-fork/rules/windows/credential_access_lsass_memdump_handle_access.toml
============================================================================================ warnings summary ============================================================================================
env/detection-rules-build/lib/python3.8/site-packages/_pytest/config/__init__.py:1129
  /Users/jibarra/PycharmProjects/detection-rules-fork/env/detection-rules-build/lib/python3.8/site-packages/_pytest/config/__init__.py:1129: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: typeguard
    self._mark_plugins_for_rewrite(hook)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================================== short test summary info =========================================================================================
FAILED tests/test_all_rules.py::TestValidRules::test_all_rule_queries_optimized - AssertionError: Rule loader failure: 
========================================================================== 1 failed, 82 passed, 35 skipped, 1 warning in 42.77s ==========================================================================
make: *** [pytest] Error 1
make test  53.98s user 6.36s system 93% cpu 1:04.40 total
```

</details>