### PR TITLE
[Rule Tuning] Update `LMD` Rules Min-Stack to `8.5`

### DIFF
--- a/rules/integrations/lmd/lateral_movement_malicious_remote_file_creation.toml
+++ b/rules/integrations/lmd/lateral_movement_malicious_remote_file_creation.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd","endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/lmd/lateral_movement_malicious_remote_file_creation.toml
+++ b/rules/integrations/lmd/lateral_movement_malicious_remote_file_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd","endpoint"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_high_mean_rdp_process_args.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_high_mean_rdp_process_args.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_high_mean_rdp_process_args.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_high_mean_rdp_process_args.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_high_mean_rdp_session_duration.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_high_mean_rdp_session_duration.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/12"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_high_mean_rdp_session_duration.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_high_mean_rdp_session_duration.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/12"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_high_remote_file_size.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_high_remote_file_size.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_high_remote_file_size.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_high_remote_file_size.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_high_variance_rdp_session_duration.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_high_variance_rdp_session_duration.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_high_variance_rdp_session_duration.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_high_variance_rdp_session_duration.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_rare_remote_file_directory.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_rare_remote_file_directory.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/12"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_rare_remote_file_directory.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_rare_remote_file_directory.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/12"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_rare_remote_file_extension.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_rare_remote_file_extension.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_rare_remote_file_extension.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_rare_remote_file_extension.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_spike_in_connections_from_a_source_ip.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_spike_in_connections_from_a_source_ip.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_spike_in_connections_from_a_source_ip.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_spike_in_connections_from_a_source_ip.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_spike_in_connections_to_a_destination_ip.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_spike_in_connections_to_a_destination_ip.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_spike_in_connections_to_a_destination_ip.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_spike_in_connections_to_a_destination_ip.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_spike_in_rdp_processes.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_spike_in_rdp_processes.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/12"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_spike_in_rdp_processes.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_spike_in_rdp_processes.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/12"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_spike_in_remote_file_transfers.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_spike_in_remote_file_transfers.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_spike_in_remote_file_transfers.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_spike_in_remote_file_transfers.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_ml_unusual_time_for_an_rdp_session.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_unusual_time_for_an_rdp_session.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 anomaly_threshold = 70

--- a/rules/integrations/lmd/lateral_movement_ml_unusual_time_for_an_rdp_session.toml
+++ b/rules/integrations/lmd/lateral_movement_ml_unusual_time_for_an_rdp_session.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 

--- a/rules/integrations/lmd/lateral_movement_remote_file_creation_in_sensitive_directory.toml
+++ b/rules/integrations/lmd/lateral_movement_remote_file_creation_in_sensitive_directory.toml
@@ -3,8 +3,8 @@ creation_date = "2023/09/13"
 integration = ["lmd","endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/09/21"
+min_stack_version = "8.5.0"
+updated_date = "2023/09/27"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/lmd/lateral_movement_remote_file_creation_in_sensitive_directory.toml
+++ b/rules/integrations/lmd/lateral_movement_remote_file_creation_in_sensitive_directory.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/13"
 integration = ["lmd","endpoint"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_comments = "LMD first package ga available in 8.5.0"
 min_stack_version = "8.5.0"
 updated_date = "2023/09/27"
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/174

## Summary
Integration was made `ga` for 8.5+. As a result, when we originally merged the PR to add the rules in https://github.com/elastic/detection-rules/pull/3119, they were min-stacked to 8.3.0. Thus, they broke some unit testing in 8.3 and 8.5 branches that checks that these rules are compatible with these stack versions. @ajosh0504 this was an oversight on my end. For the next set of rules and packages, we just need to check the min-stack for each rule according to package availability.

Solution:
1. Go to 8.3 and 8.4 branch, remove rules and push to branches
2. This PR to update min-stack and let backporting happen
