### PR TITLE
[Rule Tuning] 3 tunings to reduce FPs

### DIFF
--- a/rules/linux/discovery_sudo_allowed_command_enumeration.toml
+++ b/rules/linux/discovery_sudo_allowed_command_enumeration.toml
@@ -1,10 +1,10 @@
 [metadata]
-creation_date = "2023/07/20"
+creation_date = "2023/08/30"
 integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/24"
+updated_date = "2023/08/30"
 
 [rule]
 author = ["Elastic"]
@@ -26,7 +26,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
-process.name == "sudo" and process.args == "-l" and 
+process.name == "sudo" and process.args == "-l" and process.args_count == 2 and
 process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 not group.Ext.real.id : "0" and not user.Ext.real.id : "0"
 '''

--- a/rules/linux/execution_abnormal_process_id_file_created.toml
+++ b/rules/linux/execution_abnormal_process_id_file_created.toml
@@ -80,7 +80,7 @@ type = "new_terms"
 
 query = '''
 host.os.type:linux and event.category:file and event.action:creation and
-user.id : "0" and file.extension : ("pid" or "lock" or "reboot") and file.path : (/var/run/* or /run/*) and (
+user.id:0 and file.extension:(pid or lock or reboot) and file.path:(/var/run/* or /run/*) and (
   (process.name : (
     bash or dash or sh or tcsh or csh or zsh or ksh or fish or ash or touch or nano or vim or vi or editor or mv or cp)
   ) or (

--- a/rules/linux/execution_abnormal_process_id_file_created.toml
+++ b/rules/linux/execution_abnormal_process_id_file_created.toml
@@ -79,7 +79,7 @@ timestamp_override = "event.ingested"
 type = "new_terms"
 
 query = '''
-host.os.type : "linux" and event.category : "file" and event.action : ("creation" or "file_create_event") and
+host.os.type:linux and event.category:file and event.action:creation and
 user.id : "0" and file.extension : ("pid" or "lock" or "reboot") and file.path : (/var/run/* or /run/*) and (
   (process.name : (
     bash or dash or sh or tcsh or csh or zsh or ksh or fish or ash or touch or nano or vim or vi or editor or mv or cp)

--- a/rules/linux/execution_abnormal_process_id_file_created.toml
+++ b/rules/linux/execution_abnormal_process_id_file_created.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "Multiple field support in the New Terms rule type was added in Elastic 8.6"
 min_stack_version = "8.6.0"
-updated_date = "2023/08/24"
+updated_date = "2023/08/31"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Abnormal Process ID or Lock File Created"
@@ -74,19 +74,20 @@ references = [
 risk_score = 47
 rule_id = "cac91072-d165-11ec-a764-f661ea17fbce"
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Execution", "Threat: BPFDoor", "Resources: Investigation Guide", "Data Source: Elastic Endgame"]
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Execution", "Threat: BPFDoor", "Resources: Investigation Guide", "Data Source: Elastic Defend"]
 timestamp_override = "event.ingested"
 type = "new_terms"
 
 query = '''
 host.os.type : "linux" and event.category : "file" and event.action : ("creation" or "file_create_event") and
-user.id : "0" and file.extension : ("pid" or "lock" or "reboot") and file.path : (/var/run/* or /run/*) and not 
-file.name : ("auditd.pid" or python* or "apport.pid" or "apport.lock" or kworker* or "gdm3.pid" or "sshd.pid" or 
-"acpid.pid" or "unattended-upgrades.lock" or "unattended-upgrades.pid" or "cmd.pid" or "yum.pid" or "netconfig.pid" or 
-"docker.pid" or "atd.pid" or "lfd.pid" or "atop.pid" or "nginx.pid" or "dhclient.pid" or "smtpd.pid" or "stunnel.pid" or 
-"1_waagent.pid" or "crond.pid" or "cron.reboot" or "sssd.pid" or "tomcat8.pid" or "winbindd.pid" or "chronyd.pid") and
-not process.name : ("runc" or "ufw" or "snapd" or "snap" or "iptables" or "libvirtd" or "containerd-shim-runc-v2" or 
-"ifdown" or "snap-confine" or "ifup" or "dhclient" or "containerd")
+user.id : "0" and file.extension : ("pid" or "lock" or "reboot") and file.path : (/var/run/* or /run/*) and (
+  (process.name : (
+    bash or dash or sh or tcsh or csh or zsh or ksh or fish or ash or touch or nano or vim or vi or editor or mv or cp)
+  ) or (
+  process.executable : (
+    ./* or /tmp/* or /var/tmp/* or /dev/shm/* or /var/run/* or /boot/* or /srv/* or /run/*
+  ))
+) and not process.name : (go or git)
 '''
 
 [[rule.threat]]

--- a/rules/linux/privilege_escalation_sda_disk_mount_non_root.toml
+++ b/rules/linux/privilege_escalation_sda_disk_mount_non_root.toml
@@ -1,10 +1,10 @@
 [metadata]
-creation_date = "2023/07/31"
+creation_date = "2023/08/30"
 integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/07/31"
+updated_date = "2023/08/30"
 
 [rule]
 author = ["Elastic"]
@@ -29,7 +29,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.action in ("exec", "exec_event") and event.type == "start" and 
-process.name == "debugfs" and process.args : "/dev/sd*" and not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
+process.name == "debugfs" and process.args : "/dev/sd*" and not process.args == "-R" and 
+not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary
Just 2 small tunings to reduce FPs on these rules back to 0.

**edit**
I added one more tuning to address issue [#3041](https://github.com/elastic/detection-rules/issues/3041). This will reduce FPs and trigger on TPs:

<img width="1362" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/a4aaaf58-6c93-4246-8b22-32f90c6960ba">
