### PR TITLE
[New Rule] Google Workspace Drive - Encryption Key(s) Accessed from Anonymous User

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -115,6 +115,7 @@
     "gsuite.admin.setting.name": "keyword",
     "google_workspace.drive.owner_is_team_drive": "keyword",
     "google_workspace.drive.copy_type": "keyword",
-    "google_workspace.drive.file.type": "keyword"
+    "google_workspace.drive.file.type": "keyword",
+    "google_workspace.drive.visibility": "keyword"
   }
 }

--- a/rules/integrations/google_workspace/credential_access_google_workspace_drive_encryption_key_accessed_by_anonymous_user.toml
+++ b/rules/integrations/google_workspace/credential_access_google_workspace_drive_encryption_key_accessed_by_anonymous_user.toml
@@ -1,0 +1,84 @@
+[metadata]
+creation_date = "2023/03/21"
+integration = ["google_workspace"]
+maturity = "production"
+min_stack_comments = "Breaking changes for Google Workspace integration."
+min_stack_version = "8.4.0"
+updated_date = "2023/03/21"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when an external (anonymous) user has viewed, copied or downloaded an encryption key file from a Google
+Workspace drive. Adversaries may gain access to encryption keys stored in private drives from rogue access links that do
+not have an expiration. Access to encryption keys may allow adversaries to access sensitive data or authenticate on
+behalf of users.
+"""
+false_positives = [
+    """
+    A user may generate a shared access link to encryption key files to share with others. It is unlikely that the
+    intended recipient is an external or anonymous user.
+    """,
+]
+from = "now-130m"
+index = ["filebeat-*", "logs-google_workspace*"]
+interval = "10m"
+language = "eql"
+license = "Elastic License v2"
+name = "Google Workspace Drive Encryption Key(s) Accessed from Anonymous User"
+note = """## Setup
+
+The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
+### Important Information Regarding Google Workspace Event Lag Times
+- As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
+- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
+- By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
+- See the following references for further information:
+  - https://support.google.com/a/answer/7061566
+  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-google_workspace.html"""
+references = ["https://support.google.com/a/answer/6328701?hl=en#"]
+risk_score = 47
+rule_id = "980b70a0-c820-11ed-8799-f661ea17fbcc"
+severity = "medium"
+tags = [
+    "Elastic",
+    "Cloud",
+    "Google Workspace",
+    "Continuous Monitoring",
+    "SecOps",
+    "Configuration Audit",
+    "Credential Access",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+file where event.dataset == "google_workspace.drive" and event.action : ("copy", "view", "download") and
+    google_workspace.drive.visibility: "people_with_link" and source.user.email == "" and
+    file.extension: (
+        "token","assig", "pssc", "keystore", "pub", "pgp.asc", "ps1xml", "pem", "gpg.sig", "der", "key",
+        "p7r", "p12", "asc", "jks", "p7b", "signature", "gpg", "pgp.sig", "sst", "pgp", "gpgz", "pfx", "crt",
+        "p8", "sig", "pkcs7", "jceks", "pkcs8", "psc1", "p7c", "csr", "cer", "spc", "ps2xml")
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1562"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1562/"
+[[rule.threat.technique.subtechnique]]
+id = "T1552.004"
+name = "Private Keys"
+reference = "https://attack.mitre.org/techniques/T1552/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+


### PR DESCRIPTION

## Issues
* https://github.com/elastic/security-team/issues/5915

## Summary
Detects when an external (anonymous) user has viewed, copied or downloaded an encryption key file from a Google Workspace drive. Adversaries may gain access to encryption keys stored in private drives from rogue access links that do not have an expiration. Access to encryption keys may allow adversaries to access sensitive data or authenticate on behalf of users.

## Additional Information
When sharing files from Google Drive, users within the organization can be given permission to the object via lookup after which permissions are set. Expiration dates for the link can ONLY be set if it is not a shared drive.

Optionally, a shared drive link can be generated for general access, where permissions are also set for the link. "Anyone with access link" is an option to share the object outside of an organization in which access simply involves knowing the link. Again, these links do not expire for shared drives and only expire for specific internal users if explicitly set.

An adversary can rely on access to messaging applications, logs, forums, etc. for shared links.

* `event.action : ("copy", "view", "download")` - limits to view, copy or download of encryption key files
* `google_workspace.drive.visibility: "people_with_link"` helps scope this to access events where a "anyone with access link" link was previously generated or a rogue link
* `source.user.email == ""` - This is key to ensuring that we only care about users outside the organization and not internal user access.

The following is a collection of token, encryption keys, signature files, etc.
```sql
file.extension: (
        "token","assig", "pssc", "keystore", "pub", "pgp.asc", "ps1xml", "pem", "gpg.sig", "der", "key",
        "p7r", "p12", "asc", "jks", "p7b", "signature", "gpg", "pgp.sig", "sst", "pgp", "gpgz", "pfx", "crt",
        "p8", "sig", "pkcs7", "jceks", "pkcs8", "psc1", "p7c", "csr", "cer", "spc", "ps2xml")
``` 

