### PR TITLE
Add Rule Id and Rule Name to the RTA Test List Function

### DIFF
--- a/rta/__init__.py
+++ b/rta/__init__.py
@@ -62,7 +62,8 @@ def get_available_tests(print_list: bool = False, os_filter: str = None) -> Dict
             test_metadata[file.stem] = asdict(module.metadata)
 
     if print_list:
-        longest_test_name = len(max(test_metadata.keys(), key=len)) + 3
+        py_ext = 3  # account for the .py ext
+        longest_test_name = len(max(test_metadata.keys(), key=len)) + py_ext
         header = f"{'name':{longest_test_name}} | {'platforms':<21} | {'rule id':<36} | {'rule name':<30}"
 
         print("Printing available tests")

--- a/rta/__init__.py
+++ b/rta/__init__.py
@@ -62,15 +62,26 @@ def get_available_tests(print_list: bool = False, os_filter: str = None) -> Dict
             test_metadata[file.stem] = asdict(module.metadata)
 
     if print_list:
-        longest_test_name = len(max(test_metadata.keys(), key=len))
-        header = f"{'name':{longest_test_name}} | {'platforms':<30}"
+        longest_test_name = len(max(test_metadata.keys(), key=len)) + 3
+        header = f"{'name':{longest_test_name}} | {'platforms':<21} | {'rule id':<36} | {'rule name':<30}"
 
         print("Printing available tests")
         print(header)
         print("=" * len(header))
 
         for test in test_metadata.values():
-            print(f"{test['name']:<{longest_test_name}} | {', '.join(test['platforms'])}")
+            rule_list = []
+            if test['endpoint'] and test['siem']:
+                rule_list = test['endpoint'] + test['siem']
+            elif test['endpoint']:
+                rule_list = test['endpoint']
+            elif test['siem']:
+                rule_list = test['siem']
+            else:
+                rule_list = [{"rule_name": "", "rule_id": ""}]
+            print(f"{test['name']:<{longest_test_name}} | {', '.join(test['platforms']):<21} | {rule_list[0]['rule_id']:36} | {rule_list[0]['rule_name']}")
+            for rule in rule_list[1:]:
+                print(f"{'':<{longest_test_name}} | {'':<21} | {rule['rule_id']:36} | {rule['rule_name']}")
 
     return test_metadata
 


### PR DESCRIPTION
## Summary
Enhancing the rta test print option to include the rule id and rule name the test triggers.  This make it easier to find the rule in Kibana to enable it.

I also increased the longest test name size by three to account for the `.py` file extension. 

### Sample Output
```
% python -m rta -l -o linux
Printing available tests
name                              | platforms             | rule id                              | rule name
=================================================================================================================================
empire_stager.py                  | macos, linux          | b7974ff6-82ff-4743-9e07-1c6901b1f0ea | Empire Stager Execution
eggshell_backdoor.py              | macos, linux          | feed7842-34a6-4764-b858-6e5ac01a5ab7 | EggShell Backdoor Execution
                                  |                       | 41824afb-d68c-4d0e-bfee-474dac1fa56e | EggShell Backdoor Execution
darkradiation.py                  | macos, linux          | 33309858-3154-47a6-b601-eda2de62557b | DARKRADIATION Ransomware Infection
enumeration_linpeas.py            | macos, linux          | 92bb2a27-745b-4291-90a1-b7b654df1379 | Privilege Escalation Enumeration via LinPEAS
eicar.py                          | macos, linux, windows | c4539c79-9f55-4b36-b06f-8aff82563bca | Behavior Protection - EICAR
browser_debugging.py              | windows, macos, linux | 5d7328aa-973b-41e7-a6b3-6f40ea3094f1 | Potential Cookies Theft via Browser Debugging
                                  |                       | 027ff9ea-85e7-42e3-99d2-bbb7069e02eb | Potential Cookies Theft via Browser Debugging
hosts_file_modify.py              | windows, linux, macos | 9c260313-c811-4ec8-ab89-8f6530e0246c | Hosts File Modified
builtin_cmd_file_delete.py        | macos, linux          | 15019d7c-42e6-4cf7-88b0-0c3a6963e6f5 | Suspicious Recursive File Deletion via Built-In Utilities
pkexec_shell.py                   | linux                 | 30c89cc9-d93c-4134-a976-58f8413f2f32 | Privilege Escalation via PKEXEC Exploitation
bash_cmdline_history.py           | linux, macos          | 31da6564-b3d3-4fc8-9a96-75ad0b364363 | Tampering of Bash Command-Line History
linux_compress_sensitive_files.py | linux                 | 6b84d470-9036-4cc0-a27c-6d90bbfe81ab | Sensitive Files Compression
grep_software_discovery.py        | macos, linux          | 13eade2e-73dd-4fab-a511-88258635559d | Potential Security Software Discovery via Grep
                                  |                       | 870aecc0-cea4-4110-af3f-e02e9b373655 | Security Software Discovery via Grep
reverse_shell.py                  | macos, linux          | d0e45f6c-1f83-4d97-a8d9-c8f9eb61c15c | Potential Reverse Shell Activity via Terminal
sudo_exploit.py                   | linux, macos          | 95718a3c-edc7-46ef-978b-77891ca6198f | Sudo Heap-Based Buffer Overflow Attempt
                                  |                       | f37f3054-d40b-49ac-aa9b-a786c74c58b8 | Sudo Heap-Based Buffer Overflow Attempt
```