### PR TITLE
[Tuning] Update min_stack for container rules new ecs field 

### DIFF
--- a/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
@@ -2,9 +2,9 @@
 creation_date = "2023/10/26"
 integration = ["cloud_defend"]
 maturity = "production"
-min_stack_comments = "New Integration: Cloud Defend"
-min_stack_version = "8.8.0"
-updated_date = "2023/12/18"
+min_stack_comments = "New field added to ecs : container.security_context.privileged"
+min_stack_version = "8.10.0"
+updated_date = "2024/01/05"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/privilege_escalation_mount_launched_inside_a_privileged_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_mount_launched_inside_a_privileged_container.toml
@@ -2,9 +2,9 @@
 creation_date = "2023/10/26"
 integration = ["cloud_defend"]
 maturity = "production"
-min_stack_comments = "New Integration: Cloud Defend"
-min_stack_version = "8.8.0"
-updated_date = "2023/12/18"
+min_stack_comments = "New field added to ecs : container.security_context.privileged"
+min_stack_version = "8.10.0"
+updated_date = "2024/01/05"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Summary
Tuning to update the min_stack version for 2 rules using a field introduced to ecs in 8.10.0 : `container.security_context.privileged`
