### PR TITLE
FR] Add Core Support for ES|QL Rule Type

### DIFF
--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -292,7 +292,7 @@ def get_integration_schema_data(data, meta, package_integrations: dict) -> Gener
 
     # lazy import to avoid circular import
     from .rule import (  # pylint: disable=import-outside-toplevel
-        QueryRuleData, RuleMeta)
+        ESQLRuleData, QueryRuleData, RuleMeta)
 
     data: QueryRuleData = data
     meta: RuleMeta = meta
@@ -301,7 +301,8 @@ def get_integration_schema_data(data, meta, package_integrations: dict) -> Gener
     integrations_schemas = load_integrations_schemas()
 
     # validate the query against related integration fields
-    if isinstance(data, QueryRuleData) and data.language != 'lucene' and meta.maturity == "production":
+    if (isinstance(data, QueryRuleData) or isinstance(data, ESQLRuleData)) \
+       and data.language != 'lucene' and meta.maturity == "production":
 
         # flag to only warn once per integration for available upgrades
         notify_update_available = True

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -569,6 +569,8 @@ class QueryRuleData(BaseRuleData):
             return KQLValidator(self.query)
         elif self.language == "eql":
             return EQLValidator(self.query)
+        elif self.language == "esql":
+            return ESQLValidator(self.query)
 
     def validate_query(self, meta: RuleMeta) -> None:
         validator = self.validator
@@ -600,6 +602,21 @@ class QueryRuleData(BaseRuleData):
         # alert suppression is only valid for query rule type and not any of its subclasses
         if data.get('alert_suppression') and data['type'] != 'query':
             raise ValidationError("Alert suppression is only valid for query rule type.")
+
+
+@dataclass(frozen=True)
+class ESQLRuleData(BaseRuleData):
+    """ESQL rules are a special case of query rules."""
+    type: Literal["esql"]
+    language: Literal["esql"]
+    query: str
+
+    @cached_property
+    def validator(self) -> Optional[QueryValidator]:
+        return ESQLValidator(self.query)
+
+    def validate_query(self, meta: RuleMeta) -> None:
+        return self.validator.validate(self, meta)
 
 
 @dataclass(frozen=True)
@@ -760,7 +777,7 @@ class ThreatMatchRuleData(QueryRuleData):
 
 # All of the possible rule types
 # Sort inverse of any inheritance - see comment in TOMLRuleContents.to_dict
-AnyRuleData = Union[EQLRuleData, ThresholdQueryRuleData, ThreatMatchRuleData,
+AnyRuleData = Union[EQLRuleData, ESQLRuleData, ThresholdQueryRuleData, ThreatMatchRuleData,
                     MachineLearningRuleData, QueryRuleData, NewTermsRuleData]
 
 
@@ -1084,11 +1101,12 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         packaged_integrations = []
         datasets = set()
 
-        for node in data.get('ast', []):
-            if isinstance(node, eql.ast.Comparison) and str(node.left) == 'event.dataset':
-                datasets.update(set(n.value for n in node if isinstance(n, eql.ast.Literal)))
-            elif isinstance(node, FieldComparison) and str(node.field) == 'event.dataset':
-                datasets.update(set(str(n) for n in node if isinstance(n, kql.ast.Value)))
+        if data.type != "esql":
+            for node in data.get('ast', []):
+                if isinstance(node, eql.ast.Comparison) and str(node.left) == 'event.dataset':
+                    datasets.update(set(n.value for n in node if isinstance(n, eql.ast.Literal)))
+                elif isinstance(node, FieldComparison) and str(node.field) == 'event.dataset':
+                    datasets.update(set(str(n) for n in node if isinstance(n, kql.ast.Value)))
 
         # integration is None to remove duplicate references upstream in Kibana
         # chronologically, event.dataset is checked for package:integration, then rule tags
@@ -1333,4 +1351,4 @@ def get_unique_query_fields(rule: TOMLRule) -> List[str]:
 
 
 # avoid a circular import
-from .rule_validators import EQLValidator, KQLValidator  # noqa: E402
+from .rule_validators import EQLValidator, ESQLValidator, KQLValidator  # noqa: E402

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -346,6 +346,25 @@ class EQLValidator(QueryValidator):
             return [], False
 
 
+class ESQLValidator(QueryValidator):
+    """Validate specific fields for ESQL query event types."""
+
+    @cached_property
+    def ast(self):
+        """Return an AST."""
+        return None
+
+    @cached_property
+    def unique_fields(self) -> List[str]:
+        """Return a list of unique fields in the query."""
+        # return empty list for ES|QL rules until ast is available
+        return []
+
+    def validate(self, data: 'QueryRuleData', meta: RuleMeta) -> None:
+        """Validate an ESQL query while checking TOMLRule."""
+        return None
+
+
 def extract_error_field(exc: Union[eql.EqlParseError, kql.KqlParseError]) -> Optional[str]:
     """Extract the field name from an EQL or KQL parse error."""
     lines = exc.source.splitlines()

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -362,6 +362,7 @@ class ESQLValidator(QueryValidator):
 
     def validate(self, data: 'QueryRuleData', meta: RuleMeta) -> None:
         """Validate an ESQL query while checking TOMLRule."""
+        print("Warning: ESQL queries are not validated at this time.")
         return None
 
 

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -138,7 +138,7 @@ CardinalityFields = NewType('CardinalityFields', List[NonEmptyStr], validate=val
 CodeString = NewType("CodeString", str)
 ConditionSemVer = NewType('ConditionSemVer', str, validate=validate.Regexp(CONDITION_VERSION_PATTERN))
 Date = NewType('Date', str, validate=validate.Regexp(DATE_PATTERN))
-FilterLanguages = Literal["kuery", "lucene"]
+FilterLanguages = Literal["kuery", "lucene", "eql", "esql"]
 Interval = NewType('Interval', str, validate=validate.Regexp(INTERVAL_PATTERN))
 Markdown = NewType("MarkdownField", CodeString)
 Maturity = Literal['development', 'experimental', 'beta', 'production', 'deprecated']
@@ -149,7 +149,7 @@ OSType = Literal['windows', 'linux', 'macos']
 PositiveInteger = NewType('PositiveInteger', int, validate=validate.Range(min=1))
 RiskScore = NewType("MaxSignals", int, validate=validate.Range(min=1, max=100))
 RuleName = NewType('RuleName', str, validate=validate.Regexp(NAME_PATTERN))
-RuleType = Literal['query', 'machine_learning', 'eql', 'threshold', 'threat_match', 'new_terms']
+RuleType = Literal['query', 'saved_query', 'machine_learning', 'eql', 'esql', 'threshold', 'threat_match', 'new_terms']
 SemVer = NewType('SemVer', str, validate=validate.Regexp(VERSION_PATTERN))
 SemVerMinorOnly = NewType('SemVerFullStrict', str, validate=validate.Regexp(MINOR_SEMVER))
 Severity = Literal['low', 'medium', 'high', 'critical']


### PR DESCRIPTION
## Issues

https://github.com/elastic/detection-rules/issues/3275

## Summary

- Adds support for the ES|QL Rule type based on the [kibana implementation](https://github.com/elastic/kibana/blob/3a18916b31d27d2ffeb7df682e69224a273b39b4/x-pack/plugins/security_solution/server/lib/detection_engine/rule_schema/model/rule_schemas.ts#L160-L168)
- Adds base stub classes to validate esql rules


## Testing 

1. Unit tests should pass with the sample esql rule locally.
2. Manual testing with CLI commands. 


<details><summary>Sample Rule</summary>
<p>

Use the following rule, and run view-rule command to ensure the esql rule loads successfully, skipping validation.

```toml

[metadata]
creation_date = "2023/02/27"
integration = ["endpoint"]
maturity = "production"
min_stack_comments = "New fields added: required_fields, related_integrations, setup"
min_stack_version = "8.11.0"
updated_date = "2023/06/22"

[rule]
author = ["Elastic"]
description = """
Identifies the execution of the unshadow utility which is part of John the Ripper,
a password-cracking tool on the host machine. Malicious actors can use the utility to retrieve
the combined contents of the '/etc/shadow' and '/etc/password' files.
Using the combined file generated from the utility, the malicious threat actors can use them as input
for password-cracking utilities or prepare themselves for future operations by gathering
credential information of the victim.
"""
from = "now-9m"
language = "esql"
license = "Elastic License v2"
name = "ESQL Potential Linux Credential Dumping via Unshadow"
references = [
    "https://www.cyberciti.biz/faq/unix-linux-password-cracking-john-the-ripper/",
]
risk_score = 47
rule_id = "77af47d0-5bd4-11ee-8f6d-f661ea17fbce"
severity = "medium"
tags = ["Data Source: Elastic Endgame", "Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access", "Data Source: Elastic Defend"]
timestamp_override = "event.ingested"
type = "esql"
query = '''
from logs-endpoint.events.*, logs-endpoint.events.process*
    | keep host.os.type, process.name, process.working_directory, event.type, event.action
    | where host.os.type == "linux" and process.name == "unshadow" and event.type == "start" and event.action in ("exec", "exec_event")
'''


[[rule.threat]]
framework = "MITRE ATT&CK"
[[rule.threat.technique]]
id = "T1003"
name = "OS Credential Dumping"
reference = "https://attack.mitre.org/techniques/T1003/"
[[rule.threat.technique.subtechnique]]
id = "T1003.008"
name = "/etc/passwd and /etc/shadow"
reference = "https://attack.mitre.org/techniques/T1003/008/"



[rule.threat.tactic]
id = "TA0006"
name = "Credential Access"
reference = "https://attack.mitre.org/tactics/TA0006/"
```

</p>
</details> 

<details><summary>CLI Testing Commands</summary>
<p>


```bash
python -m detection_rules view-rule /Users/stryker/workspace/Elastic/detection
-rules/rules/linux/credential_access_credential_dumping_via_unshadow.toml --api-format 
```

Or run:

```bash
python -m detection_rules validate-rule /Users/stryker/workspace/Elastic/detection
-rules/rules/linux/credential_access_credential_dumping_via_unshadow.toml
```


</p>
</details> 


<details><summary>Output should look similar to the following:</summary>
<p>




```bash
Loaded config file: /Users/stryker/workspace/Elastic/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

{
  "author": [
    "Elastic"
  ],
  "description": "Identifies the execution of the unshadow utility which is part of John the Ripper, a password-cracking tool on the host machine. Malicious actors can use the utility to retrieve the combined contents of the '/etc/shadow' and '/etc/password' files. Using the combined file generated from the utility, the malicious threat actors can use them as input for password-cracking utilities or prepare themselves for future operations by gathering credential information of the victim.",
  "from": "now-9m",
  "language": "esql",
  "license": "Elastic License v2",
  "name": "ESQL Potential Linux Credential Dumping via Unshadow",
  "query": "from logs-endpoint.events.*, logs-endpoint.events.process*\n    | keep host.os.type, process.name, process.working_directory, event.type, event.action\n    | where host.os.type == \"linux\" and process.name == \"unshadow\" and event.type == \"start\" and event.action in (\"exec\", \"exec_event\")\n",
  "references": [
    "https://www.cyberciti.biz/faq/unix-linux-password-cracking-john-the-ripper/"
  ],
  "risk_score": 47,
  "rule_id": "77af47d0-5bd4-11ee-8f6d-f661ea17fbce",
  "severity": "medium",
  "tags": [
    "Data Source: Elastic Endgame",
    "Domain: Endpoint",
    "OS: Linux",
    "Use Case: Threat Detection",
    "Tactic: Credential Access",
    "Data Source: Elastic Defend"
  ],
  "threat": [
    {
      "framework": "MITRE ATT&CK",
      "tactic": {
        "id": "TA0006",
        "name": "Credential Access",
        "reference": "https://attack.mitre.org/tactics/TA0006/"
      },
      "technique": [
        {
          "id": "T1003",
          "name": "OS Credential Dumping",
          "reference": "https://attack.mitre.org/techniques/T1003/",
          "subtechnique": [
            {
              "id": "T1003.008",
              "name": "/etc/passwd and /etc/shadow",
              "reference": "https://attack.mitre.org/techniques/T1003/008/"
            }
          ]
        }
      ]
    }
  ],
  "timestamp_override": "event.ingested",
  "type": "esql",
  "version": 1
}

```


</p>
</details> 


## Additional Information

- ESQL query validation is not available with this PR. A warning is provided to the user notifying them for each ESQL rule. 
- In the interim, users can read our [Blog](https://www.elastic.co/security-labs/streamlining-esql-query-and-rule-validation) for more details on ES|QL validation. 
