### PR TITLE
[FR] Add release-docs workflow and automation

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -52,6 +52,7 @@ jobs:
           token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
           path: security-docs
           fetch-depth: 0
+          ref: ${{ github.event.inputs.target_branch }}
 
       - name: Build Integration Docs
         env:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -7,13 +7,6 @@ on:
         description: 'Target branch for PR base'
         required: true
         default: 'main'
-      draft:
-        type: choice
-        description: 'Create a PR as draft'
-        required: true
-        options:
-          - "yes"
-          - "no"
       update_message:
         description: 'Update status message for the latest package'
         required: true
@@ -26,7 +19,7 @@ on:
 
 jobs:
   build-docs:
-    name: Prepare Docs
+    name: Build Security Docs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout detection-rules
@@ -63,7 +56,7 @@ jobs:
           cd detection-rules
           python -m detection_rules dev build-integration-docs $POST_VERSION \
             --pre integration-v$PRE_VERSION --post integration-v$POST_VERSION \
-            -d .../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
+            -d ../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
             --update-message $UPDATE_MESSAGE --force
 
       - name: Commit and push changes

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,95 @@
+name: Release Docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: 'Target branch for PR base'
+        required: true
+        default: 'main'
+      draft:
+        type: choice
+        description: 'Create a PR as draft'
+        required: true
+        options:
+          - "yes"
+          - "no"
+      new_package:
+        type: choice
+        description: 'New Package'
+        required: true
+        options:
+          - "true"
+          - "false"
+      update_message:
+        description: 'Update status message for the latest package'
+        required: true
+      commit_hash:
+        description: 'Commit hash'
+        required: true
+
+jobs:
+  build-package:
+    name: Prepare Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout detection-rules
+        uses: actions/checkout@v3
+        with:
+          path: detection-rules
+          fetch-depth: 0
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install Python dependencies
+        run: |
+          cd detection-rules
+          python -m pip install --upgrade pip
+          pip install .[dev]
+
+      - name: Bump prebuilt rules package version
+        env:
+          NEW_PACKAGE: "${{github.event.inputs.new_package}}"
+          UPDATE_MESSAGE: "${{github.event.inputs.update_message}}"
+        run: |
+          cd detection-rules
+          python -m detection_rules dev bump-pkg-versions \
+            --patch-release                               \
+            --new-package $NEW_PACKAGE                    \
+            --maturity "ga"
+
+      - name: Build Release Package
+        run: |
+          cd detection-rules
+          python -m detection_rules dev build-release --add-historical "yes" \
+            --update-message $UPDATE_MESSAGE
+
+      - name: Build Integration Docs
+        run: |
+          cd detection-rules
+          python -m detection_rules dev build-integration-docs
+
+      - name: Checkout elastic/security-docs
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
+          repository: ${{github.event.inputs.target_repo}}
+
+      - name: Commit and push changes
+        run: |
+          cd security-docs
+          git branch -b update_docs
+          git checkout update_docs
+          git add -A
+          git commit -m "Update latest docs"
+          git push origin --set-upstream origin update_docs
+
+      - name: Create PR to elastic/security-docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
+        run: |
+          cd security-docs
+          gh pr create --title "Update Docs" --body "This PR updates security docs" --base update_docs --head main

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -24,9 +24,6 @@ on:
       update_message:
         description: 'Update status message for the latest package'
         required: true
-      commit_hash:
-        description: 'Commit hash'
-        required: true
       pre_version:
         description: 'Previous version'
         required: true

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -57,7 +57,7 @@ jobs:
           cd detection-rules
           python -m detection_rules dev build-integration-docs $REGISTRY_VERSION \
             --pre $PRE_VERSION --post $POST_VERSION \
-            -d ../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
+            -d security-docs/docs/detections/prebuilt-rules/downloadable-packages \
             --update-message '$UPDATE_MESSAGE' --force
 
       - name: Commit and push changes

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -63,7 +63,7 @@ jobs:
           cd detection-rules
           python -m detection_rules dev build-integration-docs $POST_VERSION \
             --pre integration-v$PRE_VERSION --post integration-v$POST_VERSION \
-            -d /.../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
+            -d .../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
             --update-message $UPDATE_MESSAGE --force
 
       - name: Commit and push changes

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -78,13 +78,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
-          repository: ${{github.event.inputs.target_repo}}
+          path: security-docs
+          fetch-depth: 0
 
       - name: Commit and push changes
         run: |
           cd security-docs
-          git branch -b update_docs
-          git checkout update_docs
+          git checkout -b update_docs
           git add -A
           git commit -m "Update latest docs"
           git push origin --set-upstream origin update_docs

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -50,12 +50,13 @@ jobs:
       - name: Build Integration Docs
         env:
           UPDATE_MESSAGE: ${{ github.event.inputs.update_message }}
-          PRE_VERSION: ${{ github.event.inputs.pre_version }}
-          POST_VERSION: ${{ github.event.inputs.post_version }}
+          REGISTRY_VERSION: ${{ github.event.inputs.post_version }}
+          PRE_VERSION: "integration-v${{ github.event.inputs.pre_version }}"
+          POST_VERSION: "integration-v${{ github.event.inputs.post_version }}"
         run: |
           cd detection-rules
-          python -m detection_rules dev build-integration-docs $POST_VERSION \
-            --pre integration-v$PRE_VERSION --post integration-v$POST_VERSION \
+          python -m detection_rules dev build-integration-docs $REGISTRY_VERSION \
+            --pre $PRE_VERSION --post $POST_VERSION \
             -d ../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
             --update-message $UPDATE_MESSAGE --force
 

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -61,6 +61,11 @@ jobs:
             -d ../security-docs \
             --update-message '$UPDATE_MESSAGE' --force
 
+      - name: Set github config
+        run: |
+          git config --global user.email "72879786+protectionsmachine@users.noreply.github.com"
+          git config --global user.name "protectionsmachine"
+
       - name: Commit and push changes
         run: |
           cd security-docs

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -27,6 +27,12 @@ on:
       commit_hash:
         description: 'Commit hash'
         required: true
+      pre_version:
+        description: 'Previous version'
+        required: true
+      post_version:
+        description: 'Post version'
+        required: true
 
 jobs:
   build-package:
@@ -52,12 +58,12 @@ jobs:
 
       - name: Bump prebuilt rules package version
         env:
-          NEW_PACKAGE: "${{github.event.inputs.new_package}}"
+          NEW_PACKAGE: ${{ github.event.inputs.new_package }}
         run: |
           cd detection-rules
           python -m detection_rules dev bump-pkg-versions \
             --patch-release                               \
-            --new-package $NEW_PACKAGE                    \
+            --new-package "$NEW_PACKAGE"                  \
             --maturity "ga"
 
       - name: Build Release Package
@@ -67,12 +73,15 @@ jobs:
 
       - name: Build Integration Docs
         env:
-          UPDATE_MESSAGE: "${{github.event.inputs.update_message}}"
+          UPDATE_MESSAGE: ${{ github.event.inputs.update_message }}
+          PRE_VERSION: ${{ github.event.inputs.pre_version }}
+          POST_VERSION: ${{ github.event.inputs.post_version }}
         run: |
           cd detection-rules
-          python -m detection_rules dev build-integration-docs 8.7.2 \
-            --pre integration-v8.7.1 --post integration-v8.7.2 \
-            -d /.../security-docs/ --update-message $UPDATE_MESSAGE
+          python -m detection_rules dev build-integration-docs $PRE_VERSION \
+            --pre integration-v$PRE_VERSION --post integration-v$POST_VERSION \
+            -d /.../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
+            --update-message $UPDATE_MESSAGE --force
 
       - name: Checkout elastic/security-docs
         uses: actions/checkout@v3

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -71,6 +71,13 @@ jobs:
           cd detection-rules
           python -m detection_rules dev build-release --add-historical "yes"
 
+      - name: Checkout elastic/security-docs
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
+          path: security-docs
+          fetch-depth: 0
+
       - name: Build Integration Docs
         env:
           UPDATE_MESSAGE: ${{ github.event.inputs.update_message }}
@@ -82,13 +89,6 @@ jobs:
             --pre integration-v$PRE_VERSION --post integration-v$POST_VERSION \
             -d /.../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
             --update-message $UPDATE_MESSAGE --force
-
-      - name: Checkout elastic/security-docs
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
-          path: security-docs
-          fetch-depth: 0
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -28,6 +28,14 @@ jobs:
           path: detection-rules
           fetch-depth: 0
 
+      - name: Checkout elastic/security-docs
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
+          path: security-docs
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.target_branch }}
+
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -38,14 +46,6 @@ jobs:
           cd detection-rules
           python -m pip install --upgrade pip
           pip install .[dev]
-
-      - name: Checkout elastic/security-docs
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
-          path: security-docs
-          fetch-depth: 0
-          ref: ${{ github.event.inputs.target_branch }}
 
       - name: Build Integration Docs
         env:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
+          repository: "elastic/security-docs"
           path: security-docs
           fetch-depth: 0
           ref: ${{ github.event.inputs.target_branch }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -59,7 +59,7 @@ jobs:
           python -m detection_rules dev build-integration-docs $REGISTRY_VERSION \
             --pre $PRE_VERSION --post $POST_VERSION \
             -d ../security-docs \
-            --update-message '$UPDATE_MESSAGE' --force
+            --update-message "$UPDATE_MESSAGE" --force
 
       - name: Set github config
         run: |

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -72,7 +72,7 @@ jobs:
           git checkout -b update_docs
           git add -A
           git commit -m "Update latest docs"
-          git push origin --set-upstream origin update_docs
+          git push --set-upstream origin update_docs
 
       - name: Create PR to elastic/security-docs
         env:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -57,7 +57,7 @@ jobs:
           cd detection-rules
           python -m detection_rules dev build-integration-docs $REGISTRY_VERSION \
             --pre $PRE_VERSION --post $POST_VERSION \
-            -d security-docs/docs/detections/prebuilt-rules/downloadable-packages \
+            -d ../security-docs \
             --update-message '$UPDATE_MESSAGE' --force
 
       - name: Commit and push changes

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -80,4 +80,4 @@ jobs:
           TARGET_BRANCH: "${{github.event.inputs.target_branch}}"
         run: |
           cd security-docs
-          gh pr create --title "Update Docs" --body "This PR updates security docs" --base update_docs --head $TARGET_BRANCH
+          gh pr create --title "Update Docs" --body "This PR updates security docs" --base $TARGET_BRANCH --head update_docs

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -14,13 +14,6 @@ on:
         options:
           - "yes"
           - "no"
-      new_package:
-        type: choice
-        description: 'New Package'
-        required: true
-        options:
-          - "true"
-          - "false"
       update_message:
         description: 'Update status message for the latest package'
         required: true
@@ -32,7 +25,7 @@ on:
         required: true
 
 jobs:
-  build-package:
+  build-docs:
     name: Prepare Docs
     runs-on: ubuntu-latest
     steps:
@@ -53,21 +46,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install .[dev]
 
-      - name: Bump prebuilt rules package version
-        env:
-          NEW_PACKAGE: ${{ github.event.inputs.new_package }}
-        run: |
-          cd detection-rules
-          python -m detection_rules dev bump-pkg-versions \
-            --patch-release                               \
-            --new-package "$NEW_PACKAGE"                  \
-            --maturity "ga"
-
-      - name: Build Release Package
-        run: |
-          cd detection-rules
-          python -m detection_rules dev build-release --add-historical "yes"
-
       - name: Checkout elastic/security-docs
         uses: actions/checkout@v3
         with:
@@ -82,7 +60,7 @@ jobs:
           POST_VERSION: ${{ github.event.inputs.post_version }}
         run: |
           cd detection-rules
-          python -m detection_rules dev build-integration-docs $PRE_VERSION \
+          python -m detection_rules dev build-integration-docs $POST_VERSION \
             --pre integration-v$PRE_VERSION --post integration-v$POST_VERSION \
             -d /.../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
             --update-message $UPDATE_MESSAGE --force
@@ -98,6 +76,7 @@ jobs:
       - name: Create PR to elastic/security-docs
         env:
           GITHUB_TOKEN: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
+          TARGET_BRANCH: "${{github.event.inputs.target_branch}}"
         run: |
           cd security-docs
-          gh pr create --title "Update Docs" --body "This PR updates security docs" --base update_docs --head main
+          gh pr create --title "Update Docs" --body "This PR updates security docs" --base update_docs --head $TARGET_BRANCH

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -58,7 +58,7 @@ jobs:
           python -m detection_rules dev build-integration-docs $REGISTRY_VERSION \
             --pre $PRE_VERSION --post $POST_VERSION \
             -d ../security-docs/docs/detections/prebuilt-rules/downloadable-packages \
-            --update-message $UPDATE_MESSAGE --force
+            --update-message '$UPDATE_MESSAGE' --force
 
       - name: Commit and push changes
         run: |

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -79,8 +79,9 @@ jobs:
       - name: Create PR to elastic/security-docs
         env:
           GITHUB_TOKEN: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
-          TARGET_BRANCH: "${{github.event.inputs.target_branch}}"
+          POST_VERSION: "v${{ github.event.inputs.post_version }}"
+          TARGET_BRANCH: "${{ github.event.inputs.target_branch }}"
           UPDATE_BRANCH: "update-security-docs-prebuilt-rules-${{github.event.inputs.post_version}}"
         run: |
           cd security-docs
-          gh pr create --title "Update Docs" --body "This PR updates security docs" --base $TARGET_BRANCH --head $UPDATE_BRANCH
+          gh pr create --title "[Detection Rules] Adding Documents for $POST_VERSION Pre-Built Detection Rules" --body "Security Doc updates for prebuilt security rule integration package version $POST_VERSION. Please note these are meant to merge into $TARGET_BRANCH only and not backport." --base $TARGET_BRANCH --head $UPDATE_BRANCH

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -67,17 +67,20 @@ jobs:
           git config --global user.name "protectionsmachine"
 
       - name: Commit and push changes
+        env:
+          UPDATE_BRANCH: "update-security-docs-prebuilt-rules-${{github.event.inputs.post_version}}"
         run: |
           cd security-docs
-          git checkout -b update_docs
+          git checkout -b $UPDATE_BRANCH
           git add -A
           git commit -m "Update latest docs"
-          git push --set-upstream origin update_docs
+          git push --set-upstream origin $UPDATE_BRANCH
 
       - name: Create PR to elastic/security-docs
         env:
           GITHUB_TOKEN: ${{ secrets.PROTECTIONS_MACHINE_TOKEN }}
           TARGET_BRANCH: "${{github.event.inputs.target_branch}}"
+          UPDATE_BRANCH: "update-security-docs-prebuilt-rules-${{github.event.inputs.post_version}}"
         run: |
           cd security-docs
-          gh pr create --title "Update Docs" --body "This PR updates security docs" --base $TARGET_BRANCH --head update_docs
+          gh pr create --title "Update Docs" --body "This PR updates security docs" --base $TARGET_BRANCH --head $UPDATE_BRANCH

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Bump prebuilt rules package version
         env:
           NEW_PACKAGE: "${{github.event.inputs.new_package}}"
-          UPDATE_MESSAGE: "${{github.event.inputs.update_message}}"
         run: |
           cd detection-rules
           python -m detection_rules dev bump-pkg-versions \
@@ -64,13 +63,16 @@ jobs:
       - name: Build Release Package
         run: |
           cd detection-rules
-          python -m detection_rules dev build-release --add-historical "yes" \
-            --update-message $UPDATE_MESSAGE
+          python -m detection_rules dev build-release --add-historical "yes"
 
       - name: Build Integration Docs
+        env:
+          UPDATE_MESSAGE: "${{github.event.inputs.update_message}}"
         run: |
           cd detection-rules
-          python -m detection_rules dev build-integration-docs
+          python -m detection_rules dev build-integration-docs 8.7.2 \
+            --pre integration-v8.7.1 --post integration-v8.7.2 \
+            -d /.../security-docs/ --update-message $UPDATE_MESSAGE
 
       - name: Checkout elastic/security-docs
         uses: actions/checkout@v3

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -150,8 +150,10 @@ def get_release_diff(pre: str, post: str, remote: Optional[str] = 'origin'
 @click.option('--directory', '-d', type=Path, required=True, help='Output directory to save docs to')
 @click.option('--force', '-f', is_flag=True, help='Bypass the confirmation prompt')
 @click.option('--remote', '-r', default='origin', help='Override the remote from "origin"')
+@click.option('--update-message', default='Rule Updates.', help='Update message for new package')
 @click.pass_context
-def build_integration_docs(ctx: click.Context, registry_version: str, pre: str, post: str, directory: Path, force: bool,
+def build_integration_docs(ctx: click.Context, registry_version: str, pre: str, post: str,
+                           directory: Path, force: bool, update_message: str,
                            remote: Optional[str] = 'origin') -> IntegrationSecurityDocs:
     """Build documents from two git tags for an integration package."""
     if not force:
@@ -159,7 +161,7 @@ def build_integration_docs(ctx: click.Context, registry_version: str, pre: str, 
             ctx.exit(1)
 
     rules_changes = get_release_diff(pre, post, remote)
-    docs = IntegrationSecurityDocs(registry_version, directory, True, *rules_changes)
+    docs = IntegrationSecurityDocs(registry_version, directory, True, *rules_changes, update_message=update_message)
     package_dir = docs.generate()
 
     click.echo(f'Generated documents saved to: {package_dir}')

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -295,7 +295,7 @@ class IntegrationSecurityDocs:
                                                    deprecated_rules.values()))
 
         self.registry_version_str, self.base_name, self.prebuilt_rule_base = self.parse_registry(registry_version)
-        self.package_directory = directory / self.base_name
+        self.package_directory = directory / "docs" / "detections" / "prebuilt-rules" / "downloadable-packages" / self.base_name  # noqa: E501
         self.update_message = update_message
 
         if overwrite:
@@ -305,7 +305,7 @@ class IntegrationSecurityDocs:
 
     @staticmethod
     def parse_registry(registry_version: str) -> (str, str, str):
-        registry_version = Version.parse(registry_version)
+        registry_version = Version.parse(registry_version, optional_minor_and_patch=True)
         short_registry_version = [str(n) for n in registry_version[:3]]
         registry_version_str = '.'.join(short_registry_version)
         base_name = "-".join(short_registry_version)

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -421,7 +421,7 @@ class IntegrationSecurityDocs:
         insert_position = header_index + len(header)
 
         # Insert the new content at the insert_position
-        updated_contents = file_contents[:insert_position] + new_content + file_contents[insert_position:]
+        updated_contents = file_contents[:insert_position] + f"\n{new_content}\n" + file_contents[insert_position:]
 
         # Write the updated contents back to the file
         file_path.write_text(updated_contents)

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -286,7 +286,7 @@ class IntegrationSecurityDocs:
 
     def __init__(self, registry_version: str, directory: Path, overwrite=False,
                  updated_rules: Optional[Dict[str, TOMLRule]] = None, new_rules: Optional[Dict[str, TOMLRule]] = None,
-                 deprecated_rules: Optional[Dict[str, TOMLRule]] = None):
+                 deprecated_rules: Optional[Dict[str, TOMLRule]] = None, update_message: str = ""):
         self.new_rules = new_rules
         self.updated_rules = updated_rules
         self.deprecated_rules = deprecated_rules
@@ -296,6 +296,7 @@ class IntegrationSecurityDocs:
 
         self.registry_version_str, self.base_name, self.prebuilt_rule_base = self.parse_registry(registry_version)
         self.package_directory = directory / self.base_name
+        self.update_message = update_message
 
         if overwrite:
             shutil.rmtree(self.package_directory, ignore_errors=True)
@@ -365,27 +366,66 @@ class IntegrationSecurityDocs:
             rule_path.write_text(rule_detail.generate())
 
     def generate_manual_updates(self):
-        update_file = self.package_directory / 'manual-updates.json'
+        """
+        Generate manual updates for prebuilt rules downloadable updates and index.
+        """
         updates = {}
 
-        # update downloadable rule updates entry
-        # https://www.elastic.co/guide/en/security/current/prebuilt-rules-downloadable-updates.html
+        # Update downloadable rule updates entry
         today = datetime.today().strftime('%d %b %Y')
 
-        updates['detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc'] = {
-            'update_table_entry': (f'|<<prebuilt-rule-{self.base_name}-prebuilt-rules-{self.base_name}-summary, '
-                                   f'{self.registry_version_str}>> | {today} | {len(self.new_rules)} | '
-                                   f'{len(self.updated_rules)} | '),
-            'update_table_include': (f'include::downloadable-packages/{self.base_name}/'
-                                     f'prebuilt-rules-{self.base_name}-summary.asciidoc[leveloffset=+1]')
+        updates[f'downloadable-updates.asciidoc'] = {
+            'table_entry': (
+                f'|<<prebuilt-rule-{self.base_name}-prebuilt-rules-{self.base_name}-summary, '
+                f'{self.registry_version_str}>> | {today} | {len(self.new_rules)} | '
+                f'{len(self.updated_rules)} | '
+            ),
+            'table_include': (
+                f'include::downloadable-packages/{self.base_name}/'
+                f'prebuilt-rules-{self.base_name}-summary.asciidoc[leveloffset=+1]'
+            )
         }
 
         updates['index.asciidoc'] = {
-            'update_index_include': (f'include::detections/prebuilt-rules/downloadable-packages/{self.base_name}/'
-                                     f'prebuilt-rules-{self.base_name}-appendix.asciidoc[]')
+            'index_include': (
+                f'include::detections/prebuilt-rules/downloadable-packages/{self.base_name}/'
+                f'prebuilt-rules-{self.base_name}-appendix.asciidoc[]'
+            )
         }
 
-        update_file.write_text(json.dumps(updates, indent=2))
+        # Add index.asciidoc:index_include in docs/index.asciidoc
+        docs_index = self.package_directory.parent.parent.parent.parent / 'index.asciidoc'
+        docs_index.write_text(docs_index.read_text() + '\n' + updates['index.asciidoc']['index_include'] + '\n')
+
+        # Add table_entry to docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+        downloadable_updates = self.package_directory.parent.parent / 'prebuilt-rules-downloadable-updates.asciidoc'
+        new_content = updates['downloadable-updates.asciidoc']['table_entry'] + '\n' + self.update_message
+        self.add_content_to_table_top(downloadable_updates, new_content)
+
+        # Add table_include to/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
+        downloadable_updates.write_text(downloadable_updates.read_text() +
+                                        updates['downloadable-updates.asciidoc']['table_include'] + '\n')
+
+
+    def add_content_to_table_top(self, file_path: Path, new_content: str):
+        """Insert content at the top of a Markdown table right after the specified header."""
+        file_contents = file_path.read_text()
+
+        # Find the header in the file
+        header = '|Update version |Date | New rules | Updated rules | Notes\n'
+        header_index = file_contents.find(header)
+
+        if header_index == -1:
+            raise ValueError("Header not found in the file")
+
+        # Calculate the position to insert new content
+        insert_position = header_index + len(header)
+
+        # Insert the new content at the insert_position
+        updated_contents = file_contents[:insert_position] + new_content + file_contents[insert_position:]
+
+        # Write the updated contents back to the file
+        file_path.write_text(updated_contents)
 
     def generate(self) -> Path:
         self.generate_appendix()

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -374,7 +374,7 @@ class IntegrationSecurityDocs:
         # Update downloadable rule updates entry
         today = datetime.today().strftime('%d %b %Y')
 
-        updates[f'downloadable-updates.asciidoc'] = {
+        updates['downloadable-updates.asciidoc'] = {
             'table_entry': (
                 f'|<<prebuilt-rule-{self.base_name}-prebuilt-rules-{self.base_name}-summary, '
                 f'{self.registry_version_str}>> | {today} | {len(self.new_rules)} | '
@@ -403,9 +403,8 @@ class IntegrationSecurityDocs:
         self.add_content_to_table_top(downloadable_updates, new_content)
 
         # Add table_include to/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
-        downloadable_updates.write_text(downloadable_updates.read_text() +
+        downloadable_updates.write_text(downloadable_updates.read_text() +  # noqa: W504
                                         updates['downloadable-updates.asciidoc']['table_include'] + '\n')
-
 
     def add_content_to_table_top(self, file_path: Path, new_content: str):
         """Insert content at the top of a Markdown table right after the specified header."""


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
#2743 

## Summary

Adds a release-docs workflow that automates pushing docs to the security-docs repo. 

## Testing

- Run the release-docs workflow (which should create a [PR](https://github.com/elastic/security-docs/pull/3194))
- Run `python -m detection_rules dev build-integration-docs 8.3.3 --pre integration-v8.3.2 --post integration-v8.3.3 -d /Users/stryker/workspace/ElasticGitHub/security-docs/docs/detections/prebuilt-rules/downloadable-packages --force` and make sure docs are updated as expected in the security-docs repo per the instructions [here](https://github.com/elastic/ia-trade-team/wiki/Detection-Rules-Releasing-v2)
  - Adds index.asciidoc:index_include in docs/index.asciidoc
  - Adds table_entry to docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
  - Adds table_include to/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc

<details><summary>Release Docs Images</summary>
<p>

![Screenshot 2023-04-27 at 11 05 47 AM](https://user-images.githubusercontent.com/1636709/234905317-345e2d6a-4587-45e7-9092-6ba5bf084bc3.png)

![Screenshot 2023-04-27 at 11 32 15 AM](https://user-images.githubusercontent.com/1636709/234912179-cf90ed64-aacf-429a-af1b-49dec50aeaa5.png)

![Screenshot 2023-04-27 at 11 34 34 AM](https://user-images.githubusercontent.com/1636709/234912823-6043fd9e-896d-4464-a9eb-a17858dfe409.png)



</p>
</details> 
