### PR TITLE
[New Rules] ftp/rdp bruteforce

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -125,5 +125,9 @@
   },
   "logs-ti_*": {
     "labels.is_ioc_transform_source": "keyword"
+  },
+  "logs-auditd_manager.auditd-*": {
+    "auditd.data.terminal": "keyword",
+    "auditd.data.addr": "keyword"
   }
 }

--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -125,9 +125,5 @@
   },
   "logs-ti_*": {
     "labels.is_ioc_transform_source": "keyword"
-  },
-  "logs-auditd_manager.auditd-*": {
-    "auditd.data.terminal": "keyword",
-    "auditd.data.addr": "keyword"
   }
 }

--- a/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
@@ -1,0 +1,75 @@
+[metadata]
+creation_date = "2023/07/06"
+integration = ["auditd_manager"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/07/06"
+
+[rule]
+author = ["Elastic"]
+description = """
+An FTP (file transfer protocol) brute force attack is a method where an attacker systematically tries different 
+combinations of usernames and passwords to gain unauthorized access to an FTP server, and if successful, the impact can 
+include unauthorized data access, manipulation, or theft, compromising the security and integrity of the server and 
+potentially exposing sensitive information. This rule identifies multiple consecutive authentication failures targeting 
+a specific user account from the same source address and within a short time interval, followed by a succesful 
+authentication.
+"""
+from = "now-9m"
+index = ["auditbeat-*", "logs-auditd_manager.auditd-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Successful Linux FTP Brute Force Attack Detected"
+note = """## Setup
+This rule requires the use of the `auditd_manager` integration. `Auditd_manager` is a tool designed to simplify and enhance the management of the audit subsystem in Linux systems. It provides a user-friendly interface and automation capabilities for configuring and monitoring system auditing through the auditd daemon. With `auditd_manager`, administrators can easily define audit rules, track system events, and generate comprehensive audit reports, improving overall security and compliance in the system. The following steps should be executed in order to install and deploy `auditd_manager` on a Linux system. 
+```
+Kibana -->
+Management -->
+Integrations -->
+Auditd Manager -->
+Add Auditd Manager
+```
+`Auditd_manager` subscribes to the kernel and receives events as they occur without any additional configuration. However, if more advanced configuration is required to detect specific behavior, audit rules can be added to the integration in either the "audit rules" configuration box or the "auditd rule files" box by specifying a file to read the audit rules from. 
+```
+For this detection rule no additional audit rules are required to be added to the integration. 
+```
+Add the newly installed `auditd manager` to an agent policy, and deploy the agent on a Linux system from which auditd log files are desirable.
+"""
+risk_score = 47
+rule_id = "66712812-e7f2-4a1d-bbda-dd0b5cf20c5d"
+severity = "medium"
+tags = ["OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
+type = "eql"
+query = '''
+sequence by host.id, auditd.data.addr, related.user with maxspan=5s
+  [authentication where host.os.type == "linux" and event.action == "authenticated" and 
+   auditd.data.terminal == "ftp" and event.outcome == "failure" and auditd.data.addr != null and 
+   auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] with runs=10
+  [authentication where host.os.type == "linux" and event.action  == "authenticated" and 
+   auditd.data.terminal == "ftp" and event.outcome == "success" and auditd.data.addr != null and 
+   auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] | tail 1
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.001"
+name = "Password Guessing"
+reference = "https://attack.mitre.org/techniques/T1110/001/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.003"
+name = "Password Spraying"
+reference = "https://attack.mitre.org/techniques/T1110/003/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
@@ -13,7 +13,7 @@ An FTP (file transfer protocol) brute force attack is a method where an attacker
 combinations of usernames and passwords to gain unauthorized access to an FTP server, and if successful, the impact can 
 include unauthorized data access, manipulation, or theft, compromising the security and integrity of the server and 
 potentially exposing sensitive information. This rule identifies multiple consecutive authentication failures targeting 
-a specific user account from the same source address and within a short time interval, followed by a succesful 
+a specific user account from the same source address and within a short time interval, followed by a successful 
 authentication.
 """
 from = "now-9m"

--- a/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
@@ -43,12 +43,12 @@ tags = ["OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
 type = "eql"
 query = '''
 sequence by host.id, auditd.data.addr, related.user with maxspan=5s
-  [authentication where host.os.type == "linux" and event.action == "authenticated" and 
-   auditd.data.terminal == "ftp" and event.outcome == "failure" and auditd.data.addr != null and 
-   auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] with runs=10
-  [authentication where host.os.type == "linux" and event.action  == "authenticated" and 
-   auditd.data.terminal == "ftp" and event.outcome == "success" and auditd.data.addr != null and 
-   auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] | tail 1
+  [authentication where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
+   event.action == "authenticated" and auditd.data.terminal == "ftp" and event.outcome == "failure" and 
+   auditd.data.addr != null and auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] with runs=10
+  [authentication where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
+   event.action  == "authenticated" and auditd.data.terminal == "ftp" and event.outcome == "success" and 
+   auditd.data.addr != null and auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] | tail 1
 '''
 
 [[rule.threat]]

--- a/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
@@ -39,7 +39,7 @@ Add the newly installed `auditd manager` to an agent policy, and deploy the agen
 risk_score = 47
 rule_id = "66712812-e7f2-4a1d-bbda-dd0b5cf20c5d"
 severity = "medium"
-tags = ["OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
 type = "eql"
 query = '''
 sequence by host.id, auditd.data.addr, related.user with maxspan=5s

--- a/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
@@ -14,7 +14,7 @@ password combinations to gain unauthorized access to a remote computer via RDP, 
 can include unauthorized control over the compromised system, data theft, or the ability to launch further attacks 
 within the network, jeopardizing the security and confidentiality of the targeted system and potentially compromising 
 the entire network infrastructure. This rule identifies multiple consecutive authentication failures targeting a 
-specific user account within a short time interval, followed by a succesful authentication.
+specific user account within a short time interval, followed by a successful authentication.
 """
 from = "now-9m"
 index = ["auditbeat-*", "logs-auditd_manager.auditd-*"]

--- a/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
@@ -43,10 +43,10 @@ tags = ["OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
 type = "eql"
 query = '''
 sequence by host.id, related.user with maxspan=5s
-  [authentication where host.os.type == "linux" and event.action == "authenticated" and 
-   auditd.data.terminal : "*rdp*" and event.outcome == "failure"] with runs=10
-  [authentication where host.os.type == "linux" and event.action  == "authenticated" and 
-   auditd.data.terminal : "*rdp*" and event.outcome == "success"] | tail 1
+  [authentication where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
+   event.action == "authenticated" and auditd.data.terminal : "*rdp*" and event.outcome == "failure"] with runs=10
+  [authentication where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
+   event.action  == "authenticated" and auditd.data.terminal : "*rdp*" and event.outcome == "success"] | tail 1
 '''
 
 [[rule.threat]]

--- a/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
@@ -39,7 +39,7 @@ Add the newly installed `auditd manager` to an agent policy, and deploy the agen
 risk_score = 47
 rule_id = "521fbe5c-a78d-4b6b-a323-f978b0e4c4c0"
 severity = "medium"
-tags = ["OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
 type = "eql"
 query = '''
 sequence by host.id, related.user with maxspan=5s

--- a/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
@@ -1,0 +1,73 @@
+[metadata]
+creation_date = "2023/07/06"
+integration = ["auditd_manager"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/07/06"
+
+[rule]
+author = ["Elastic"]
+description = """
+An RDP (Remote Desktop Protocol) brute force attack involves an attacker repeatedly attempting various username and 
+password combinations to gain unauthorized access to a remote computer via RDP, and if successful, the potential impact
+can include unauthorized control over the compromised system, data theft, or the ability to launch further attacks 
+within the network, jeopardizing the security and confidentiality of the targeted system and potentially compromising 
+the entire network infrastructure. This rule identifies multiple consecutive authentication failures targeting a 
+specific user account within a short time interval, followed by a succesful authentication.
+"""
+from = "now-9m"
+index = ["auditbeat-*", "logs-auditd_manager.auditd-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Successful Linux RDP Brute Force Attack Detected"
+note = """## Setup
+This rule requires the use of the `auditd_manager` integration. `Auditd_manager` is a tool designed to simplify and enhance the management of the audit subsystem in Linux systems. It provides a user-friendly interface and automation capabilities for configuring and monitoring system auditing through the auditd daemon. With `auditd_manager`, administrators can easily define audit rules, track system events, and generate comprehensive audit reports, improving overall security and compliance in the system. The following steps should be executed in order to install and deploy `auditd_manager` on a Linux system. 
+```
+Kibana -->
+Management -->
+Integrations -->
+Auditd Manager -->
+Add Auditd Manager
+```
+`Auditd_manager` subscribes to the kernel and receives events as they occur without any additional configuration. However, if more advanced configuration is required to detect specific behavior, audit rules can be added to the integration in either the "audit rules" configuration box or the "auditd rule files" box by specifying a file to read the audit rules from. 
+```
+For this detection rule no additional audit rules are required to be added to the integration. 
+```
+Add the newly installed `auditd manager` to an agent policy, and deploy the agent on a Linux system from which auditd log files are desirable.
+"""
+risk_score = 47
+rule_id = "521fbe5c-a78d-4b6b-a323-f978b0e4c4c0"
+severity = "medium"
+tags = ["OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
+type = "eql"
+query = '''
+sequence by host.id, related.user with maxspan=5s
+  [authentication where host.os.type == "linux" and event.action == "authenticated" and 
+   auditd.data.terminal : "*rdp*" and event.outcome == "failure"] with runs=10
+  [authentication where host.os.type == "linux" and event.action  == "authenticated" and 
+   auditd.data.terminal : "*rdp*" and event.outcome == "success"] | tail 1
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.001"
+name = "Password Guessing"
+reference = "https://attack.mitre.org/techniques/T1110/001/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.003"
+name = "Password Spraying"
+reference = "https://attack.mitre.org/techniques/T1110/003/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"


### PR DESCRIPTION
## Summary
This PR proposes the addition of two new `auditd_manager` rules to detect a successful brute force attack on FTP/RDP services in Linux. This behavior is not logged by default such as for example ssh login attempts are. The PR proposes the following two new rules:

1. Potential Successful Linux RDP Brute Force Attack Detected
2. Potential Successful Linux FTP Brute Force Attack Detected

## Auditd Manager Setup Guide
As there was no `auditd manager` setup guide available yet, I wrote a new one. Please comment on how to improve this set up guide, and I will add the improvements to all upcoming auditd manager related rules.

## Potential Successful Linux RDP Brute Force Attack Detected
An RDP (Remote Desktop Protocol) brute force attack involves an attacker repeatedly attempting various username and password combinations to gain unauthorized access to a remote computer via RDP, and if successful, the potential impact can include unauthorized control over the compromised system, data theft, or the ability to launch further attacks within the network, jeopardizing the security and confidentiality of the targeted system and potentially compromising the entire network infrastructure. This rule identifies multiple consecutive authentication failures targeting a specific user account within a short time interval, followed by a succesful authentication.

### Detection 
```
sequence by host.id, related.user with maxspan=5s
  [authentication where host.os.type == "linux" and event.action == "authenticated" and 
   auditd.data.terminal : "*rdp*" and event.outcome == "failure"] with runs=10

  [authentication where host.os.type == "linux" and event.action  == "authenticated" and 
   auditd.data.terminal : "*rdp*" and event.outcome == "success"] | tail 1
```
<img width="2028" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/a0283e9a-88f6-488f-82ba-c2d7178c699b">

The reasoning behind the higher runs for the RDP rule is that `auditd_manager` does not capture a source.ip or auditd.data.addr for RDP. By increasing the runs, I figured it would be less prone to FPs. 

## Potential Successful Linux FTP Brute Force Attack Detected
An FTP (file transfer protocol) brute force attack is a method where an attacker systematically tries different combinations of usernames and passwords to gain unauthorized access to an FTP server, and if successful, the impact can include unauthorized data access, manipulation, or theft, compromising the security and integrity of the server and potentially exposing sensitive information. This rule identifies multiple consecutive authentication failures targeting a specific user account from the same source address and within a short time interval, followed by a succesful authentication.

### Detection
```
sequence by host.id, auditd.data.addr, related.user with maxspan=3s
  [authentication where host.os.type == "linux" and event.action == "authenticated" and 
   auditd.data.terminal == "ftp" and event.outcome == "failure" and auditd.data.addr != null and 
   auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] with runs=5

  [authentication where host.os.type == "linux" and event.action  == "authenticated" and 
   auditd.data.terminal == "ftp" and event.outcome == "success" and auditd.data.addr != null and 
   auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] | tail 1
```
<img width="1967" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/f5cf3b37-0418-4b62-bd9f-d54a30873480">