### PR TITLE
[Bug] Fixes Unit Test `test_integration_tag` in Older Branches 

### DIFF
--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -462,8 +462,8 @@ class TestRuleMetadata(BaseRuleTest):
                 package_integrations_list = list(set([integration["package"] for integration in package_integrations]))
                 indices = data.get('index')
                 for rule_integration in rule_integrations:
-                    if (not package_integrations and not rule_promotion and  # noqa: W504
-                       rule_integration not in definitions.NON_DATASET_PACKAGES):
+                    if ("even.dataset" in rule.contents.data.query and not package_integrations and  # noqa: W504
+                       not rule_promotion and rule_integration not in definitions.NON_DATASET_PACKAGES):  # noqa: W504
                         err_msg = f'{self.rule_str(rule)} {rule_integration} tag, but integration not \
                                 found in manifests/schemas.'
                         failures.append(err_msg)


### PR DESCRIPTION
## Related
* https://github.com/elastic/detection-rules/pull/2682

## Summary
Kubernetes rules in 8.3 did not have `event.dataset` in them as the integration did not have that field available. They were min-stacked to 8.4 where these were then added. As a result the `TOMLRuleContents.get_packaged_integrations` call returns None, indicating that Kubernetes is not in the manifest file on the 8.3 branch.

To resolve this, we emulate the `TOMLRuleContents.get_packaged_integrations` logic by checking if `event.dataset` is in the rule being tested. If it is, then it should be parsable and a `package:integration` returned.

Change implemented and tested on the 8.3 branch.
