### PR TITLE
[FR] Add base pipeline to trigger react 

### DIFF
--- a/.github/workflows/trigger-react.yml
+++ b/.github/workflows/trigger-react.yml
@@ -1,0 +1,30 @@
+name: Trigger REACT Buildkite Pipeline
+
+on:
+  push:
+    branches: [ "*" ]
+    # paths:
+    #   - 'rules/**/*.toml'
+  workflow_dispatch:
+    # paths:
+    #   - 'rules/**/*.toml'
+
+jobs:
+  trigger_buildkite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger a Buildkite REACT Build
+        run: |
+          curl -X POST "https://api.buildkite.com/v2/organizations/elastic/pipelines/react/builds" \
+            -H "Authorization: Bearer ${{ secrets.REACT_BUILDKITE_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "commit": "HEAD",
+              "branch": "main",
+              "message": ":github: Triggered from a DR GitHub Action",
+              "env": {
+                "GITHUB_COMMIT_HASH": "${{ github.sha }}",
+                "GITHUB_HEAD_BRANCH": "${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}",
+                "GITHUB_SRC_BRANCH": "${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || github.ref_name }}"
+              }
+            }'


### PR DESCRIPTION
## Issues
<!-- Link to related issues. Use closing keywords when appropriate. E.g. "Resolves #1" -->
https://github.com/elastic/ia-trade-team/issues/112

## Summary
<!-- A summary of the changes included in this PR. -->

- Sets up the base pipeline to trigger Jobs in react. Will later limit only to toml file paths. This is to start testing ability to push information to react in buildkite.