### PR TITLE
[New Rule] Attempt to Clear Kernel Ring Buffer

### DIFF
--- a/rules/linux/defense_evasion_clear_kernel_ring_buffer.toml
+++ b/rules/linux/defense_evasion_clear_kernel_ring_buffer.toml
@@ -1,0 +1,81 @@
+[metadata]
+creation_date = "2023/10/24"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/10/24"
+
+[rule]
+author = ["Elastic"]
+description = """
+Monitors for the deletion of the kernel ring buffer events through dmesg. Attackers may clear kernel ring buffer events
+to evade detection after installing a Linux kernel module (LKM).
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Attempt to Clear Kernel Ring Buffer"
+risk_score = 21
+rule_id = "2724808c-ba5d-48b2-86d2-0002103df753"
+setup = """
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows
+the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click Add integrations.
+- In the query bar, search for Elastic Defend and select the integration to see more details about it.
+- Click Add Elastic Defend.
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either Traditional Endpoints or Cloud Workloads.
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest to select "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in New agent policy name. If other agent policies already exist, you can click the Existing hosts tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click Save and Continue.
+- To complete the integration, select Add Elastic Agent to your hosts and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+
+"""
+severity = "low"
+tags = [
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Defense Evasion",
+        "Data Source: Elastic Defend"
+        ]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and
+process.name == "dmesg" and process.args : "-c"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+name = "Impair Defenses"
+id = "T1562"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+name = "Disable or Modify Tools"
+id = "T1562.001"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+name = "Defense Evasion"
+id = "TA0005"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/linux/defense_evasion_clear_kernel_ring_buffer.toml
+++ b/rules/linux/defense_evasion_clear_kernel_ring_buffer.toml
@@ -74,6 +74,16 @@ name = "Disable or Modify Tools"
 id = "T1562.001"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
 
+[[rule.threat.technique]]
+name = "Indicator Removal"
+id = "T1070"
+reference = "https://attack.mitre.org/techniques/T1070/"
+
+[[rule.threat.technique.subtechnique]]
+name = "Clear Linux or Mac System Logs"
+id = "T1070.002"
+reference = "https://attack.mitre.org/techniques/T1070/002/"
+
 [rule.threat.tactic]
 name = "Defense Evasion"
 id = "TA0005"


### PR DESCRIPTION
## Summary
Monitors for the deletion of the kernel ring buffer events through dmesg. Attackers may clear kernel ring buffer events to evade detection after installing a Linux kernel module (LKM).

This behavior was observed in [BDS LKM ROOTKIT](https://github.com/bluedragonsecurity/bds_lkm#bds-lkm-rootkit). More information and progress on root kit rule dev is documented in https://github.com/elastic/detection-rules/issues/3210.

### Detection
```
process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and
process.name == "dmesg" and process.args : "-c"
```
Root kit executing these commands upon and after installation:
<img width="1418" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/b988dc21-d1db-40f1-bebf-3f7c8fa4dd7f">
