### PR TITLE
[Security Content] Added Compatibility note to all IGs

### DIFF
--- a/rules/linux/persistence_init_d_file_creation.toml
+++ b/rules/linux/persistence_init_d_file_creation.toml
@@ -68,7 +68,7 @@ This rule looks for the creation of new files within the `/etc/init.d/` director
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.   
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 #### Possible Investigation Steps
 
 - Investigate the file that was created or modified.

--- a/rules/linux/persistence_init_d_file_creation.toml
+++ b/rules/linux/persistence_init_d_file_creation.toml
@@ -68,7 +68,7 @@ This rule looks for the creation of new files within the `/etc/init.d/` director
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.   
 #### Possible Investigation Steps
 
 - Investigate the file that was created or modified.

--- a/rules/linux/persistence_init_d_file_creation.toml
+++ b/rules/linux/persistence_init_d_file_creation.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "Multiple field support in the New Terms rule type was added in Elastic 8.6"
 min_stack_version = "8.6.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -68,7 +68,7 @@ This rule looks for the creation of new files within the `/etc/init.d/` director
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 #### Possible Investigation Steps
 
 - Investigate the file that was created or modified.

--- a/rules/linux/persistence_linux_backdoor_user_creation.toml
+++ b/rules/linux/persistence_linux_backdoor_user_creation.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -50,6 +50,7 @@ This rule identifies the usage of the `usermod` command to set a user's UID to 0
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible investigation steps
 - Investigate the user account that got assigned a uid of 0, and analyze its corresponding attributes.

--- a/rules/linux/persistence_linux_backdoor_user_creation.toml
+++ b/rules/linux/persistence_linux_backdoor_user_creation.toml
@@ -50,7 +50,7 @@ This rule identifies the usage of the `usermod` command to set a user's UID to 0
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible investigation steps
 - Investigate the user account that got assigned a uid of 0, and analyze its corresponding attributes.

--- a/rules/linux/persistence_linux_group_creation.toml
+++ b/rules/linux/persistence_linux_group_creation.toml
@@ -4,7 +4,7 @@ integration = ["system"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -45,6 +45,7 @@ This rule identifies the usages of `groupadd` and `addgroup` to create new group
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible investigation steps
 

--- a/rules/linux/persistence_linux_group_creation.toml
+++ b/rules/linux/persistence_linux_group_creation.toml
@@ -45,7 +45,7 @@ This rule identifies the usages of `groupadd` and `addgroup` to create new group
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible investigation steps
 

--- a/rules/linux/persistence_linux_shell_activity_via_web_server.toml
+++ b/rules/linux/persistence_linux_shell_activity_via_web_server.toml
@@ -55,7 +55,7 @@ This rule detects a web server process spawning script and command line interfac
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible investigation steps
 

--- a/rules/linux/persistence_linux_shell_activity_via_web_server.toml
+++ b/rules/linux/persistence_linux_shell_activity_via_web_server.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -55,6 +55,7 @@ This rule detects a web server process spawning script and command line interfac
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible investigation steps
 

--- a/rules/linux/persistence_linux_user_account_creation.toml
+++ b/rules/linux/persistence_linux_user_account_creation.toml
@@ -4,7 +4,7 @@ integration = ["system"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -45,6 +45,7 @@ This rule identifies the usage of `useradd` and `adduser` to create new accounts
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible investigation steps
 

--- a/rules/linux/persistence_linux_user_account_creation.toml
+++ b/rules/linux/persistence_linux_user_account_creation.toml
@@ -45,7 +45,7 @@ This rule identifies the usage of `useradd` and `adduser` to create new accounts
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible investigation steps
 

--- a/rules/linux/persistence_linux_user_added_to_privileged_group.toml
+++ b/rules/linux/persistence_linux_user_added_to_privileged_group.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -46,6 +46,7 @@ This rule identifies the usages of `usermod`, `adduser` and `gpasswd` to assign 
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible investigation steps
 

--- a/rules/linux/persistence_linux_user_added_to_privileged_group.toml
+++ b/rules/linux/persistence_linux_user_added_to_privileged_group.toml
@@ -46,7 +46,7 @@ This rule identifies the usages of `usermod`, `adduser` and `gpasswd` to assign 
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible investigation steps
 

--- a/rules/linux/persistence_message_of_the_day_creation.toml
+++ b/rules/linux/persistence_message_of_the_day_creation.toml
@@ -69,7 +69,7 @@ This rule identifies the creation of new files within the `/etc/update-motd.d/` 
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible Investigation Steps
 

--- a/rules/linux/persistence_message_of_the_day_creation.toml
+++ b/rules/linux/persistence_message_of_the_day_creation.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "Multiple field support in the New Terms rule type was added in Elastic 8.6"
 min_stack_version = "8.6.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -69,6 +69,7 @@ This rule identifies the creation of new files within the `/etc/update-motd.d/` 
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible Investigation Steps
 

--- a/rules/linux/persistence_message_of_the_day_execution.toml
+++ b/rules/linux/persistence_message_of_the_day_execution.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -68,6 +68,7 @@ This rule identifies the execution of potentially malicious processes from a MOT
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible Investigation Steps
 

--- a/rules/linux/persistence_message_of_the_day_execution.toml
+++ b/rules/linux/persistence_message_of_the_day_execution.toml
@@ -68,7 +68,7 @@ This rule identifies the execution of potentially malicious processes from a MOT
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible Investigation Steps
 

--- a/rules/linux/persistence_rc_script_creation.toml
+++ b/rules/linux/persistence_rc_script_creation.toml
@@ -50,7 +50,7 @@ Detection alerts from this rule indicate the creation of a new `/etc/rc.local` f
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible Investigation Steps
 

--- a/rules/linux/persistence_rc_script_creation.toml
+++ b/rules/linux/persistence_rc_script_creation.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "Multiple field support in the New Terms rule type was added in Elastic 8.6"
 min_stack_version = "8.6.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -50,6 +50,7 @@ Detection alerts from this rule indicate the creation of a new `/etc/rc.local` f
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible Investigation Steps
 

--- a/rules/linux/persistence_systemd_scheduled_timer_created.toml
+++ b/rules/linux/persistence_systemd_scheduled_timer_created.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "Multiple field support in the New Terms rule type was added in Elastic 8.6"
 min_stack_version = "8.6.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -81,6 +81,7 @@ This rule monitors the creation of new systemd timer files, potentially indicati
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
 
 #### Possible Investigation Steps
 

--- a/rules/linux/persistence_systemd_scheduled_timer_created.toml
+++ b/rules/linux/persistence_systemd_scheduled_timer_created.toml
@@ -81,7 +81,7 @@ This rule monitors the creation of new systemd timer files, potentially indicati
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide leverages functionality that allows the usage of variables within the OSQuery queries. These variables will be directly populated by the corresponding values within the detection alert at run time. This feature has been introduced in Elastic Stack version 8.7.0. Older Elastic Stack versions will not be able to leverage this feature, and will require manual adjustments to run the query.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
 
 #### Possible Investigation Steps
 


### PR DESCRIPTION
## Summary
Added the following note:

`> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.`

To the following IGs:

- Potential Persistence Through init.d Detected
- Potential Linux Backdoor User Account Creation
- Linux Group Creation
- Potential Remote Code Execution via Web Server
- Linux User Account Creation
- Linux User Added to Privileged Group
- Potential Persistence Through MOTD File Creation Detected
- Suspicious Process Spawned from MOTD Detected
- Potential Persistence Through Run Control Detected
- New Systemd Timer Created