### PR TITLE
[Security Content] Add Investigation Guides to Linux Persistence Rules - 1

### DIFF
--- a/rules/linux/persistence_chkconfig_service_add.toml
+++ b/rules/linux/persistence_chkconfig_service_add.toml
@@ -3,8 +3,56 @@ creation_date = "2022/07/22"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/11/02"
+updated_date = "2023/11/22"
 integration = ["endpoint"]
+
+[transform]
+[[transform.osquery]]
+label = "Osquery - Retrieve File Listing Information"
+query = "SELECT * FROM file WHERE (path LIKE '/etc/init.d/%' OR path LIKE '/etc/rc%.d/%')"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Additional File Listing Information"
+query = """
+SELECT
+  f.path,
+  u.username AS file_owner,
+  g.groupname AS group_owner,
+  datetime(f.atime, 'unixepoch') AS file_last_access_time,
+  datetime(f.mtime, 'unixepoch') AS file_last_modified_time,
+  datetime(f.ctime, 'unixepoch') AS file_last_status_change_time,
+  datetime(f.btime, 'unixepoch') AS file_created_time,
+  f.size AS size_bytes
+FROM
+  file f
+  LEFT JOIN users u ON f.uid = u.uid
+  LEFT JOIN groups g ON f.gid = g.gid
+WHERE (path LIKE '/etc/init.d/%' OR path LIKE '/etc/rc%.d/%')
+"""
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Running Processes by User"
+query = "SELECT pid, username, name FROM processes p JOIN users u ON u.uid = p.uid ORDER BY username"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Crontab Information"
+query = "SELECT * FROM crontab"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Listening Ports"
+query = "SELECT pid, address, port, socket, protocol, path FROM listening_ports"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Open Sockets"
+query = "SELECT pid, family, remote_address, remote_port, socket, state FROM process_open_sockets"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Information for a Specific User"
+query = "SELECT * FROM users WHERE username = {{user.name}}"
+
+[[transform.osquery]]
+label = "Osquery - Investigate the Account Authentication Status"
+query = "SELECT * FROM logged_in_users WHERE user = {{user.name}}"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +67,81 @@ index = ["logs-endpoint.events.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Chkconfig Service Add"
+note = """## Triage and analysis
+
+### Investigating Chkconfig Service Add
+Service files are configuration files in Linux systems used to define and manage system services. The `Chkconfig` binary can be used to manually add, delete or modify a service. 
+
+Malicious actors can leverage services to achieve persistence by creating or modifying service files to execute malicious commands or payloads during system startup. This allows them to maintain unauthorized access, execute additional malicious activities, or evade detection.
+
+This rule monitors the usage of the `chkconfig` binary to manually add a service for management by `chkconfig`, potentially indicating the creation of a persistence mechanism.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the service that was created or modified.
+- Investigate the currently enabled system services through the following commands `sudo chkconfig --list | grep on` and `sudo systemctl list-unit-files`.
+- Investigate the status of potentially suspicious services through the `chkconfig --list service_name` command. 
+- Search for the `rc.d` or `init.d` service files that were created or modified, and analyze their contents.
+- Investigate whether any other files in any of the available `rc.d` or `init.d` directories have been altered through OSQuery.
+  - $osquery_0
+  - $osquery_1
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence and whether they are located in expected locations.
+  - $osquery_2
+- Investigate syslog through the `sudo cat /var/log/syslog | grep 'LSB'` command to find traces of the LSB header of the script (if present). If syslog is being ingested into Elasticsearch, the same can be accomplished through Kibana.
+- Investigate other alerts associated with the user/host during the past 48 hours.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Investigate whether the altered scripts call other malicious scripts elsewhere on the file system. 
+  - If scripts or executables were dropped, retrieve the files and determine if they are malicious:
+    - Use a private sandboxed malware analysis system to perform analysis.
+      - Observe and collect information about the following activities:
+        - Attempts to contact external domains and addresses.
+          - Check if the domain is newly registered or unexpected.
+          - Check the reputation of the domain or IP address.
+        - File access, modification, and creation activities.
+        - Cron jobs, services and other persistence mechanisms.
+            - $osquery_3
+- Investigate abnormal behaviors by the subject process/user such as network connections, file modifications, and any other spawned child processes.
+  - Investigate listening ports and open sockets to look for potential command and control traffic or data exfiltration.
+    - $osquery_4
+    - $osquery_5
+  - Identify the user account that performed the action, analyze it, and check whether it should perform this kind of action.
+    - $osquery_6
+- Investigate whether the user is currently logged in and active.
+    - $osquery_7
+
+### False Positive Analysis
+
+- If this activity is related to new benign software installation activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- If this activity is related to a system administrator who uses the `chkconfig` binary for administrative purposes, consider adding exceptions for this specific administrator user account. 
+- Try to understand the context of the execution by thinking about the user, machine, or business purpose. A small number of endpoints, such as servers with unique software, might appear unusual but satisfy a specific business need.
+
+### Related Rules
+
+- Suspicious File Creation in /etc for Persistence - 1c84dd64-7e6c-4bad-ac73-a5014ee37042
+- Potential Persistence Through Run Control Detected - 0f4d35e4-925e-4959-ab24-911be207ee6f
+- Potential Persistence Through init.d Detected - 474fd20e-14cc-49c5-8160-d9ab4ba16c8b
+- New Systemd Timer Created - 7fb500fa-8e24-4bd1-9480-2a819352602c
+- New Systemd Service Created by Previously Unknown Process - 17b0a495-4d9f-414c-8ad0-92f018b8e001
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- Isolate the involved host to prevent further post-compromise behavior.
+- If the triage identified malware, search the environment for additional compromised hosts.
+  - Implement temporary network rules, procedures, and segmentation to contain the malware.
+  - Stop suspicious processes.
+  - Immediately block the identified indicators of compromise (IoCs).
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Delete the service/timer or restore its original configuration.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Leverage the incident response data and logging to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+"""
 references = [
     "https://www.intezer.com/blog/research/lightning-framework-new-linux-threat/"
 ]
@@ -51,7 +174,15 @@ For more details on Elastic Defend refer to the [helper guide](https://www.elast
 
 """
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Persistence", "Threat: Lightning Framework", "Data Source: Elastic Endgame", "Data Source: Elastic Defend"]
+tags = [
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Persistence",
+        "Threat: Lightning Framework",
+        "Data Source: Elastic Endgame",
+        "Data Source: Elastic Defend"
+        ]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/linux/persistence_cron_job_creation.toml
+++ b/rules/linux/persistence_cron_job_creation.toml
@@ -4,7 +4,71 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup, New Term"
 min_stack_version = "8.6.0"
-updated_date = "2023/11/02"
+updated_date = "2023/11/22"
+
+[transform]
+[[transform.osquery]]
+label = "Osquery - Retrieve File Listing Information"
+query = """
+SELECT * FROM file WHERE (
+  path LIKE '/etc/cron.allow.d/%' OR
+  path LIKE '/etc/cron.d/%' OR
+  path LIKE '/etc/cron.hourly/%' OR
+  path LIKE '/etc/cron.daily/%' OR
+  path LIKE '/etc/cron.weekly/%' OR
+  path LIKE '/etc/cron.monthly/%'
+)
+"""
+[[transform.osquery]]
+label = "Osquery - Retrieve rc-local.service File Information"
+query = """
+SELECT * FROM file WHERE (
+  path = '/etc/cron.allow' OR
+  path = '/etc/cron.deny' OR
+  path = '/etc/crontab' OR
+  path = '/usr/sbin/cron' OR
+  path = '/usr/sbin/anacron'
+)
+"""
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Additional File Listing Information"
+query = """
+SELECT
+  f.path,
+  u.username AS file_owner,
+  g.groupname AS group_owner,
+  datetime(f.atime, 'unixepoch') AS file_last_access_time,
+  datetime(f.mtime, 'unixepoch') AS file_last_modified_time,
+  datetime(f.ctime, 'unixepoch') AS file_last_status_change_time,
+  datetime(f.btime, 'unixepoch') AS file_created_time,
+  f.size AS size_bytes
+FROM
+  file f
+  LEFT JOIN users u ON f.uid = u.uid
+  LEFT JOIN groups g ON f.gid = g.gid
+WHERE (path LIKE '/etc/cron.allow.d/%' OR path LIKE '/etc/cron.d/%' OR path LIKE '/etc/cron.hourly/%' OR path LIKE '/etc/cron.daily/%' OR path LIKE '/etc/cron.weekly/%' OR path LIKE '/etc/cron.monthly/%')
+"""
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Running Processes by User"
+query = "SELECT pid, username, name FROM processes p JOIN users u ON u.uid = p.uid ORDER BY username"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Listening Ports"
+query = "SELECT pid, address, port, socket, protocol, path FROM listening_ports"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Open Sockets"
+query = "SELECT pid, family, remote_address, remote_port, socket, state FROM process_open_sockets"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Information for a Specific User"
+query = "SELECT * FROM users WHERE username = {{user.name}}"
+
+[[transform.osquery]]
+label = "Osquery - Investigate the Account Authentication Status"
+query = "SELECT * FROM logged_in_users WHERE user = {{user.name}}"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +82,76 @@ index = ["logs-endpoint.events.*", "endgame-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Cron Job Created or Changed by Previously Unknown Process"
+note = """## Triage and analysis
+
+### Investigating Cron Job Created or Changed by Previously Unknown Process
+Linux cron jobs are scheduled tasks that run at specified intervals or times, managed by the cron daemon. 
+
+By creating or modifying cron job configurations, attackers can execute malicious commands or scripts at predefined intervals, ensuring their continued presence and enabling unauthorized activities.
+
+This rule monitors the creation of never before seen cron jobs by monitoring for file creation events in the most common cron job task location directories.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the cron job file that was created or modified.
+- Investigate whether any other files in any of the available cron job directories have been altered through OSQuery.
+  - $osquery_0
+  - $osquery_1
+  - $osquery_2
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence and whether they are located in expected locations.
+  - $osquery_3
+- Investigate other alerts associated with the user/host during the past 48 hours.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Investigate whether the altered scripts call other malicious scripts elsewhere on the file system. 
+  - If scripts or executables were dropped, retrieve the files and determine if they are malicious:
+    - Use a private sandboxed malware analysis system to perform analysis.
+      - Observe and collect information about the following activities:
+        - Attempts to contact external domains and addresses.
+          - Check if the domain is newly registered or unexpected.
+          - Check the reputation of the domain or IP address.
+        - File access, modification, and creation activities.
+- Investigate abnormal behaviors by the subject process/user such as network connections, file modifications, and any other spawned child processes.
+  - Investigate listening ports and open sockets to look for potential command and control traffic or data exfiltration.
+    - $osquery_4
+    - $osquery_5
+  - Identify the user account that performed the action, analyze it, and check whether it should perform this kind of action.
+    - $osquery_6
+- Investigate whether the user is currently logged in and active.
+    - $osquery_7
+
+### False Positive Analysis
+
+- If this activity is related to new benign software installation activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- If this activity is related to a system administrator who uses cron jobs for administrative purposes, consider adding exceptions for this specific administrator user account. 
+- Try to understand the context of the execution by thinking about the user, machine, or business purpose. A small number of endpoints, such as servers with unique software, might appear unusual but satisfy a specific business need.
+
+### Related Rules
+
+- Suspicious File Creation in /etc for Persistence - 1c84dd64-7e6c-4bad-ac73-a5014ee37042
+- Potential Persistence Through Run Control Detected - 0f4d35e4-925e-4959-ab24-911be207ee6f
+- Potential Persistence Through init.d Detected - 474fd20e-14cc-49c5-8160-d9ab4ba16c8b
+- New Systemd Timer Created - 7fb500fa-8e24-4bd1-9480-2a819352602c
+- New Systemd Service Created by Previously Unknown Process - 17b0a495-4d9f-414c-8ad0-92f018b8e001
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- Isolate the involved host to prevent further post-compromise behavior.
+- If the triage identified malware, search the environment for additional compromised hosts.
+  - Implement temporary network rules, procedures, and segmentation to contain the malware.
+  - Stop suspicious processes.
+  - Immediately block the identified indicators of compromise (IoCs).
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Delete the service/timer or restore its original configuration.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Leverage the incident response data and logging to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+"""
 references = [
     "https://pberba.github.io/security/2022/01/30/linux-threat-hunting-for-persistence-systemd-timers-cron/"
 ]

--- a/rules/linux/persistence_cron_job_creation.toml
+++ b/rules/linux/persistence_cron_job_creation.toml
@@ -47,7 +47,14 @@ FROM
   file f
   LEFT JOIN users u ON f.uid = u.uid
   LEFT JOIN groups g ON f.gid = g.gid
-WHERE (path LIKE '/etc/cron.allow.d/%' OR path LIKE '/etc/cron.d/%' OR path LIKE '/etc/cron.hourly/%' OR path LIKE '/etc/cron.daily/%' OR path LIKE '/etc/cron.weekly/%' OR path LIKE '/etc/cron.monthly/%')
+WHERE (
+  path LIKE '/etc/cron.allow.d/%' OR
+  path LIKE '/etc/cron.d/%' OR
+  path LIKE '/etc/cron.hourly/%' OR
+  path LIKE '/etc/cron.daily/%' OR
+  path LIKE '/etc/cron.weekly/%' OR
+  path LIKE '/etc/cron.monthly/%'
+)
 """
 
 [[transform.osquery]]

--- a/rules/linux/persistence_cron_job_creation.toml
+++ b/rules/linux/persistence_cron_job_creation.toml
@@ -96,7 +96,7 @@ Linux cron jobs are scheduled tasks that run at specified intervals or times, ma
 
 By creating or modifying cron job configurations, attackers can execute malicious commands or scripts at predefined intervals, ensuring their continued presence and enabling unauthorized activities.
 
-This rule monitors the creation of never before seen cron jobs by monitoring for file creation events in the most common cron job task location directories.
+This rule monitors the creation of previously unknown cron jobs by monitoring for file creation events in the most common cron job task location directories.
 
 > **Note**:
 > This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.

--- a/rules/linux/persistence_etc_file_creation.toml
+++ b/rules/linux/persistence_etc_file_creation.toml
@@ -1,10 +1,75 @@
 [metadata]
 creation_date = "2022/07/22"
+integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/11/02"
-integration = ["endpoint"]
+updated_date = "2023/11/22"
+
+[transform]
+[[transform.osquery]]
+label = "Osquery - Retrieve File Listing Information"
+query = """
+SELECT * FROM file WHERE (
+  path LIKE '/etc/ld.so.conf.d/%' OR
+  path LIKE '/etc/cron.d/%' OR
+  path LIKE '/etc/sudoers.d/%' OR
+  path LIKE '/etc/rc%.d/%' OR
+  path LIKE '/etc/init.d/%' OR
+  path LIKE '/etc/systemd/system/%' OR
+  path LIKE '/usr/lib/systemd/system/%'
+)
+"""
+[[transform.osquery]]
+label = "Osquery - Retrieve Additional File Listing Information"
+query = """
+SELECT
+  f.path,
+  u.username AS file_owner,
+  g.groupname AS group_owner,
+  datetime(f.atime, 'unixepoch') AS file_last_access_time,
+  datetime(f.mtime, 'unixepoch') AS file_last_modified_time,
+  datetime(f.ctime, 'unixepoch') AS file_last_status_change_time,
+  datetime(f.btime, 'unixepoch') AS file_created_time,
+  f.size AS size_bytes
+FROM
+  file f
+  LEFT JOIN users u ON f.uid = u.uid
+  LEFT JOIN groups g ON f.gid = g.gid
+WHERE (
+  path LIKE '/etc/ld.so.conf.d/%' OR
+  path LIKE '/etc/cron.d/%' OR
+  path LIKE '/etc/sudoers.d/%' OR
+  path LIKE '/etc/rc%.d/%' OR
+  path LIKE '/etc/init.d/%' OR
+  path LIKE '/etc/systemd/system/%' OR
+  path LIKE '/usr/lib/systemd/system/%'
+)
+"""
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Running Processes by User"
+query = "SELECT pid, username, name FROM processes p JOIN users u ON u.uid = p.uid ORDER BY username"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Crontab Information"
+query = "SELECT * FROM crontab"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Listening Ports"
+query = "SELECT pid, address, port, socket, protocol, path FROM listening_ports"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Open Sockets"
+query = "SELECT pid, family, remote_address, remote_port, socket, state FROM process_open_sockets"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Information for a Specific User"
+query = "SELECT * FROM users WHERE username = {{user.name}}"
+
+[[transform.osquery]]
+label = "Osquery - Investigate the Account Authentication Status"
+query = "SELECT * FROM logged_in_users WHERE user = {{user.name}}"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +83,78 @@ index = ["logs-endpoint.events.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious File Creation in /etc for Persistence"
+note = """## Triage and analysis
+
+### Investigating Suspicious File Creation in /etc for Persistence
+
+The /etc/ directory in Linux is used to store system-wide configuration files and scripts.
+
+By creating or modifying specific system-wide configuration files, attackers can leverage system services to execute malicious commands or scripts at predefined intervals, ensuring their continued presence and enabling unauthorized activities.
+
+This rule monitors for the creation of the most common system-wide configuration files and scripts abused by attackers for persistence. 
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the file that was created or modified.
+- Investigate whether any other files in any of the commonly abused directories have been altered through OSQuery.
+  - $osquery_0
+  - $osquery_1
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence and whether they are located in expected locations.
+  - $osquery_2
+- Investigate other alerts associated with the user/host during the past 48 hours.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Investigate whether the altered scripts call other malicious scripts elsewhere on the file system. 
+  - If scripts or executables were dropped, retrieve the files and determine if they are malicious:
+    - Use a private sandboxed malware analysis system to perform analysis.
+      - Observe and collect information about the following activities:
+        - Attempts to contact external domains and addresses.
+          - Check if the domain is newly registered or unexpected.
+          - Check the reputation of the domain or IP address.
+        - File access, modification, and creation activities.
+        - Cron jobs, services and other persistence mechanisms.
+            - $osquery_3
+- Investigate abnormal behaviors by the subject process/user such as network connections, file modifications, and any other spawned child processes.
+  - Investigate listening ports and open sockets to look for potential command and control traffic or data exfiltration.
+    - $osquery_4
+    - $osquery_5
+  - Identify the user account that performed the action, analyze it, and check whether it should perform this kind of action.
+    - $osquery_6
+- Investigate whether the user is currently logged in and active.
+    - $osquery_7
+
+### False Positive Analysis
+
+- If this activity is related to new benign software installation activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- If this activity is related to a system administrator that performed these actions for administrative purposes, consider adding exceptions for this specific administrator user account. 
+- Try to understand the context of the execution by thinking about the user, machine, or business purpose. A small number of endpoints, such as servers with unique software, might appear unusual but satisfy a specific business need.
+
+### Related Rules
+
+- Cron Job Created or Changed by Previously Unknown Process - ff10d4d8-fea7-422d-afb1-e5a2702369a9
+- Potential Persistence Through Run Control Detected - 0f4d35e4-925e-4959-ab24-911be207ee6f
+- Potential Persistence Through init.d Detected - 474fd20e-14cc-49c5-8160-d9ab4ba16c8b
+- New Systemd Timer Created - 7fb500fa-8e24-4bd1-9480-2a819352602c
+- New Systemd Service Created by Previously Unknown Process - 17b0a495-4d9f-414c-8ad0-92f018b8e001
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- Isolate the involved host to prevent further post-compromise behavior.
+- If the triage identified malware, search the environment for additional compromised hosts.
+  - Implement temporary network rules, procedures, and segmentation to contain the malware.
+  - Stop suspicious processes.
+  - Immediately block the identified indicators of compromise (IoCs).
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Delete the service/timer or restore its original configuration.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Leverage the incident response data and logging to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+"""
 references = [
     "https://www.intezer.com/blog/incident-response/orbit-new-undetected-linux-threat/",
     "https://www.intezer.com/blog/research/lightning-framework-new-linux-threat/"
@@ -51,7 +188,16 @@ For more details on Elastic Defend refer to the [helper guide](https://www.elast
 
 """
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Persistence", "Threat: Orbit", "Threat: Lightning Framework", "Data Source: Elastic Endgame", "Data Source: Elastic Defend"]
+tags = [
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Persistence",
+        "Threat: Orbit",
+        "Threat: Lightning Framework",
+        "Data Source: Elastic Endgame",
+        "Data Source: Elastic Defend"
+        ]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/linux/persistence_systemd_service_creation.toml
+++ b/rules/linux/persistence_systemd_service_creation.toml
@@ -4,7 +4,73 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup, New Term"
 min_stack_version = "8.6.0"
-updated_date = "2023/11/02"
+updated_date = "2023/11/22"
+
+[transform]
+[[transform.osquery]]
+label = "Osquery - Retrieve File Information"
+query = "SELECT * FROM file WHERE path = {{file.path}}"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve File Listing Information"
+query = """
+SELECT * FROM file WHERE (
+path LIKE '/etc/systemd/system/%' OR 
+path LIKE '/usr/local/lib/systemd/system/%' OR 
+path LIKE '/lib/systemd/system/%' OR
+path LIKE '/usr/lib/systemd/system/%' OR
+path LIKE '/home/user/.config/systemd/user/%'
+)
+"""
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Additional File Listing Information"
+query = """
+SELECT
+  f.path,
+  u.username AS file_owner,
+  g.groupname AS group_owner,
+  datetime(f.atime, 'unixepoch') AS file_last_access_time,
+  datetime(f.mtime, 'unixepoch') AS file_last_modified_time,
+  datetime(f.ctime, 'unixepoch') AS file_last_status_change_time,
+  datetime(f.btime, 'unixepoch') AS file_created_time,
+  f.size AS size_bytes
+FROM
+  file f
+  LEFT JOIN users u ON f.uid = u.uid
+  LEFT JOIN groups g ON f.gid = g.gid
+WHERE (
+path LIKE '/etc/systemd/system/%' OR 
+path LIKE '/usr/local/lib/systemd/system/%' OR 
+path LIKE '/lib/systemd/system/%' OR
+path LIKE '/usr/lib/systemd/system/%' OR
+path LIKE '/home/{{user.name}}/.config/systemd/user/%'
+)
+"""
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Running Processes by User"
+query = "SELECT pid, username, name FROM processes p JOIN users u ON u.uid = p.uid ORDER BY username"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Crontab Information"
+query = "SELECT * FROM crontab"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Listening Ports"
+query = "SELECT pid, address, port, socket, protocol, path FROM listening_ports"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Open Sockets"
+query = "SELECT pid, family, remote_address, remote_port, socket, state FROM process_open_sockets"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Information for a Specific User"
+query = "SELECT * FROM users WHERE username = {{user.name}}"
+
+[[transform.osquery]]
+label = "Osquery - Investigate the Account Authentication Status"
+query = "SELECT * FROM logged_in_users WHERE user = {{user.name}}"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +85,72 @@ index = ["logs-endpoint.events.*", "endgame-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "New Systemd Service Created by Previously Unknown Process"
+note = """## Triage and analysis
+
+### Investigating New Systemd Timer Created
+
+Systemd service files are configuration files in Linux systems used to define and manage system services.
+
+Malicious actors can leverage systemd service files to achieve persistence by creating or modifying service files to execute malicious commands or payloads during system startup. This allows them to maintain unauthorized access, execute additional malicious activities, or evade detection.
+
+This rule monitors the creation of new systemd service files, potentially indicating the creation of a persistence mechanism.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the systemd service file that was created or modified.
+  - $osquery_0
+- Investigate the currently enabled systemd services through the following command `sudo systemctl list-unit-files`.
+- Investigate whether any other files in any of the available systemd directories have been altered through OSQuery.
+  - $osquery_1
+  - $osquery_2
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence and whether they are located in expected locations.
+  - $osquery_3
+- Investigate other alerts associated with the user/host during the past 48 hours.
+- Validate the activity is not related to planned patches, updates, network administrator activity, or legitimate software installations.
+- Investigate whether the altered scripts call other malicious scripts elsewhere on the file system. 
+  - If scripts or executables were dropped, retrieve the files and determine if they are malicious:
+    - Use a private sandboxed malware analysis system to perform analysis.
+      - Observe and collect information about the following activities:
+        - Attempts to contact external domains and addresses.
+          - Check if the domain is newly registered or unexpected.
+          - Check the reputation of the domain or IP address.
+        - File access, modification, and creation activities.
+        - Cron jobs, services and other persistence mechanisms.
+            - $osquery_4
+- Investigate abnormal behaviors by the subject process/user such as network connections, file modifications, and any other spawned child processes.
+  - Investigate listening ports and open sockets to look for potential command and control traffic or data exfiltration.
+    - $osquery_5
+    - $osquery_6
+  - Identify the user account that performed the action, analyze it, and check whether it should perform this kind of action.
+    - $osquery_7
+- Investigate whether the user is currently logged in and active.
+    - $osquery_8
+
+### False Positive Analysis
+
+- If this activity is related to new benign software installation activity, consider adding exceptions — preferably with a combination of user and command line conditions.
+- If this activity is related to a system administrator who uses systemd services for administrative purposes, consider adding exceptions for this specific administrator user account. 
+- Try to understand the context of the execution by thinking about the user, machine, or business purpose. A small number of endpoints, such as servers with unique software, might appear unusual but satisfy a specific business need.
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- Isolate the involved host to prevent further post-compromise behavior.
+- If the triage identified malware, search the environment for additional compromised hosts.
+  - Implement temporary network rules, procedures, and segmentation to contain the malware.
+  - Stop suspicious processes.
+  - Immediately block the identified indicators of compromise (IoCs).
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Delete the service/timer or restore its original configuration.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Leverage the incident response data and logging to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+"""
 references = [
     "https://opensource.com/article/20/7/systemd-timers",
     "https://pberba.github.io/security/2022/01/30/linux-threat-hunting-for-persistence-systemd-timers-cron/"

--- a/rules/linux/persistence_systemd_service_creation.toml
+++ b/rules/linux/persistence_systemd_service_creation.toml
@@ -87,7 +87,7 @@ license = "Elastic License v2"
 name = "New Systemd Service Created by Previously Unknown Process"
 note = """## Triage and analysis
 
-### Investigating New Systemd Timer Created
+### Investigating New Systemd Service Created by Previously Unknown Process
 
 Systemd service files are configuration files in Linux systems used to define and manage system services.
 
@@ -135,6 +135,12 @@ This rule monitors the creation of new systemd service files, potentially indica
 - If this activity is related to new benign software installation activity, consider adding exceptions — preferably with a combination of user and command line conditions.
 - If this activity is related to a system administrator who uses systemd services for administrative purposes, consider adding exceptions for this specific administrator user account. 
 - Try to understand the context of the execution by thinking about the user, machine, or business purpose. A small number of endpoints, such as servers with unique software, might appear unusual but satisfy a specific business need.
+
+### Related Rules
+
+- Potential Persistence Through Run Control Detected - 0f4d35e4-925e-4959-ab24-911be207ee6f
+- Potential Persistence Through init.d Detected - 474fd20e-14cc-49c5-8160-d9ab4ba16c8b
+- New Systemd Timer Created - 7fb500fa-8e24-4bd1-9480-2a819352602c
 
 ### Response and remediation
 


### PR DESCRIPTION
## Summary
This rule adds Investigation Guides for 4 persistence related Linux rules. Due to PTO I will split this task up in 2 PRs. The next PR will add 6 more. 