### PR TITLE
[Bug] Fix typo in downgrade_contents_from_rule

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1290,8 +1290,12 @@ def downgrade_contents_from_rule(rule: TOMLRule, target_version: str, replace_id
 
     rule_dict = downgrade(rule_dict, target_version=str(min_stack_version))
     meta = rule_dict.pop("meta")
-    rule_contents = TOMLRuleContents.from_dict({"rule": rule_dict, "metadata": meta,
-                                                "transform": rule.contents.transform})
+    rule_contents_dict = {"rule": rule_dict, "metadata": meta}
+
+    if rule.contents.transform:
+        rule_contents_dict["transform"] = rule.contents.transform.to_dict()
+
+    rule_contents = TOMLRuleContents.from_dict(rule_contents_dict)
     payload = rule_contents.to_api_format()
     payload = strip_non_public_fields(min_stack_version, payload)
     return payload

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 	"elasticsearch~=8.1",
 	"eql==0.9.19",
 	"jsl==0.2.4",
-	"jsonschema==3.2.0",
+	"jsonschema>=3.2.0",
 	"marko==2.0.1",
 	"marshmallow-dataclass[union]~=8.5.12",
 	"marshmallow-jsonschema~=0.12.0",


### PR DESCRIPTION
## Issues
Directly Resolves: https://github.com/elastic/detection-rules/issues/3130
Tangentially Resolves: https://github.com/elastic/detection-rules/issues/3255


## Summary
This PR fixes an issue where exporting rules would fail due to invalid values being based to the TomlRuleContents schema when a rule had a transform section. This occurred as the transform was not properly cast to a dictionary before being attempting to load it with the rest of the rule contents via `TOMLRuleContents.from_dict()`. This fix was to convert it to a dictionary directly via `.to_dict()` before passing it following a similar pattern to what is used in [devtools.py](https://github.com/elastic/detection-rules/blob/f53f46efd54ac50d776330a0191f6c93cbd39c8e/detection_rules/devtools.py#L1471).

Additionally, this PR includes an update to the `pyproject.toml` that allows for higher `jsonschema` versions. This has been tested across Python versions 3.8, 3.9, 3.10 and 3.11. Additionally, this has been tested with latest `jsonschema` and marshmallow library versions in 3.11. 

<details><summary>Dockerfile for test verification</summary>
<p>

```dockerfile
FROM python:3.8-buster
RUN apt-get update && apt-get install -y git
RUN pip install --upgrade pip
RUN git clone https://github.com/elastic/detection-rules.git siem-rules-git-sync/detection-rules/
# set directory 
WORKDIR /siem-rules-git-sync/detection-rules
RUN git pull && git checkout 3130-bug-export-rules-errors-on-jsonschemas
RUN pip install ".[dev]"
RUN make
#RUN python -m detection_rules export-rules --stack-version 8.7 --directory rules
RUN python -m detection_rules export-rules --stack-version 8.6 --skip-unsupported --directory rules
```

</p>
</details> 

## Testing

Run the following command. If it is successful, then this PR has fixed the issue. 

```shell
python -m detection_rules export-rules --stack-version 8.6 --skip-unsupported --directory rules
```

However, If you get a `marshmallow.exceptions.ValidationError` then the issue likely still exists. See full error below.

```shell
  File "/Users/jibarra/PycharmProjects/detection-rules-fork/venv38/lib/python3.8/site-packages/marshmallow_dataclass/__init__.py", line 768, in load
    all_loaded = super().load(data, many=many, **kwargs)
  File "/Users/jibarra/PycharmProjects/detection-rules-fork/venv38/lib/python3.8/site-packages/marshmallow/schema.py", line 719, in load
    return self._do_load(
  File "/Users/jibarra/PycharmProjects/detection-rules-fork/venv38/lib/python3.8/site-packages/marshmallow/schema.py", line 901, in _do_load
    raise exc
marshmallow.exceptions.ValidationError: {'transform': {'_schema': ['Invalid input type.']}}

```

For additional debugging, one can compare the starting RuleTransform object `rule.contents.transform` value in the downgrade_contents_from_rule function to the transformed `rule_contents.transform` before the return of the function to see if they match. If they do, then it is working as intended. 

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/elastic/detection-rules/assets/119343520/50f0df08-ad55-4335-92c4-91412bc4ff57)


</p>
</details> 