### PR TITLE
[Rule Tuning] Bump Minimum Stacks for AWS and Okta for Version Control

### DIFF
--- a/rules/integrations/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/integrations/aws/collection_cloudtrail_logging_created.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/10"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/integrations/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/16"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/integrations/aws/credential_access_iam_user_addition_to_group.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/04"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/credential_access_new_terms_secretsmanager_getsecretvalue.toml
+++ b/rules/integrations/aws/credential_access_new_terms_secretsmanager_getsecretvalue.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/06"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.6.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Nick Jones", "Elastic"]

--- a/rules/integrations/aws/credential_access_root_console_failure_brute_force.toml
+++ b/rules/integrations/aws/credential_access_root_console_failure_brute_force.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/21"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/26"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/10"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/15"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_config_service_rule_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/26"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/integrations/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/16"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/15"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/26"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_elasticache_security_group_creation.toml
+++ b/rules/integrations/aws/defense_evasion_elasticache_security_group_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/07/19"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/defense_evasion_elasticache_security_group_modified_or_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_elasticache_security_group_modified_or_deleted.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/07/19"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/defense_evasion_escalation_aws_suspicious_saml_activity.toml
+++ b/rules/integrations/aws/defense_evasion_escalation_aws_suspicious_saml_activity.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/09/22"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/28"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/27"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_waf_acl_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/09"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/exfiltration_ec2_full_network_packet_capture_detected.toml
+++ b/rules/integrations/aws/exfiltration_ec2_full_network_packet_capture_detected.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/05"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/integrations/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/24"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/exfiltration_ec2_vm_export_failure.toml
+++ b/rules/integrations/aws/exfiltration_ec2_vm_export_failure.toml
@@ -2,10 +2,9 @@
 creation_date = "2021/04/22"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
-
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 [rule]
 author = ["Elastic", "Austin Songer"]
 description = """

--- a/rules/integrations/aws/exfiltration_rds_snapshot_export.toml
+++ b/rules/integrations/aws/exfiltration_rds_snapshot_export.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/06/06"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/exfiltration_rds_snapshot_restored.toml
+++ b/rules/integrations/aws/exfiltration_rds_snapshot_restored.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/06/29"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/impact_aws_eventbridge_rule_disabled_or_deleted.toml
+++ b/rules/integrations/aws/impact_aws_eventbridge_rule_disabled_or_deleted.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/10/17"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/integrations/aws/impact_cloudtrail_logging_updated.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/10"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/18"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/20"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/integrations/aws/impact_ec2_disable_ebs_encryption.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/05"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_efs_filesystem_or_mount_deleted.toml
+++ b/rules/integrations/aws/impact_efs_filesystem_or_mount_deleted.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/08/27"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/26"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/impact_iam_group_deletion.toml
+++ b/rules/integrations/aws/impact_iam_group_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_kms_cmk_disabled_or_scheduled_for_deletion.toml
+++ b/rules/integrations/aws/impact_kms_cmk_disabled_or_scheduled_for_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/09/21"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Xavier Pich"]

--- a/rules/integrations/aws/impact_rds_group_deletion.toml
+++ b/rules/integrations/aws/impact_rds_group_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/06/05"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_stoppage.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/20"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/initial_access_console_login_root.toml
+++ b/rules/integrations/aws/initial_access_console_login_root.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/11"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/initial_access_password_recovery.toml
+++ b/rules/integrations/aws/initial_access_password_recovery.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/02"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/initial_access_via_system_manager.toml
+++ b/rules/integrations/aws/initial_access_via_system_manager.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/06"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/ml_cloudtrail_error_message_spike.toml
+++ b/rules/integrations/aws/ml_cloudtrail_error_message_spike.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 integration = ["aws"]
 
 [rule]

--- a/rules/integrations/aws/ml_cloudtrail_rare_error_code.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_error_code.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 integration = ["aws"]
 
 [rule]

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_city.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_city.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 integration = ["aws"]
 
 [rule]

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_country.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_country.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 integration = ["aws"]
 
 [rule]

--- a/rules/integrations/aws/ml_cloudtrail_rare_method_by_user.toml
+++ b/rules/integrations/aws/ml_cloudtrail_rare_method_by_user.toml
@@ -1,9 +1,9 @@
 [metadata]
 creation_date = "2020/07/13"
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 integration = ["aws"]
 
 [rule]

--- a/rules/integrations/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/integrations/aws/persistence_ec2_network_acl_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/04"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_ec2_security_group_configuration_change_detection.toml
+++ b/rules/integrations/aws/persistence_ec2_security_group_configuration_change_detection.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/05"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/persistence_iam_group_creation.toml
+++ b/rules/integrations/aws/persistence_iam_group_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/06/05"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_rds_cluster_creation.toml
+++ b/rules/integrations/aws/persistence_rds_cluster_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/20"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_rds_group_creation.toml
+++ b/rules/integrations/aws/persistence_rds_group_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/06/05"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/persistence_rds_instance_creation.toml
+++ b/rules/integrations/aws/persistence_rds_instance_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/06/06"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/persistence_redshift_instance_creation.toml
+++ b/rules/integrations/aws/persistence_redshift_instance_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/04/12"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_route_53_domain_transfer_lock_disabled.toml
+++ b/rules/integrations/aws/persistence_route_53_domain_transfer_lock_disabled.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/10"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/persistence_route_53_domain_transferred_to_another_account.toml
+++ b/rules/integrations/aws/persistence_route_53_domain_transferred_to_another_account.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/10"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/persistence_route_53_hosted_zone_associated_with_a_vpc.toml
+++ b/rules/integrations/aws/persistence_route_53_hosted_zone_associated_with_a_vpc.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/07/19"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/persistence_route_table_created.toml
+++ b/rules/integrations/aws/persistence_route_table_created.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/06/05"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/persistence_route_table_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_route_table_modified_or_deleted.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/06/05"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/integrations/aws/privilege_escalation_root_login_without_mfa.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/06"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/privilege_escalation_sts_assumerole_usage.toml
+++ b/rules/integrations/aws/privilege_escalation_sts_assumerole_usage.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/17"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/privilege_escalation_sts_getsessiontoken_abuse.toml
+++ b/rules/integrations/aws/privilege_escalation_sts_getsessiontoken_abuse.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/17"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/integrations/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/06"
 integration = ["aws"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/credential_access_attempted_bypass_of_okta_mfa.toml
+++ b/rules/integrations/okta/credential_access_attempted_bypass_of_okta_mfa.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
+++ b/rules/integrations/okta/credential_access_attempts_to_brute_force_okta_user_account.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/08/19"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "@BenB196", "Austin Songer"]

--- a/rules/integrations/okta/credential_access_mfa_push_brute_force.toml
+++ b/rules/integrations/okta/credential_access_mfa_push_brute_force.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/01/05"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/credential_access_okta_brute_force_or_password_spraying.toml
+++ b/rules/integrations/okta/credential_access_okta_brute_force_or_password_spraying.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/16"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/credential_access_user_impersonation_access.toml
+++ b/rules/integrations/okta/credential_access_user_impersonation_access.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/03/22"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_attempt_to_deactivate_okta_network_zone.toml
+++ b/rules/integrations/okta/defense_evasion_attempt_to_deactivate_okta_network_zone.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/06"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_attempt_to_delete_okta_network_zone.toml
+++ b/rules/integrations/okta/defense_evasion_attempt_to_delete_okta_network_zone.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/06"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_okta_attempt_to_deactivate_okta_policy.toml
+++ b/rules/integrations/okta/defense_evasion_okta_attempt_to_deactivate_okta_policy.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_okta_attempt_to_deactivate_okta_policy_rule.toml
+++ b/rules/integrations/okta/defense_evasion_okta_attempt_to_deactivate_okta_policy_rule.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_okta_attempt_to_delete_okta_policy.toml
+++ b/rules/integrations/okta/defense_evasion_okta_attempt_to_delete_okta_policy.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/28"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_okta_attempt_to_delete_okta_policy_rule.toml
+++ b/rules/integrations/okta/defense_evasion_okta_attempt_to_delete_okta_policy_rule.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/06"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_okta_attempt_to_modify_okta_network_zone.toml
+++ b/rules/integrations/okta/defense_evasion_okta_attempt_to_modify_okta_network_zone.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_okta_attempt_to_modify_okta_policy.toml
+++ b/rules/integrations/okta/defense_evasion_okta_attempt_to_modify_okta_policy.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_okta_attempt_to_modify_okta_policy_rule.toml
+++ b/rules/integrations/okta/defense_evasion_okta_attempt_to_modify_okta_policy_rule.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/defense_evasion_suspicious_okta_user_password_reset_or_unlock_attempts.toml
+++ b/rules/integrations/okta/defense_evasion_suspicious_okta_user_password_reset_or_unlock_attempts.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/08/19"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "@BenB196", "Austin Songer"]

--- a/rules/integrations/okta/impact_attempt_to_revoke_okta_api_token.toml
+++ b/rules/integrations/okta/impact_attempt_to_revoke_okta_api_token.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/impact_okta_attempt_to_deactivate_okta_application.toml
+++ b/rules/integrations/okta/impact_okta_attempt_to_deactivate_okta_application.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/06"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/30"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/impact_okta_attempt_to_delete_okta_application.toml
+++ b/rules/integrations/okta/impact_okta_attempt_to_delete_okta_application.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/06"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/impact_okta_attempt_to_modify_okta_application.toml
+++ b/rules/integrations/okta/impact_okta_attempt_to_modify_okta_application.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/06"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/impact_possible_okta_dos_attack.toml
+++ b/rules/integrations/okta/impact_possible_okta_dos_attack.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/initial_access_okta_user_attempted_unauthorized_access.toml
+++ b/rules/integrations/okta/initial_access_okta_user_attempted_unauthorized_access.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/14"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
+++ b/rules/integrations/okta/initial_access_suspicious_activity_reported_by_okta_user.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/okta_threatinsight_threat_suspected_promotion.toml
+++ b/rules/integrations/okta/okta_threatinsight_threat_suspected_promotion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 promotion = true
 
 [rule]

--- a/rules/integrations/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
+++ b/rules/integrations/okta/persistence_administrator_privileges_assigned_to_okta_group.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/persistence_administrator_role_assigned_to_okta_user.toml
+++ b/rules/integrations/okta/persistence_administrator_role_assigned_to_okta_user.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/06"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/persistence_attempt_to_create_okta_api_token.toml
+++ b/rules/integrations/okta/persistence_attempt_to_create_okta_api_token.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
+++ b/rules/integrations/okta/persistence_attempt_to_deactivate_mfa_for_okta_user_account.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/20"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
+++ b/rules/integrations/okta/persistence_attempt_to_reset_mfa_factors_for_okta_user_account.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/05/21"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/persistence_okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
+++ b/rules/integrations/okta/persistence_okta_attempt_to_modify_or_delete_application_sign_on_policy.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/07/01"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/10/24"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/197

## Summary
This PR bumps the minimum stack versions for all Okta rules to `8.10.0` and AWS `8.9.0`. During the `8.11.2` release, we identified several double version bumps caused from build time field `related_integrations.version` being different between branches. Analysis revealed this was caused due to a breaking change in AWS and Okta integrations, thus bumping their versions to `^2.0.0` which changed the value of `related_integrations.version` between branches. 

To solve, we must fork these rules where the change was introduced, thus allowing versions to increment over time but be separately tracked.
