### PR TITLE
[Tuning] Remote Scheduled Task Creation

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -42,6 +42,7 @@
         "TargetSid": "keyword",
       	"SchemaFriendlyName": "keyword",
         "Resource": "keyword",
+        "RpcCallClientLocality": "keyword",
         "PrivilegeList": "keyword",
         "AuthenticationPackageName" : "keyword",
         "TargetUserSid" : "keyword",

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -52,10 +52,7 @@ tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic
 type = "eql"
 
 query = '''
-iam where event.action == "scheduled-task-created" and 
-
-  /* populated for Win10 and Win2019 - 0 means remote and 1 local */
-  winlog.event_data.RpcCallClientLocality : "0"
+iam where event.action == "scheduled-task-created" and winlog.event_data.RpcCallClientLocality : "0"
 '''
 
 

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -50,6 +50,7 @@ rule_id = "9c865691-5599-447a-bac9-b3f2df5f9a9d"
 severity = "medium"
 tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Lateral Movement"]
 type = "eql"
+timestamp_override = "event.ingested"
 
 query = '''
 iam where event.action == "scheduled-task-created" and winlog.event_data.RpcCallClientLocality : "0"

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -4,19 +4,18 @@ integration = ["system", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+updated_date = "2023/12/14"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies a remote logon followed by a scheduled task creation on the target host. This could be indicative of
-adversary lateral movement.
+Identifies scheduled task creation from a remote source. This could be indicative of adversary lateral movement.
 """
 from = "now-9m"
 index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
-name = "Remote Logon followed by Scheduled Task Creation"
+name = "Remote Scheduled Task Creation"
 note = """## Triage and analysis
 
 ### Investigating Remote Scheduled Task Creation
@@ -53,15 +52,10 @@ tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic
 type = "eql"
 
 query = '''
-/* Network Logon followed by Scheduled Task creation  */
+iam where event.action == "scheduled-task-created" and 
 
-sequence by winlog.computer_name with maxspan=1m
-  [authentication where event.action == "logged-in" and
-   winlog.logon.type == "Network" and event.outcome == "success" and
-   not user.name == "ANONYMOUS LOGON" and not winlog.event_data.SubjectUserName : "*$" and
-   not user.domain == "NT AUTHORITY" and source.ip != "127.0.0.1" and source.ip !="::1"] by winlog.event_data.TargetLogonId
-
-  [iam where event.action == "scheduled-task-created"] by winlog.event_data.SubjectLogonId
+  /* populated for Win10 and Win2019 - 0 means remote and 1 local */
+  winlog.event_data.RpcCallClientLocality : "0"
 '''
 
 

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -15,7 +15,7 @@ from = "now-9m"
 index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
-name = "Remote Scheduled Task Creation"
+name = "Remote Scheduled Task Creation via RPC"
 note = """## Triage and analysis
 
 ### Investigating Remote Scheduled Task Creation

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -12,7 +12,7 @@ description = """
 Identifies scheduled task creation from a remote source. This could be indicative of adversary lateral movement.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-system.security*", "logs-windows.forwarded*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote Scheduled Task Creation via RPC"


### PR DESCRIPTION
Related to https://github.com/elastic/ia-trade-team/issues/232

using `winlog.event_data.RpcCallClientLocality : 0` we can infer that the task was created via remote RPC calls. This will limit rule scope to Win10/19 + 

![image](https://github.com/elastic/detection-rules/assets/64742097/84338b5c-893a-45b7-b3b8-8f1a1f8dc6eb)
