### PR TITLE
[Rule Tuning] Adjust Lucene queries to use Uppercase operators

### DIFF
--- a/rules/network/command_and_control_cobalt_strike_beacon.toml
+++ b/rules/network/command_and_control_cobalt_strike_beacon.toml
@@ -4,7 +4,7 @@ integration = ["network_traffic"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/08/01"
+updated_date = "2023/10/16"
 
 [rule]
 author = ["Elastic"]
@@ -40,9 +40,9 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-((event.category: (network or network_traffic) and type: (tls or http))
-    or event.dataset: (network_traffic.tls or network_traffic.http)
-) and destination.domain:/[a-z]{3}.stage.[0-9]{8}\..*/
+((event.category: (network OR network_traffic) AND type: (tls OR http))
+    OR event.dataset: (network_traffic.tls OR network_traffic.http)
+) AND destination.domain:/[a-z]{3}.stage.[0-9]{8}\..*/
 '''
 
 

--- a/rules/network/command_and_control_fin7_c2_behavior.toml
+++ b/rules/network/command_and_control_fin7_c2_behavior.toml
@@ -4,7 +4,7 @@ integration = ["network_traffic"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/08/01"
+updated_date = "2023/10/16"
 
 [rule]
 author = ["Elastic"]
@@ -37,8 +37,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-(event.dataset: (network_traffic.tls or network_traffic.http) or
-    (event.category: (network or network_traffic) and type: (tls or http) and network.transport: tcp)) and
+(event.dataset: (network_traffic.tls OR network_traffic.http) or
+    (event.category: (network OR network_traffic) AND type: (tls OR http) AND network.transport: tcp)) AND
 destination.domain:/[a-zA-Z]{4,5}\.(pw|us|club|info|site|top)/ AND NOT destination.domain:zoom.us
 '''
 

--- a/rules/network/command_and_control_halfbaked_beacon.toml
+++ b/rules/network/command_and_control_halfbaked_beacon.toml
@@ -4,7 +4,7 @@ integration = ["network_traffic"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/08/01"
+updated_date = "2023/10/16"
 
 [rule]
 author = ["Elastic"]
@@ -38,10 +38,10 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-(event.dataset: (network_traffic.tls or network_traffic.http) or
-  (event.category: (network or network_traffic) and network.protocol: http)) and
-  network.transport:tcp and url.full:/http:\/\/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}\/cd/ and
-  destination.port:(53 or 80 or 8080 or 443)
+(event.dataset: (network_traffic.tls OR network_traffic.http) OR
+  (event.category: (network OR network_traffic) AND network.protocol: http)) AND
+  network.transport:tcp AND url.full:/http:\/\/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}\/cd/ AND
+  destination.port:(53 OR 80 OR 8080 OR 443)
 '''
 
 

--- a/rules/network/initial_access_unsecure_elasticsearch_node.toml
+++ b/rules/network/initial_access_unsecure_elasticsearch_node.toml
@@ -4,7 +4,7 @@ integration = ["network_traffic"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/08/01"
+updated_date = "2023/10/16"
 
 [rule]
 author = ["Elastic"]
@@ -38,8 +38,8 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-(event.dataset: network_traffic.http or (event.category: network_traffic and network.protocol: http)) and
-    status:OK and destination.port:9200 and network.direction:inbound and NOT http.response.headers.content-type:"image/x-icon" and not
+(event.dataset: network_traffic.http OR (event.category: network_traffic AND network.protocol: http)) AND
+    status:OK AND destination.port:9200 AND network.direction:inbound AND NOT http.response.headers.content-type:"image/x-icon" AND NOT
     _exists_:http.request.headers.authorization
 '''
 


### PR DESCRIPTION
## Issues

Resolves #3187 

## Summary

Adjust Lucene queries to use Uppercase operators in order to avoid non-intentional matches.