### PR TITLE
Tune lateral movement incoming wmi

### DIFF
--- a/rules/windows/discovery_remote_system_discovery_commands_windows.toml
+++ b/rules/windows/discovery_remote_system_discovery_commands_windows.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/02/22"
+updated_date = "2023/06/06"
 
 [rule]
 author = ["Elastic"]
@@ -58,6 +58,7 @@ process where host.os.type == "windows" and event.type == "start" and
   ((process.name : "nbtstat.exe" and process.args : ("-n", "-s")) or
   (process.name : "arp.exe" and process.args : "-a") or
   (process.name : "nltest.exe" and process.args : ("/dclist", "/dsgetdc")) or
+  (process.name : "nslookup.exe" and process.args : "*_ldap._tcp.dc.*") or
   (process.name: ("dsquery.exe", "dsget.exe") and process.args: "subnet") or
   ((((process.name : "net.exe" or process.pe.original_file_name == "net.exe") or
     ((process.name : "net1.exe" or process.pe.original_file_name == "net1.exe") and not 

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/05/03"
+updated_date = "2023/06/08"
 
 [rule]
 author = ["Elastic"]
@@ -37,7 +37,7 @@ sequence by host.id with maxspan = 2s
   [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "WmiPrvSE.exe" and
    not process.args : ("C:\\windows\\temp\\nessus_*.txt",
                        "*C:\\windows\\TEMP\\nessus_*.TMP*",
-                       "C:\\Windows\\CCM\\SystemTemp\\*",
+                       "*C:\\Windows\\CCM\\SystemTemp\\*",
                        "C:\\Windows\\CCMCache\\*",
                        "C:\\CCM\\Cache\\*")
    ]


### PR DESCRIPTION
## Issues
- Closes #2841 

## Summary
There is an existing exception in the query where process.args is:

`C:\\Windows\\CCM\\SystemTemp\\*`

Unfortunately, we have received some events where that same argument is single-quoted and is preceded with an ampersand:

`& 'C:\WINDOWS\CCM\SystemTemp\9b69a355-c98b-40c9-b315-1d9ba1542251.ps1'`

The preceding ampersand and single quote caused this event to trigger a detection when it is already expected to be ignored. 

This PR adds a wildcard to the existing exclusion to include events with the prepended ampersand and single quote. 

## Contributor checklist

- [X] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [X] Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
