### PR TITLE
[Rule Tuning] Adjust Min-Stack for `Okta FastPass Phishing Detection` Rule

### DIFF
--- a/rules/integrations/okta/initial_access_okta_fastpass_phishing.toml
+++ b/rules/integrations/okta/initial_access_okta_fastpass_phishing.toml
@@ -2,8 +2,8 @@
 creation_date = "2023/05/07"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.10.0"
 updated_date = "2023/11/07"
 
 [rule]
@@ -38,7 +38,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:okta.system and event.category:authentication and 
+event.dataset:okta.system and event.category:authentication and
   okta.event_type:user.authentication.auth_via_mfa and event.outcome:failure and okta.outcome.reason:"FastPass declined phishing attempt"
 '''
 


### PR DESCRIPTION
## Summary
This pull request adjusts min-stack for the `Okta FastPass Phishing Detection` rule. This min-stack was set to `8.3.0` which caused the dynamically generated `related_integrations` field to refer an older version below `2.0.0`. The Okta integration had a breaking change at `2.0.0` which is why all Okta rules are min-stacked to `8.10.0` where `^2.0.0` version is compatible.

This was found during the release for `8.11.5` regarding the version locking PR:
* https://github.com/elastic/detection-rules/pull/3317

