### PR TITLE
[Tweak] Use global constants to speed up tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -13,6 +13,11 @@ from detection_rules.rule import TOMLRule
 from detection_rules.rule_loader import DeprecatedCollection, DeprecatedRule, RuleCollection, production_filter
 
 
+RULE_LOADER_FAIL = False
+RULE_LOADER_FAIL_MSG = None
+RULE_LOADER_FAIL_RAISED = False
+
+
 @lru_cache
 def default_rules() -> RuleCollection:
     return RuleCollection.default()
@@ -27,10 +32,12 @@ class BaseRuleTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        global RULE_LOADER_FAIL, RULE_LOADER_FAIL_MSG
+
         # too noisy; refactor
         # os.environ["DR_NOTIFY_INTEGRATION_UPDATE_AVAILABLE"] = "1"
 
-        if not cls.RULE_LOADER_FAIL:
+        if not RULE_LOADER_FAIL:
             try:
                 rc = default_rules()
                 cls.all_rules = rc.rules
@@ -38,21 +45,23 @@ class BaseRuleTest(unittest.TestCase):
                 cls.production_rules = rc.filter(production_filter)
                 cls.deprecated_rules: DeprecatedCollection = rc.deprecated
             except Exception as e:
-                cls.RULE_LOADER_FAIL = True
-                cls.RULE_LOADER_FAIL_MSG = str(e)
+                RULE_LOADER_FAIL = True
+                RULE_LOADER_FAIL_MSG = str(e)
 
     @staticmethod
     def rule_str(rule: Union[DeprecatedRule, TOMLRule], trailer=' ->') -> str:
         return f'{rule.id} - {rule.name}{trailer or ""}'
 
     def setUp(self) -> None:
-        if self.RULE_LOADER_FAIL:
+        global RULE_LOADER_FAIL, RULE_LOADER_FAIL_MSG, RULE_LOADER_FAIL_RAISED
+
+        if RULE_LOADER_FAIL:
             # limit the loader failure to just one run
             # raise a dedicated test failure for the loader
-            if not self.RULE_LOADER_FAIL_RAISED:
-                self.RULE_LOADER_FAIL_RAISED = True
+            if not RULE_LOADER_FAIL_RAISED:
+                RULE_LOADER_FAIL_RAISED = True
                 with self.subTest('Test that the rule loader loaded with no validation or other failures.'):
-                    self.fail(f'Rule loader failure: \n{self.RULE_LOADER_FAIL_MSG}')
+                    self.fail(f'Rule loader failure: \n{RULE_LOADER_FAIL_MSG}')
 
             self.skipTest('Rule loader failure')
         else:


### PR DESCRIPTION
## Issues
related to #2626 

## Summary
Rolls back to initial commit in #2626. Uses global constants to hold flags rather than using class variables. This is necessary because of how `SetUpClass` is called and because each new `TestCase` reloads the base class