### PR TITLE
[FR] Add EQL Rule Type Configuration Fields

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -698,9 +698,9 @@ class EQLRuleData(QueryRuleData):
     """EQL rules are a special case of query rules."""
     type: Literal["eql"]
     language: Literal["eql"]
-    timestamp_field: Optional[str]
-    event_category_override: Optional[str]
-    tiebreaker_field: Optional[str]
+    timestamp_field: Optional[str] = field(metadata=dict(metadata=dict(min_compat="8.0")))
+    event_category_override: Optional[str] = field(metadata=dict(metadata=dict(min_compat="8.0")))
+    tiebreaker_field: Optional[str] = field(metadata=dict(metadata=dict(min_compat="8.0")))
 
     def convert_relative_delta(self, lookback: str) -> int:
         now = len("now")

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -698,6 +698,9 @@ class EQLRuleData(QueryRuleData):
     """EQL rules are a special case of query rules."""
     type: Literal["eql"]
     language: Literal["eql"]
+    timestamp_field: Optional[str]
+    event_category_override: Optional[str]
+    tiebreaker_field: Optional[str]
 
     def convert_relative_delta(self, lookback: str) -> int:
         now = len("now")

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -6,6 +6,7 @@
 """Validation logic for rules containing queries."""
 from functools import cached_property
 from typing import List, Optional, Union
+from semver import Version
 
 import eql
 
@@ -13,6 +14,7 @@ import kql
 
 from . import ecs, endgame
 from .integrations import get_integration_schema_data, load_integrations_manifests
+from .misc import load_current_package_version
 from .schemas import get_stack_schemas
 from .rule import QueryRuleData, QueryValidator, RuleMeta, TOMLRuleContents
 
@@ -197,7 +199,8 @@ class EQLValidator(QueryValidator):
 
             rule_type_config_fields, rule_type_config_validation = self.validate_rule_type_configurations(data, meta)
             if rule_type_config_validation:
-                raise ValueError(f"Rule type config values are not valid, check these values: {rule_type_config_fields}")
+                raise ValueError(f"""Rule type config values are not valid, check these values:
+                                 {rule_type_config_fields}""")
 
     def validate_stack_combos(self, data: QueryRuleData, meta: RuleMeta) -> Union[EQL_ERROR_TYPES, None, ValueError]:
         """Validate the query against ECS and beats schemas across stack combinations."""

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -200,7 +200,7 @@ class EQLValidator(QueryValidator):
             rule_type_config_fields, rule_type_config_validation_failed = \
                 self.validate_rule_type_configurations(data, meta)
             if rule_type_config_validation_failed:
-                raise ValueError(f"""Rule type config values are not valid, check these values:
+                raise ValueError(f"""Rule type config values are not ECS compliant, check these values:
                                  {rule_type_config_fields}""")
 
     def validate_stack_combos(self, data: QueryRuleData, meta: RuleMeta) -> Union[EQL_ERROR_TYPES, None, ValueError]:

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -323,10 +323,9 @@ class EQLValidator(QueryValidator):
         if data.timestamp_field or data.event_category_override or data.tiebreaker_field:
 
             # get a list of rule type configuration fields
-            set_fields = [f for f in [
-                data.get("timestamp_field"),
-                data.get("event_category_override"),
-                data.get("tiebreaker_field")] if f]
+            # Get a list of rule type configuration fields
+            fields = ["timestamp_field", "event_category_override", "tiebreaker_field"]
+            set_fields = list(filter(None, (data.get(field) for field in fields)))
 
             # get stack_version and ECS schema
             min_stack_version = meta.get("min_stack_version")


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/2811

## Summary
This PR adds the following EQL rule type configuration fields:

* `timestamp_field`
* `event_category_override`
* `tiebreaker_field`

These fields are only available in EQL rules as shown in the image below.

<img width="1015" alt="Screenshot 2023-07-10 at 10 45 15 PM" src="https://github.com/elastic/detection-rules/assets/99630311/132f2046-4d72-4b58-98f3-c2f8b8ae27c9">

To begin, a custom rule was created in the UI and then exported. These three fields are in the base of the rule.

<details>
<summary> Exported Rule </summary>

```
{
  "id": "4fcc35d0-1f97-11ee-9323-995da7e2ec1a",
  "updated_at": "2023-07-11T03:02:04.098Z",
  "updated_by": "4220331459",
  "created_at": "2023-07-11T03:02:03.444Z",
  "created_by": "4220331459",
  "name": "EQL Defined Rule",
  "tags": [
    "Testing"
  ],
  "interval": "10m",
  "enabled": false,
  "description": "EQL Defined RUle",
  "risk_score": 21,
  "severity": "low",
  "license": "",
  "output_index": "",
  "meta": {
    "from": "1m",
    "kibana_siem_app_url": "https://dejesus-threat-detection-dev.kb.us-central1.gcp.cloud.es.io:9243/app/security"
  },
  "author": [],
  "false_positives": [],
  "from": "now-660s",
  "rule_id": "6e38e1ab-48bc-4919-8707-0d3f6e0b1122",
  "max_signals": 100,
  "risk_score_mapping": [],
  "severity_mapping": [],
  "threat": [],
  "to": "now",
  "references": [],
  "version": 1,
  "exceptions_list": [],
  "immutable": false,
  "related_integrations": [],
  "required_fields": [],
  "setup": "",
  "type": "eql",
  "language": "eql",
  "index": [
    "logs-endpoint*"
  ],
  "query": "process where process.name : \"0utlook.exe\"",
  "filters": [],
  "timestamp_field": "@timestamp",
  "event_category_override": "event.module",
  "tiebreaker_field": "event.dataset",
  "throttle": "no_actions",
  "actions": []
}
```

</details>

#### Solution
Since these fields are only available for EQL rule types, they have been added to `EQLRuleData` which when instantiated, takes `QueryRuleData`. This is more appropriate than `BaseRuleData` which would then make it acceptable for other rule types.

Below is an example rule created to test if the import was successful, indicating the rule object, when converted, is properly loaded and accepted.

<details>
<summary> Custom Rule for UI Import </summary>

```
[metadata]
creation_date = "2023/01/31"
integration = ["endpoint", "windows"]
maturity = "production"
min_stack_comments = "New fields added: required_fields, related_integrations, setup"
min_stack_version = "8.3.0"
updated_date = "2023/06/22"

[transform]
[[transform.osquery]]
label = "Osquery - Retrieve All Non-Microsoft Drivers with Virustotal Link"
query = """
SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, class, description, directory, image, issuer_name, manufacturer, service, signed, subject_name FROM drivers JOIN authenticode ON drivers.image = authenticode.path JOIN hash ON drivers.image = hash.path WHERE NOT (provider == "Microsoft" AND signed == "1")
"""

[[transform.osquery]]
label = "Osquery - Retrieve All Unsigned Drivers with Virustotal Link"
query = """
SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, class, description, directory, image, issuer_name, manufacturer, service, signed, subject_name FROM drivers JOIN authenticode ON drivers.image = authenticode.path JOIN hash ON drivers.image = hash.path WHERE signed == "0"
"""

[rule]
author = ["Elastic"]
description = """
Identifies attempts to disable/modify the code signing policy through the registry. Code signing provides
authenticity on a program, and grants the user with the ability to check whether the program has been tampered with.
By allowing the execution of unsigned or self-signed code, threat actors can craft and execute malicious code.
"""
from = "now-9m"
index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*", "endgame-*"]
language = "eql"
license = "Elastic License v2"
name = "Code Signing Policy Modification Through Registry"
note = """## Triage and analysis

### Investigating Code Signing Policy Modification Through Registry

Microsoft created the Windows Driver Signature Enforcement (DSE) security feature to prevent drivers with invalid signatures from loading and executing into the kernel (ring 0). DSE aims to protect systems by blocking attackers from loading malicious drivers on targets.

This protection is essential for maintaining system security. However, attackers or administrators can disable DSE and load untrusted drivers, which can put the system at risk. Therefore, it's important to keep this feature enabled and only load drivers from trusted sources to ensure system integrity and security.

This rule identifies registry modifications that can disable DSE.

> **Note**:
> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.

#### Possible investigation steps

- Identify the user account that performed the action and whether it should perform this kind of action.
- Investigate the process execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
- Investigate other alerts associated with the user/host during the past 48 hours.
- Use Osquery and endpoint driver events (`event.category = "driver"`) to investigate if suspicious drivers were loaded into the system after the registry was modified.
  - $osquery_0
  - $osquery_1
- Identify the driver's `Device Name` and `Service Name`.
- Check for alerts from the rules specified in the `Related Rules` section.

### False positive analysis

- This activity should not happen legitimately. The security team should address any potential benign true positive (B-TP), as this configuration can put the user and the domain at risk.

### Related Rules

- First Time Seen Driver Loaded - df0fd41e-5590-4965-ad5e-cd079ec22fa9
- Untrusted Driver Loaded - d8ab1ec1-feeb-48b9-89e7-c12e189448aa
- Code Signing Policy Modification Through Built-in tools - b43570de-a908-4f7f-8bdb-b2df6ffd8c80

### Response and remediation

- Initiate the incident response process based on the outcome of the triage.
- Isolate the involved host to prevent further post-compromise behavior.
- Disable and uninstall all suspicious drivers found in the system. This can be done via Device Manager. (Note that this step may require you to boot the system into Safe Mode.)
- Remove the related services and registry keys found in the system. Note that the service will probably not stop if the driver is still installed.
  - This can be done via PowerShell `Remove-Service` cmdlet.
- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
- Remove and block malicious artifacts identified during triage.
- Ensure that the Driver Signature Enforcement is enabled on the system.
- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
"""
risk_score = 47
rule_id = "4e6f51c4-1f9a-11ee-9b79-f661ea17fbcd"
severity = "medium"
tags = [
    "Domain: Endpoint",
    "OS: Windows",
    "Use Case: Threat Detection",
    "Tactic: Defense Evasion",
    "Data Source: Elastic Endgame",
    "Resources: Investigation Guide"
]
timestamp_override = "event.ingested"
timestamp_field = "@timestamp"
event_category_override = "event.module"
tiebreaker_field = "event.ingested"
type = "eql"

query = '''
registry where host.os.type == "windows" and event.type : ("creation", "change") and
(
  registry.path : "HKEY_USERS\\*\\Software\\Policies\\Microsoft\\Windows NT\\Driver Signing\\BehaviorOnFailedVerify" and
  registry.value: "BehaviorOnFailedVerify" and
  registry.data.strings : ("0", "0x00000000", "1", "0x00000001")
)
'''

[[rule.threat]]
framework = "MITRE ATT&CK"
[[rule.threat.technique]]
id = "T1553"
name = "Subvert Trust Controls"
reference = "https://attack.mitre.org/techniques/T1553/"
[[rule.threat.technique.subtechnique]]
id = "T1553.006"
name = "Code Signing Policy Modification"
reference = "https://attack.mitre.org/techniques/T1553/006/"



[rule.threat.tactic]
id = "TA0005"
name = "Defense Evasion"
reference = "https://attack.mitre.org/tactics/TA0005/"

```

</details>

Below shows the rule successfully importing, loading and the configuration fields being set.

<img width="400" alt="Screenshot 2023-07-10 at 11 28 16 PM" src="https://github.com/elastic/detection-rules/assets/99630311/88e207f8-964d-4790-bd24-e140f651d787">
<img width="1392" alt="Screenshot 2023-07-10 at 11 28 53 PM" src="https://github.com/elastic/detection-rules/assets/99630311/346184b7-2f8c-43f6-a7e1-6f41533d6328">
<img width="1096" alt="Screenshot 2023-07-10 at 11 29 57 PM" src="https://github.com/elastic/detection-rules/assets/99630311/98acc10b-71f6-40a6-82e9-b3fb0c7bf5e3">


## Testing
### Prerequisites
1: Checkout branch
2: Copy test rule for import above locally to `/windows` folder

### Test Rules Load Properly into Stack
1. copy the rule ID to your clipboard
1. build a package: `python -m detection_rules dev build-release`
2. trim the importable rules file; under `detection_rules/releases/8.10/extras/8.10-consolidated-rules.ndjson` search for the rule id; remove all lines that are NOT this rule
3. Save file
4. Open Kibana UI > Security > manage rules > import
5. drag and drop or upload the `8.10-consolidated-rules.ndjson`
6. Expected result: `Rule Successfully loaded` or similar


### Test Only ECS Fields are Valid
1. run `python -m detection_rules view-rule PATH_TO_RULE`
2. this rule already has ECS fields in it that are valid, the rule API object should be shown in the output

### Test Any Non-ECS Fields Fail Correctly
1. change any of the following field values and run `view-rule`; an error should be raised

```
timestamp_field
event_category_override
tiebreaker_field
```


