### PR TITLE
[Rule Tuning] Untrusted Driver Loaded

### DIFF
--- a/rules/windows/defense_evasion_untrusted_driver_loaded.toml
+++ b/rules/windows/defense_evasion_untrusted_driver_loaded.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/02/22"
+updated_date = "2023/03/22"
 
 [rule]
 author = ["Elastic"]
@@ -28,7 +28,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-library where host.os.type == "windows" and process.pid == 4 and
+driver where host.os.type == "windows" and process.pid == 4 and
   dll.code_signature.trusted != true and 
   not dll.code_signature.status : ("errorExpired", "errorRevoked")
 '''


### PR DESCRIPTION
## Summary

Changes the event.category to `driver`, in order to make the rule work with the stack EQL. 

![image](https://user-images.githubusercontent.com/26856693/226999635-6fb34b87-8917-4c65-bc66-78445696e717.png)
