### PR TITLE
[FR] Adjust Risk Severity Unit Test to Match UI

### DIFF
--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1156,15 +1156,17 @@ class TestRiskScoreMismatch(BaseRuleTest):
     def test_rule_risk_score_severity_mismatch(self):
         invalid_list = []
         risk_severity = {
-            "critical": 99,
-            "high": 73,
-            "medium": 47,
-            "low": 21,
+            "critical": (74, 100),  # updated range for critical
+            "high": (48, 73),       # updated range for high
+            "medium": (22, 47),     # updated range for medium
+            "low": (0, 21),         # updated range for low
         }
         for rule in self.all_rules:
             severity = rule.contents.data.severity
             risk_score = rule.contents.data.risk_score
-            if risk_severity[severity] != risk_score:
+
+            # Check if the risk_score falls within the range for the severity level
+            if not risk_severity[severity][0] <= risk_score <= risk_severity[severity][1]:
                 invalid_list.append(f'{self.rule_str(rule)} Severity: {severity}, Risk Score: {risk_score}')
 
         if invalid_list:

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1166,7 +1166,8 @@ class TestRiskScoreMismatch(BaseRuleTest):
             risk_score = rule.contents.data.risk_score
 
             # Check if the risk_score falls within the range for the severity level
-            if not risk_severity[severity][0] <= risk_score <= risk_severity[severity][1]:
+            min_score, max_score = risk_severity[severity]
+            if not min_score <= risk_score <= max_score:
                 invalid_list.append(f'{self.rule_str(rule)} Severity: {severity}, Risk Score: {risk_score}')
 
         if invalid_list:


### PR DESCRIPTION
## Issues
Resolves https://github.com/elastic/detection-rules/issues/3137

## Summary
This PR adjusts the risk severity settings to allow specific ranges for low, medium, high and critical severity as [documented](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#rule-ui-basic-params). When community members are creating custom rules, unit tests fail for what is acceptable upstream. For more information, please see issue.