### PR TITLE
[Rule Tuning] Threat Intel Hash Indicator Match

### DIFF
--- a/kibana/connector.py
+++ b/kibana/connector.py
@@ -91,6 +91,11 @@ class Kibana(object):
             body = json.dumps(data)
 
         response = self.session.request(method, url, params=params, data=body, **kwargs)
+
+        if response.status_code != 200:
+            # retry once
+            response = self.session.request(method, url, params=params, data=body, **kwargs)
+
         if error:
             try:
                 response.raise_for_status()
@@ -168,8 +173,9 @@ class Kibana(object):
 
     def add_cookie(self, cookie):
         """Add cookie to be used for auth (such as from an SSO session)."""
-        # the request to /api/status will also add the cookie to the cookie jar upon a successful response
-        self.session.headers['cookie'] = cookie
+        # https://www.elastic.co/guide/en/kibana/7.10/security-settings-kb.html#security-session-and-cookie-settings
+        self.session.headers['sid'] = cookie
+        self.session.cookies.set('sid', cookie)
         self.status = self.get('/api/status')
         self.authenticated = True
 

--- a/rules/cross-platform/threat_intel_indicator_match_hash.toml
+++ b/rules/cross-platform/threat_intel_indicator_match_hash.toml
@@ -1,4 +1,3 @@
-
 [metadata]
 creation_date = "2023/05/22"
 maturity = "production"

--- a/rules/cross-platform/threat_intel_indicator_match_hash.toml
+++ b/rules/cross-platform/threat_intel_indicator_match_hash.toml
@@ -1,7 +1,8 @@
+
 [metadata]
 creation_date = "2023/05/22"
 maturity = "production"
-updated_date = "2023/07/24"
+updated_date = "2023/08/23"
 min_stack_comments = """
 Limiting the backport of these rules to the stack version which we are deprecating the Threat Intel Indicator Match
 general rules.
@@ -104,7 +105,7 @@ threat_query = '''
 '''
 
 query = """
-file.hash.*:* or file.pe.imphash:* or process.hash.*:* or process.pe.imphash:* or dll.hash.*:*
+file.hash.*:* or process.hash.*:* or dll.hash.*:*
 """
 
 
@@ -167,12 +168,6 @@ value = "threat.indicator.file.hash.sha256"
 
 [[rule.threat_mapping]]
 [[rule.threat_mapping.entries]]
-field = "file.pe.imphash"
-type = "mapping"
-value = "threat.indicator.file.pe.imphash"
-
-[[rule.threat_mapping]]
-[[rule.threat_mapping.entries]]
 field = "dll.hash.md5"
 type = "mapping"
 value = "threat.indicator.file.hash.md5"
@@ -206,9 +201,3 @@ value = "threat.indicator.file.hash.sha1"
 field = "process.hash.sha256"
 type = "mapping"
 value = "threat.indicator.file.hash.sha256"
-
-[[rule.threat_mapping]]
-[[rule.threat_mapping.entries]]
-field = "process.pe.imphash"
-type = "mapping"
-value = "threat.indicator.file.pe.imphash"


### PR DESCRIPTION
## Issues

- Closes #3030 

## Summary

This rule currently watches for matches on "imphash" hashes. Unfortunately this may only mean a file was created in a similar manner to a malware sample, but it does not mean the file is inherently malicious. While an imphash may assist with forensics, this is unfortunately causing false positives to the point of the rule exceeding "the maximum alert limit for the rule execution". I am proposing the removal of "imphash" matches due to the infeasibility of investigating and whitelisting hashes based on imphash matches.

## Contributor checklist

- [X] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [X] Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
