### PR TITLE
[New Rule] Adding DGA Rules from Advanced Analytic DGA Package

### DIFF
--- a/rules/integrations/dga/command_and_control_ml_dga_activity_using_sunburst_domain.toml
+++ b/rules/integrations/dga/command_and_control_ml_dga_activity_using_sunburst_domain.toml
@@ -1,0 +1,58 @@
+[metadata]
+creation_date = "2023/09/14"
+integration = ["dga"]
+maturity = "production"
+min_stack_comments = "New rule"
+min_stack_version = "8.3.0"
+updated_date = "2023/09/14"
+
+[rule]
+author = ["Elastic"]
+description = """
+A supervised machine learning model has identified a DNS question name that used by the SUNBURST malware and is
+predicted to be the result of a Domain Generation Algorithm.
+"""
+from = "now-10m"
+index = ["logs-endpoint.events.*", "logs-network_traffic.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Machine Learning Detected DGA activity using a known SUNBURST DNS domain"
+references = [
+    "https://www.elastic.co/security-labs/detect-domain-generation-algorithm-activity-with-new-kibana-integration",
+]
+risk_score = 99
+rule_id = "bcaa15ce-2d41-44d7-a322-918f9db77766"
+severity = "critical"
+tags = [
+    "Domain: Network",
+    "Use Case: Domain Generation Algorithm Detection",
+    "Rule Type: ML",
+    "Rule Type: Machine Learning",
+    "Tactic: Command and Control",
+]
+type = "query"
+
+query = '''
+event.category:network and network.protocol:dns and
+ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1568"
+name = "Dynamic Resolution"
+reference = "https://attack.mitre.org/techniques/T1568/"
+[[rule.threat.technique.subtechnique]]
+id = "T1568.002"
+name = "Domain Generation Algorithms"
+reference = "https://attack.mitre.org/techniques/T1568/002/"
+
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/integrations/dga/command_and_control_ml_dga_high_sum_probability.toml
+++ b/rules/integrations/dga/command_and_control_ml_dga_high_sum_probability.toml
@@ -1,0 +1,45 @@
+[metadata]
+creation_date = "2023/09/14"
+integration = ["dga"]
+maturity = "production"
+min_stack_comments = "New rule"
+min_stack_version = "8.3.0"
+updated_date = "2023/09/14"
+
+[rule]
+anomaly_threshold = 70
+author = ["Elastic"]
+description = """
+A population analysis machine learning job detected potential DGA (domain generation algorithm) activity. Such activity
+is often used by malware command and control (C2) channels. This machine learning job looks for a source IP address
+making DNS requests that have an aggregate high probability of being DGA activity.
+"""
+from = "now-45m"
+interval = "15m"
+license = "Elastic License v2"
+machine_learning_job_id = "dga_high_sum_probability"
+name = "Potential DGA Activity"
+references = ["https://www.elastic.co/guide/en/security/current/prebuilt-ml-jobs.html"]
+risk_score = 21
+rule_id = "ff0d807d-869b-4a0d-a493-52bc46d2f1b1"
+severity = "low"
+tags = [
+    "Use Case: Domain Generation Algorithm Detection",
+    "Rule Type: ML",
+    "Rule Type: Machine Learning",
+    "Tactic: Command and Control",
+]
+type = "machine_learning"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1568"
+name = "Dynamic Resolution"
+reference = "https://attack.mitre.org/techniques/T1568/"
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/integrations/dga/command_and_control_ml_dns_request_high_dga_probability.toml
+++ b/rules/integrations/dga/command_and_control_ml_dns_request_high_dga_probability.toml
@@ -1,0 +1,57 @@
+[metadata]
+creation_date = "2023/09/14"
+integration = ["dga"]
+maturity = "production"
+min_stack_comments = "New rule"
+min_stack_version = "8.3.0"
+updated_date = "2023/09/14"
+
+[rule]
+author = ["Elastic"]
+description = """
+A supervised machine learning model has identified a DNS question name with a high probability of sourcing from a Domain
+Generation Algorithm (DGA), which could indicate command and control network activity.
+"""
+from = "now-10m"
+index = ["logs-endpoint.events.*", "logs-network_traffic.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Machine Learning Detected a DNS Request With a High DGA Probability Score"
+references = [
+    "https://www.elastic.co/security-labs/detect-domain-generation-algorithm-activity-with-new-kibana-integration",
+]
+risk_score = 21
+rule_id = "da7f5803-1cd4-42fd-a890-0173ae80ac69"
+severity = "low"
+tags = [
+    "Domain: Network",
+    "Use Case: Domain Generation Algorithm Detection",
+    "Rule Type: ML",
+    "Rule Type: Machine Learning",
+    "Tactic: Command and Control",
+]
+type = "query"
+
+query = '''
+event.category:network and network.protocol:dns and ml_is_dga.malicious_probability > 0.98
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1568"
+name = "Dynamic Resolution"
+reference = "https://attack.mitre.org/techniques/T1568/"
+[[rule.threat.technique.subtechnique]]
+id = "T1568.002"
+name = "Domain Generation Algorithms"
+reference = "https://attack.mitre.org/techniques/T1568/002/"
+
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+

--- a/rules/integrations/dga/command_and_control_ml_dns_request_predicted_to_be_a_dga_domain.toml
+++ b/rules/integrations/dga/command_and_control_ml_dns_request_predicted_to_be_a_dga_domain.toml
@@ -1,0 +1,58 @@
+[metadata]
+creation_date = "2023/09/14"
+integration = ["dga"]
+maturity = "production"
+min_stack_comments = "New rule"
+min_stack_version = "8.3.0"
+updated_date = "2023/09/14"
+
+[rule]
+author = ["Elastic"]
+description = """
+A supervised machine learning model has identified a DNS question name that is predicted to be the result of a Domain
+Generation Algorithm (DGA), which could indicate command and control network activity.
+"""
+from = "now-10m"
+index = ["logs-endpoint.events.*", "logs-network_traffic.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Machine Learning Detected a DNS Request Predicted to be a DGA Domain"
+references = [
+    "https://www.elastic.co/security-labs/detect-domain-generation-algorithm-activity-with-new-kibana-integration",
+]
+risk_score = 21
+rule_id = "f3403393-1fd9-4686-8f6e-596c58bc00b4"
+severity = "low"
+tags = [
+    "Domain: Network",
+    "Use Case: Domain Generation Algorithm Detection",
+    "Rule Type: ML",
+    "Rule Type: Machine Learning",
+    "Tactic: Command and Control",
+]
+type = "query"
+
+query = '''
+event.category:network and network.protocol:dns and
+ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1568"
+name = "Dynamic Resolution"
+reference = "https://attack.mitre.org/techniques/T1568/"
+[[rule.threat.technique.subtechnique]]
+id = "T1568.002"
+name = "Domain Generation Algorithms"
+reference = "https://attack.mitre.org/techniques/T1568/002/"
+
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+


### PR DESCRIPTION
## Summary
This PR moves the detection rules from the DGA Detection [integration](https://github.com/elastic/integrations/tree/main/packages/dga/kibana/security_rule) package, into the detection-rules repo.
