### PR TITLE
[New BBR] Potential Suspicious File Edit

### DIFF
--- a/rules_building_block/persistence_suspicious_file_opened_through_editor.toml
+++ b/rules_building_block/persistence_suspicious_file_opened_through_editor.toml
@@ -1,0 +1,106 @@
+[metadata]
+creation_date = "2023/07/25"
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/07/25"
+integration = ["endpoint"]
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule monitors for the potential edit of a suspicious file. In Linux, when editing a file through an editor, a 
+temporary .swp file is created. By monitoring for the creation of this .swp file, we can detect potential file edits of
+suspicious files. The execution of this rule is not a clear sign of the file being edited, as just opening the file 
+through an editor will trigger this event. Attackers may alter any of the files added in this rule to establish
+persistence, escalate privileges or perform reconnaisance on the system. 
+"""
+from = "now-119m"
+interval = "60m"
+index = ["logs-endpoint.events.*", "endgame-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Suspicious File Edit"
+risk_score = 21
+rule_id = "3728c08d-9b70-456b-b6b8-007c7d246128"
+severity = "low"
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Persistence", "Tactic: Privilege Escalation", "Data Source: Elastic Endgame", "Rule Type: BBR"]
+timestamp_override = "event.ingested"
+type = "eql"
+building_block_type = "default"
+
+query = '''
+file where event.action in ("creation", "file_create_event") and file.extension == "swp" and 
+file.path : (
+  /* common interesting files and locations */
+  "/etc/.shadow.swp", "/etc/.passwd.swp", "/etc/.hosts.swp", "/etc/.environment.swp", "/etc/.profile.swp",
+  "/etc/ld.so.conf.d/.*.swp", "/etc/sudoers.d/.*.swp", "/etc/init.d/.*.swp", "/etc/.rc.local.swp", "/etc/rc*.d/.*.swp",
+  "/dev/shm/.*.swp", "/etc/update-motd.d/.*.swp", "/usr/lib/update-notifier/.*.swp",
+
+  /* service, timer, want, socket and lock files */
+  "/etc/systemd/system/.*.swp", "/usr/local/lib/systemd/system/.*.swp", "/lib/systemd/system/.*.swp",
+  "/usr/lib/systemd/system/.*.swp","/home/*/.config/systemd/user/.*.swp", "/run/.*.swp", "/var/run/.*.swp/",
+
+  /* profile and shell configuration files */  
+  "/home/*.profile.swp", "/home/*.bash_profile.swp", "/home/*.bash_login.swp", "/home/*.bashrc.swp", "/home/*.bash_logout.swp",
+  "/home/*.zshrc.swp", "/home/*.zlogin.swp", "/home/*.tcshrc.swp", "/home/*.kshrc.swp", "/home/*.config.fish.swp",
+  "/root/*.profile.swp", "/root/*.bash_profile.swp", "/root/*.bash_login.swp", "/root/*.bashrc.swp", "/root/*.bash_logout.swp",
+  "/root/*.zshrc.swp", "/root/*.zlogin.swp", "/root/*.tcshrc.swp", "/root/*.kshrc.swp", "/root/*.config.fish.swp"
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat.technique]]
+id = "T1037"
+name = "Boot or Logon Initialization Scripts"
+reference = "https://attack.mitre.org/techniques/T1037/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1037.004"
+name = "RC Scripts"
+reference = "https://attack.mitre.org/techniques/T1037/004/"
+
+[[rule.threat.technique]]
+id = "T1574"
+name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1574.006"
+name = "Dynamic Linker Hijacking"
+reference = "https://attack.mitre.org/techniques/T1574/006/"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1543.002"
+name = "Systemd Service"
+reference = "https://attack.mitre.org/techniques/T1543/002/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+
+[[rule.threat.technique]]
+id = "T1548"
+name = "Abuse Elevation Control Mechanism"
+reference = "https://attack.mitre.org/techniques/T1548/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1548.003"
+name = "Sudo and Sudo Caching"
+reference = "https://attack.mitre.org/techniques/T1548/003/"

--- a/rules_building_block/persistence_suspicious_file_opened_through_editor.toml
+++ b/rules_building_block/persistence_suspicious_file_opened_through_editor.toml
@@ -33,8 +33,10 @@ query = '''
 file where event.action in ("creation", "file_create_event") and file.extension == "swp" and 
 file.path : (
   /* common interesting files and locations */
-  "/etc/.shadow.swp", "/etc/.passwd.swp", "/etc/.hosts.swp", "/etc/.environment.swp", "/etc/.profile.swp",
-  "/etc/ld.so.conf.d/.*.swp", "/etc/sudoers.d/.*.swp", "/etc/init.d/.*.swp", "/etc/.rc.local.swp", "/etc/rc*.d/.*.swp",
+  "/etc/.shadow.swp", "/etc/.shadow-.swp", "/etc/.shadow~.swp", "/etc/.gshadow.swp", "/etc/.gshadow-.swp",
+  "/etc/.passwd.swp", "/etc/.pwd.db.swp", "/etc/.master.passwd.swp", "/etc/.spwd.db.swp", "/etc/security/.opasswd.swp",
+  "/etc/.hosts.swp", "/etc/.environment.swp", "/etc/.profile.swp", "/etc/sudoers.d/.*.swp",
+  "/etc/ld.so.conf.d/.*.swp", "/etc/init.d/.*.swp", "/etc/.rc.local.swp", "/etc/rc*.d/.*.swp",
   "/dev/shm/.*.swp", "/etc/update-motd.d/.*.swp", "/usr/lib/update-notifier/.*.swp",
 
   /* service, timer, want, socket and lock files */


### PR DESCRIPTION
## Summary
This rule monitors for the potential edit of a suspicious file. In Linux, when editing a file through an editor, a temporary .swp file is created. By monitoring for the creation of this .swp file, we can detect potential file edits of suspicious files. The execution of this rule is not a clear sign of the file being edited, as just opening the file through an editor will trigger this event. Attackers may alter any of the files added in this rule to establish persistence, escalate privileges or perform reconnaisance on the system. 

## Detection
The interesting part about this rule is that we aren't really capable of capturing file edit events on Linux, and this bypasses this limitation when files are being edited through an editor. By monitoring for the creation of a .swp file, we are basically monitoring for the file open event of a file through an editor. 

This rule triggers 100+ events on my testing cluster. All of these hits however are TPs. All of the hits are me editing /etc/passwd, /etc/shadow, service, timer, init.d, rc.local, motd or other files for testing malicious persistence/privesc mechanisms. 

Within red sector, this rule triggers 0 times in the last 365 days. Will add this to BBR and monitor rule executions. After some good tunings it might be able to move over to DR. Just making sure it's in BBR first before I flood DR telemetry. 

```
file where event.action in ("creation", "file_create_event") and file.extension == "swp" and 
file.path : (
  /* common interesting files and locations */
  "/etc/.shadow.swp", "/etc/.passwd.swp", "/etc/.hosts.swp", "/etc/.environment.swp", "/etc/.profile.swp",
  "/etc/ld.so.conf.d/.*.swp", "/etc/sudoers.d/.*.swp", "/etc/init.d/.*.swp", "/etc/.rc.local.swp", "/etc/rc*.d/.*.swp",
  "/dev/shm/.*.swp", "/etc/update-motd.d/.*.swp", "/usr/lib/update-notifier/.*.swp",

  /* service, timer, want, socket and lock files */
  "/etc/systemd/system/.*.swp", "/usr/local/lib/systemd/system/.*.swp", "/lib/systemd/system/.*.swp",
  "/usr/lib/systemd/system/.*.swp","/home/*/.config/systemd/user/.*.swp", "/run/.*.swp", "/var/run/.*.swp/",

  /* profile and shell configuration files */  
  "/home/*.profile.swp", "/home/*.bash_profile.swp", "/home/*.bash_login.swp", "/home/*.bashrc.swp", "/home/*.bash_logout.swp",
  "/home/*.zshrc.swp", "/home/*.zlogin.swp", "/home/*.tcshrc.swp", "/home/*.kshrc.swp", "/home/*.config.fish.swp",
  "/root/*.profile.swp", "/root/*.bash_profile.swp", "/root/*.bash_login.swp", "/root/*.bashrc.swp", "/root/*.bash_logout.swp",
  "/root/*.zshrc.swp", "/root/*.zlogin.swp", "/root/*.tcshrc.swp", "/root/*.kshrc.swp", "/root/*.config.fish.swp"
)
```
<img width="2181" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/761a319a-b328-4b3f-b1fe-c0c6fe933510">