### PR TITLE
[Bug] Remove `timestamp_override` requirement for all rules 8.3+

### DIFF
--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -920,11 +920,6 @@ class TestRuleTiming(BaseRuleTest):
                 'msg': ('eql rules include beats indexes. Non-elastic-agent indexes do not add the `event.ingested` '
                         'field and there is no default fallback to @timestamp for EQL rules <8.2, so the override '
                         'should be removed or a config entry included to manually add it in a custom pipeline')
-            },
-            'gte_82_eql': {
-                'errors': [],
-                'msg': ('should have the `timestamp_override` set to `event.ingested` - default fallback to '
-                        '@timestamp was added in 8.2')
             }
         }
 
@@ -961,9 +956,9 @@ class TestRuleTiming(BaseRuleTest):
                             errors['lt_82_eql']['errors'].append(rule_str)
                         elif beats_indexes and has_event_ingested and pipeline_config not in config:
                             errors['lt_82_eql_beats']['errors'].append(rule_str)
-                    else:
-                        if not has_event_ingested:
-                            errors['gte_82_eql']['errors'].append(rule_str)
+                        else:
+                            if not has_event_ingested:
+                                errors['lt_82_eql']['errors'].append(rule_str)
 
         if any([v['errors'] for k, v in errors.items()]):
             err_strings = ['errors with `timestamp_override = "event.ingested"`']


### PR DESCRIPTION
## Summary
Discussed with @imays11 regarding https://github.com/elastic/detection-rules/pull/3054, there appears to be a simple logic bug in the `TestRuleTiming` testing class, specifically with `test_event_override`. Prior to these changes, if a rule had a min stack that was 8.3+ it would error stating that the `timestamp_override` field was needed. Rather it should check that if the min stack is less than 8.2 and it has no `event_ingested` value set for `timestamp_override` set, error since `@timestamp` was not available as a default prior to 8.2.

To double check, I created a test EQL rule via the UI and left the override option blank and exported the rule, to which the field was not required.

```
{"id":"a8be5920-4765-11ee-b5f2-23722df344dd","updated_at":"2023-08-30T18:47:29.482Z","updated_by":"4220331459","created_at":"2023-08-30T18:47:25.058Z","created_by":"4220331459","name":"timestamp test","tags":[],"interval":"5m","enabled":false,"revision":0,"description":"timestamp test","risk_score":21,"severity":"low","license":"","output_index":"","meta":{"from":"1m","kibana_siem_app_url":"https://dejesus-threat-detection-dev.kb.us-central1.gcp.cloud.es.io:9243/app/security"},"author":[],"false_positives":[],"from":"now-360s","rule_id":"35cd0be9-3f6e-4ac8-b25d-2dcd6d357ec9","max_signals":100,"risk_score_mapping":[],"severity_mapping":[],"threat":[],"to":"now","references":[],"version":1,"exceptions_list":[],"immutable":false,"related_integrations":[],"required_fields":[],"setup":"","type":"eql","language":"eql","index":["apm-*-transaction*","auditbeat-*","endgame-*","filebeat-*","logs-*","packetbeat-*","traces-apm*","winlogbeat-*","-*elastic-cloud-logs-*"],"query":"process where process.name == \"outlook.exe\"","filters":[],"actions":[]}
{"exported_count":1,"exported_rules_count":1,"missing_rules":[],"missing_rules_count":0,"exported_exception_list_count":0,"exported_exception_list_item_count":0,"missing_exception_list_item_count":0,"missing_exception_list_items":[],"missing_exception_lists":[],"missing_exception_lists_count":0,"exported_action_connector_count":0,"missing_action_connection_count":0,"missing_action_connections":[],"excluded_action_connection_count":0,"excluded_action_connections":[]}
```

I checked out the branch for https://github.com/elastic/detection-rules/pull/3054, made these changes locally and ran tests as well.
<img width="1966" alt="Screenshot 2023-08-30 at 3 23 49 PM" src="https://github.com/elastic/detection-rules/assets/99630311/6134a412-9d70-45ef-8099-ff3b9bed78cd">
