### PR TITLE
Update typing-extensions dependency for Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 	"requests~=2.27",
 	"toml==0.10.0",
 	"typing-inspect==0.8.0",
-	"typing-extensions==4.5.0",
+	"typing-extensions==4.8.0",
 	"XlsxWriter~=1.3.6",
 	"semver==3.0.0-dev.4"
 ]


### PR DESCRIPTION
## Issue
When uploading rules with Python 3.12, it won't upload, raising the following error:
```
raceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/detection-rules/detection_rules/detection_rules/__init__.py", line 13, in <module>
    from . import (  # noqa: E402
  File "/detection-rules/detection_rules/detection_rules/devtools.py", line 33, in <module>
    from . import attack, rule_loader, utils
  File "/detection-rules/detection_rules/detection_rules/rule_loader.py", line 19, in <module>
    from .mappings import RtaMappings
  File "/detection-rules/detection_rules/detection_rules/mappings.py", line 12, in <module>
    from .rule import TOMLRule
  File "/detection-rules/detection_rules/detection_rules/rule.py", line 31, in <module>
    from .mixins import MarshmallowDataclassMixin, StackCompatMixin
  File "/detection-rules/detection_rules/detection_rules/mixins.py", line 12, in <module>
    import marshmallow_dataclass
  File "/usr/local/lib/python3.12/site-packages/marshmallow_dataclass/__init__.py", line 67, in <module>
    import typing_inspect
  File "/usr/local/lib/python3.12/site-packages/typing_inspect.py", line 23, in <module>
    from typing_extensions import _TypedDictMeta as _TypedDictMeta_TE
  File "/usr/local/lib/python3.12/site-packages/typing_extensions.py", line 1174, in <module>
    class TypeVar(typing.TypeVar, _DefaultMixin, _root=True):
TypeError: type 'typing.TypeVar' is not an acceptable base type
```
## Solution
This problem is specific to 3.12. The solution was to update typing-extensions package to its latest version.