### PR TITLE
[Tuning] Reverse Shell Rules

### DIFF
--- a/rules/linux/execution_shell_suspicious_parent_child_revshell_linux.toml
+++ b/rules/linux/execution_shell_suspicious_parent_child_revshell_linux.toml
@@ -40,7 +40,8 @@ sequence by host.id, process.parent.entity_id with maxspan=1s
   (process.name : "awk")) and 
   process.parent.name : ("python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk") ]
 [ network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and 
-  process.name : ("python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk") ]
+  process.name : ("python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk") and
+  destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1" ]
 '''
 
 [[rule.threat]]

--- a/rules/linux/execution_shell_suspicious_parent_child_revshell_linux.toml
+++ b/rules/linux/execution_shell_suspicious_parent_child_revshell_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/04"
+updated_date = "2023/07/25"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/execution_shell_via_java_revshell_linux.toml
+++ b/rules/linux/execution_shell_via_java_revshell_linux.toml
@@ -28,7 +28,8 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=5s
 [ network where host.os.type == "linux" and event.action in ("connection_accepted", "connection_attempted") and 
-  process.executable : ("/usr/bin/java", "/bin/java", "/usr/lib/jvm/*", "/usr/java/*") ] by process.entity_id
+  process.executable : ("/usr/bin/java", "/bin/java", "/usr/lib/jvm/*", "/usr/java/*") and
+  destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1" ] by process.entity_id
 [ process where host.os.type == "linux" and event.action == "exec" and 
   process.parent.executable : ("/usr/bin/java", "/bin/java", "/usr/lib/jvm/*", "/usr/java/*") and
   process.parent.args : "-jar"  and process.executable : "*sh" ] by process.parent.entity_id

--- a/rules/linux/execution_shell_via_java_revshell_linux.toml
+++ b/rules/linux/execution_shell_via_java_revshell_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/04"
+updated_date = "2023/07/25"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/execution_shell_via_lolbin_interpreter_linux.toml
+++ b/rules/linux/execution_shell_via_lolbin_interpreter_linux.toml
@@ -40,7 +40,8 @@ sequence by host.id, process.entity_id with maxspan=1s
   (process.name : "awk")) and 
   process.parent.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") ]
 [ network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and 
-  process.name : ("python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk") ]
+  process.name : ("python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk") and
+  destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1" ]
 '''
 
 [[rule.threat]]

--- a/rules/linux/execution_shell_via_lolbin_interpreter_linux.toml
+++ b/rules/linux/execution_shell_via_lolbin_interpreter_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/04"
+updated_date = "2023/07/25"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/execution_shell_via_suspicious_binary.toml
+++ b/rules/linux/execution_shell_via_suspicious_binary.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/05"
+updated_date = "2023/07/25"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/execution_shell_via_suspicious_binary.toml
+++ b/rules/linux/execution_shell_via_suspicious_binary.toml
@@ -42,7 +42,7 @@ sequence by host.id, process.entity_id with maxspan=1s
   "./*", "/tmp/*", "/var/tmp/*", "/var/www/*", "/dev/shm/*", "/etc/init.d/*", "/etc/rc*.d/*",
   "/etc/crontab", "/etc/cron.*", "/etc/update-motd.d/*", "/usr/lib/update-notifier/*",
   "/boot/*", "/srv/*", "/run/*", "/root/*", "/etc/rc.local"
-   ) ]
+   ) and destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1" ]
 [ process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
   process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
   process.parent.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") ]

--- a/rules/linux/execution_shell_via_tcp_cli_utility_linux.toml
+++ b/rules/linux/execution_shell_via_tcp_cli_utility_linux.toml
@@ -29,7 +29,8 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=1s
 [ network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and 
-  process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "socat") ] by process.entity_id
+  process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "socat") and 
+  destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1" ] by process.entity_id
 [ process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "fork") and 
   process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
   process.parent.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "socat") ] by process.parent.entity_id

--- a/rules/linux/execution_shell_via_tcp_cli_utility_linux.toml
+++ b/rules/linux/execution_shell_via_tcp_cli_utility_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/04"
+updated_date = "2023/07/25"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Summary
Added the following extra check to minimize FPs. Found some FPs of services connecting to databases etc. on 127.0.0.1. This tuning reduces the number of hits from 12,179 back to 17, which are 17 TPs. 

```
and destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1"
```