### PR TITLE
[Rule Tuning] Potential Masquerading as Communication Apps

### DIFF
--- a/rules/windows/persistence_run_key_and_startup_broad.toml
+++ b/rules/windows/persistence_run_key_and_startup_broad.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/08/03"
+updated_date = "2023/08/15"
 
 [transform]
 [[transform.osquery]]
@@ -134,7 +134,7 @@ registry where host.os.type == "windows" and registry.data.strings != null and
   not (
     /* Logitech G Hub */
     (
-      process.code_signature.trusted == true and process.code_signature.subject_name : "Logitech Inc" and
+      process.code_signature.trusted == true and process.code_signature.subject_name == "Logitech Inc" and
       process.name : "lghub_agent.exe" and registry.data.strings : (
         "\"?:\\Program Files\\LGHUB\\lghub.exe\" --background"
       )
@@ -142,7 +142,7 @@ registry where host.os.type == "windows" and registry.data.strings != null and
 
     /* Google Drive File Stream, Chrome, and Google Update */
     (
-      process.code_signature.trusted == true and process.code_signature.subject_name : "Google LLC" and
+      process.code_signature.trusted == true and process.code_signature.subject_name == "Google LLC" and
       (
         process.name : "GoogleDriveFS.exe" and registry.data.strings : (
         "\"?:\\Program Files\\Google\\Drive File Stream\\*\\GoogleDriveFS.exe\" --startup_mode"
@@ -161,7 +161,7 @@ registry where host.os.type == "windows" and registry.data.strings != null and
 
     /* MS Programs */
     (
-      process.code_signature.trusted == true and process.code_signature.subject_name : ("Microsoft Windows", "Microsoft Corporation") and
+      process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation") and
       (
         process.name : "msedge.exe" and registry.data.strings : (
           "\"?:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\" --no-startup-window --win-session-start /prefetch:5"
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and registry.data.strings != null and
 
     /* Slack */
     (
-      process.code_signature.trusted == true and process.code_signature.subject_name : (
+      process.code_signature.trusted == true and process.code_signature.subject_name in (
        "Slack Technologies, Inc.", "Slack Technologies, LLC"
       ) and process.name : "slack.exe" and registry.data.strings : (
         "\"?:\\Users\\*\\AppData\\Local\\slack\\slack.exe\" --process-start-args --startup"
@@ -199,7 +199,7 @@ registry where host.os.type == "windows" and registry.data.strings != null and
 
     /* WebEx */
     (
-      process.code_signature.trusted == true and process.code_signature.subject_name : ("Cisco WebEx LLC", "Cisco Systems, Inc.") and
+      process.code_signature.trusted == true and process.code_signature.subject_name in ("Cisco WebEx LLC", "Cisco Systems, Inc.") and
       process.name : "WebexHost.exe" and registry.data.strings : (
         "\"?:\\Users\\*\\AppData\\Local\\WebEx\\WebexHost.exe\" /daemon /runFrom=autorun"
       )

--- a/rules/windows/persistence_run_key_and_startup_broad.toml
+++ b/rules/windows/persistence_run_key_and_startup_broad.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/08/03"
 
 [transform]
 [[transform.osquery]]
@@ -190,8 +190,9 @@ registry where host.os.type == "windows" and registry.data.strings != null and
 
     /* Slack */
     (
-      process.code_signature.trusted == true and process.code_signature.subject_name : "Slack Technologies, Inc." and
-      process.name : "slack.exe" and registry.data.strings : (
+      process.code_signature.trusted == true and process.code_signature.subject_name : (
+       "Slack Technologies, Inc.", "Slack Technologies, LLC"
+      ) and process.name : "slack.exe" and registry.data.strings : (
         "\"?:\\Users\\*\\AppData\\Local\\slack\\slack.exe\" --process-start-args --startup"
       )
     ) or

--- a/rules_building_block/defense_evasion_masquerading_communication_apps.toml
+++ b/rules_building_block/defense_evasion_masquerading_communication_apps.toml
@@ -86,7 +86,7 @@ process where host.os.type == "windows" and
     (process.name : "thunderbird.exe" and not
       (process.code_signature.subject_name == "Mozilla Corporation" and process.code_signature.trusted == true)
     )
-  ) 
+  )
 '''
 
 

--- a/rules_building_block/defense_evasion_masquerading_communication_apps.toml
+++ b/rules_building_block/defense_evasion_masquerading_communication_apps.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/08/03"
+updated_date = "2023/08/15"
 bypass_bbr_timing = true
 
 [rule]
@@ -32,7 +32,7 @@ process where host.os.type == "windows" and
   (
     /* Slack */
     (process.name : "slack.exe" and not
-      (process.code_signature.subject_name : (
+      (process.code_signature.subject_name in (
         "Slack Technologies, Inc.",
         "Slack Technologies, LLC"
        ) and process.code_signature.trusted == true)
@@ -40,32 +40,32 @@ process where host.os.type == "windows" and
 
     /* WebEx */
     (process.name : "WebexHost.exe" and not
-      (process.code_signature.subject_name : ("Cisco WebEx LLC", "Cisco Systems, Inc.") and process.code_signature.trusted == true)
+      (process.code_signature.subject_name in ("Cisco WebEx LLC", "Cisco Systems, Inc.") and process.code_signature.trusted == true)
     ) or
 
     /* Teams */
     (process.name : "Teams.exe" and not
-      (process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true)
+      (process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true)
     ) or
 
     /* Discord */
     (process.name : "Discord.exe" and not
-      (process.code_signature.subject_name : "Discord Inc." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name == "Discord Inc." and process.code_signature.trusted == true)
     ) or
 
     /* RocketChat */
     (process.name : "Rocket.Chat.exe" and not
-      (process.code_signature.subject_name : "Rocket.Chat Technologies Corp." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name == "Rocket.Chat Technologies Corp." and process.code_signature.trusted == true)
     ) or
 
     /* Mattermost */
     (process.name : "Mattermost.exe" and not
-      (process.code_signature.subject_name : "Mattermost, Inc." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name == "Mattermost, Inc." and process.code_signature.trusted == true)
     ) or
 
     /* WhatsApp */
     (process.name : "WhatsApp.exe" and not
-      (process.code_signature.subject_name : (
+      (process.code_signature.subject_name in (
         "WhatsApp LLC",
         "WhatsApp, Inc",
         "24803D75-212C-471A-BC57-9EF86AB91435"
@@ -74,17 +74,17 @@ process where host.os.type == "windows" and
 
     /* Zoom */
     (process.name : "Zoom.exe" and not
-      (process.code_signature.subject_name : "Zoom Video Communications, Inc." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name == "Zoom Video Communications, Inc." and process.code_signature.trusted == true)
     ) or
 
     /* Outlook */
     (process.name : "outlook.exe" and not
-      (process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true)
+      (process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true)
     ) or
 
     /* Thunderbird */
     (process.name : "thunderbird.exe" and not
-      (process.code_signature.subject_name : "Mozilla Corporation" and process.code_signature.trusted == true)
+      (process.code_signature.subject_name == "Mozilla Corporation" and process.code_signature.trusted == true)
     )
   )
 '''

--- a/rules_building_block/defense_evasion_masquerading_communication_apps.toml
+++ b/rules_building_block/defense_evasion_masquerading_communication_apps.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+updated_date = "2023/08/03"
 bypass_bbr_timing = true
 
 [rule]
@@ -32,7 +32,10 @@ process where host.os.type == "windows" and
   (
     /* Slack */
     (process.name : "slack.exe" and not
-      (process.code_signature.subject_name : "Slack Technologies, Inc." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : (
+        "Slack Technologies, Inc.",
+        "Slack Technologies, LLC"
+       ) and process.code_signature.trusted == true)
     ) or
 
     /* WebEx */
@@ -62,12 +65,26 @@ process where host.os.type == "windows" and
 
     /* WhatsApp */
     (process.name : "WhatsApp.exe" and not
-      (process.code_signature.subject_name : "WhatsApp LLC" and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : (
+        "WhatsApp LLC",
+        "WhatsApp, Inc",
+        "24803D75-212C-471A-BC57-9EF86AB91435"
+       ) and process.code_signature.trusted == true)
     ) or
 
     /* Zoom */
     (process.name : "Zoom.exe" and not
       (process.code_signature.subject_name : "Zoom Video Communications, Inc." and process.code_signature.trusted == true)
+    ) or
+
+    /* Outlook */
+    (process.name : "outlook.exe" and not
+      (process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true)
+    ) or
+
+    /* Thunderbird */
+    (process.name : "thunderbird.exe" and not
+      (process.code_signature.subject_name : "Mozilla Corporation" and process.code_signature.trusted == true)
     )
   )
 '''

--- a/rules_building_block/defense_evasion_masquerading_communication_apps.toml
+++ b/rules_building_block/defense_evasion_masquerading_communication_apps.toml
@@ -86,7 +86,7 @@ process where host.os.type == "windows" and
     (process.name : "thunderbird.exe" and not
       (process.code_signature.subject_name == "Mozilla Corporation" and process.code_signature.trusted == true)
     )
-  )
+  ) 
 '''
 
 


### PR DESCRIPTION
## Summary

- Expand the rules to cover Outlook and Thunderbird
- Tunings on legitimate signatures for some of the executables
- Resolves #2993 