### PR TITLE
[Bug] Path object passed instead of String

### DIFF
--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -327,7 +327,7 @@ def load_rule_contents(rule_file: Path, single_only=False) -> list:
     elif extension == '.toml':
         rule = pytoml.loads(raw_text)
     else:
-        rule = load_dump(rule_file)
+        rule = load_dump(str(rule_file))
 
     if isinstance(rule, dict):
         return [rule]


### PR DESCRIPTION

## Issues
https://github.com/elastic/detection-rules/issues/3170

## Summary

This PR updates the `load_rule_contents` function to properly send a string of the rule file name instead of the Path to eql's `load_dump` function. For more information see the above issue. 

## Testing

1. Create a directory with only valid rules and run ` python -m detection_rules import-rules -d <test_dir>`
2. Add an invalid rule file to that directory and run ` python -m detection_rules import-rules -d <test_dir>`
3. Observe correct error


<details><summary>Correct Output Example</summary>
<p>

```shell

detection-rules on  3170-bug-incorrect-error-on-invalid-rules [$!?] is  v0.1.0 via  v3.8.10 (detection-rules-build) on  eric.forte 
❯ ls test_rules/
collection_email_outlook_mailbox_via_com.toml

detection-rules on  3170-bug-incorrect-error-on-invalid-rules [$!?] is  v0.1.0 via  v3.8.10 (detection-rules-build) on  eric.forte 
❯ python -m detection_rules import-rules -d test_rules/

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /home/forteea1/Code/elastic/detection-rules/rules/suspicious_inter_process_communication_via_outlook.toml

detection-rules on  3170-bug-incorrect-error-on-invalid-rules [$!?] is  v0.1.0 via  v3.8.10 (detection-rules-build) on  eric.forte 
❯ touch test_rules/README.md

detection-rules on  3170-bug-incorrect-error-on-invalid-rules [$!?] is  v0.1.0 via  v3.8.10 (detection-rules-build) on  eric.forte 
❯ python -m detection_rules import-rules -d test_rules/

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/forteea1/Code/elastic/detection-rules/detection_rules/__main__.py", line 34, in <module>
    main()
  File "/home/forteea1/Code/elastic/detection-rules/detection_rules/__main__.py", line 31, in main
    root(prog_name="detection_rules")
  File "/home/forteea1/Code/elastic/detection-rules/env/detection-rules-build/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/forteea1/Code/elastic/detection-rules/env/detection-rules-build/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/forteea1/Code/elastic/detection-rules/env/detection-rules-build/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/forteea1/Code/elastic/detection-rules/env/detection-rules-build/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/forteea1/Code/elastic/detection-rules/env/detection-rules-build/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/forteea1/Code/elastic/detection-rules/detection_rules/main.py", line 102, in import_rules
    rule_contents.extend(load_rule_contents(Path(rule_file)))
  File "/home/forteea1/Code/elastic/detection-rules/detection_rules/utils.py", line 330, in load_rule_contents
    rule = load_dump(str(rule_file))
  File "/home/forteea1/Code/elastic/detection-rules/env/detection-rules-build/lib/python3.8/site-packages/eql/utils.py", line 149, in load_dump
    raise ValueError("Unsupported file type {}".format(extension))
ValueError: Unsupported file type md

````

</p>
</details> 
