### PR TITLE
[Bug] Fix misspelled variable call for `deprecated_rules` in doc generation

### DIFF
--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -711,7 +711,7 @@ class IntegrationSecurityDocsMDX:
 
         deprecated_rule_ids = list(set(deprecated_rule_ids))
         for rule_id in deprecated_rule_ids:
-            rule_changes['deprecated'].append(self.new_package.deprecate_rules.id_map[rule_id])
+            rule_changes['deprecated'].append(self.new_package.deprecated_rules.id_map[rule_id])
 
         return dict(rule_changes)
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/122

## Summary
The following code snippet had a misspelling, thus causing an error with the `8.7` OOB package release.

```python
        deprecated_rule_ids = list(set(deprecated_rule_ids))
        for rule_id in deprecated_rule_ids:
            rule_changes['deprecated'].append(self.new_package.deprecate_rules.id_map[rule_id])
```
Fix is: `self.new_package.deprecated_rules.id_map[rule_id]`

Failed GitHub Actions reference: https://github.com/elastic/detection-rules/actions/runs/5015866807/jobs/8992007360
