### PR TITLE
[New Rule] Adding Detection Logic for Okta User Sessions Started from Different Geolocations

### DIFF
--- a/rules/integrations/okta/initial_access_okta_user_sessions_started_from_different_geolocations.toml
+++ b/rules/integrations/okta/initial_access_okta_user_sessions_started_from_different_geolocations.toml
@@ -25,7 +25,8 @@ references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",
     "https://www.elastic.co/security-labs/testing-okta-visibility-and-detection-dorothy",
-    "https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection"
+    "https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection",
+    "https://www.rezonate.io/blog/okta-logs-decoded-unveiling-identity-threats-through-threat-hunting/"
 ]
 risk_score = 47
 rule_id = "2e56e1bc-867a-11ee-b13e-f661ea17fbcd"

--- a/rules/integrations/okta/initial_access_okta_user_sessions_started_from_different_geolocations.toml
+++ b/rules/integrations/okta/initial_access_okta_user_sessions_started_from_different_geolocations.toml
@@ -1,0 +1,65 @@
+[metadata]
+creation_date = "2023/11/18"
+integration = ["okta"]
+maturity = "production"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
+updated_date = "2023/11/18"
+
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when a specific Okta actor has multiple sessions started from different geolocations.
+"""
+from = "now-30m"
+interval = "15m"
+index = ["filebeat-*", "logs-okta*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Okta User Sessions Started from Different Geolocations"
+note = """## Setup
+
+The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
+references = [
+    "https://developer.okta.com/docs/reference/api/system-log/",
+    "https://developer.okta.com/docs/reference/api/event-types/",
+    "https://www.elastic.co/security-labs/testing-okta-visibility-and-detection-dorothy",
+    "https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection"
+]
+risk_score = 47
+rule_id = "2e56e1bc-867a-11ee-b13e-f661ea17fbcd"
+severity = "medium"
+tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Initial Access"]
+timestamp_override = "event.ingested"
+type = "threshold"
+query = '''
+event.dataset:okta.system and okta.event_type:user.session.start and not okta.security_context.is_proxy:true
+    and okta.actor.id:* and client.geo.country_name:*
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1078.004"
+name = "Cloud Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/004/"
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+
+[rule.threshold]
+field = ["okta.actor.id"]
+value = 1
+
+[[rule.threshold.cardinality]]
+field = "client.geo.country_name"
+value = 2


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/106

## Summary
This pull request adds detection logic for Okta user sessions started by a user from different geolocations. This query also negates `okta.security_context.is_proxy:true` to eliminate false-positives where a user may be using a VPN or proxy. This is a threshold rule that groups the events by `okta.actor.id` and adds cardinality by `client.geo.country_name`.
