### PR TITLE
[Tuning] Azure Network Packet Capture Detected

### DIFF
--- a/rules/integrations/azure/credential_access_azure_full_network_packet_capture_detected.toml
+++ b/rules/integrations/azure/credential_access_azure_full_network_packet_capture_detected.toml
@@ -4,7 +4,7 @@ integration = ["azure"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/06/28"
 
 [rule]
 author = ["Austin Songer"]
@@ -40,9 +40,9 @@ type = "query"
 query = '''
 event.dataset:azure.activitylogs and azure.activitylogs.operation_name:
     (
-        "MICROSOFT.NETWORK/*/STARTPACKETCAPTURE/ACTION" or
-        "MICROSOFT.NETWORK/*/VPNCONNECTIONS/STARTPACKETCAPTURE/ACTION" or
-        "MICROSOFT.NETWORK/*/PACKETCAPTURES/WRITE"
+        MICROSOFT.NETWORK/*/STARTPACKETCAPTURE/ACTION or
+        MICROSOFT.NETWORK/*/VPNCONNECTIONS/STARTPACKETCAPTURE/ACTION or
+        MICROSOFT.NETWORK/*/PACKETCAPTURES/WRITE
     ) and
 event.outcome:(Success or success)
 '''


### PR DESCRIPTION
## Summary
Fixed an issue pointed out [here](https://github.com/elastic/geneve/issues/168) of using double quotes when working with KQL wildcards, which turns the string into a literal and therefore does no longer capture the wished-for behavior.

This PR fixes this unwanted behavior.

