### PR TITLE
add rounding logic

### DIFF
--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -193,6 +193,13 @@ def event_sort(events, timestamp='@timestamp', date_format='%Y-%m-%dT%H:%M:%S.%f
 
     def _event_sort(event):
         t = event[timestamp]
+        # If t has more than 6 decimal places round to 6
+        micro_seconds = t.split('.')[-1].split("Z")[0]
+        if t and len(micro_seconds) > 6:
+            print("Converting Time...")
+            micro_seconds = "0."+ micro_seconds
+            micro_seconds = str(round(float(micro_seconds), 6)).split(".")[-1]
+            t = t.split('.')[0] + '.' + micro_seconds + "Z"
         return (time.mktime(time.strptime(t, date_format)) + int(t.split('.')[-1][:-1]) / 1000) * 1000
 
     return sorted(events, key=_event_sort, reverse=not asc)


### PR DESCRIPTION

## Summary
Adds a safeguard to handling the timestamps from elasticsearch data. In some cases, the timestamps may have a greater degree of specificity than python in able to handle. This code rounds the fractions of a second to six decimal places, if the timestamp contains more than six.

