### PR TITLE
[Rule Tuning] Optimize query for Direct Outbound SMB Connection

### DIFF
--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -109,8 +109,9 @@ sequence by process.entity_id with maxspan=2m
    not (process.executable : "?:\\EnterpriseCare\\tools\\*\\bin\\java.exe" and process.args : "com.*.launcher.Invoker") and
    not (process.executable : "?:\\Docusnap*\\Tools\\*\\nmap.exe" and process.args : "smb-os-discovery.nse") and
    not process.executable :
-              ("?:\\Program Files\\SentinelOne\\Sentinel Agent *\\Ranger\\SentinelRanger.exe",
-               "?:\\Program Files\\Ivanti\\Security Controls\\ST.EngineHost.exe",
+              ("?:\\Program Files\\*.exe",
+               "?:\\Program Files (x86)\\*.exe", 
+               "?:\\Windows\\ProPatches\\Installation\\InstallationSandbox*\\stdeploy.exe"
                "?:\\Program Files (x86)\\Fortinet\\FSAE\\collectoragent.exe",
                "?:\\Program Files (x86)\\Nmap\\nmap.exe",
                "?:\\Program Files\\Azure Advanced Threat Protection Sensor\\*\\Microsoft.Tri.Sensor.exe",

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/012/13"
+updated_date = "2023/12/13"
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -111,7 +111,7 @@ sequence by process.entity_id with maxspan=2m
    not process.executable :
               ("?:\\Program Files\\*.exe",
                "?:\\Program Files (x86)\\*.exe", 
-               "?:\\Windows\\ProPatches\\Installation\\InstallationSandbox*\\stdeploy.exe"
+               "?:\\Windows\\ProPatches\\Installation\\InstallationSandbox*\\stdeploy.exe",
                "?:\\Program Files (x86)\\Fortinet\\FSAE\\collectoragent.exe",
                "?:\\Program Files (x86)\\Nmap\\nmap.exe",
                "?:\\Program Files\\Azure Advanced Threat Protection Sensor\\*\\Microsoft.Tri.Sensor.exe",
@@ -122,7 +122,6 @@ sequence by process.entity_id with maxspan=2m
   [network where host.os.type == "windows" and destination.port == 445 and process.pid != 4 and
      not cidrmatch(destination.ip, "127.0.0.1", "::1")]
 until [process where host.os.type == "windows" and event.type == "end"]
-
 '''
 
 

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -101,7 +101,7 @@ tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic
 type = "eql"
 
 query = '''
-sequence by process.entity_id with maxspan=5m
+sequence by process.entity_id with maxspan=2m
   [process where host.os.type == "windows" and event.type == "start" and process.pid != 4 and 
    not user.id : ("S-1-5-19", "S-1-5-20") and 
    not (process.code_signature.trusted == true and not process.code_signature.subject_name : ("Microsoft*", "Famatech Corp.", "Insecure.Com LLC")) and 

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -102,7 +102,10 @@ type = "eql"
 
 query = '''
 sequence by process.entity_id with maxspan=5m
-  [process where host.os.type == "windows" and event.type == "start" and process.pid != 4 and
+  [process where host.os.type == "windows" and event.type == "start" and process.pid != 4 and 
+   not user.id : ("S-1-5-19", "S-1-5-20") and 
+   not (process.code_signature.trusted == true and not process.code_signature.subject_name : ("Microsoft*", "Famatech Corp.", "Insecure.Com LLC")) and 
+   not (process.name : "powershell.exe" and process.args : "?:\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Downloads\\PSScript_*.ps1") and 
    not (process.executable : "?:\\EnterpriseCare\\tools\\*\\bin\\java.exe" and process.args : "com.*.launcher.Invoker") and
    not (process.executable : "?:\\Docusnap*\\Tools\\*\\nmap.exe" and process.args : "smb-os-discovery.nse") and
    not process.executable :

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/012/13"
 
 [transform]
 [[transform.osquery]]
@@ -101,10 +101,10 @@ tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic
 type = "eql"
 
 query = '''
-sequence by process.entity_id
+sequence by process.entity_id with maxspan=5m
   [process where host.os.type == "windows" and event.type == "start" and process.pid != 4 and
-   not (process.executable : "D:\\EnterpriseCare\\tools\\jre.1\\bin\\java.exe" and process.args : "com.emeraldcube.prism.launcher.Invoker") and
-   not (process.executable : "C:\\Docusnap 11\\Tools\\nmap\\nmap.exe" and process.args : "smb-os-discovery.nse") and
+   not (process.executable : "?:\\EnterpriseCare\\tools\\*\\bin\\java.exe" and process.args : "com.*.launcher.Invoker") and
+   not (process.executable : "?:\\Docusnap*\\Tools\\*\\nmap.exe" and process.args : "smb-os-discovery.nse") and
    not process.executable :
               ("?:\\Program Files\\SentinelOne\\Sentinel Agent *\\Ranger\\SentinelRanger.exe",
                "?:\\Program Files\\Ivanti\\Security Controls\\ST.EngineHost.exe",
@@ -117,6 +117,8 @@ sequence by process.entity_id
                "?:\\Program Files\\Rumble\\rumble-agent-*.exe")]
   [network where host.os.type == "windows" and destination.port == 445 and process.pid != 4 and
      not cidrmatch(destination.ip, "127.0.0.1", "::1")]
+until [process where host.os.type == "windows" and event.type == "end"]
+
 '''
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
Related to https://github.com/elastic/ia-trade-team/issues/232

## Summary

The goal of this PR is to optimize the query for performance, as it has been identified as an overly expensive execution. To do so, I targeted a few things:
* added a `maxspan`
* added a short circuit using `until`
* modified some of the exclusions

The primary thing we need to do is to attempt to restrict the first subquery down even more, because right now it is too wide open, essentially matching on _all_ non `pid 4` processes and holding on to state. We should look to restrict it based on executable location or user.id. I know this may present opportunity for FN, however, for performance reasons, I think it is worth the tradeoff.

## Details

### added a `maxspan`

Without a `maxspan`, this is unbounded for the entire rule run. While this was only 9m, restricting it down to 5m matches the interval and so cuts the time window almost in half with no loss


### added a short circuit using `until`

The idea here is that it will drop state immediately once the process closes rather than waiting the full 5m maxspan, if not needed


### modified some of the exclusions

These were more for resiliency of the exclusions, but the added benefit is that the exclusions are slightly more encompassing.


### TODO: restrict the process (1st) subquery to minimize matches

As suggested, the easiest ways may be targeting `user.id` or `process.executable` or even `process.parent.executable` to reduce the high match scenario. Looking for your input here @Samirbous  