### PR TITLE
[Bug] Add pywin32 to windows install

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Commands:
   view-rule       View an internal rule or specified rule file.
 ```
 
+Note:
+- If you are using a virtual environment, make sure to activate it before running the above command.
+- If using Windows, you may have to also run `<venv_directory>\Scripts\pywin32_postinstall.py -install` depending on your python version.
+
 The [contribution guide](CONTRIBUTING.md) describes how to use the `create-rule` and `test` commands to create and test a new rule when contributing to Detection Rules.
 
 For more advanced command line interface (CLI) usage, refer to the [CLI guide](CLI.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
 	"marshmallow-jsonschema~=0.12.0",
 	"marshmallow-union~=0.1.15",
 	"marshmallow~=3.13.0",
+	"pywin32 ; platform_system=='Windows'",
 	"pytoml",
 	"PyYAML~=5.3",
 	"requests~=2.27",


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves #2884

## Summary

Adds "pywin32" for windows builds.

## Testing

Should be able to run `python -m detection_rules --help` after installing via `pip3 install ".[dev]"` with no errors.