### PR TITLE
[Bug][FR] Remove Rule Type Change Restriction and Fix Version Lock Bug

### DIFF
--- a/detection_rules/version_lock.py
+++ b/detection_rules/version_lock.py
@@ -208,15 +208,6 @@ class VersionLock:
                 lock_from_rule = rule.contents.lock_info(bump=not exclude_version_update)
                 lock_from_file: dict = lock_file_contents.setdefault(rule.id, {})
 
-                # prevent rule type changes for already locked and released rules (#1854)
-                if lock_from_file:
-                    name = lock_from_rule['rule_name']
-                    existing_type = lock_from_file['type']
-                    current_type = lock_from_rule['type']
-                    if existing_type != current_type:
-                        err_msg = f'cannot change "type" in locked rule: {name} from {existing_type} to {current_type}'
-                        raise ValueError(err_msg)
-
                 # scenarios to handle, assuming older stacks are always locked first:
                 # 1) no breaking changes ever made or the first time a rule is created
                 # 2) on the latest, after a breaking change has been locked
@@ -244,7 +235,8 @@ class VersionLock:
                 elif min_stack > latest_locked_stack_version:
                     route = 'B'
                     # 3) on the latest stack, locking in a breaking change
-
+                    stripped_latest_locked_stack_version = f"{latest_locked_stack_version.major}." \
+                                                            f"{latest_locked_stack_version.minor}"
                     # preserve buffer space to support forked version spacing
                     if exclude_version_update:
                         buffer_int -= 1
@@ -260,14 +252,14 @@ class VersionLock:
                     lock_from_file.setdefault("previous", {})
 
                     # move the current locked info into the previous section
-                    lock_from_file["previous"][str(latest_locked_stack_version)] = previous_lock_info
+                    lock_from_file["previous"][stripped_latest_locked_stack_version] = previous_lock_info
 
                     # overwrite the "latest" part of the lock at the top level
                     lock_from_file.update(lock_from_rule, min_stack_version=stripped_version)
                     new_version = lock_from_rule['version']
                     log_changes(
                         rule, route, new_version,
-                        f'previous {latest_locked_stack_version} saved as version: {previous_lock_info["version"]}',
+                        f'previous {stripped_latest_locked_stack_version} saved as version: {previous_lock_info["version"]}',
                         f'current min_stack updated to {stripped_version}'
                     )
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/2765

## Summary
This PR removes the restriction of changing rule types. This was made a restriction due to a bug in the Detection Engine that was resolved in 8.2. Our rules currently only backport to >=8.3 and therefore are clear of the stack version window the bug exists in.

To solve this, we removing an assertion error check that compares the `version_lock.json` rule contents `type` value to the existing from the loaded rule.

### Bug - Version lock route B (forked rule); previous key fully semantic
During testing, `dev build-release --update-version-lock` was ran to ensure a proper prebuilt rules package could be built after changing the rule type of an existing rule.

The `VersionLockFile` schema in `version_lock.py` failed due to the additional `previous` entry being fully semantic `8.3.0` instead of major and minor `8.3` as expected.

To solve this a new variable `stripped_latest_locked_stack_version` was added by only assigning the major and minor versions from `latest_locked_stack_version` as such `{latest.major}.{latest.minor}`. This then becomes the `previous` key in the `version_lock.json` file if a rule if forked.

<img width="1009" alt="Screenshot 2023-05-01 at 11 20 50 AM" src="https://user-images.githubusercontent.com/99630311/235479227-35baa725-e72e-442e-b8a2-b9cca4932e5b.png">
<img width="1260" alt="Screenshot 2023-05-01 at 11 21 29 AM" src="https://user-images.githubusercontent.com/99630311/235479243-ce9dd5d5-195e-4272-bc9a-f7bbf883030c.png">
<img width="1243" alt="Screenshot 2023-05-01 at 11 24 07 AM" src="https://user-images.githubusercontent.com/99630311/235479253-f9b76354-d957-40dd-9f53-a3f291c9d62e.png">




