### PR TITLE
[New Rule] Shared Object Created

### DIFF
--- a/rules/linux/persistence_shared_object_creation.toml
+++ b/rules/linux/persistence_shared_object_creation.toml
@@ -44,6 +44,11 @@ id = "T1574"
 name = "Hijack Execution Flow"
 reference = "https://attack.mitre.org/techniques/T1574/"
 
+[[rule.threat.technique.subtechnique]]
+id = "T1574.006"
+name = "Dynamic Linker Hijacking"
+reference = "https://attack.mitre.org/techniques/T1574/006/"
+
 [rule.threat.tactic]
 id = "TA0003"
 name = "Persistence"


### PR DESCRIPTION
## Summary
This PR proposes the addition of a detection rule that monitors the creation and change of `shared object files` within the `/usr/lib` or `/dev/shm` directories. 

The creation of a shared object file involves compiling code into a dynamically linked library that can be loaded by 
other programs at runtime. While this process is typically used for legitimate purposes, malicious actors can leverage
shared object files (e.g., .so files) to execute unauthorized code, inject malicious functionality into legitimate
processes, or bypass security controls. This allows malware to persist on the system, evade detection, and potentially
compromise the integrity and confidentiality of the affected system and its data. This rule monitors the creation of
shared object files by previously unknown processes. 

The rule has been checked in clusters with several Linux servers with data ranging back over half a year ago, and does not trigger any false positives based on the exclusions added such as `dockerd`. Additionally, it detected most if not all malicious shared object file creations originating from the Linux malware. Additionally, a new terms rule was chosen in order to minimize potential FPs even further. 

## Detection
```
host.os.type : "linux" and event.action:("creation" or "file_create_event" or "rename" or "file_rename_event") and 
file.path : (/usr/lib/* or /dev/shm/*) and file.extension : "so" and process.name : * and not 
process.name : ("dpkg" or "dockerd" or "rpm" or "snapd" or "5")

[rule.new_terms]
field = "new_terms_fields"
value = ["file.path", "process.name"]

[[rule.new_terms.history_window_start]]
field = "history_window_start"
value = "now-7d"
```
<img width="2057" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/4950303f-0b6d-4da6-9e1d-303bf7b643ca">

## Malware Analysis
These rules are found to be triggered by real malware samples, which @1337-42 and I have been detonating and analysing. Updates will be added to [#105](https://github.com/elastic/elastic-security-labs/issues/105).