### PR TITLE
[Rule Tuning] added additional event action

### DIFF
--- a/rules/linux/execution_shell_suspicious_parent_child_revshell_linux.toml
+++ b/rules/linux/execution_shell_suspicious_parent_child_revshell_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/25"
+updated_date = "2023/08/10"
 
 [rule]
 author = ["Elastic"]
@@ -39,7 +39,7 @@ sequence by host.id, process.parent.entity_id with maxspan=1s
   (process.name : "telnet" and process.args_count >= 3) or
   (process.name : "awk")) and 
   process.parent.name : ("python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk") ]
-[ network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and 
+[ network where host.os.type == "linux" and event.type == "start" and event.action in ("connection_attempted", "connection_accepted") and 
   process.name : ("python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk") and
   destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1" ]
 '''

--- a/rules/linux/execution_shell_via_lolbin_interpreter_linux.toml
+++ b/rules/linux/execution_shell_via_lolbin_interpreter_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/25"
+updated_date = "2023/08/10"
 
 [rule]
 author = ["Elastic"]
@@ -39,7 +39,7 @@ sequence by host.id, process.entity_id with maxspan=1s
   (process.name : "telnet" and process.args_count >= 3) or
   (process.name : "awk")) and 
   process.parent.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") ]
-[ network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and 
+[ network where host.os.type == "linux" and event.type == "start" and event.action in ("connection_attempted", "connection_accepted") and 
   process.name : ("python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk") and
   destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1" ]
 '''

--- a/rules/linux/execution_shell_via_suspicious_binary.toml
+++ b/rules/linux/execution_shell_via_suspicious_binary.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/25"
+updated_date = "2023/08/10"
 
 [rule]
 author = ["Elastic"]
@@ -37,7 +37,7 @@ sequence by host.id, process.entity_id with maxspan=1s
    ) and
   process.parent.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and not
   process.name : ("curl", "wget", "ping", "apt", "dpkg", "yum", "rpm", "dnf", "dockerd") ]
-[ network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
+[ network where host.os.type == "linux" and event.type == "start" and event.action in ("connection_attempted", "connection_accepted") and
   process.executable : (
   "./*", "/tmp/*", "/var/tmp/*", "/var/www/*", "/dev/shm/*", "/etc/init.d/*", "/etc/rc*.d/*",
   "/etc/crontab", "/etc/cron.*", "/etc/update-motd.d/*", "/usr/lib/update-notifier/*",

--- a/rules/linux/execution_shell_via_tcp_cli_utility_linux.toml
+++ b/rules/linux/execution_shell_via_tcp_cli_utility_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/25"
+updated_date = "2023/08/10"
 
 [rule]
 author = ["Elastic"]
@@ -28,7 +28,7 @@ tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: 
 type = "eql"
 query = '''
 sequence by host.id with maxspan=1s
-[ network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and 
+[ network where host.os.type == "linux" and event.type == "start" and event.action in ("connection_attempted", "connection_accepted") and 
   process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "socat") and 
   destination.ip != null and destination.ip != "127.0.0.1" and destination.ip != "::1" ] by process.entity_id
 [ process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "fork") and 


### PR DESCRIPTION
## Summary
While testing for socat tunneling, I noticed I didn't detect a bind shell with my reverse shell rules. I went to check why, and noticed the rules only checked for "connection_attempted", which indeed is the most common event.action, however it missed several occurences in which event.action == "connection_accepted". This PR fixes this. 