### PR TITLE
[Rule Tuning] Multiple Users with the Same Okta Device Token Hash

### DIFF
--- a/rules/integrations/okta/credential_access_multiple_auth_events_from_single_device_behind_proxy.toml
+++ b/rules/integrations/okta/credential_access_multiple_auth_events_from_single_device_behind_proxy.toml
@@ -61,6 +61,8 @@ This rule detects when Okta user authentication events are reported for multiple
     - If so, confirm with the user this was a legitimate request.
     - If so and this was not a legitimate request, consider deactivating the user's account temporarily.
         - Reset passwords and reset MFA for the user.
+- If this is a false positive, consider adding the `okta.debug_context.debug_data.dt_hash` field to the `exceptions` list in the rule.
+    - This will prevent future occurrences of this event for this device from triggering the rule.
 """
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",

--- a/rules/integrations/okta/credential_access_multiple_auth_events_from_single_device_behind_proxy.toml
+++ b/rules/integrations/okta/credential_access_multiple_auth_events_from_single_device_behind_proxy.toml
@@ -24,7 +24,7 @@ license = "Elastic License v2"
 name = "Multiple Okta User Auth Events with Same Device Token Hash Behind a Proxy"
 note = """## Triage and analysis
 
-### Investigating Multiple Okta User Auth Events with Same Device Token Hash Using a Proxy
+### Investigating Multiple Okta User Auth Events with Same Device Token Hash Behind a Proxy
 
 This rule detects when Okta user authentication events are reported for multiple users with the same device token hash behind a proxy. This may indicate that a shared device between users, or that a user is using a proxy to access multiple accounts for password spraying.
 

--- a/rules/integrations/okta/credential_access_multiple_auth_events_from_single_device_behind_proxy.toml
+++ b/rules/integrations/okta/credential_access_multiple_auth_events_from_single_device_behind_proxy.toml
@@ -8,11 +8,14 @@ updated_date = "2023/12/05"
 
 [rule]
 author = ["Elastic"]
-description = "Detects when Okta user authentication events are reported for multiple users with the same device token hash behind a proxy."
+description = """
+Detects when Okta user authentication events are reported for multiple users with the same device token hash behind a
+proxy.
+"""
 false_positives = [
     "An Okta admnistrator may be logged into multiple accounts from the same host for legitimate reasons.",
     "Users may share an endpoint related to work or personal use in which separate Okta accounts are used.",
-    "Shared systems such as Kiosks and conference room computers may be used by multiple users."
+    "Shared systems such as Kiosks and conference room computers may be used by multiple users.",
 ]
 from = "now-9m"
 index = ["filebeat-*", "logs-okta*"]
@@ -59,8 +62,6 @@ This rule detects when Okta user authentication events are reported for multiple
     - If so and this was not a legitimate request, consider deactivating the user's account temporarily.
         - Reset passwords and reset MFA for the user.
 """
-setup = """
-The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
     "https://developer.okta.com/docs/reference/api/event-types/",
@@ -69,6 +70,7 @@ references = [
 ]
 risk_score = 47
 rule_id = "50887ba8-7ff7-11ee-a038-f661ea17fbcd"
+setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
 severity = "medium"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Initial Access"]
 timestamp_override = "event.ingested"
@@ -98,7 +100,6 @@ reference = "https://attack.mitre.org/techniques/T1110/003/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
@@ -123,4 +124,5 @@ value = 1
 [[rule.threshold.cardinality]]
 field = "okta.actor.id"
 value = 3
+
 

--- a/rules/integrations/okta/credential_access_multiple_auth_events_from_single_device_behind_proxy.toml
+++ b/rules/integrations/okta/credential_access_multiple_auth_events_from_single_device_behind_proxy.toml
@@ -74,7 +74,7 @@ risk_score = 47
 rule_id = "50887ba8-7ff7-11ee-a038-f661ea17fbcd"
 setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
 severity = "medium"
-tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Initial Access"]
+tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]
 timestamp_override = "event.ingested"
 type = "threshold"
 
@@ -91,29 +91,21 @@ framework = "MITRE ATT&CK"
 id = "T1110"
 name = "Brute Force"
 reference = "https://attack.mitre.org/techniques/T1110/"
-[[rule.threat.technique.subtechnique]]
-id = "T1110.003"
-name = "Password Spraying"
-reference = "https://attack.mitre.org/techniques/T1110/003/"
 
+    [[rule.threat.technique.subtechnique]]
+    id = "T1110.003"
+    name = "Password Spraying"
+    reference = "https://attack.mitre.org/techniques/T1110/003/"
 
-
-[rule.threat.tactic]
-id = "TA0006"
-name = "Credential Access"
-reference = "https://attack.mitre.org/tactics/TA0006/"
-[[rule.threat]]
-framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1110"
 name = "Brute Force"
 reference = "https://attack.mitre.org/techniques/T1110/"
-[[rule.threat.technique.subtechnique]]
-id = "T1110.004"
-name = "Credential Stuffing"
-reference = "https://attack.mitre.org/techniques/T1110/004/"
 
-
+    [[rule.threat.technique.subtechnique]]
+    id = "T1110.004"
+    name = "Credential Stuffing"
+    reference = "https://attack.mitre.org/techniques/T1110/004/"
 
 [rule.threat.tactic]
 id = "TA0006"

--- a/rules/integrations/okta/initial_access_multiple_active_users_from_single_device.toml
+++ b/rules/integrations/okta/initial_access_multiple_active_users_from_single_device.toml
@@ -8,7 +8,7 @@ updated_date = "2023/12/05"
 
 [rule]
 author = ["Elastic"]
-description = "Detects when Okta user authentication events are reported for multiple users with the same device token hash."
+description = "Detects when Okta user authentication events are reported for multiple users with the same device token hash behind a proxy."
 false_positives = [
     "An Okta admnistrator may be logged into multiple accounts from the same host for legitimate reasons.",
     "Users may share an endpoint related to work or personal use in which separate Okta accounts are used.",
@@ -84,20 +84,38 @@ event.dataset:okta.system
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-id = "T1078"
-name = "Valid Accounts"
-reference = "https://attack.mitre.org/techniques/T1078/"
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
 [[rule.threat.technique.subtechnique]]
-id = "T1078.004"
-name = "Cloud Accounts"
-reference = "https://attack.mitre.org/techniques/T1078/004/"
+id = "T1110.003"
+name = "Password Spraying"
+reference = "https://attack.mitre.org/techniques/T1110/003/"
 
 
 
 [rule.threat.tactic]
-id = "TA0001"
-name = "Initial Access"
-reference = "https://attack.mitre.org/tactics/TA0001/"
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+[[rule.threat.technique.subtechnique]]
+id = "T1110.004"
+name = "Credential Stuffing"
+reference = "https://attack.mitre.org/techniques/T1110/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
 
 [rule.threshold]
 field = ["okta.debug_context.debug_data.dt_hash"]
@@ -105,5 +123,4 @@ value = 1
 [[rule.threshold.cardinality]]
 field = "okta.actor.id"
 value = 3
-
 

--- a/rules/integrations/okta/initial_access_multiple_active_users_from_single_device.toml
+++ b/rules/integrations/okta/initial_access_multiple_active_users_from_single_device.toml
@@ -4,11 +4,11 @@ integration = ["okta"]
 maturity = "production"
 min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
 min_stack_version = "8.10.0"
-updated_date = "2023/11/10"
+updated_date = "2023/12/05"
 
 [rule]
 author = ["Elastic"]
-description = "Detects when Okta user or system events are reported for multiple users with the same device token hash."
+description = "Detects when Okta user authentication events are reported for multiple users with the same device token hash."
 false_positives = [
     "An Okta admnistrator may be logged into multiple accounts from the same host for legitimate reasons.",
     "Users may share an endpoint related to work or personal use in which separate Okta accounts are used.",
@@ -18,8 +18,48 @@ from = "now-9m"
 index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "Multiple Okta Users with the Same Device Token Hash"
-note = """## Setup
+name = "Multiple Okta User Auth Events with Same Device Token Hash Behind a Proxy"
+note = """## Triage and analysis
+
+### Investigating Multiple Okta User Auth Events with Same Device Token Hash Using a Proxy
+
+This rule detects when Okta user authentication events are reported for multiple users with the same device token hash behind a proxy. This may indicate that a shared device between users, or that a user is using a proxy to access multiple accounts for password spraying.
+
+#### Possible investigation steps:
+- Identify the users involved in this action by examining the `okta.actor.id`, `okta.actor.type`, `okta.actor.alternate_id`, and `okta.actor.display_name` fields.
+- Determine the device client used for these actions by analyzing `okta.client.ip`, `okta.client.user_agent.raw_user_agent`, `okta.client.zone`, `okta.client.device`, and `okta.client.id` fields.
+    - Since the device is behind a proxy, the `okta.client.ip` field will not be useful for determining the actual device IP address.
+- Review the `okta.request.ip_chain` field for more information about the geographic location of the proxy.
+- With Okta end users identified, review the `okta.debug_context.debug_data.dt_hash` field.
+    - Historical analysis should indicate if this device token hash is commonly associated with the user.
+- Review the `okta.event_type` field to determine the type of authentication event that occurred.
+    - If the event type is `user.authentication.sso`, the user may have legitimately started a session via a proxy for security or privacy reasons.
+    - If the event type is `user.authentication.password`, the user may be using a proxy to access multiple accounts for password spraying.
+- Examine the `okta.outcome.result` field to determine if the authentication was successful.
+- Review the past activities of the actor(s) involved in this action by checking their previous actions.
+- Evaluate the actions that happened just before and after this event in the `okta.event_type` field to help understand the full context of the activity.
+    - This may help determine the authentication and authorization actions that occurred between the user, Okta and application.
+
+### False positive analysis:
+- A user may have legitimately started a session via a proxy for security or privacy reasons.
+- Users may share an endpoint related to work or personal use in which separate Okta accounts are used.
+    - Architecturally, this shared endpoint may leverage a proxy for security or privacy reasons.
+    - Shared systems such as Kiosks and conference room computers may be used by multiple users.
+    - Shared working spaces may have a single endpoint that is used by multiple users.
+
+### Response and remediation:
+- Review the profile of the users involved in this action to determine if proxy usage may be expected.
+- If the user is legitimate and the authentication behavior is not suspicious based on device analysis, no action is required.
+- If the user is legitimate but the authentication behavior is suspicious, consider resetting passwords for the users involves and enabling multi-factor authentication (MFA).
+    - If MFA is already enabled, consider resetting MFA for the users.
+- If any of the users are not legitimate, consider deactivating the user's account.
+- Conduct a review of Okta policies and ensure they are in accordance with security best practices.
+- Check with internal IT teams to determine if the accounts involved recently had MFA reset at the request of the user.
+    - If so, confirm with the user this was a legitimate request.
+    - If so and this was not a legitimate request, consider deactivating the user's account temporarily.
+        - Reset passwords and reset MFA for the user.
+"""
+setup = """
 The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://developer.okta.com/docs/reference/api/system-log/",
@@ -35,7 +75,9 @@ timestamp_override = "event.ingested"
 type = "threshold"
 
 query = '''
-event.dataset:okta.system and not okta.actor.id:okta* and okta.debug_context.debug_data.dt_hash:* and okta.event_type:(system* or user*)
+event.dataset:okta.system
+    and not okta.actor.id:okta* and okta.debug_context.debug_data.dt_hash:*
+    and okta.event_type:user.authentication* and okta.security_context.is_proxy:true
 '''
 
 
@@ -62,6 +104,6 @@ field = ["okta.debug_context.debug_data.dt_hash"]
 value = 1
 [[rule.threshold.cardinality]]
 field = "okta.actor.id"
-value = 2
+value = 3
 
 


### PR DESCRIPTION
## Summary
A user has given feedback that the detection logic for this rule is too broad. Rule tuning and an investigation guide has been added to reduce potential false-positive rate.

- Before: Alert for >= 2 users with the same sourcing device token hash for any system or user events
- After: Alert for >= 3 users with the same sourcing device token hash for only user authentication events where the device is behind a proxy.

This should align more with credential stuffing and password spraying attempts. Additionally, MITRE ATT&CK mappings have been updated to more accurately reflect these techniques.
