### PR TITLE
Add "logs-network_traffic*" to List of Queried Indices

### DIFF
--- a/rules/network/command_and_control_accepted_default_telnet_port_connection.toml
+++ b/rules/network/command_and_control_accepted_default_telnet_port_connection.toml
@@ -24,7 +24,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["auditbeat-*", "filebeat-*", "packetbeat-*", "logs-endpoint.events.*"]
+index = ["auditbeat-*", "filebeat-*", "packetbeat-*", "logs-endpoint.events.*", "logs-network_traffic*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Accepted Default Telnet Port Connection"


### PR DESCRIPTION
Adding `logs-network_traffic*` data streams to the list of indices to incorporate data from Network Packet Capture Integration (Elastic Agent implementation of Packetbeat).

<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
#2646 

## Summary
As we work to utilize more and more Elastic Agent Integrations, we are noticing none of the Security Detection Rules that utilize Packetbeat data include data streams for the Network Packet Capture Integration (Elastic Agent implementation of Packetbeat). This PR will include the required `logs-network_traffic*` indices. 

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? Yes
