### PR TITLE
[Rule Tuning] Fork `Suspicious WMI Event Subscription Created` for Version Control

### DIFF
--- a/rules/windows/persistence_sysmon_wmi_event_subscription.toml
+++ b/rules/windows/persistence_sysmon_wmi_event_subscription.toml
@@ -2,9 +2,9 @@
 creation_date = "2023/02/02"
 integration = ["windows"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/08"
+min_stack_comments = "Related integrations field type changes in 8.8.0"
+min_stack_version = "8.8.0"
+updated_date = "2023/10/03"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/pull/3151

## Summary
This PR adjusts the minimum stack version of this rule. This is due to backporting and version control, where the build time field `required_fields` has a field `winlog.event_data.Operation` where the type is `unknown` up until 8.8. After 8.8, the field type is `keyword`. As a result, the SHA256 of the rule changes between branches and when version lock occurs, causes the double bump mentioned [here](https://github.com/elastic/detection-rules/pull/3151/files#r1344412618). This occurs when the integration (here it is the Windows integration) changes OOB and causes changes downstream to build time fields.

As a result, we need to fork the rule to separate it from 8.3-8.7 and 8.8+. This will make 8.3-8.7 version 5 with a buffer to 103, whereas 8.8+ will be version 104+

`8.7 API formatted`

<img width="492" alt="Screenshot 2023-10-03 at 12 38 42 PM" src="https://github.com/elastic/detection-rules/assets/99630311/2b0acb56-bd24-45b6-a7b6-dfc88e6ef94f">


`8.8 API formatted`
<img width="471" alt="Screenshot 2023-10-03 at 12 39 03 PM" src="https://github.com/elastic/detection-rules/assets/99630311/3af60370-7a22-4082-a356-5f44489eb9e1">

@w0rk3r - While we were at it, I checked telemetry to determine any potential rule tunings but noticed this rule has no alerts since it's creation. If you have any additional changes, feel free to make them.