### PR TITLE
[Tuning] Multiple Logon Failure Followed by Logon Success

### DIFF
--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
@@ -4,7 +4,7 @@ integration = ["system", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/10/23"
+updated_date = "2023/12/14"
 
 [transform]
 [[transform.osquery]]
@@ -40,7 +40,7 @@ brute force login attempts across multiple users with a common or known password
 accounts.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-system.*", "logs-windows.*"]
+index = ["winlogbeat-*", "logs-system.security*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Multiple Logon Failure Followed by Logon Success"
@@ -118,7 +118,8 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
   [authentication where event.action == "logon-failed" and
     /* event 4625 need to be logged */
     winlog.logon.type : "Network" and
-    source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1" and
+    source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1" and 
+    not winlog.event_data.TargetUserSid : "S-1-0-0" and not user.id : "S-1-0-0" and 
     not user.name : ("ANONYMOUS LOGON", "-", "*$") and not user.domain == "NT AUTHORITY" and
 
     /* noisy failure status codes often associated to authentication misconfiguration */

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
@@ -117,7 +117,7 @@ query = '''
 sequence by winlog.computer_name, source.ip with maxspan=5s
   [authentication where event.action == "logon-failed" and
     /* event 4625 need to be logged */
-    winlog.logon.type : "Network" and
+    winlog.logon.type : "Network" and user.id != null and 
     source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1" and 
     not winlog.event_data.TargetUserSid : "S-1-0-0" and not user.id : "S-1-0-0" and 
     not user.name : ("ANONYMOUS LOGON", "-", "*$") and not user.domain == "NT AUTHORITY" and


### PR DESCRIPTION
https://github.com/elastic/ia-trade-team/issues/232

99% of noise is coming from Anonymous logon ("S-1-0-0"), not always populated in user.name thus the addition of `not user.id : "S-1-0-0"`