### PR TITLE
[New Rule] Container Management Binary Run Inside A Container

### DIFF
--- a/rules/integrations/cloud_defend/execution_container_management_binary_launched_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_container_management_binary_launched_inside_a_container.toml
@@ -1,0 +1,50 @@
+[metadata]
+creation_date = "2023/04/26"
+integration = ["cloud_defend"]
+maturity = "production"
+min_stack_comments = "New Integration: Cloud Defend"
+min_stack_version = "8.8.0"
+updated_date = "2023/04/26"
+
+[rule]
+author = ["Elastic"]
+description = "This rule detects when a container management binary is run from inside a container. These binaries are critical components of many containerized environments, and their presence in unexpected locations or in unauthorized containers could indicate compromise or a misconfiguration."
+false_positives = [ ]
+from = "now-360s"
+index = [ "logs-cloud_defend*" ]
+interval = "5m"
+language = "eql"
+license = "Elastic Licence v2"
+name = "Container Management Binary Run Inside A Container"
+references = [ ]
+risk_score = 21
+rule_id = "6c6bb7ea-0636-44ca-b541-201478ef6b50"
+severity = "low"
+tags = [
+  "Elastic",
+  "Host",
+  "Linux",
+  "Threat Detection",
+  "Execution",
+  "Container"
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = """
+process where process.entry_leader.entry_meta.type== "container" and event.type== "start" 
+  and process.name: ("dockerd", "docker", "kubelet", "kube-proxy", "kubectl", "containerd", "runc", "systemd", "crictl")
+"""
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+  [rule.threat.tactic]
+  id = "TA0002"
+  reference = "https://attack.mitre.org/tactics/TA0002/"
+  name = "Execution"
+
+  [[rule.threat.technique]]
+  id = "T1609"
+  reference = "https://attack.mitre.org/techniques/T1609/"
+  name = "Container Administration Command"


### PR DESCRIPTION
## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
https://github.com/elastic/detection-rules/issues/2723
## Summary
This rule detects the use of common container management binaries, like kubectl or docker, from inside a container. This could be an indicator of compromise and at the very least should be investigated.

### Query
```
process where process.entry_leader.entry_meta.type== "container" and event.type== "start" 
and process.name: ("dockerd", "docker", "kubelet", "kube-proxy", "kubectl", "containerd", "runc", "systemd", "crictl")
```
## Example Data
<!-- Example JSON data from the actual detonated activity makes this process much quicker -->
<details>
<summary/>Screenshot</summary>

![image](https://user-images.githubusercontent.com/59296946/233186693-5c84240d-2759-4230-8635-1a9a384700e3.png)

</details>