### PR TITLE
[Rule Tuning] [BUG] Revert PowerShell Query modifications from #2823

### DIFF
--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -35,6 +35,7 @@ SUBTECHNIQUE_URL = r'^https://attack.mitre.org/techniques/T[0-9]+/[0-9]+/$'
 MACHINE_LEARNING = 'machine_learning'
 SAVED_QUERY = 'saved_query'
 QUERY = 'query'
+QUERY_FIELD_OP_EXCEPTIONS = ["powershell.file.script_block_text"]
 
 # we had a bad rule ID make it in before tightening up the pattern, and so we have to let it bypass
 KNOWN_BAD_RULE_IDS = Literal['119c8877-8613-416d-a98a-96b6664ee73a5']

--- a/rules/windows/collection_posh_clipboard_capture.toml
+++ b/rules/windows/collection_posh_clipboard_capture.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/06/28"
 
 [rule]
 author = ["Elastic"]
@@ -85,14 +85,17 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and host.os.type:windows and 
-  powershell.file.script_block_text:((Windows.Clipboard or 
-                                      Windows.Forms.Clipboard or 
-                                      Windows.Forms.TextBox) and 
-                                    (".Paste()" or 
-                                    "]::GetText")) or 
-  powershell.file.script_block_text:Get-Clipboard and 
-  not user.id:S-1-5-18
+event.category:process and host.os.type:windows and
+  (powershell.file.script_block_text : (
+    "Windows.Clipboard" or
+    "Windows.Forms.Clipboard" or
+    "Windows.Forms.TextBox"
+   ) and
+   powershell.file.script_block_text : (
+    "]::GetText" or
+    ".Paste()"
+  )) or powershell.file.script_block_text : "Get-Clipboard"
+  and not user.id : "S-1-5-18"
 '''
 
 

--- a/rules/windows/collection_posh_keylogger.toml
+++ b/rules/windows/collection_posh_keylogger.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/06/28"
 
 [rule]
 author = ["Elastic"]
@@ -85,23 +85,14 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and host.os.type:windows and 
-powershell.file.script_block_text : ( 
-    Get-Keystrokes or GetAsyncKeyState or GetKeyboardState or NtUserGetAsyncKeyState or 
-        (
-            NtUserSetWindowsHookEx or 
-            SetWindowsHookA or 
-            SetWindowsHookEx or 
-            SetWindowsHookExA or 
-            SetWindowsHookW
-        ) and 
-        (
-            GetForegroundWindow or 
-            GetWindowTextA or 
-            GetWindowTextW or 
-            WM_KEYBOARD_LL)
-        ) 
-and not user.id:S-1-5-18
+event.category:process and host.os.type:windows and
+  (
+   powershell.file.script_block_text : (GetAsyncKeyState or NtUserGetAsyncKeyState or GetKeyboardState or "Get-Keystrokes") or
+   powershell.file.script_block_text : (
+        (SetWindowsHookA or SetWindowsHookW or SetWindowsHookEx or SetWindowsHookExA or NtUserSetWindowsHookEx) and
+        (GetForegroundWindow or GetWindowTextA or GetWindowTextW or "WM_KEYBOARD_LL")
+   )
+   ) and not user.id : "S-1-5-18"
 '''
 
 

--- a/rules/windows/collection_posh_mailbox.toml
+++ b/rules/windows/collection_posh_mailbox.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/06/28"
 
 [rule]
 author = ["Elastic"]
@@ -86,13 +86,18 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and host.os.type:windows and 
-powershell.file.script_block_text : ( 
-    "::olFolderInBox" or 
-    Interop.Outlook.olDefaultFolders or 
-    Microsoft.Exchange.WebServices.Data.FileAttachment or 
-    Microsoft.Exchange.WebServices.Data.Folder or 
-    Microsoft.Office.Interop.Outlook)
+event.category:process and host.os.type:windows and
+  (
+   powershell.file.script_block_text : (
+      "Microsoft.Office.Interop.Outlook" or
+      "Interop.Outlook.olDefaultFolders" or
+      "::olFolderInBox"
+   ) or
+   powershell.file.script_block_text : (
+      "Microsoft.Exchange.WebServices.Data.Folder" or
+      "Microsoft.Exchange.WebServices.Data.FileAttachment"
+   )
+   )
 '''
 
 

--- a/rules/windows/defense_evasion_amsi_bypass_powershell.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_powershell.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/06/28"
 
 [transform]
 [[transform.osquery]]
@@ -104,25 +104,26 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and host.os.type:windows and 
-powershell.file.script_block_text : (
-  AmsiInitialize or 
-  AmsiX32 or 
-  AmsiX64 or 
-  AntimalwareProvider or 
-  Bypass.AMSI or 
-  FindAmsiFun or 
-  Invoke-AmsiBypass or 
-  System.Management.Automation.AmsiUtils or 
-  System.Management.Automation.ScriptBlock or 
-  amsi.dll or 
-  amsiContext or 
-  amsiInitFailed or 
-  amsiSession or 
-  unloadobfuscated or 
-  unloadsilent or 
-  VirtualProtect and "[System.Runtime.InteropServices.Marshal]::Copy" or 
-  ".SetValue(" and "[Ref].Assembly.GetType(('System.Management.Automation")
+event.category:"process" and host.os.type:windows and
+ (powershell.file.script_block_text :
+        ("System.Management.Automation.AmsiUtils" or
+				 amsiInitFailed or 
+				 "Invoke-AmsiBypass" or 
+				 "Bypass.AMSI" or 
+				 "amsi.dll" or 
+				 AntimalwareProvider  or 
+				 amsiSession or 
+				 amsiContext or 
+				 "System.Management.Automation.ScriptBlock" or
+				 AmsiInitialize or 
+				 unloadobfuscated or 
+				 unloadsilent or 
+				 AmsiX64 or 
+				 AmsiX32 or 
+				 FindAmsiFun) or
+  powershell.file.script_block_text:("[System.Runtime.InteropServices.Marshal]::Copy" and "VirtualProtect") or
+  powershell.file.script_block_text:("[Ref].Assembly.GetType(('System.Management.Automation" and ".SetValue(")
+ )
 '''
 
 

--- a/rules/windows/defense_evasion_posh_encryption.toml
+++ b/rules/windows/defense_evasion_posh_encryption.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/06/28"
 
 [rule]
 author = ["Elastic"]
@@ -26,21 +26,27 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and host.os.type:windows and 
-powershell.file.script_block_text : (
-    CipherMode and 
-    PaddingMode and 
-    ( 
-        Cryptography.AESManaged or 
-        Cryptography.RijndaelManaged or 
-        Cryptography.SHA1Managed or 
-        Cryptography.SHA256Managed or 
-        Cryptography.SHA384Managed or 
-        Cryptography.SHA512Managed or 
-        Cryptography.SymmetricAlgorithm or 
-        PasswordDeriveBytes or 
-        Rfc2898DeriveBytes
-    ) and (.CreateDecryptor or .CreateEncryptor)) and not user.id:S-1-5-18
+event.category:process and host.os.type:windows and
+  powershell.file.script_block_text : (
+    (
+      "Cryptography.AESManaged" or
+      "Cryptography.RijndaelManaged" or
+      "Cryptography.SHA1Managed" or
+      "Cryptography.SHA256Managed" or
+      "Cryptography.SHA384Managed" or
+      "Cryptography.SHA512Managed" or
+      "Cryptography.SymmetricAlgorithm" or
+      "PasswordDeriveBytes" or
+      "Rfc2898DeriveBytes"
+    ) and
+    (
+      CipherMode and PaddingMode
+    ) and
+    (
+      ".CreateEncryptor" or
+      ".CreateDecryptor"
+    )
+  ) and not user.id : "S-1-5-18"
 '''
 
 

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -59,7 +59,7 @@ class TestValidRules(BaseRuleTest):
     def test_all_rule_queries_optimized(self):
         """Ensure that every rule query is in optimized form."""
         for rule in self.production_rules:
-            if rule.contents.data.get("language") == "kuery":
+            if rule.contents.data.get("language") == "kuery" and "powershell.file.script_block_text" not in rule.contents.data.query:
                 source = rule.contents.data.query
                 tree = kql.parse(source, optimize=False)
                 optimized = tree.optimize(recursive=True)

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -59,7 +59,10 @@ class TestValidRules(BaseRuleTest):
     def test_all_rule_queries_optimized(self):
         """Ensure that every rule query is in optimized form."""
         for rule in self.production_rules:
-            if rule.contents.data.get("language") == "kuery" and "powershell.file.script_block_text" not in rule.contents.data.query:
+            if (
+                rule.contents.data.get("language") == "kuery"
+                and "powershell.file.script_block_text" not in rule.contents.data.query
+            ):
                 source = rule.contents.data.query
                 tree = kql.parse(source, optimize=False)
                 optimized = tree.optimize(recursive=True)

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -60,8 +60,8 @@ class TestValidRules(BaseRuleTest):
         """Ensure that every rule query is in optimized form."""
         for rule in self.production_rules:
             if (
-                rule.contents.data.get("language") == "kuery"
-                and "powershell.file.script_block_text" not in rule.contents.data.query
+                rule.contents.data.get("language") == "kuery" and "powershell.file.script_block_text"
+                not in rule.contents.data.query
             ):
                 source = rule.contents.data.query
                 tree = kql.parse(source, optimize=False)

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -60,8 +60,9 @@ class TestValidRules(BaseRuleTest):
         """Ensure that every rule query is in optimized form."""
         for rule in self.production_rules:
             if (
-                rule.contents.data.get("language") == "kuery" and "powershell.file.script_block_text"
-                not in rule.contents.data.query
+                rule.contents.data.get("language") == "kuery" and not any(
+                item in rule.contents.data.query for item in definitions.QUERY_FIELD_OP_EXCEPTIONS
+                )
             ):
                 source = rule.contents.data.query
                 tree = kql.parse(source, optimize=False)

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -61,7 +61,7 @@ class TestValidRules(BaseRuleTest):
         for rule in self.production_rules:
             if (
                 rule.contents.data.get("language") == "kuery" and not any(
-                item in rule.contents.data.query for item in definitions.QUERY_FIELD_OP_EXCEPTIONS
+                    item in rule.contents.data.query for item in definitions.QUERY_FIELD_OP_EXCEPTIONS
                 )
             ):
                 source = rule.contents.data.query


### PR DESCRIPTION
## Summary

The query optimization PR (https://github.com/elastic/detection-rules/pull/2823) removed the quotes from some of the powershell KQL queries' keywords, introducing partial matches (FPs). Here is a summary of what this means from #2614


> Tune the rule to not have FPs due to partial match.
>
>Due to the nature of the `powershell.file.script_block_text` field (Some context can be found [here](https://github.com/elastic/integrations/pull/1931)), we need to double quote any field value that contains non-alphanumerical chars, because KQL will use them as delimiters and treat the text as separated keywords instead of a full text. For example:
>
> ![image](https://user-images.githubusercontent.com/26856693/222544527-54dce0ec-667f-4c49-a7a0-3b60a754eb4b.png)