### PR TITLE
[FR] Generate Prebuilt Rules Reference Page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ The branching workflow we currently follow for Detection Rules:
 * During feature freeze for a release, we will create a branch from `main` for the release version `{majorVersion.minorVersion}`. This means that we can continue contributing to `main`, even during feature freeze, and it will target `{majorVersion.minorVersion+1}`
 * Rules are automatically backported to old branches (starting at `7.13`) if the `backport: auto` label is set on GitHub. This is done automatically for all PRs that merge to main `main` with the label `backport: auto`.
 * To opt-out of a backport, add the label `backport: skip`. GitHub will automatically remove the `backport: auto` label from the PR when this label is set
-* As of 7.13, you can use Fleet to [update prebuilt rules](https://www.elastic.co/guide/en/security/current/rules-ui-management.html#download-prebuilt-rules) for your stack
+* From 7.13 to 8.1, you can use Fleet to [download prebuilt rules](https://www.elastic.co/guide/en/security/current/rules-ui-management.html#download-prebuilt-rules) for your stack, and subsequent releases will follow the instructions at [Update prebuilt rules](https://www.elastic.co/guide/en/security/current/rules-ui-management.html#update-prebuilt-rules)
 * Changes to rules in an already-released branch will be included in an update to the "Prebuilt Security Detection Rules" integration
 
 **Prior to 7.13**

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -816,7 +816,7 @@ class IntegrationSecurityDocsMDX:
     def generate_downloadable_updates_summary(self):
         """Generate a summary of all the downloadable updates."""
 
-        docs_url = 'https://www.elastic.co/guide/en/security/current/rules-ui-management.html#download-prebuilt-rules'
+        docs_url = 'https://www.elastic.co/guide/en/security/current/rules-ui-management.html#update-prebuilt-rules'
         slug = 'prebuilt-rules-downloadable-packages-summary.mdx'
         title = "Downloadable rule updates"
         summary = self.package_directory / slug
@@ -853,7 +853,7 @@ class IntegrationSecurityDocsMDX:
         This section lists all updates to prebuilt detection rules, made available
             with the Prebuilt Security Detection Rules integration in Fleet.
 
-        To download the latest updates, follow the instructions in [download-prebuilt-rules]({docs_url})
+        To update your rules to the latest versions, follow the instructions in [update-prebuilt-rules]({docs_url})
 
 
         |Update version |Date | New rules | Updated rules | Notes

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -366,6 +366,7 @@ class IntegrationSecurityDocs:
         summary.write_text(summary_str)
 
     def generate_rule_reference(self):
+        """Generate rule reference page for prebuilt rules."""
         summary = self.directory / "docs" / "detections" / "prebuilt-rules" / 'prebuilt-rules-reference.asciidoc'
         rule_list = self.directory / "docs" / "detections" / "prebuilt-rules" / 'rule-desc-index.asciidoc'
 
@@ -415,6 +416,7 @@ class IntegrationSecurityDocs:
         rule_list.write_text('\n'.join(rule_includes))
 
     def generate_rule_details(self):
+        """Generate rule details for each prebuilt rule."""
         included_rules = [x.name for x in self.included_rules]
         for rule in self.sorted_rules:
             rule_detail = IntegrationRuleDetail(rule.id, rule.contents.to_api_format(), {}, self.base_name)

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -365,6 +365,7 @@ class IntegrationSecurityDocs:
 
     def generate_rule_reference(self):
         summary = self.directory / "docs" / "detections" / "prebuilt-rules" / 'prebuilt-rules-reference.asciidoc'
+        rule_list = self.directory / "docs" / "detections" / "prebuilt-rules" / 'rule-desc-index.asciidoc'
 
         summary_header = textwrap.dedent("""
         [[prebuilt-rules]]
@@ -385,12 +386,14 @@ class IntegrationSecurityDocs:
         """).lstrip()  # noqa: E501
 
         rule_entries = []
+        rule_includes = []
         all_rules = RuleCollection.default().rules
         sorted_rules = sorted(all_rules, key=lambda rule: rule.name)
         for rule in sorted_rules:
             if isinstance(rule, DeprecatedRule):
                 continue
             title_name = name_to_title(rule.name)
+            rule_includes.append(f'include::rule-details/{title_name}.asciidoc[]')
 
             # skip rules not built for this package
             built_rules = [x.name for x in self.rule_details.glob('*.asciidoc')]
@@ -405,6 +408,9 @@ class IntegrationSecurityDocs:
         summary_lines = [summary_header] + rule_entries + ['|==============================================']
         summary_str = '\n'.join(summary_lines) + '\n'
         summary.write_text(summary_str)
+
+        # update rule-desc-index.asciidoc
+        rule_list.write_text('\n'.join(rule_includes))
 
     def generate_rule_details(self):
         for rule in self.included_rules:

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -380,19 +380,23 @@ class IntegrationSecurityDocs:
         [width="100%",options="header"]
         |==============================================
         |Rule |Description |Tags |Added |Version
+
         """).lstrip()  # noqa: E501
 
         rule_entries = []
         all_rules = RuleCollection.default().rules
-        for rule in all_rules:
+        sorted_rules = sorted(all_rules, key=lambda rule: rule.name)
+        for rule in sorted_rules:
             if isinstance(rule, DeprecatedRule):
                 continue
             title_name = name_to_title(rule.name)
             tags = ', '.join(f'[{tag}]' for tag in rule.contents.data.tags)
             description = rule.contents.to_api_format()['description']
             version = rule.contents.autobumped_version
+            version_history = f" <<{title_name}, Version history>>" if version > 1 else ""
+            version_info = f"{version}{version_history}"
             added = rule.contents.metadata.min_stack_version
-            rule_entries.append(f'|<<{title_name}, {rule.name}>> | {description} | {added} | {tags} | {version} \n')
+            rule_entries.append(f'|<<{title_name}, {rule.name}>> |{description} |{tags} |{added} |{version_info}\n')
 
         summary_lines = [summary_header] + rule_entries + ['|==============================================']
         summary_str = '\n'.join(summary_lines) + '\n'

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -405,7 +405,9 @@ class IntegrationSecurityDocs:
         self.add_content_to_table_top(downloadable_updates, new_content)
 
         # Add table_include to/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
-        downloadable_updates.write_text(downloadable_updates.read_text() +  # noqa: W504
+        # Reset the historic information at the beginning of each minor version
+        historic_data = downloadable_updates.read_text() if Version.parse(self.registry_version_str).patch > 1 else ''
+        downloadable_updates.write_text(historic_data +  # noqa: W504
                                         updates['downloadable-updates.asciidoc']['table_include'] + '\n')
 
     def add_content_to_table_top(self, file_path: Path, new_content: str):

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -442,8 +442,28 @@ class IntegrationSecurityDocs:
 
         # Add table_entry to docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
         downloadable_updates = self.package_directory.parent.parent / 'prebuilt-rules-downloadable-updates.asciidoc'
+        version = Version.parse(self.registry_version_str)
+        last_version = f"{version.major}.{version.minor - 1}"
+        version_url = f"https://www.elastic.co/guide/en/security/{last_version}/prebuilt-rules.html"
+        summary_header = textwrap.dedent(f"""
+        [[prebuilt-rules-downloadable-updates]]
+        [role="xpack"]
+        == Downloadable rule updates
+
+        This section lists all updates to prebuilt detection rules, made available with the *Prebuilt Security Detection Rules* integration in Fleet.
+
+        To update your installed rules to the latest versions, follow the instructions in <<update-prebuilt-rules>>.
+
+        For previous rule updates, please navigate to the {version_url}[last version].
+
+
+        [width="100%",options="header"]
+        |==============================================
+        |Update version |Date | New rules | Updated rules | Notes
+
+        """).lstrip()  # noqa: E501
         new_content = updates['downloadable-updates.asciidoc']['table_entry'] + '\n' + self.update_message
-        self.add_content_to_table_top(downloadable_updates, new_content)
+        self.add_content_to_table_top(downloadable_updates, summary_header, new_content)
 
         # Add table_include to/docs/detections/prebuilt-rules/prebuilt-rules-downloadable-updates.asciidoc
         # Reset the historic information at the beginning of each minor version
@@ -451,7 +471,7 @@ class IntegrationSecurityDocs:
         downloadable_updates.write_text(historic_data +  # noqa: W504
                                         updates['downloadable-updates.asciidoc']['table_include'] + '\n')
 
-    def add_content_to_table_top(self, file_path: Path, new_content: str):
+    def add_content_to_table_top(self, file_path: Path, summary_header: str, new_content: str):
         """Insert content at the top of a Markdown table right after the specified header."""
         file_contents = file_path.read_text()
 
@@ -466,7 +486,7 @@ class IntegrationSecurityDocs:
         insert_position = header_index + len(header)
 
         # Insert the new content at the insert_position
-        updated_contents = file_contents[:insert_position] + f"\n{new_content}\n" + file_contents[insert_position:]
+        updated_contents = summary_header + f"\n{new_content}\n" + file_contents[insert_position:]
 
         # Write the updated contents back to the file
         file_path.write_text(updated_contents)

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -384,9 +384,6 @@ class IntegrationSecurityDocs:
 
         rule_entries = []
         all_rules = RuleCollection.default().rules
-        package_version = Version.parse(self.registry_version_str)
-        rule_version = f"{package_version.major}.{package_version.minor}"
-        prebuilt_rule_url = f"https://www.elastic.co/guide/en/security/{rule_version}/"
         for rule in all_rules:
             if isinstance(rule, DeprecatedRule):
                 continue
@@ -395,8 +392,7 @@ class IntegrationSecurityDocs:
             description = rule.contents.to_api_format()['description']
             version = rule.contents.autobumped_version
             added = rule.contents.metadata.min_stack_version
-            rule_url = f'{prebuilt_rule_url}{title_name}.html'
-            rule_entries.append(f'|<<{rule_url}, {rule.name}>> | {description} | {added} | {tags} | {version} \n')
+            rule_entries.append(f'|<<{title_name}, {rule.name}>> | {description} | {added} | {tags} | {version} \n')
 
         summary_lines = [summary_header] + rule_entries + ['|==============================================']
         summary_str = '\n'.join(summary_lines) + '\n'


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Related to #2867

## Summary
- Generates a duplicate of the [prebuilt rule reference](https://www.elastic.co/guide/en/security/8.9/prebuilt-rules.html) page  without version history
- Small tweaks to our build to point users to `update-prebuilt-rules` moving forward instead of `download-prebuilt-rules`
