### PR TITLE
[Rule Tuning] Suspicious service was installed in the system

### DIFF
--- a/rules/windows/persistence_service_windows_service_winlog.toml
+++ b/rules/windows/persistence_service_windows_service_winlog.toml
@@ -60,16 +60,16 @@ any where host.os.type == "windows" and
    (winlog.event_data.ServiceFileName : 
            ("*COMSPEC*", "*\\172.0.0.1*", "*Admin$*", "*powershell*", "*rundll32*", "*cmd.exe*", "*PSEXESVC*", 
             "*echo*", "*RemComSvc*", "*.bat*", "*.cmd*", "*certutil*", "*vssadmin*", "*certmgr*", "*bitsadmin*", 
-            "*\\Users\\*", "*\\ProgramData\\*", "*\\Windows\\Temp\\*", "*\\Windows\\Tasks\\*", "*\\PerfLogs\\*", 
-            "*\\Intel\\*", "*\\Windows\\Debug\\*", "*:\\HP\\*", "*regsvr32*", "*msbuild*") or
+            "*\\Users\\*", "*\\Windows\\Temp\\*", "*\\Windows\\Tasks\\*", "*\\PerfLogs\\*", "*\\Windows\\Debug\\*",
+            "*regsvr32*", "*msbuild*") or
    winlog.event_data.ServiceFileName regex~ """%systemroot%\\[a-z0-9]+\.exe""")) or
 
   (event.code : "7045" and
    winlog.event_data.ImagePath : (
        "*COMSPEC*", "*\\172.0.0.1*", "*Admin$*", "*powershell*", "*rundll32*", "*cmd.exe*", "*PSEXESVC*",
        "*echo*", "*RemComSvc*", "*.bat*", "*.cmd*", "*certutil*", "*vssadmin*", "*certmgr*", "*bitsadmin*",
-       "*\\Users\\*", "*\\ProgramData\\*", "*\\Windows\\Temp\\*", "*\\Windows\\Tasks\\*", "*\\PerfLogs\\*",
-       "*\\Intel\\*", "*\\Windows\\Debug\\*", "*:\\HP\\*", "*regsvr32*", "*msbuild*"))
+       "*\\Users\\*", "*\\Windows\\Temp\\*", "*\\Windows\\Tasks\\*", "*\\PerfLogs\\*", "*\\Windows\\Debug\\*",
+       "*regsvr32*", "*msbuild*"))
 '''
 
 

--- a/rules/windows/persistence_service_windows_service_winlog.toml
+++ b/rules/windows/persistence_service_windows_service_winlog.toml
@@ -4,7 +4,7 @@ integration = ["system", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/02/22"
+updated_date = "2023/04/05"
 
 [rule]
 author = ["Elastic"]
@@ -61,14 +61,15 @@ any where host.os.type == "windows" and
            ("*COMSPEC*", "*\\172.0.0.1*", "*Admin$*", "*powershell*", "*rundll32*", "*cmd.exe*", "*PSEXESVC*", 
             "*echo*", "*RemComSvc*", "*.bat*", "*.cmd*", "*certutil*", "*vssadmin*", "*certmgr*", "*bitsadmin*", 
             "*\\Users\\*", "*\\ProgramData\\*", "*\\Windows\\Temp\\*", "*\\Windows\\Tasks\\*", "*\\PerfLogs\\*", 
-            "*\\Intel\\*", "*\\Windows\\Debug\\*", "*:\\HP\\*", "*.sys*", "*regsvr32*", "*msbuild*", "*svchost*") or
+            "*\\Intel\\*", "*\\Windows\\Debug\\*", "*:\\HP\\*", "*regsvr32*", "*msbuild*") or
    winlog.event_data.ServiceFileName regex~ """%systemroot%\\[a-z0-9]+\.exe""")) or
 
   (event.code : "7045" and
-   winlog.event_data.ImagePath : ("*COMSPEC*", "*\\172.0.0.1*", "*Admin$*", "*powershell*", "*rundll32*", "*cmd.exe*", "*svchost*", 
-                                  "*PSEXESVC*", "*echo*", "*RemComSvc*", "*.bat*", "*.cmd*", "*certutil*", "*vssadmin*", "*certmgr*", 
-                                  "*bitsadmin*", "*\\Users\\*", "*\\ProgramData\\*", "*\\Windows\\Temp\\*", "*\\Windows\\Tasks\\*", 
-                                  "*\\PerfLogs\\*", "*\\Intel\\*", "*\\Windows\\Debug\\*", "*:\\HP\\*", "*.sys*", "*regsvr32*", "*msbuild*"))
+   winlog.event_data.ImagePath : (
+       "*COMSPEC*", "*\\172.0.0.1*", "*Admin$*", "*powershell*", "*rundll32*", "*cmd.exe*", "*PSEXESVC*",
+       "*echo*", "*RemComSvc*", "*.bat*", "*.cmd*", "*certutil*", "*vssadmin*", "*certmgr*", "*bitsadmin*",
+       "*\\Users\\*", "*\\ProgramData\\*", "*\\Windows\\Temp\\*", "*\\Windows\\Tasks\\*", "*\\PerfLogs\\*",
+       "*\\Intel\\*", "*\\Windows\\Debug\\*", "*:\\HP\\*", "*regsvr32*", "*msbuild*"))
 '''
 
 


### PR DESCRIPTION
## Summary

Remove the following patterns to avoid FPs with legitimate software and system processes:

Reduce alerts in the last 90d by ~90%

Noisy ones:
*  `\\ProgramData\\`
*  `*.sys*` -> Any driver, including Elastic ones
*  `*svchost*` -> Noisiest, ~70% of the alerts

Some I think we should remove to avoid FPs on legitimate software:
*  `\\Intel\\`
*  `:\\HP\\`