### PR TITLE
Create execution_interactive_shell_spawned_from_inside_a_container.toml

### DIFF
--- a/rules/integrations/cloud_defend/execution_interactive_shell_spawned_from_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_shell_spawned_from_inside_a_container.toml
@@ -1,0 +1,64 @@
+[metadata]
+creation_date = "2023/04/26"
+integration = ["cloud_defend"]
+maturity = "production"
+min_stack_comments = "New Integration: Cloud Defend"
+min_stack_version = "8.8.0"
+updated_date = "2023/04/26"
+
+[rule]
+author = ["Elastic"]
+description = "This rule detects when an interactive shell is spawned inside a running container. This could indicate an attacker's attempt to gain unauthorized access to the container."
+false_positives = ["""
+  Legitimate users and processes, such as system administration tools, may utilize shell binaries inside a container resulting in false positives.
+  """
+]
+from = "now-360s"
+index = [ "logs-cloud_defend*" ]
+interval = "5m"
+language = "eql"
+license = "Elastic License v2"
+name = "Interactive Shell Spawned From Inside A Container"
+tags = [
+  "Elastic",
+  "Host",
+  "Linux",
+  "Container",
+  "Threat Detection",
+  "Execution"
+]
+references = [ ]
+risk_score = 47
+rule_id = "8d3d0794-c776-476b-8674-ee2e685f6470"
+severity = "medium"
+type = "eql"
+
+query = """
+process where process.entry_leader.entry_meta.type== "container" and
+event.type== "start" and event.action== "fork" and event.action== "exec" and not event.action== "end" 
+and process.entry_leader.same_as_process== "false" and
+(
+(process.name: "*sh" and process.args: ("-i", "*sh")) or
+/* account for tools like busybox, coreutils that package various utilities into a single executable*/
+/* this also captures netcat reverse shell connections*/
+process.args: ("*/*sh*")
+)
+"""
+
+[[threat]]
+framework = "MITRE ATT&CK"
+
+  [threat.tactic]
+  id = "TA0002"
+  reference = "https://attack.mitre.org/tactics/TA0002"
+  name = "Execution"
+
+  [[threat.technique]]
+  id = "T1059"
+  reference = "https://attack.mitre.org/techniques/T1059"
+  name = "Command and Scripting Interpreter"
+
+    [[threat.technique.subtechnique]]
+    id = "T1059.004"
+    reference = "https://attack.mitre.org/techniques/T1059/004"
+    name = "Unix Shell"


### PR DESCRIPTION
## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2722
## Summary
This rule detects the spawning of a shell from inside a container. It captures common linux shell utilities and the use of the -i flag. This rule also capture reverse shell connections initiated via netcat and interactive shells spawned by interpreters like python and perl.

### Query
```
process where process.entry_leader.entry_meta.type== "container" and
event.type== "start" and event.action== "fork" and event.action== "exec" and not event.action== "end" 
and process.entry_leader.same_as_process== "false" and
(
(process.name: "*sh" and process.args: ("-i", "*sh")) or
/* account for tools like busybox, coreutils that package various utilities into a single executable*/
/* this also captures netcat reverse shell connections*/
process.args: ("*/*sh*")
)
```
## Example Data
<!-- Example JSON data from the actual detonated activity makes this process much quicker -->
<details>
<summary> Screenshot </summary>

![image](https://user-images.githubusercontent.com/59296946/233175264-0d38014f-f6a5-408c-b1aa-0e3c3b1004bb.png)

</details>