### PR TITLE
[Rule Tuning] PowerShell Rule Tunings

### DIFF
--- a/rules/windows/collection_mailbox_export_winlog.toml
+++ b/rules/windows/collection_mailbox_export_winlog.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 
 [rule]
 author = ["Elastic"]
@@ -68,7 +68,10 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:process and host.os.type:windows and powershell.file.script_block_text : "New-MailboxExportRequest"
+event.category:process and host.os.type:windows and
+  powershell.file.script_block_text : "New-MailboxExportRequest" and
+  not (file.path : (*Microsoft* and *Exchange* and *RemotePowerShell* or *AppData* and *Local*) and
+  file.name:(*.psd1 or *.psm1))
 '''
 
 

--- a/rules/windows/collection_mailbox_export_winlog.toml
+++ b/rules/windows/collection_mailbox_export_winlog.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/collection_posh_audio_capture.toml
+++ b/rules/windows/collection_posh_audio_capture.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/collection_posh_audio_capture.toml
+++ b/rules/windows/collection_posh_audio_capture.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 
 [rule]
 author = ["Elastic"]
@@ -83,7 +83,11 @@ query = '''
 event.category:process and host.os.type:windows and
   powershell.file.script_block_text : (
     "Get-MicrophoneAudio" or (waveInGetNumDevs and mciSendStringA)
-  ) and not user.id : "S-1-5-18"
+  )
+  and not powershell.file.script_block_text : (
+    "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
+  )
+  and not user.id : "S-1-5-18"
 '''
 
 

--- a/rules/windows/collection_posh_clipboard_capture.toml
+++ b/rules/windows/collection_posh_clipboard_capture.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/collection_posh_clipboard_capture.toml
+++ b/rules/windows/collection_posh_clipboard_capture.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/28"
+updated_date = "2023/00/00"
 
 [rule]
 author = ["Elastic"]
@@ -95,7 +95,15 @@ event.category:process and host.os.type:windows and
     "]::GetText" or
     ".Paste()"
   )) or powershell.file.script_block_text : "Get-Clipboard"
+  and not powershell.file.script_block_text : (
+    "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
+  )
   and not user.id : "S-1-5-18"
+  and not file.path : (*WindowsPowerShell*Modules*.psd1 or *WindowsPowerShell*Modules*.psm1)
+  and not (
+    file.path : *WindowsPowerShell*Modules*.ps1 and
+    file.name : ("Convert-ExcelRangeToImage.ps1" or "Read-Clipboard.ps1")
+  )
 '''
 
 

--- a/rules/windows/collection_posh_keylogger.toml
+++ b/rules/windows/collection_posh_keylogger.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/collection_posh_keylogger.toml
+++ b/rules/windows/collection_posh_keylogger.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/28"
+updated_date = "2023/00/00"
 
 [rule]
 author = ["Elastic"]
@@ -93,6 +93,9 @@ event.category:process and host.os.type:windows and
         (GetForegroundWindow or GetWindowTextA or GetWindowTextW or "WM_KEYBOARD_LL")
    )
    ) and not user.id : "S-1-5-18"
+  and not powershell.file.script_block_text : (
+    "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
+  )
 '''
 
 

--- a/rules/windows/credential_access_posh_invoke_ninjacopy.toml
+++ b/rules/windows/credential_access_posh_invoke_ninjacopy.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_posh_invoke_ninjacopy.toml
+++ b/rules/windows/credential_access_posh_invoke_ninjacopy.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 
 [rule]
 author = ["Elastic"]
@@ -39,6 +39,9 @@ event.category:process and host.os.type:windows and
     "Invoke-NinjaCopy"
    )
   and not user.id : "S-1-5-18"
+  and not powershell.file.script_block_text : (
+    "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
+  )
 '''
 
 

--- a/rules/windows/credential_access_posh_request_ticket.toml
+++ b/rules/windows/credential_access_posh_request_ticket.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_posh_request_ticket.toml
+++ b/rules/windows/credential_access_posh_request_ticket.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 
 [rule]
 author = ["Elastic"]
@@ -85,6 +85,9 @@ event.category:process and host.os.type:windows and
   powershell.file.script_block_text : (
     KerberosRequestorSecurityToken
   ) and not user.id : "S-1-5-18"
+  and not powershell.file.script_block_text : (
+    "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_amsi_bypass_powershell.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_powershell.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/28"
+updated_date = "2023/00/00"
 
 [transform]
 [[transform.osquery]]
@@ -113,8 +113,7 @@ event.category:"process" and host.os.type:windows and
 				 "amsi.dll" or 
 				 AntimalwareProvider  or 
 				 amsiSession or 
-				 amsiContext or 
-				 "System.Management.Automation.ScriptBlock" or
+				 amsiContext or
 				 AmsiInitialize or 
 				 unloadobfuscated or 
 				 unloadsilent or 
@@ -124,6 +123,9 @@ event.category:"process" and host.os.type:windows and
   powershell.file.script_block_text:("[System.Runtime.InteropServices.Marshal]::Copy" and "VirtualProtect") or
   powershell.file.script_block_text:("[Ref].Assembly.GetType(('System.Management.Automation" and ".SetValue(")
  )
+  and not powershell.file.script_block_text : (
+    "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_amsi_bypass_powershell.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_powershell.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/defense_evasion_posh_assembly_load.toml
+++ b/rules/windows/defense_evasion_posh_assembly_load.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/10/15"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 

--- a/rules/windows/defense_evasion_posh_assembly_load.toml
+++ b/rules/windows/defense_evasion_posh_assembly_load.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/10/15"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -133,7 +133,16 @@ event.category:process and host.os.type:windows and
   powershell.file.script_block_text : (
     "[System.Reflection.Assembly]::Load" or
     "[Reflection.Assembly]::Load"
-  ) and not user.id : "S-1-5-18"
+  ) and not 
+  powershell.file.script_block_text : (
+    ("CommonWorkflowParameters" or "RelatedLinksHelpInfo") and
+    "HelpDisplayStrings"
+  ) and not 
+  (powershell.file.script_block_text :
+    ("Get-SolutionFiles" or "Get-VisualStudio" or "Select-MSBuildPath") and
+    not file.name : "PathFunctions.ps1"
+  )
+  and not user.id : "S-1-5-18"
 '''
 
 

--- a/rules/windows/defense_evasion_posh_compressed.toml
+++ b/rules/windows/defense_evasion_posh_compressed.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 
 [transform]
 [[transform.osquery]]
@@ -141,6 +141,7 @@ event.category:process and host.os.type:windows and
   ) and not 
   (user.id:("S-1-5-18" or "S-1-5-19") and
    file.directory: "C:\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Downloads")
+  and not user.id : "S-1-5-18"
 '''
 
 

--- a/rules/windows/defense_evasion_posh_compressed.toml
+++ b/rules/windows/defense_evasion_posh_compressed.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/discovery_posh_suspicious_api_functions.toml
+++ b/rules/windows/discovery_posh_suspicious_api_functions.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/discovery_posh_suspicious_api_functions.toml
+++ b/rules/windows/discovery_posh_suspicious_api_functions.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 
 [rule]
 author = ["Elastic"]
@@ -109,9 +109,8 @@ event.category:process and host.os.type:windows and
     LsaEnumerateTrustedDomains  or
     NetScheduleJobEnum or
     NetUserModalsGet
-  ) and not 
-  (user.id:("S-1-5-18" or "S-1-5-19") and
-   file.directory: "C:\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\DataCollection")
+  )
+  and not user.id : ("S-1-5-18" or "S-1-5-19")
 '''
 
 

--- a/rules/windows/execution_posh_hacktool_functions.toml
+++ b/rules/windows/execution_posh_hacktool_functions.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/17"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 

--- a/rules/windows/execution_posh_hacktool_functions.toml
+++ b/rules/windows/execution_posh_hacktool_functions.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/17"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -53,8 +53,7 @@ event.category:process and host.os.type:windows and
     "Add-RemoteConnection" or "Add-ServiceDacl" or
     "Add-Win32Type" or "Convert-ADName" or
     "Convert-LDAPProperty" or "ConvertFrom-LDAPLogonHours" or
-    "ConvertFrom-SID" or "ConvertFrom-UACValue" or
-    "ConvertTo-SID" or "Copy-ArrayOfMemAddresses" or
+    "ConvertFrom-UACValue" or "Copy-ArrayOfMemAddresses" or
     "Create-NamedPipe" or "Create-ProcessWithToken" or
     "Create-RemoteThread" or "Create-SuspendedWinLogon" or
     "Create-WinLogonProcess" or "Emit-CallThreadStub" or
@@ -70,7 +69,7 @@ event.category:process and host.os.type:windows and
     "Find-ProcessDLLHijack" or "Find-RDPClientConnection" or
     "Get-AllAttributesForClass" or "Get-CachedGPPPassword" or
     "Get-DecryptedCpassword" or "Get-DecryptedSitelistPassword" or
-    "Get-DelegateType" or "Get-DomainController" or
+    "Get-DelegateType" or
     "Get-DomainDFSShare" or "Get-DomainDFSShareV1" or
     "Get-DomainDFSShareV2" or "Get-DomainDNSRecord" or
     "Get-DomainDNSZone" or "Get-DomainFileServer" or
@@ -94,7 +93,7 @@ event.category:process and host.os.type:windows and
     "Get-GPPInnerFields" or "Get-GPPPassword" or
     "Get-GptTmpl" or "Get-GroupsXML" or
     "Get-HttpStatus" or "Get-ImageNtHeaders" or
-    "Get-IniContent" or "Get-Keystrokes" or
+    "Get-Keystrokes" or
     "Get-MemoryProcAddress" or "Get-MicrophoneAudio" or
     "Get-ModifiablePath" or "Get-ModifiableRegistryAutoRun" or
     "Get-ModifiableScheduledTaskFile" or "Get-ModifiableService" or
@@ -105,9 +104,8 @@ event.category:process and host.os.type:windows and
     "Get-NetShare" or "Get-PEArchitecture" or
     "Get-PEBasicInfo" or "Get-PEDetailedInfo" or
     "Get-PathAcl" or "Get-PrimaryToken" or
-    "Get-PrincipalContext" or "Get-ProcAddress" or
-    "Get-ProcessTokenGroup" or "Get-ProcessTokenPrivilege" or
-    "Get-ProcessTokenType" or "Get-Property" or
+    "Get-ProcAddress" or "Get-ProcessTokenGroup" or
+    "Get-ProcessTokenPrivilege" or "Get-ProcessTokenType" or
     "Get-RegLoggedOn" or "Get-RegistryAlwaysInstallElevated" or
     "Get-RegistryAutoLogon" or "Get-RemoteProcAddress" or
     "Get-Screenshot" or "Get-ServiceDetail" or
@@ -140,7 +138,7 @@ event.category:process and host.os.type:windows and
     "Invoke-WmiCommand" or "Mount-VolumeShadowCopy" or
     "New-ADObjectAccessControlEntry" or "New-DomainGroup" or
     "New-DomainUser" or "New-DynamicParameter" or
-    "New-InMemoryModule" or "New-ScriptBlockCallback" or
+    "New-InMemoryModule" or
     "New-ThreadedFunction" or "New-VolumeShadowCopy" or
     "Out-CompressedDll" or "Out-EncodedCommand" or
     "Out-EncryptedScript" or "Out-Minidump" or
@@ -162,6 +160,9 @@ event.category:process and host.os.type:windows and
     "Get-DomainAccountPolicy" or "Get-DomainAdmins" or
     "Get-AVProcesses" or "Get-AVInfo" or
     "Get-RecycleBin"
+  )
+  and not powershell.file.script_block_text : (
+    "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
   )
 '''
 

--- a/rules/windows/privilege_escalation_posh_token_impersonation.toml
+++ b/rules/windows/privilege_escalation_posh_token_impersonation.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/00/00"
+updated_date = "2023/07/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/privilege_escalation_posh_token_impersonation.toml
+++ b/rules/windows/privilege_escalation_posh_token_impersonation.toml
@@ -4,7 +4,7 @@ integration = ["windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/00/00"
 
 [rule]
 author = ["Elastic"]
@@ -76,6 +76,9 @@ event.category:process and host.os.type:windows and
   ) and not 
   (user.id:("S-1-5-18" or "S-1-5-19") and
    file.directory: "C:\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Downloads")
+  and not powershell.file.script_block_text : (
+    "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
+  )
 '''
 
 


### PR DESCRIPTION
## Summary

Exclude widespread False Positives from PowerShell rules, with an honorable mention to SentinelOne https://github.com/mttaggart/wtfbins/issues/24:

> A legitimate PowerShell script associated with SentinelOne includes encoded PowerShell, AMSI bypass encoding, as well as strings for offensive security commands such as 'Invoke-Mimikatz'. If running another security solution - like Defender - it may flag this SentinelOne legitimate PowerShell activity as malicious.

This also corrects some legitimate activity and removes keywords used in many legitimate modules.