### PR TITLE
[New Rule] Linux Local Account Brute Force

### DIFF
--- a/rules/linux/credential_access_potential_linux_local_account_bruteforce.toml
+++ b/rules/linux/credential_access_potential_linux_local_account_bruteforce.toml
@@ -1,0 +1,48 @@
+[metadata]
+creation_date = "2023/07/26"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/07/26"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies multiple consecutive login attempts executed by one process targeting a local linux user account within a 
+short time interval. Adversaries might brute force login attempts across different users with a default wordlist or a 
+set of customly crafted passwords in an attempt to gain access to these accounts.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Linux Local Account Brute Force Detected"
+risk_score = 47
+rule_id = "835c0622-114e-40b5-a346-f843ea5d01f1"
+severity = "medium"
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
+type = "eql"
+query = '''
+sequence by host.id, process.parent.executable, user.name with maxspan=1s
+[ process where host.os.type == "linux" and event.type == "start" and 
+  event.action == "exec" and process.name == "su" ] with runs=10
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.001"
+name = "Password Guessing"
+reference = "https://attack.mitre.org/techniques/T1110/001/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"


### PR DESCRIPTION
## Summary
Identifies multiple consecutive login attempts executed by one process targeting a local linux user account within a short time interval. Adversaries might brute force login attempts across different users with a default wordlist or a set of customly crafted passwords in an attempt to gain access to these accounts.

## Detection
This behavior is common across different local account brute force scripts e.g. https://github.com/carlospolop/su-bruteforce or manual attempts of brute forcing a useraccount. As new process.entity_id's and process.parent.entity_id's are generated per authentication attempt, the only feasible way of detecting this is through the process.parent.executable. As the timespan is set to 1 second, this shouldn't be a big performance hit.

Red sector shows 0 hits for this query in the last year. 10 authentication attemps should not occur in 1 second unless a brute force is being executed. 

```
sequence by host.id, process.parent.executable, user.name with maxspan=1s
[ process where host.os.type == "linux" and event.type == "start" and 
  event.action == "exec" and process.name == "su" ] with runs=10
```
<img width="2392" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/8f3983b2-1fb9-4d97-855e-ec2feec653a1">
