### PR TITLE
[Bug] Render transform logic on rule build

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -352,7 +352,7 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
                 rendered_patterns.update(**{f'{plugin}_{i}': e for i, e in enumerate(entries)})
 
             note_template = PatchedTemplate(note)
-            rendered_note = note_template.substitute(**rendered_patterns)
+            rendered_note = note_template.safe_substitute(**rendered_patterns)
             obj['note'] = rendered_note
 
         # call transform functions
@@ -1107,8 +1107,8 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
 
     def to_api_format(self, include_version=True) -> dict:
         """Convert the TOML rule to the API format."""
-        converted = self.data.to_dict()
-        converted = self._post_dict_conversion(converted)
+        converted_data = self.to_dict()['rule']
+        converted = self._post_dict_conversion(converted_data)
 
         if include_version:
             converted["version"] = self.autobumped_version

--- a/tests/test_transform_fields.py
+++ b/tests/test_transform_fields.py
@@ -92,7 +92,7 @@ class TestGuideMarkdownPlugins(unittest.TestCase):
 
         new_rule_contents = TOMLRuleContents.from_dict(rule_dict)
         new_rule = TOMLRule(path=sample_rule.path, contents=new_rule_contents)
-        rendered_note = new_rule.contents.to_dict()['rule']['note']
+        rendered_note = new_rule.contents.to_api_format()['note']
 
         for pattern in self.osquery_patterns:
             self.assertIn(pattern, rendered_note)
@@ -109,6 +109,6 @@ class TestGuideMarkdownPlugins(unittest.TestCase):
             rule_dict_copy.update(**transform)
             new_rule_contents = TOMLRuleContents.from_dict(rule_dict_copy)
             new_rule = TOMLRule(path=sample_rule.path, contents=new_rule_contents)
-            rendered_note = new_rule.contents.to_dict()['rule']['note']
+            rendered_note = new_rule.contents.to_api_format()['note']
 
             self.assertIn(pattern, rendered_note)


### PR DESCRIPTION
## Issues
resolves #2740 

## Summary
This bug actually led to the discovery of 2 additional bugs

- A: `TOMLRuleContents.to_dict` was not called from `TOMLRuleContents.to_api_format`, bypassing the transform logic (original bug)
- B: `test_transform_fields` tests were calling the `TOMLRuleContents.to_dict` rather than `TOMLRuleContents.to_api_format` method, bypassing the emulated check on actual rule generation
- C: for the substitution rendering, there was the potential for pattern poisoning where any word within the investigation guide starting with `$` would render as a pattern and raise a key error for missing values. 


## Details
- A: resolved by making the call
- B: resolved by fixing the test
- C: resolved by using `safe_substitute` to ignore non-explicit patterns


## Testing

- `make test` and view `test_transform_fields`
- `make release` and search for `$osquery_` pattern in `extras/rules` as well as `extras/fleet/kibana`

<details>

<img width="855" alt="image" src="https://user-images.githubusercontent.com/16747370/234103657-f6105285-2c32-405d-8103-bb7ea938362b.png">

</details>
