### PR TITLE
[New Rule] PE through Writable Docker Socket

### DIFF
--- a/rules/linux/privilege_escalation_writable_docker_socket.toml
+++ b/rules/linux/privilege_escalation_writable_docker_socket.toml
@@ -30,7 +30,8 @@ type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
 (
-  (process.name == "docker" and process.args : "run" and process.args : "-it"  and process.args : ("unix://*/docker.sock", "unix://*/dockershim.sock")) or 
+  (process.name == "docker" and process.args : "run" and process.args : "-it"  and 
+   process.args : ("unix://*/docker.sock", "unix://*/dockershim.sock")) or 
   (process.name == "socat" and process.args : ("UNIX-CONNECT:*/docker.sock", "UNIX-CONNECT:*/dockershim.sock"))
 ) and not user.Ext.real.id : "0" and not group.Ext.real.id : "0"
 '''

--- a/rules/linux/privilege_escalation_writable_docker_socket.toml
+++ b/rules/linux/privilege_escalation_writable_docker_socket.toml
@@ -1,0 +1,57 @@
+[metadata]
+creation_date = "2023/07/25"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/07/25"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule monitors for the usage of Docker runtime sockets to escalate privileges on Linux systems. Docker sockets by 
+default are only be writable by the root user and docker group. Attackers that have permissions to write to these 
+sockets may be able to create and run a container that allows them to escalate privileges and gain further access onto 
+the host file system.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*", "endgame-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Privilege Escalation through Writable Docker Socket"
+references = ["https://book.hacktricks.xyz/linux-hardening/privilege-escalation/docker-security/docker-breakout-privilege-escalation#automatic-enumeration-and-escape"]
+risk_score = 47
+rule_id = "7acb2de3-8465-472a-8d9c-ccd7b73d0ed8"
+severity = "medium"
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Privilege Escalation", "Data Source: Elastic Endgame"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
+(
+  (process.name == "docker" and process.args : "run" and process.args : "-it"  and process.args : (
+    "unix:///var/run/docker.sock", "unix:///run/docker.sock",
+    "unix:///var/run/dockershim.sock", "unix:///run/dockershim.sock"
+    )
+  ) or 
+  (process.name == "socat" and process.args : (
+    "UNIX-CONNECT:/var/run/docker.sock", "UNIX-CONNECT:/run/docker.sock",
+    "UNIX-CONNECT:/var/run/dockershim.sock", "UNIX-CONNECT:/run/dockershim.sock"
+    )
+  )
+) and not user.Ext.real.id : "0" and not group.Ext.real.id : "0"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1611"
+name = "Escape to Host"
+reference = "https://attack.mitre.org/techniques/T1611/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"

--- a/rules/linux/privilege_escalation_writable_docker_socket.toml
+++ b/rules/linux/privilege_escalation_writable_docker_socket.toml
@@ -15,7 +15,7 @@ sockets may be able to create and run a container that allows them to escalate p
 the host file system.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privilege Escalation through Writable Docker Socket"
@@ -23,12 +23,12 @@ references = ["https://book.hacktricks.xyz/linux-hardening/privilege-escalation/
 risk_score = 47
 rule_id = "7acb2de3-8465-472a-8d9c-ccd7b73d0ed8"
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Privilege Escalation", "Data Source: Elastic Endgame"]
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Privilege Escalation"]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
 (
   (process.name == "docker" and process.args : "run" and process.args : "-it"  and 
    process.args : ("unix://*/docker.sock", "unix://*/dockershim.sock")) or 

--- a/rules/linux/privilege_escalation_writable_docker_socket.toml
+++ b/rules/linux/privilege_escalation_writable_docker_socket.toml
@@ -30,16 +30,8 @@ type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
 (
-  (process.name == "docker" and process.args : "run" and process.args : "-it"  and process.args : (
-    "unix:///var/run/docker.sock", "unix:///run/docker.sock",
-    "unix:///var/run/dockershim.sock", "unix:///run/dockershim.sock"
-    )
-  ) or 
-  (process.name == "socat" and process.args : (
-    "UNIX-CONNECT:/var/run/docker.sock", "UNIX-CONNECT:/run/docker.sock",
-    "UNIX-CONNECT:/var/run/dockershim.sock", "UNIX-CONNECT:/run/dockershim.sock"
-    )
-  )
+  (process.name == "docker" and process.args : "run" and process.args : "-it"  and process.args : ("unix://*/docker.sock", "unix://*/dockershim.sock")) or 
+  (process.name == "socat" and process.args : ("UNIX-CONNECT:*/docker.sock", "UNIX-CONNECT:*/dockershim.sock"))
 ) and not user.Ext.real.id : "0" and not group.Ext.real.id : "0"
 '''
 

--- a/rules/linux/privilege_escalation_writable_docker_socket.toml
+++ b/rules/linux/privilege_escalation_writable_docker_socket.toml
@@ -23,7 +23,7 @@ references = ["https://book.hacktricks.xyz/linux-hardening/privilege-escalation/
 risk_score = 47
 rule_id = "7acb2de3-8465-472a-8d9c-ccd7b73d0ed8"
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Privilege Escalation"]
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Privilege Escalation", "Domain: Container"]
 timestamp_override = "event.ingested"
 type = "eql"
 


### PR DESCRIPTION
## Summary
This rule monitors for the usage of Docker runtime sockets to escalate privileges on Linux systems. Docker sockets by default are only be writable by the root user and docker group. Attackers that have permissions to write to these sockets may be able to create and run a container that allows them to escalate privileges and gain further access onto the host file system.

## Detection
0 hits last 365 days in red sector, nor in my docker test clusters. Added `and not user.Ext.real.id : "0" and not group.Ext.real.id : "0"` to minimize FPs. 
```
process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
(
  (process.name == "docker" and process.args : "run" and process.args : "-it"  and 
   process.args : ("unix://*/docker.sock", "unix://*/dockershim.sock")) or 
  (process.name == "socat" and process.args : ("UNIX-CONNECT:*/docker.sock", "UNIX-CONNECT:*/dockershim.sock"))
) and not user.Ext.real.id : "0" and not group.Ext.real.id : "0"
```
<img width="2690" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/1fa8f5c9-3216-493c-88ad-8cbcc5ae08a5">
