### PR TITLE
[Bug] Add `--add-historical` argument to lock versions workflow

### DIFF
--- a/.github/workflows/lock-versions.yml
+++ b/.github/workflows/lock-versions.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Build release package
         run: |
-          python -m detection_rules dev build-release
+          python -m detection_rules dev build-release --add-historical 'no'
 
       - name: Set github config
         run: |


### PR DESCRIPTION
## Summary
`lock-versions` workflow calls `build-release` CLI command but was not added during the recent update for historical rules.

Reference: https://github.com/elastic/detection-rules/pull/2715

<img width="1015" alt="Screenshot 2023-04-24 at 10 36 02 AM" src="https://user-images.githubusercontent.com/99630311/234030348-75aaafb7-fc8c-42d4-b7d3-83a4459b55e6.png">
