### PR TITLE
[Tuning] Improve Performance

### DIFF
--- a/rules/windows/credential_access_remote_sam_secretsdump.toml
+++ b/rules/windows/credential_access_remote_sam_secretsdump.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "system", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/21"
 
 [rule]
 author = ["Elastic"]
@@ -76,19 +76,9 @@ tags = [
 type = "eql"
 
 query = '''
-sequence by host.id, user.id with maxspan=1m
- [authentication where
-   event.outcome == "success" and event.action == "logged-in" and
-   winlog.logon.type == "Network" and not user.name == "ANONYMOUS LOGON" and
-   not user.domain == "NT AUTHORITY" and source.ip != "127.0.0.1" and source.ip !="::1"]
- [file where event.action == "creation" and process.name : "svchost.exe" and
+file where event.action == "creation" and process.name : "svchost.exe" and
   file.Ext.header_bytes : "72656766*" and user.id : ("S-1-5-21-*", "S-1-12-1-*") and file.size >= 30000 and
-  not file.path :
-           ("?:\\Windows\\system32\\HKEY_LOCAL_MACHINE_SOFTWARE_Microsoft_*.registry",
-            "?:\\Users\\*\\AppData\\Local\\Microsoft\\Windows\\UsrClass.dat.LOG?",
-            "?:\\Users\\*\\AppData\\Local\\Microsoft\\Windows\\UsrClass.dat",
-            "?:\\Users\\*\\ntuser.dat.LOG?",
-            "?:\\Users\\*\\NTUSER.DAT")]
+  file.path : ("?:\\Windows\\system32\\*.tmp", "?:\\WINDOWS\\Temp\\*.tmp")
 '''
 
 

--- a/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
+++ b/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
@@ -4,7 +4,7 @@ integration = ["system", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/21"
 
 [rule]
 author = ["Elastic"]
@@ -30,21 +30,13 @@ tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic
 type = "eql"
 
 query = '''
-sequence by winlog.computer_name with maxspan=5m
-
-  [authentication where event.action == "logged-in" and
-   winlog.logon.type == "Network" and event.outcome == "success" and
-   not user.name == "ANONYMOUS LOGON" and not winlog.event_data.SubjectUserName : "*$" and
-   not user.domain == "NT AUTHORITY" and source.ip != "127.0.0.1" and source.ip !="::1"] by winlog.event_data.TargetLogonId
-
-  [iam where event.action == "changed-computer-account" and
+iam where event.action == "changed-computer-account" and
 
     /* if DnsHostName value equal a DC DNS hostname then it's highly suspicious */
     winlog.event_data.DnsHostName : "??*" and
 
     /* exclude FPs where DnsHostName starts with the ComputerName that was changed */
     not startswith~(winlog.event_data.DnsHostName, substring(winlog.event_data.TargetUserName, 0, length(winlog.event_data.TargetUserName) - 1))
-    ] by winlog.event_data.SubjectLogonId
 '''
 
 


### PR DESCRIPTION
Remote Computer Account DnsHostName Update : sequence not needed, removed auth event to improve rule execution time.

Potential Remote Credential Access via Registry : removed sequence, since user.id is reported as std user SID (svchost is impersonating a remote user), and reduced file.path to known bad (based on observed TPs)

