### PR TITLE
[Bug] Unit Tests Passing for Rules with Integrations Not Reflected in Manifests

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -61,6 +61,7 @@ class RuleMeta(MarshmallowDataclassMixin):
     os_type_list: Optional[List[definitions.OSType]]
     query_schema_validation: Optional[bool]
     related_endpoint_rules: Optional[List[str]]
+    promotion: Optional[bool]
 
     # Extended information as an arbitrary dictionary
     extended: Optional[Dict[str, Any]]

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
@@ -5,6 +5,7 @@ maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 updated_date = "2022/12/14"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
@@ -4,7 +4,7 @@ integration = ["cyberarkpas"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
@@ -4,7 +4,8 @@ integration = ["cyberarkpas"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
@@ -4,7 +4,7 @@ integration = ["cyberarkpas"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/integrations/endpoint/elastic_endpoint_security.toml
+++ b/rules/integrations/endpoint/elastic_endpoint_security.toml
@@ -4,7 +4,8 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/endpoint/elastic_endpoint_security.toml
+++ b/rules/integrations/endpoint/elastic_endpoint_security.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/integrations/google_workspace/google_workspace_alert_center_promotion.toml
+++ b/rules/integrations/google_workspace/google_workspace_alert_center_promotion.toml
@@ -4,7 +4,7 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "Google Workspace feature only present in 8.4+ stack versions"
 min_stack_version = "8.4.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/integrations/google_workspace/google_workspace_alert_center_promotion.toml
+++ b/rules/integrations/google_workspace/google_workspace_alert_center_promotion.toml
@@ -4,7 +4,8 @@ integration = ["google_workspace"]
 maturity = "production"
 min_stack_comments = "Google Workspace feature only present in 8.4+ stack versions"
 min_stack_version = "8.4.0"
-updated_date = "2023/01/16"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/credential_access_mfa_push_brute_force.toml
+++ b/rules/integrations/okta/credential_access_mfa_push_brute_force.toml
@@ -4,7 +4,7 @@ integration = ["okta"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/12/14"
+updated_date = "2023/03/31"
 
 [rule]
 author = ["Elastic"]
@@ -32,9 +32,9 @@ type = "eql"
 
 query = '''
 sequence by user.email with maxspan=10m
-  [any where event.module == "okta" and event.action == "user.mfa.okta_verify.deny_push"]
-  [any where event.module == "okta" and event.action == "user.mfa.okta_verify.deny_push"]
-  [any where event.module == "okta" and event.action == "user.authentication.sso"]
+  [any where event.dataset == "okta.system" and event.module == "okta" and event.action == "user.mfa.okta_verify.deny_push"]
+  [any where event.dataset == "okta.system" and event.module == "okta" and event.action == "user.mfa.okta_verify.deny_push"]
+  [any where event.dataset == "okta.system" and event.module == "okta" and event.action == "user.authentication.sso"]
 '''
 
 

--- a/rules/promotions/credential_access_endgame_cred_dumping_detected.toml
+++ b/rules/promotions/credential_access_endgame_cred_dumping_detected.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/credential_access_endgame_cred_dumping_detected.toml
+++ b/rules/promotions/credential_access_endgame_cred_dumping_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/credential_access_endgame_cred_dumping_prevented.toml
+++ b/rules/promotions/credential_access_endgame_cred_dumping_prevented.toml
@@ -4,6 +4,7 @@ maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 updated_date = "2022/08/24"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/credential_access_endgame_cred_dumping_prevented.toml
+++ b/rules/promotions/credential_access_endgame_cred_dumping_prevented.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/endgame_adversary_behavior_detected.toml
+++ b/rules/promotions/endgame_adversary_behavior_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/endgame_adversary_behavior_detected.toml
+++ b/rules/promotions/endgame_adversary_behavior_detected.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/10/31"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_malware_detected.toml
+++ b/rules/promotions/endgame_malware_detected.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_malware_detected.toml
+++ b/rules/promotions/endgame_malware_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/endgame_malware_prevented.toml
+++ b/rules/promotions/endgame_malware_prevented.toml
@@ -4,6 +4,7 @@ maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 updated_date = "2022/08/24"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_malware_prevented.toml
+++ b/rules/promotions/endgame_malware_prevented.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/endgame_ransomware_detected.toml
+++ b/rules/promotions/endgame_ransomware_detected.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_ransomware_detected.toml
+++ b/rules/promotions/endgame_ransomware_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/endgame_ransomware_prevented.toml
+++ b/rules/promotions/endgame_ransomware_prevented.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/endgame_ransomware_prevented.toml
+++ b/rules/promotions/endgame_ransomware_prevented.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/execution_endgame_exploit_detected.toml
+++ b/rules/promotions/execution_endgame_exploit_detected.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/execution_endgame_exploit_detected.toml
+++ b/rules/promotions/execution_endgame_exploit_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/execution_endgame_exploit_prevented.toml
+++ b/rules/promotions/execution_endgame_exploit_prevented.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/execution_endgame_exploit_prevented.toml
+++ b/rules/promotions/execution_endgame_exploit_prevented.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -3,7 +3,8 @@ creation_date = "2020/07/08"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/external_alerts.toml
+++ b/rules/promotions/external_alerts.toml
@@ -3,7 +3,7 @@ creation_date = "2020/07/08"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/privilege_escalation_endgame_cred_manipulation_detected.toml
+++ b/rules/promotions/privilege_escalation_endgame_cred_manipulation_detected.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/privilege_escalation_endgame_cred_manipulation_detected.toml
+++ b/rules/promotions/privilege_escalation_endgame_cred_manipulation_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/privilege_escalation_endgame_cred_manipulation_prevented.toml
+++ b/rules/promotions/privilege_escalation_endgame_cred_manipulation_prevented.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/privilege_escalation_endgame_cred_manipulation_prevented.toml
+++ b/rules/promotions/privilege_escalation_endgame_cred_manipulation_prevented.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/privilege_escalation_endgame_permission_theft_detected.toml
+++ b/rules/promotions/privilege_escalation_endgame_permission_theft_detected.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/privilege_escalation_endgame_permission_theft_detected.toml
+++ b/rules/promotions/privilege_escalation_endgame_permission_theft_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/privilege_escalation_endgame_permission_theft_prevented.toml
+++ b/rules/promotions/privilege_escalation_endgame_permission_theft_prevented.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/privilege_escalation_endgame_permission_theft_prevented.toml
+++ b/rules/promotions/privilege_escalation_endgame_permission_theft_prevented.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/privilege_escalation_endgame_process_injection_detected.toml
+++ b/rules/promotions/privilege_escalation_endgame_process_injection_detected.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/privilege_escalation_endgame_process_injection_detected.toml
+++ b/rules/promotions/privilege_escalation_endgame_process_injection_detected.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/rules/promotions/privilege_escalation_endgame_process_injection_prevented.toml
+++ b/rules/promotions/privilege_escalation_endgame_process_injection_prevented.toml
@@ -3,7 +3,8 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/08/24"
+updated_date = "2022/03/31"
+promotion = true
 
 [rule]
 author = ["Elastic"]

--- a/rules/promotions/privilege_escalation_endgame_process_injection_prevented.toml
+++ b/rules/promotions/privilege_escalation_endgame_process_injection_prevented.toml
@@ -3,7 +3,7 @@ creation_date = "2020/02/18"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2022/03/31"
+updated_date = "2023/03/31"
 promotion = true
 
 [rule]

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -455,12 +455,18 @@ class TestRuleMetadata(BaseRuleTest):
             if isinstance(rule.contents.data, QueryRuleData) and rule.contents.data.language != 'lucene':
                 rule_integrations = rule.contents.metadata.get('integration') or []
                 rule_integrations = [rule_integrations] if isinstance(rule_integrations, str) else rule_integrations
+                rule_promotion = rule.contents.metadata.get('promotion') or None
                 data = rule.contents.data
                 meta = rule.contents.metadata
                 package_integrations = TOMLRuleContents.get_packaged_integrations(data, meta, packages_manifest)
                 package_integrations_list = list(set([integration["package"] for integration in package_integrations]))
                 indices = data.get('index')
                 for rule_integration in rule_integrations:
+                    if (not package_integrations and not rule_promotion and
+                        rule_integration not in definitions.NON_DATASET_PACKAGES):
+                            err_msg = f'{self.rule_str(rule)} {rule_integration} tag, but integration not \
+                                 found in manifests/schemas.'
+                            failures.append(err_msg)
 
                     # checks if the rule path matches the intended integration
                     if rule_integration in valid_integration_folders:


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/2681

## Summary
This pull request fixes a bug in the `test_integration_tag` unit test regarding integration rules. Discovered in #2681, this bug exists because we do not raise an error if a rule has an integration tag but the integration is not found in the integration manifest and schema files. 

## Additional Information
To solve this, several changes were made.

* `test_integration_tag` was updated to check if a rule has an integration tag but no integration schema/manifest is found locally. If this is not a promotional rule or a rule that does not have a dataset package from `definitions.NON_DATASET_PACKAGES`, raise an error.
* The `RuleMeta` class in `rule.py` was updated to add an optional field `promotion`. This field allows us to explicitly specify if a rule is a promotional rule or not while not altering the sha256 calculation of the rule contents. Prior to this PR, promotion rules were identified based on generic query or `promotion` being in the file name with inconsistencies. The reason this was added is to ignore promotion rules regarding their integration tag and `event.dataset` field not being set.  

## Testing
1. To test, clone the repository
2. Checkout this branch
3. Add the following rule locally under `rules/integrations/cloud_defend/`

```sql
[metadata]
creation_date = "2023/03/29"
integration = ["cloud_defend"]
maturity = "production"
min_stack_comments = "Initial version of cloud_defend alerts rule"
min_stack_version = "8.8.0"
updated_date = "2023/03/29"

[rule]
author = ["Elastic"]
description = """
Generates a detection alert each time a 'Container Workload Protection' alert is received. Enabling this rule allows you to
immediately begin triaging and investigating these alerts.
"""
enabled = true
from = "now-10m"
index = ["logs-cloud_defend.alerts-*"]
language = "kuery"
license = "Elastic License v2"
max_signals = 10000
name = "Container Workload Protection"
risk_score = 47
rule_id = "4b4e9c99-27ea-4621-95c8-82341bc6e512"
rule_name_override = "message"
severity = "medium"
tags = ["Elastic", "Container Workload Protection"]
timestamp_override = "event.ingested"
type = "query"

query = '''
event.kind:alert
'''

```

4. Run `pytest tests/test_all_rules.py::TestRuleMetadata::test_integration_tag` (tests should ❌ )
5. Add `promotion = true` to rule metadata
6. Run `pytest tests/test_all_rules.py::TestRuleMetadata::test_integration_tag` (tests should ✅ )
