### PR TITLE
[New Rules] GDB Secret Dumping

### DIFF
--- a/rules/linux/credential_access_gdb_init_memory_dump.toml
+++ b/rules/linux/credential_access_gdb_init_memory_dump.toml
@@ -1,0 +1,52 @@
+[metadata]
+creation_date = "2023/08/30"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/08/30"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule monitors for the potential memory dump of the init process (PID 1) through gdb. Attackers may leverage memory 
+dumping techniques to attempt secret extraction from privileged processes. Tools that display this behavior include
+"truffleproc" and "bash-memory-dump". This behavior should not happen by default, and should be investigated thoroughly.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Linux init (PID 1) Secret Dump via GDB"
+references = [
+    "https://github.com/controlplaneio/truffleproc",
+    "https://github.com/hajzer/bash-memory-dump"
+]
+risk_score = 47
+rule_id = "d4ff2f53-c802-4d2e-9fb9-9ecc08356c3f"
+severity = "medium"
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access", "Data Source: Elastic Defend"]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
+process.name == "gdb" and process.args == "--pid" and process.args == "1"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1003"
+name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1003.007"
+name = "Proc Filesystem"
+reference = "https://attack.mitre.org/techniques/T1003/007/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/linux/credential_access_gdb_init_memory_dump.toml
+++ b/rules/linux/credential_access_gdb_init_memory_dump.toml
@@ -30,7 +30,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
-process.name == "gdb" and process.args == "--pid" and process.args == "1"
+process.name == "gdb" and process.args in ("--pid", "-p") and process.args == "1"
 '''
 
 [[rule.threat]]

--- a/rules_building_block/credential_access_gdb_memory_dump.toml
+++ b/rules_building_block/credential_access_gdb_memory_dump.toml
@@ -32,7 +32,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
-process.name == "gdb" and process.args in ("--pid", "-p") and not process.args == "1"
+process.name == "gdb" and process.args in ("--pid", "-p") and process.args != "1"
 '''
 
 [[rule.threat]]

--- a/rules_building_block/credential_access_gdb_memory_dump.toml
+++ b/rules_building_block/credential_access_gdb_memory_dump.toml
@@ -20,6 +20,10 @@ index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Linux Secret Dumping via GDB"
+references = [
+    "https://github.com/controlplaneio/truffleproc",
+    "https://github.com/hajzer/bash-memory-dump"
+]
 risk_score = 21
 rule_id = "66c058f3-99f4-4d18-952b-43348f2577a0"
 severity = "low"

--- a/rules_building_block/credential_access_gdb_memory_dump.toml
+++ b/rules_building_block/credential_access_gdb_memory_dump.toml
@@ -32,7 +32,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
-process.name == "gdb" and process.args in ("--pid", "-p") and process.args != "1"
+process.name == "gdb" and process.args in ("--pid", "-p") and 
+/* Covered by d4ff2f53-c802-4d2e-9fb9-9ecc08356c3f */
+process.args != "1"
 '''
 
 [[rule.threat]]

--- a/rules_building_block/credential_access_gdb_memory_dump.toml
+++ b/rules_building_block/credential_access_gdb_memory_dump.toml
@@ -1,0 +1,50 @@
+[metadata]
+creation_date = "2023/08/30"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/08/30"
+bypass_bbr_timing = true
+
+[rule]
+author = ["Elastic"]
+building_block_type = "default"
+description = """
+This rule monitors for potential memory dumping through gdb. Attackers may leverage memory dumping techniques to attempt
+secret extraction from privileged processes. Tools that display this behavior include "truffleproc" and 
+"bash-memory-dump". This behavior should not happen by default, and should be investigated thoroughly.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Linux Secret Dumping via GDB"
+risk_score = 21
+rule_id = "66c058f3-99f4-4d18-952b-43348f2577a0"
+severity = "low"
+tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access", "Data Source: Elastic Defend", "Rule Type: BBR"]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
+process.name == "gdb" and process.args == "--pid"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1003"
+name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1003.007"
+name = "Proc Filesystem"
+reference = "https://attack.mitre.org/techniques/T1003/007/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules_building_block/credential_access_gdb_memory_dump.toml
+++ b/rules_building_block/credential_access_gdb_memory_dump.toml
@@ -32,7 +32,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
-process.name == "gdb" and process.args == "--pid"
+process.name == "gdb" and process.args in ("--pid", "-p") and not process.args == "1"
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary
This PR proposes the addition of two new GDB secret dumping rules:
1. Linux init (PID 1) Secret Dump via GDB
2. Linux Secret Dumping via GDB - BBR

## Linux init (PID 1) Secret Dump via GDB
This rule monitors for the potential memory dump of the init process (PID 1) through gdb. Attackers may leverage memory dumping techniques to attempt secret extraction from privileged processes. Tools that display this behavior include "truffleproc" and "bash-memory-dump". This behavior should not happen by default, and should be investigated thoroughly.

### Detection
**0 FPs in telemetry, also 0 FPs in my own stacks. Many FPs of security testing.**
```
process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
process.name == "gdb" and process.args == "--pid" and process.args == "1"
```
<img width="2525" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/c1653401-61ea-4778-952a-a9d74d80c08c">

## Linux Secret Dumping via GDB
This rule monitors for potential memory dumping through gdb. Attackers may leverage memory dumping techniques to attempt secret extraction from privileged processes. Tools that display this behavior include "truffleproc" and "bash-memory-dump". This behavior should not happen by default, and should be investigated thoroughly.

### Detection
**0 FPs in telemetry, also 0 FPs in my own stacks. Many FPs of security testing.**
```
process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and 
process.name == "gdb" and process.args == "--pid" and process.args == "1"
```
<img width="2552" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/1626f38c-259a-4bcb-979e-f33b5fa18745">
