### PR TITLE
[FR] Add `--include-metadata` argument to `export-rules` command

### DIFF
--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -281,7 +281,7 @@ def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optio
 @click.option('--skip-unsupported', '-s', is_flag=True,
               help='If `--stack-version` is passed, skip rule types which are unsupported '
                    '(an error will be raised otherwise)')
-@click.option('--add-metadata', type=bool, is_flag=True, default=False, help='Add metadata to the exported rules')
+@click.option('--include-metadata', type=bool, is_flag=True, default=False, help='Add metadata to the exported rules')
 def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupported, include_metadata) -> RuleCollection:
     """Export rule(s) into an importable ndjson file."""
     assert len(rules) > 0, "No rules found"

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -282,7 +282,8 @@ def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optio
               help='If `--stack-version` is passed, skip rule types which are unsupported '
                    '(an error will be raised otherwise)')
 @click.option('--include-metadata', type=bool, is_flag=True, default=False, help='Add metadata to the exported rules')
-def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupported, include_metadata: bool) -> RuleCollection:
+def export_rules(rules, outfile: Path, replace_id, stack_version,
+                 skip_unsupported, include_metadata: bool) -> RuleCollection:
     """Export rule(s) into an importable ndjson file."""
     assert len(rules) > 0, "No rules found"
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -282,7 +282,7 @@ def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optio
               help='If `--stack-version` is passed, skip rule types which are unsupported '
                    '(an error will be raised otherwise)')
 @click.option('--include-metadata', type=bool, is_flag=True, default=False, help='Add metadata to the exported rules')
-def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupported, include_metadata) -> RuleCollection:
+def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupported, include_metadata: bool) -> RuleCollection:
     """Export rule(s) into an importable ndjson file."""
     assert len(rules) > 0, "No rules found"
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -233,7 +233,7 @@ def view_rule(ctx, rule_file, api_format):
 
 
 def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optional[definitions.SemVer] = None,
-                  verbose=True, skip_unsupported=False):
+                  verbose=True, skip_unsupported=False, add_metadata=False):
     """Export rules into a consolidated ndjson file."""
     from .rule import downgrade_contents_from_rule
 
@@ -246,17 +246,20 @@ def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optio
 
             for rule in rules:
                 try:
-                    output_lines.append(json.dumps(downgrade_contents_from_rule(rule, downgrade_version),
+                    output_lines.append(json.dumps(downgrade_contents_from_rule(rule, downgrade_version,
+                                                                                add_metadata=add_metadata),
                                                    sort_keys=True))
                 except ValueError as e:
                     unsupported.append(f'{e}: {rule.id} - {rule.name}')
                     continue
 
         else:
-            output_lines = [json.dumps(downgrade_contents_from_rule(r, downgrade_version), sort_keys=True)
+            output_lines = [json.dumps(downgrade_contents_from_rule(r, downgrade_version,
+                                                                    add_metadata=add_metadata), sort_keys=True)
                             for r in rules]
     else:
-        output_lines = [json.dumps(r.contents.to_api_format(), sort_keys=True) for r in rules]
+        output_lines = [json.dumps(r.contents.to_api_format(include_metadata=add_metadata),
+                                   sort_keys=True) for r in rules]
 
     outfile.write_text('\n'.join(output_lines) + '\n')
 
@@ -278,7 +281,8 @@ def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optio
 @click.option('--skip-unsupported', '-s', is_flag=True,
               help='If `--stack-version` is passed, skip rule types which are unsupported '
                    '(an error will be raised otherwise)')
-def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupported) -> RuleCollection:
+@click.option('--add-metadata', type=bool, is_flag=True, default=False, help='Add metadata to the exported rules')
+def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupported, add_metadata) -> RuleCollection:
     """Export rule(s) into an importable ndjson file."""
     assert len(rules) > 0, "No rules found"
 
@@ -295,7 +299,7 @@ def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupport
 
     outfile.parent.mkdir(exist_ok=True)
     _export_rules(rules=rules, outfile=outfile, downgrade_version=stack_version,
-                  skip_unsupported=skip_unsupported)
+                  skip_unsupported=skip_unsupported, add_metadata=add_metadata)
 
     return rules
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -233,7 +233,7 @@ def view_rule(ctx, rule_file, api_format):
 
 
 def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optional[definitions.SemVer] = None,
-                  verbose=True, skip_unsupported=False, add_metadata=False):
+                  verbose=True, skip_unsupported=False, add_metadata: bool = False):
     """Export rules into a consolidated ndjson file."""
     from .rule import downgrade_contents_from_rule
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -233,7 +233,7 @@ def view_rule(ctx, rule_file, api_format):
 
 
 def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optional[definitions.SemVer] = None,
-                  verbose=True, skip_unsupported=False, add_metadata: bool = False):
+                  verbose=True, skip_unsupported=False, include_metadata: bool = False):
     """Export rules into a consolidated ndjson file."""
     from .rule import downgrade_contents_from_rule
 
@@ -247,7 +247,7 @@ def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optio
             for rule in rules:
                 try:
                     output_lines.append(json.dumps(downgrade_contents_from_rule(rule, downgrade_version,
-                                                                                add_metadata=add_metadata),
+                                                                                include_metadata=include_metadata),
                                                    sort_keys=True))
                 except ValueError as e:
                     unsupported.append(f'{e}: {rule.id} - {rule.name}')
@@ -255,10 +255,10 @@ def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optio
 
         else:
             output_lines = [json.dumps(downgrade_contents_from_rule(r, downgrade_version,
-                                                                    add_metadata=add_metadata), sort_keys=True)
+                                                                    include_metadata=include_metadata), sort_keys=True)
                             for r in rules]
     else:
-        output_lines = [json.dumps(r.contents.to_api_format(include_metadata=add_metadata),
+        output_lines = [json.dumps(r.contents.to_api_format(include_metadata=include_metadata),
                                    sort_keys=True) for r in rules]
 
     outfile.write_text('\n'.join(output_lines) + '\n')
@@ -282,7 +282,7 @@ def _export_rules(rules: RuleCollection, outfile: Path, downgrade_version: Optio
               help='If `--stack-version` is passed, skip rule types which are unsupported '
                    '(an error will be raised otherwise)')
 @click.option('--add-metadata', type=bool, is_flag=True, default=False, help='Add metadata to the exported rules')
-def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupported, add_metadata) -> RuleCollection:
+def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupported, include_metadata) -> RuleCollection:
     """Export rule(s) into an importable ndjson file."""
     assert len(rules) > 0, "No rules found"
 
@@ -299,7 +299,7 @@ def export_rules(rules, outfile: Path, replace_id, stack_version, skip_unsupport
 
     outfile.parent.mkdir(exist_ok=True)
     _export_rules(rules=rules, outfile=outfile, downgrade_version=stack_version,
-                  skip_unsupported=skip_unsupported, add_metadata=add_metadata)
+                  skip_unsupported=skip_unsupported, include_metadata=include_metadata)
 
     return rules
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1299,7 +1299,7 @@ class DeprecatedRule(dict):
 
 
 def downgrade_contents_from_rule(rule: TOMLRule, target_version: str,
-                                 replace_id: bool = True, add_metadata: bool = False) -> dict:
+                                 replace_id: bool = True, include_metadata: bool = False) -> dict:
     """Generate the downgraded contents from a rule."""
     rule_dict = rule.contents.to_dict()["rule"]
     min_stack_version = target_version or rule.contents.metadata.min_stack_version or "8.3.0"
@@ -1318,7 +1318,7 @@ def downgrade_contents_from_rule(rule: TOMLRule, target_version: str,
         rule_contents_dict["transform"] = rule.contents.transform.to_dict()
 
     rule_contents = TOMLRuleContents.from_dict(rule_contents_dict)
-    payload = rule_contents.to_api_format(include_metadata=add_metadata)
+    payload = rule_contents.to_api_format(include_metadata=include_metadata)
     payload = strip_non_public_fields(min_stack_version, payload)
     return payload
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1161,11 +1161,12 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
 
     def to_api_format(self, include_version: bool = True, include_metadata: bool = False) -> dict:
         """Convert the TOML rule to the API format."""
-        converted_data = self.to_dict()['rule']
+        rule_dict = self.to_dict()
+        converted_data = rule_dict['rule']
         converted = self._post_dict_conversion(converted_data)
 
         if include_metadata:
-            converted["meta"] = self.to_dict()['metadata']
+            converted["meta"] = rule_dict['metadata']
 
         if include_version:
             converted["version"] = self.autobumped_version

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1159,7 +1159,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         flattened.update(self.metadata.to_dict())
         return flattened
 
-    def to_api_format(self, include_version=True, include_metadata=False) -> dict:
+    def to_api_format(self, include_version: bool = True, include_metadata: bool = False) -> dict:
         """Convert the TOML rule to the API format."""
         converted_data = self.to_dict()['rule']
         converted = self._post_dict_conversion(converted_data)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1159,10 +1159,13 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         flattened.update(self.metadata.to_dict())
         return flattened
 
-    def to_api_format(self, include_version=True) -> dict:
+    def to_api_format(self, include_version=True, include_metadata=False) -> dict:
         """Convert the TOML rule to the API format."""
         converted_data = self.to_dict()['rule']
         converted = self._post_dict_conversion(converted_data)
+
+        if include_metadata:
+            converted["meta"] = self.to_dict()['metadata']
 
         if include_version:
             converted["version"] = self.autobumped_version
@@ -1295,7 +1298,8 @@ class DeprecatedRule(dict):
         return self.contents.name
 
 
-def downgrade_contents_from_rule(rule: TOMLRule, target_version: str, replace_id: bool = True) -> dict:
+def downgrade_contents_from_rule(rule: TOMLRule, target_version: str,
+                                 replace_id: bool = True, add_metadata: bool = False) -> dict:
     """Generate the downgraded contents from a rule."""
     rule_dict = rule.contents.to_dict()["rule"]
     min_stack_version = target_version or rule.contents.metadata.min_stack_version or "8.3.0"
@@ -1314,7 +1318,7 @@ def downgrade_contents_from_rule(rule: TOMLRule, target_version: str, replace_id
         rule_contents_dict["transform"] = rule.contents.transform.to_dict()
 
     rule_contents = TOMLRuleContents.from_dict(rule_contents_dict)
-    payload = rule_contents.to_api_format()
+    payload = rule_contents.to_api_format(include_metadata=add_metadata)
     payload = strip_non_public_fields(min_stack_version, payload)
     return payload
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/3363

## Summary
This pull request adds `--add-metadata` argument to the `export-rules` CLI command. This addition is required for rules-as-data initiative in the issue referenced above. It also enables users to include metadata in rule JSON objects if desired. 

For this to work, `to_api_format()` had to be adjusted to add an option for including the metadata, similar to version. By default this is `False` as `to_api_format()` is commonly used for other commands, including building release packages. This way, the capability is exposed but does not alter the normal flow of rule loading and conversion.

## Testing
**Run export-rules on all rules**
```
python -m detection_rules export-rules --directory rules/ --include-metadata
```

**Test single rule**
```
python -m detection_rules export-rules --rule-id  3838e0e3-1850-4850-a411-2e8c5ba40ba8  --include-metadata
```

**Test single rule without metadata**
```
python -m detection_rules export-rules --rule-id  3838e0e3-1850-4850-a411-2e8c5ba40ba8 
```
