### PR TITLE
Update layer version to 4.4

### DIFF
--- a/detection_rules/navigator.py
+++ b/detection_rules/navigator.py
@@ -78,7 +78,7 @@ class Navigator(MarshmallowDataclassMixin):
     @dataclass
     class Versions:
         attack: str
-        layer: str = '4.3'
+        layer: str = '4.4'
         navigator: str = '4.5.5'
 
     @dataclass


### PR DESCRIPTION
## Issues
https://github.com/elastic/ia-trade-team/issues/108

## Summary
Updating Layer `4.3` -> `4.4` for updating the MIRE ATT@CK Navigator. 

### Testing
For testing see: https://github.com/elastic/ia-trade-team/issues/108#issuecomment-1490480452

And for troubleshooting testing see: https://github.com/elastic/ia-trade-team/issues/108#issuecomment-1490546545


