### PR TITLE
Tunes Unusual Parent Process for cmd.exe rule to exclude oobe activity

### DIFF
--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -26,31 +26,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-sequence with maxspan=3m 
-[process where host.os.type == "windows" and event.type == "start" and ( ( process.name: "dllhost.exe" and not process.args: ("/Processid:{CA8C87C1-929D-45BA-94DB-EF8E6CB346AD}") ) or ( process.name: ("lsass.exe",
-                         "csrss.exe",
-                         "epad.exe",
-                         "regsvr32.exe",
-                         "LogonUI.exe",
-                         "wermgr.exe",
-                         "spoolsv.exe",
-                         "jucheck.exe",
-                         "jusched.exe",
-                         "ctfmon.exe",
-                         "taskhostw.exe",
-                         "GoogleUpdate.exe",
-                         "sppsvc.exe",
-                         "sihost.exe",
-                         "slui.exe",
-                         "SIHClient.exe",
-                         "SearchIndexer.exe",
-                         "SearchProtocolHost.exe",
-                         "FlashPlayerUpdateService.exe",
-                         "WerFault.exe",
-                         "WUDFHost.exe",
-                         "unsecapp.exe",
-                         "wlanext.exe" ) ) )] by process.entity_id
-[process where host.os.type == "windows" and event.type == "start" and process.name : "cmd.exe" and process.parent.name : ("lsass.exe",
+process where host.os.type == "windows" and event.type == "start" and
+  process.name : "cmd.exe" and
+  process.parent.name : ("lsass.exe",
                          "csrss.exe",
                          "epad.exe",
                          "regsvr32.exe",
@@ -73,7 +51,8 @@ sequence with maxspan=3m
                          "WerFault.exe",
                          "WUDFHost.exe",
                          "unsecapp.exe",
-                         "wlanext.exe" )] by process.parent.entity_id
+                         "wlanext.exe" ) and
+  not (process.parent.name : "dllhost.exe" and process.parent.args : "/Processid:{CA8C87C1-929D-45BA-94DB-EF8E6CB346AD}")
 '''
 
 

--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -26,9 +26,31 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "windows" and event.type == "start" and
-  process.name : "cmd.exe" and
-  process.parent.name : ("lsass.exe",
+sequence with maxspan=3m 
+[process where host.os.type == "windows" and event.type == "start" and ( ( process.name: "dllhost.exe" and not process.args: ("/Processid:{CA8C87C1-929D-45BA-94DB-EF8E6CB346AD}") ) or ( process.name: ("lsass.exe",
+                         "csrss.exe",
+                         "epad.exe",
+                         "regsvr32.exe",
+                         "LogonUI.exe",
+                         "wermgr.exe",
+                         "spoolsv.exe",
+                         "jucheck.exe",
+                         "jusched.exe",
+                         "ctfmon.exe",
+                         "taskhostw.exe",
+                         "GoogleUpdate.exe",
+                         "sppsvc.exe",
+                         "sihost.exe",
+                         "slui.exe",
+                         "SIHClient.exe",
+                         "SearchIndexer.exe",
+                         "SearchProtocolHost.exe",
+                         "FlashPlayerUpdateService.exe",
+                         "WerFault.exe",
+                         "WUDFHost.exe",
+                         "unsecapp.exe",
+                         "wlanext.exe" ) ) )] by process.entity_id
+[process where host.os.type == "windows" and event.type == "start" and process.name : "cmd.exe" and process.parent.name : ("lsass.exe",
                          "csrss.exe",
                          "epad.exe",
                          "regsvr32.exe",
@@ -51,7 +73,7 @@ process where host.os.type == "windows" and event.type == "start" and
                          "WerFault.exe",
                          "WUDFHost.exe",
                          "unsecapp.exe",
-                         "wlanext.exe" )
+                         "wlanext.exe" )] by process.parent.entity_id
 '''
 
 


### PR DESCRIPTION
When dllhost.exe is called with the "/Processid:{CA8C87C1-929D-45BA-94DB-EF8E6CB346AD}" argument it is creating an "OOBE Elevated Object Server"  as per https://strontic.github.io/xcyclopedia/library/clsid_ca8c87c1-929d-45ba-94db-ef8e6cb346ad.html

Out of the box experience is part of the Windows autopilot and therefore should be legitimate behaviour.


