### PR TITLE
[Rule Tuning] Tune Threat Indicator Match Rules

### DIFF
--- a/rules/cross-platform/threat_intel_indicator_match_hash.toml
+++ b/rules/cross-platform/threat_intel_indicator_match_hash.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2023/05/22"
 maturity = "production"
-updated_date = "2023/06/27"
+updated_date = "2023/07/24"
 min_stack_comments = """
 Limiting the backport of these rules to the stack version which we are deprecating the Threat Intel Indicator Match
 general rules.
@@ -44,7 +44,7 @@ threat_query = '''
 '''
 
 query = """
-file.hash.*:* or file.pe.imphash:*  or process.hash.*:* or process.pe.imphash:* or dll.hash.*:* or dll.pe.imphash:* 
+file.hash.*:* or file.pe.imphash:* or process.hash.*:* or process.pe.imphash:* or dll.hash.*:*
 """
 
 
@@ -146,12 +146,6 @@ value = "threat.indicator.file.hash.sha1"
 field = "process.hash.sha256"
 type = "mapping"
 value = "threat.indicator.file.hash.sha256"
-
-[[rule.threat_mapping]]
-[[rule.threat_mapping.entries]]
-field = "dll.pe.imphash"
-type = "mapping"
-value = "threat.indicator.file.pe.imphash"
 
 [[rule.threat_mapping]]
 [[rule.threat_mapping.entries]]

--- a/rules/cross-platform/threat_intel_indicator_match_url.toml
+++ b/rules/cross-platform/threat_intel_indicator_match_url.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2023/05/22"
 maturity = "production"
-updated_date = "2023/07/03"
+updated_date = "2023/07/24"
 min_stack_comments = """
 Limiting the backport of these rules to the stack version which we are deprecating the Threat Intel Indicator Match
 general rules.
@@ -39,11 +39,11 @@ threat_language = "kuery"
 
 threat_query = '''
 @timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and
-  (threat.indicator.url.full:* or threat.indicator.url.domain:*) and not labels.is_ioc_transform_source:"true"
+  threat.indicator.url.full:* and not labels.is_ioc_transform_source:"true"
 '''
 
 query = """
-url.full:* or url.domain:*
+url.full:*
 """
 
 
@@ -91,21 +91,3 @@ query = "indicator"
 field = "url.full"
 type = "mapping"
 value = "threat.indicator.url.full"
-
-[[rule.threat_mapping]]
-[[rule.threat_mapping.entries]]
-field = "url.domain"
-type = "mapping"
-value = "threat.indicator.url.domain"
-
-[[rule.threat_mapping]]
-[[rule.threat_mapping.entries]]
-field = "source.domain"
-type = "mapping"
-value = "threat.indicator.url.domain"
-
-[[rule.threat_mapping]]
-[[rule.threat_mapping.entries]]
-field = "destination.domain"
-type = "mapping"
-value = "threat.indicator.url.domain"

--- a/rules/cross-platform/threat_intel_indicator_match_url.toml
+++ b/rules/cross-platform/threat_intel_indicator_match_url.toml
@@ -91,3 +91,9 @@ query = "indicator"
 field = "url.full"
 type = "mapping"
 value = "threat.indicator.url.full"
+
+[[rule.threat_mapping]]
+[[rule.threat_mapping.entries]]
+field = "url.original"
+type = "mapping"
+value = "threat.indicator.url.original"


### PR DESCRIPTION
## Issues

Resolves #2954 

## Summary

* Threat Intel URL Indicator Match:
  * Drops the `domain` fields on this rule, as it is more noisy than expected, as a lot of commonly used web services are included in threat intel fields. Such as Github, dropbox, discord, google drive, etc.
* Threat Intel Hash Indicator Match
  * Drops the support to `dll.pe.imphash`, as integrations such as abusech contain events with this field empty, which can match the target field in specific conditions in which it is not populated by Elastic Endpoint, generating thousands of unintended matches:
  
![image](https://github.com/elastic/detection-rules/assets/26856693/d11ac53a-ba36-429b-bb93-0cd111170825)


### Some other approaches considered:

I've looked at using QueryDSL as a filter in the Indicator index query but excluding indicators that don't populate certain fields will cause the other fields which contain the information to be excluded, causing FNs.

### Other potential solutions to the problem:

As this matches a specific condition on the endpoint, we could add a filter that excludes the events which cause this, here is a working query that we could ship as a filter:

<details>
<summary>Query</summary>

```
{
  "bool": {
    "must": [],
    "filter": [],
    "should": [],
    "must_not": [
      {
        "match_phrase": {
          "dll.hash.md5": ""
        }
      },
      {
        "match_phrase": {
          "dll.hash.sha1": ""
        }
      },
      {
        "match_phrase": {
          "dll.hash.sha256": ""
        }
      },
      {
        "match_phrase": {
          "dll.pe.imphash": ""
        }
      }
    ]
  }
}
```

</details>
