### PR TITLE
[Rule Tuning] Account Password Reset Remotely

### DIFF
--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -4,7 +4,7 @@ integration = ["system", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/10/13"
+updated_date = "2023/12/14"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ passwords to maintain access or evade password duration policies and preserve co
 """
 false_positives = ["Legitimate remote account administration."]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-system.security*", "logs-windows.forwarded*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Account Password Reset Remotely"
@@ -31,11 +31,12 @@ tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic
 type = "eql"
 
 query = '''
-sequence by winlog.computer_name with maxspan=5m
+sequence by winlog.computer_name with maxspan=1m
   [authentication where event.action == "logged-in" and
     /* event 4624 need to be logged */
     winlog.logon.type : "Network" and event.outcome == "success" and source.ip != null and
-    source.ip != "127.0.0.1" and source.ip != "::1"] by winlog.event_data.TargetLogonId
+    source.ip != "127.0.0.1" and source.ip != "::1" and 
+    not winlog.event_data.TargetUserName : ("svc*", "PIM_*", "_*_", "*-*-*", "*$")] by winlog.event_data.TargetLogonId
    /* event 4724 need to be logged */
   [iam where event.action == "reset-password" and
    (

--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -18,6 +18,7 @@ index = ["winlogbeat-*", "logs-system.security*", "logs-windows.forwarded*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Account Password Reset Remotely"
+note = "This rule may cause medium to high performance impact due to logic scoping all remote Windows logon activity."
 references = [
     "https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4724",
     "https://stealthbits.com/blog/manipulating-user-passwords-with-mimikatz/",


### PR DESCRIPTION
https://github.com/elastic/detection-rules/issues/3332

- reduced maxspan from 5m to 1m (automated pwd reset)
- excluded most observed noisy winlog.event_data.TargetUserName patterns (IAM/AD service account dedicated for mass pwd reset)
- added a note for performance impact