### PR TITLE
Rule Tuning File Permission Modification in Writable Directory

### DIFF
--- a/rules/linux/defense_evasion_file_mod_writable_dir.toml
+++ b/rules/linux/defense_evasion_file_mod_writable_dir.toml
@@ -20,7 +20,7 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["auditbeat-*", "logs-endpoint.events.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "File Permission Modification in Writable Directory"
 risk_score = 21
@@ -28,13 +28,14 @@ rule_id = "9f9a2a82-93a8-4b1a-8778-1780895626d4"
 severity = "low"
 tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Defense Evasion"]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-event.category:process and host.os.type:linux and event.type:(start or process_started) and
-  process.name:(chmod or chown or chattr or chgrp) and
-  process.working_directory:(/tmp or /var/tmp or /dev/shm) and
-  not user.name:root
+process where host.os.type == "linux" and event.type in ("start", "process_started") and
+  process.name in ("chmod", "chown", "chattr", "chgrp") and
+  process.working_directory in ("/tmp", "/var/tmp", "/dev/shm") and
+  not process.parent.name in ("update-motd-updates-available") and
+  not user.name == "root"
 '''
 
 

--- a/rules/linux/defense_evasion_file_mod_writable_dir.toml
+++ b/rules/linux/defense_evasion_file_mod_writable_dir.toml
@@ -31,7 +31,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type in ("start", "process_started") and
+process where host.os.type == "linux" and event.type == "start"and
   process.name in ("chmod", "chown", "chattr", "chgrp") and
   process.working_directory in ("/tmp", "/var/tmp", "/dev/shm") and
   not process.parent.name in ("update-motd-updates-available") and

--- a/rules/linux/defense_evasion_file_mod_writable_dir.toml
+++ b/rules/linux/defense_evasion_file_mod_writable_dir.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/07/25"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues
#2911 

## Summary

- The Rule was analyzed for False positives in the latest version of rule "103"
- The rule originally was in kquery without no quotes around the file path, which tends to generate false positives from our previous experience
- The rule is tuned to be in EQL with quotes around file paths.
- Additionally, safe parent processes are added as an exclusion to further reduce false positives
- parent.process.name exclusion is added as an "in" in EQL to support the addition of any new safe parent process to reduce false positives. 


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
