### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 	"marshmallow~=3.13.0",
 	"pywin32 ; platform_system=='Windows'",
 	"pytoml",
-	"PyYAML~=5.3",
+	"PyYAML~=6.0.1",
 	"requests~=2.27",
 	"toml==0.10.0",
 	"typing-inspect==0.8.0",


### PR DESCRIPTION
upgrading PyYAML to latest due to "The license_file parameter is deprecated, use license_files instead" error

<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- [Link to related issues. Use closing keywords when appropriate](https://github.com/elastic/detection-rules/issues/2942) -->

## Summary



## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
