### PR TITLE
[New BBR] Suspicious which Enumeration

### DIFF
--- a/rules_building_block/discovery_suspicious_which_command_execution.toml
+++ b/rules_building_block/discovery_suspicious_which_command_execution.toml
@@ -1,0 +1,51 @@
+[metadata]
+creation_date = "2023/08/30"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/08/30"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule monitors for the usage of the which command with an unusual amount of process arguments. Attackers may leverage
+the which command to enumerate the system for useful installed utilities that may be used after compromising a system to
+escalate privileges or move latteraly across the network. 
+"""
+from = "now-119m"
+interval = "60m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Suspicious which Enumeration"
+risk_score = 21
+rule_id = "5b18eef4-842c-4b47-970f-f08d24004bde"
+severity = "low"
+tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Discovery", "Data Source: Elastic Defend", "Rule Type: BBR"]
+timestamp_override = "event.ingested"
+type = "eql"
+building_block_type = "default"
+
+query = '''
+process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
+process.name == "which" and process.args_count >= 10
+
+/* potential tuning if rule would turn out to be noisy
+and process.args in ("nmap", "nc", "ncat", "netcat", nc.traditional", "gcc", "g++", "socat") and 
+process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")
+*/ 
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1082"
+name = "System Information Discovery"
+reference = "https://attack.mitre.org/techniques/T1082/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"


### PR DESCRIPTION
## Summary
This rule monitors for the usage of the which command with an unusual amount of process arguments. Attackers may leverage the which command to enumerate the system for useful installed utilities that may be used after compromising a system to escalate privileges or move latteraly across the network. 

### Detection
**This rule (without the additional tuning options) shows 0 hits in telemetry, and 0 FPs in my own stacks.**
```
process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
process.name == "which" and process.args_count >= 10

/* potential tuning if rule would turn out to be noisy
and process.args in ("nmap", "nc", "ncat", "netcat", nc.traditional", "gcc", "g++", "socat") and 
process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")
*/ 
```

<img width="2557" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/df4c7a92-6c03-4702-9e43-46a05b15752c">
