### PR TITLE
[FR] Only supporting known compatible rule file types

### DIFF
--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -100,7 +100,9 @@ def import_rules(input_file, directory, ignore_invalid_files):
 
     rule_contents = []
     for rule_file in rule_files:
-        rule_contents.extend(load_rule_contents(Path(rule_file), allow_empty_rule=ignore_invalid_files))
+        rule = load_rule_contents(Path(rule_file), allow_empty_rule=ignore_invalid_files)
+        if rule:
+            rule_contents.extend(rule)
 
     if not rule_contents:
         click.echo('Must specify at least one file!')

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -92,14 +92,15 @@ def generate_rules_index(ctx: click.Context, query, overwrite, save_files=True):
 @root.command('import-rules')
 @click.argument('input-file', type=click.Path(dir_okay=False, exists=True), nargs=-1, required=False)
 @click.option('--directory', '-d', type=click.Path(file_okay=False, exists=True), help='Load files from a directory')
-def import_rules(input_file, directory):
+@click.option('--ignore-invalid-files', '-i', is_flag=True, help='Ignore files with invalid rule data')
+def import_rules(input_file, directory, ignore_invalid_files):
     """Import rules from json, toml, or Kibana exported rule file(s)."""
     rule_files = glob.glob(os.path.join(directory, '**', '*.*'), recursive=True) if directory else []
     rule_files = sorted(set(rule_files + list(input_file)))
 
     rule_contents = []
     for rule_file in rule_files:
-        rule_contents.extend(load_rule_contents(Path(rule_file)))
+        rule_contents.extend(load_rule_contents(Path(rule_file), allow_empty_rule=ignore_invalid_files))
 
     if not rule_contents:
         click.echo('Must specify at least one file!')

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -326,8 +326,8 @@ def load_rule_contents(rule_file: Path, single_only=False) -> list:
         return contents or [{}]
     elif extension == '.toml':
         rule = pytoml.loads(raw_text)
-    else:
-        rule = load_dump(rule_file)
+    elif extension.lower() in ('yaml', 'yml'):
+        rule = load_dump(str(rule_file))
 
     if isinstance(rule, dict):
         return [rule]

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -308,10 +308,12 @@ def clear_caches():
     _cache.clear()
 
 
-def load_rule_contents(rule_file: Path, single_only=False) -> list:
+def load_rule_contents(rule_file: Path, allow_empty_rule=False, single_only=False) -> list:
     """Load a rule file from multiple formats."""
     _, extension = os.path.splitext(rule_file)
     raw_text = rule_file.read_text()
+
+    rule = None
 
     if extension in ('.ndjson', '.jsonl'):
         # kibana exported rule object is ndjson with the export metadata on the last line
@@ -334,6 +336,8 @@ def load_rule_contents(rule_file: Path, single_only=False) -> list:
     elif isinstance(rule, list):
         return rule
     else:
+        if allow_empty_rule:
+            return None
         raise ValueError(f"Expected a list or dictionary in {rule_file}")
 
 


### PR DESCRIPTION

## Issues
https://github.com/elastic/detection-rules/issues/3166

## Summary

This PR changes the behavior of `load_rule_contents` to provide an option to only load known supported file types as opposed to attempting to load any file type from the files in a given directory. The CLI can make use of this through the new `--ignore-invalid-files` flag for the`import-rules` command. This allows users to include documentation in the same directory as their rules and still be able to use the CLI to load the rules. 

## Testing

```shell

detection-rules on  3166-fr-add-support-for-loading-a-rule-directory-with-mixed-file-types-1 [✘!?⇡] is  v0.1.0 via  v3.8.10 (venv) on  eric.forte 
❯ ls test_rules/
attempt_to_disable_iptables_or_firewall.toml  base16_or_base32_encoding_decoding_activity.toml               creation_of_hidden_shared_object_file.toml          esxi_timestomping_using_touch_command.toml  file_made_immutable_by_chattr.toml
attempt_to_disable_syslog_service.toml        creation_of_hidden_files_and_directories_via_commandline.toml  deprecated_potential_dns_tunneling_via_iodine.toml  file_deletion_via_shred.toml

detection-rules on  3166-fr-add-support-for-loading-a-rule-directory-with-mixed-file-types-1 [✘!?⇡] is  v0.1.0 via  v3.8.10 (venv) on  eric.forte 
❯ python -m detection_rules import-rules -d test_rules/

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /tmp/fr_test/detection-rules/rules/attempt_to_disable_iptables_or_firewall.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/attempt_to_disable_syslog_service.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/base16_or_base32_encoding_decoding_activity.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/creation_of_hidden_files_and_directories_via_commandline.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/creation_of_hidden_shared_object_file.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/deprecated_potential_dns_tunneling_via_iodine.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/esxi_timestomping_using_touch_command.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/file_deletion_via_shred.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/file_made_immutable_by_chattr.toml

detection-rules on  3166-fr-add-support-for-loading-a-rule-directory-with-mixed-file-types-1 [✘!?⇡] is  v0.1.0 via  v3.8.10 (venv) on  eric.forte 
❯ touch test_rules/README.md

detection-rules on  3166-fr-add-support-for-loading-a-rule-directory-with-mixed-file-types-1 [✘!?⇡] is  v0.1.0 via  v3.8.10 (venv) on  eric.forte 
❯ python -m detection_rules import-rules -d test_rules/

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/fr_test/detection-rules/detection_rules/__main__.py", line 34, in <module>
    main()
  File "/tmp/fr_test/detection-rules/detection_rules/__main__.py", line 31, in main
    root(prog_name="detection_rules")
  File "/tmp/fr_test/detection-rules/venv/lib/python3.8/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/tmp/fr_test/detection-rules/venv/lib/python3.8/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/tmp/fr_test/detection-rules/venv/lib/python3.8/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/tmp/fr_test/detection-rules/venv/lib/python3.8/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/tmp/fr_test/detection-rules/venv/lib/python3.8/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/tmp/fr_test/detection-rules/detection_rules/main.py", line 103, in import_rules
    rule_contents.extend(load_rule_contents(Path(rule_file), allow_empty_rule=ignore_invalid_files))
  File "/tmp/fr_test/detection-rules/detection_rules/utils.py", line 341, in load_rule_contents
    raise ValueError(f"Expected a list or dictionary in {rule_file}")
ValueError: Expected a list or dictionary in test_rules/README.md

detection-rules on  3166-fr-add-support-for-loading-a-rule-directory-with-mixed-file-types-1 [✘!?⇡] is  v0.1.0 via  v3.8.10 (venv) on  eric.forte 
❯ python -m detection_rules import-rules -d test_rules/ --ignore-invalid-files

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /tmp/fr_test/detection-rules/rules/attempt_to_disable_iptables_or_firewall.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/attempt_to_disable_syslog_service.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/base16_or_base32_encoding_decoding_activity.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/creation_of_hidden_files_and_directories_via_commandline.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/creation_of_hidden_shared_object_file.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/deprecated_potential_dns_tunneling_via_iodine.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/esxi_timestomping_using_touch_command.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/file_deletion_via_shred.toml
[+] Building rule for /tmp/fr_test/detection-rules/rules/file_made_immutable_by_chattr.toml

```

