### PR TITLE
[Interactive Terminal Spawned via Python] Add Query Exceptions for Update Package Installations

### DIFF
--- a/rules/linux/execution_python_tty_shell.toml
+++ b/rules/linux/execution_python_tty_shell.toml
@@ -27,7 +27,10 @@ type = "eql"
 
 query = '''
 sequence with maxspan=1m
-  [process where host.os.type == "linux" and event.type == "start" and process.name : "python*"] by process.entity_id
+  [process where host.os.type == "linux" and event.type == "start" and process.name : "python*" and
+   not (process.args == "/bin/yum" and process.args == "update") and 
+   not  process.args :  "/var/lib/dpkg/info/python3-*.*"
+  ] by process.entity_id
   [process where host.os.type == "linux" and event.type == "start" and 
    process.executable : "/bin/*sh"
   ] by process.parent.entity_id


### PR DESCRIPTION
## Issues
- Closes #2828 

## Summary
Adds query exceptions for package update scripts when using `yum update`. 

## Contributor checklist

- [X] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [X] Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
