### PR TITLE
[FR] Update Validate Integrations to Check Fields Across All Schema Variations

### DIFF
--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -93,68 +93,111 @@ class KQLValidator(QueryValidator):
                 print(err_trailer)
                 return exc
 
-    def validate_integration(self, data: QueryRuleData, meta: RuleMeta, package_integrations: List[dict]) -> Union[
-            KQL_ERROR_TYPES, None, TypeError]:
+    def validate_integration(
+        self, data: QueryRuleData, meta: RuleMeta, package_integrations: List[dict]
+    ) -> Union[KQL_ERROR_TYPES, None, TypeError]:
         """Validate the query, called from the parent which contains [metadata] information."""
         if meta.query_schema_validation is False or meta.maturity == "deprecated":
-            # syntax only, which is done via self.ast
             return
 
         error_fields = {}
-        current_stack_version = ""
-        combined_schema = {}
-        for integration_schema_data in get_integration_schema_data(data, meta, package_integrations):
-            ecs_version = integration_schema_data['ecs_version']
-            integration = integration_schema_data['integration']
-            package = integration_schema_data['package']
-            package_version = integration_schema_data['package_version']
-            integration_schema = integration_schema_data['schema']
-            stack_version = integration_schema_data['stack_version']
+        package_schemas = {}
 
-            if stack_version != current_stack_version:
-                # reset the combined schema for each stack version
-                current_stack_version = stack_version
-                combined_schema = {}
+        # Initialize package_schemas with a nested structure
+        for integration_data in package_integrations:
+            package = integration_data["package"]
+            integration = integration_data["integration"]
+            if integration:
+                package_schemas.setdefault(package, {}).setdefault(integration, {})
+            else:
+                package_schemas.setdefault(package, {})
 
-            # add non-ecs-schema fields for edge cases not added to the integration
+        # Process each integration schema
+        for integration_schema_data in get_integration_schema_data(
+            data, meta, package_integrations
+        ):
+            package, integration = (
+                integration_schema_data["package"],
+                integration_schema_data["integration"],
+            )
+            integration_schema = integration_schema_data["schema"]
+
+            # Add non-ecs-schema fields
             for index_name in data.index:
                 integration_schema.update(**ecs.flatten(ecs.get_index_schema(index_name)))
 
-            # add endpoint schema fields for multi-line fields
+            # Add endpoint schema fields for multi-line fields
             integration_schema.update(**ecs.flatten(ecs.get_endpoint_schemas()))
-            combined_schema.update(**integration_schema)
+            if integration:
+                package_schemas[package][integration] = integration_schema
+            else:
+                package_schemas[package] = integration_schema
 
+            # Validate the query against the schema
             try:
-                # validate the query against the integration fields with the package version
                 kql.parse(self.query, schema=integration_schema)
             except kql.KqlParseError as exc:
                 if exc.error_msg == "Unknown field":
                     field = extract_error_field(exc)
-                    trailer = (f"\n\tTry adding event.module or event.dataset to specify integration module\n\t"
-                               f"Will check against integrations {meta.integration} combined.\n\t"
-                               f"{package=}, {integration=}, {package_version=}, "
-                               f"{stack_version=}, {ecs_version=}"
-                               )
-                    error_fields[field] = {"error": exc, "trailer": trailer}
+                    trailer = (
+                        f"\n\tTry adding event.module or event.dataset to specify integration module\n\t"
+                        f"Will check against integrations {meta.integration} combined.\n\t"
+                        f"{package=}, {integration=}, {integration_schema_data['package_version']=}, "
+                        f"{integration_schema_data['stack_version']=}, "
+                        f"{integration_schema_data['ecs_version']=}"
+                    )
+                    error_fields[field] = {
+                        "error": exc,
+                        "trailer": trailer,
+                        "package": package,
+                        "integration": integration,
+                    }
                     if data.get("notify", False):
-                        print(f"\nWarning: `{field}` in `{data.name}` not found in schema. {trailer}")
+                        print(
+                            f"\nWarning: `{field}` in `{data.name}` not found in schema. {trailer}"
+                        )
                 else:
-                    return kql.KqlParseError(exc.error_msg, exc.line, exc.column, exc.source,
-                                             len(exc.caret.lstrip()), trailer=trailer)
+                    return kql.KqlParseError(
+                        exc.error_msg,
+                        exc.line,
+                        exc.column,
+                        exc.source,
+                        len(exc.caret.lstrip()),
+                        exc.trailer,
+                    )
 
-        # don't error on fields that are in another integration schema
-        for field in list(error_fields.keys()):
-            if field in combined_schema:
-                del error_fields[field]
+        # Check error fields against schemas of different packages or different integrations
+        for field, error_data in list(error_fields.items()):
+            error_package, error_integration = (
+                error_data["package"],
+                error_data["integration"],
+            )
+            for package, integrations_or_schema in package_schemas.items():
+                if error_integration is None:
+                    # Compare against the schema directly if there's no integration
+                    if error_package != package and field in integrations_or_schema:
+                        del error_fields[field]
+                else:
+                    # Compare against integration schemas
+                    for integration, schema in integrations_or_schema.items():
+                        check_alt_schema = (
+                            error_package != package or  # noqa: W504
+                            (error_package == package and error_integration != integration)
+                        )
+                        if check_alt_schema and field in schema:
+                            del error_fields[field]
 
-        # raise the first error
+        # Raise the first error
         if error_fields:
-            _, data = next(iter(error_fields.items()))
-            exc = data["error"]
-            trailer = data["trailer"]
-
-            return kql.KqlParseError(exc.error_msg, exc.line, exc.column, exc.source,
-                                     len(exc.caret.lstrip()), trailer=trailer)
+            _, error_data = next(iter(error_fields.items()))
+            return kql.KqlParseError(
+                error_data["error"].error_msg,
+                error_data["error"].line,
+                error_data["error"].column,
+                error_data["error"].source,
+                len(error_data["error"].caret.lstrip()),
+                error_data["trailer"],
+            )
 
 
 class EQLValidator(QueryValidator):
@@ -235,28 +278,37 @@ class EQLValidator(QueryValidator):
                 if exc:
                     raise exc
 
-    def validate_integration(self, data: QueryRuleData, meta: RuleMeta, package_integrations: List[dict]) -> Union[
-            EQL_ERROR_TYPES, None, ValueError]:
+    def validate_integration(self, data: QueryRuleData, meta: RuleMeta,
+                             package_integrations: List[dict]) -> Union[EQL_ERROR_TYPES, None, ValueError]:
         """Validate an EQL query while checking TOMLRule against integration schemas."""
         if meta.query_schema_validation is False or meta.maturity == "deprecated":
             # syntax only, which is done via self.ast
             return
 
         error_fields = {}
-        current_stack_version = ""
-        combined_schema = {}
-        for integration_schema_data in get_integration_schema_data(data, meta, package_integrations):
-            ecs_version = integration_schema_data['ecs_version']
-            integration = integration_schema_data['integration']
-            package = integration_schema_data['package']
-            package_version = integration_schema_data['package_version']
-            integration_schema = integration_schema_data['schema']
-            stack_version = integration_schema_data['stack_version']
+        package_schemas = {}
 
-            if stack_version != current_stack_version:
-                # reset the combined schema for each stack version
-                current_stack_version = stack_version
-                combined_schema = {}
+        # Initialize package_schemas with a nested structure
+        for integration_data in package_integrations:
+            package = integration_data["package"]
+            integration = integration_data["integration"]
+            if integration:
+                package_schemas.setdefault(package, {}).setdefault(integration, {})
+            else:
+                package_schemas.setdefault(package, {})
+
+        # Process each integration schema
+        for integration_schema_data in get_integration_schema_data(
+            data, meta, package_integrations
+        ):
+            ecs_version = integration_schema_data["ecs_version"]
+            package, integration = (
+                integration_schema_data["package"],
+                integration_schema_data["integration"],
+            )
+            package_version = integration_schema_data["package_version"]
+            integration_schema = integration_schema_data["schema"]
+            stack_version = integration_schema_data["stack_version"]
 
             # add non-ecs-schema fields for edge cases not added to the integration
             for index_name in data.index:
@@ -264,34 +316,65 @@ class EQLValidator(QueryValidator):
 
             # add endpoint schema fields for multi-line fields
             integration_schema.update(**ecs.flatten(ecs.get_endpoint_schemas()))
-            combined_schema.update(**integration_schema)
+            package_schemas[package].update(**integration_schema)
 
             eql_schema = ecs.KqlSchema2Eql(integration_schema)
-            err_trailer = f'stack: {stack_version}, integration: {integration},' \
-                          f'ecs: {ecs_version}, package: {package}, package_version: {package_version}'
+            err_trailer = (
+                f"stack: {stack_version}, integration: {integration},"
+                f"ecs: {ecs_version}, package: {package}, package_version: {package_version}"
+            )
 
-            exc = self.validate_query_with_schema(data=data, schema=eql_schema, err_trailer=err_trailer,
-                                                  min_stack_version=meta.min_stack_version)
+            # Validate the query against the schema
+            exc = self.validate_query_with_schema(
+                data=data,
+                schema=eql_schema,
+                err_trailer=err_trailer,
+                min_stack_version=meta.min_stack_version,
+            )
 
             if isinstance(exc, eql.EqlParseError):
                 message = exc.error_msg
                 if message == "Unknown field" or "Field not recognized" in message:
                     field = extract_error_field(exc)
-                    trailer = (f"\n\tTry adding event.module or event.dataset to specify integration module\n\t"
-                               f"Will check against integrations {meta.integration} combined.\n\t"
-                               f"{package=}, {integration=}, {package_version=}, "
-                               f"{stack_version=}, {ecs_version=}"
-                               )
-                    error_fields[field] = {"error": exc, "trailer": trailer}
+                    trailer = (
+                        f"\n\tTry adding event.module or event.dataset to specify integration module\n\t"
+                        f"Will check against integrations {meta.integration} combined.\n\t"
+                        f"{package=}, {integration=}, {package_version=}, "
+                        f"{stack_version=}, {ecs_version=}"
+                    )
+                    error_fields[field] = {
+                        "error": exc,
+                        "trailer": trailer,
+                        "package": package,
+                        "integration": integration,
+                    }
                     if data.get("notify", False):
-                        print(f"\nWarning: `{field}` in `{data.name}` not found in schema. {trailer}")
+                        print(
+                            f"\nWarning: `{field}` in `{data.name}` not found in schema. {trailer}"
+                        )
                 else:
                     return exc
 
-        # don't error on fields that are in another integration schema
-        for field in list(error_fields.keys()):
-            if field in combined_schema:
-                del error_fields[field]
+        # Check error fields against schemas of different packages or different integrations
+        for field, error_data in list(error_fields.items()):
+            error_package, error_integration = (
+                error_data["package"],
+                error_data["integration"],
+            )
+            for package, integrations_or_schema in package_schemas.items():
+                if error_integration is None:
+                    # Compare against the schema directly if there's no integration
+                    if error_package != package and field in integrations_or_schema:
+                        del error_fields[field]
+                else:
+                    # Compare against integration schemas
+                    for integration, schema in integrations_or_schema.items():
+                        check_alt_schema = (
+                            error_package != package or  # noqa: W504
+                            (error_package == package and error_integration != integration)
+                        )
+                        if check_alt_schema and field in schema:
+                            del error_fields[field]
 
         # raise the first error
         if error_fields:


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

#3371 

## Summary

This PR modifies the way we validate integration rules by refactoring the validate_integrations method in the eql and kql validator classes. The major change was to ensure the validation catches different combinations of rules and edge cases:
1. The base case where rules have fields that belong to a package-integration schema
2. Case where a field is in a schema of a package with no integration (integration=None)
3. Case where a field is in a package-integration schema but not in any other package-integration combination possible with the rule (e.g. a rule that has OR between different datasets)
4. Case where a field is in a later schema of a package-integration combination, but the rule is minstacked lower to a non-supported combination
5. Case where parsing kql errors lines failed due to not having the complete source of the query
6. Case where kql failed parsing and exception due to not having the entire source of the query.
7. EQL and KQL versions of validate_integrations. 

## Testing

1. Unit test should suffice. Originally we missed a field on main, but was caught in an older branch:
- 8.8: https://github.com/elastic/detection-rules/actions/runs/7423676699/job/20212831870
- 8.9: https://github.com/elastic/detection-rules/actions/runs/7423683026/job/20201644555

This was due to a field being introduced later. (Case 4)

<details><summary>Failing on privilege_escalation_debugfs_launc
hed_inside_a_privileged_container.toml with minstack 8.8.0</summary>
<p>

```python
-m detection_rules view-rule /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/integrations/cloud_defend/privilege_escalation_debugfs_launc
hed_inside_a_privileged_container.toml 
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Error loading rule in /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/runpy.py", line 198, in _run_module_as_main
    return _run_code(code, main_globals, None,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.5/Frameworks/Python.framework/Versions/3.11/lib/python3.11/runpy.py", line 88, in _run_code
    exec(code, run_globals)
  File "/Users/stryker/.vscode/extensions/ms-python.python-2023.22.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/Users/stryker/.vscode/extensions/ms-python.python-2023.22.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/Users/stryker/.vscode/extensions/ms-python.python-2023.22.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 317, in run_module
    run_module_as_main(options.target, alter_argv=True)
  File "/Users/stryker/.vscode/extensions/ms-python.python-2023.22.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 238, in _run_module_as_main
    return _run_code(code, main_globals, None,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/.vscode/extensions/ms-python.python-2023.22.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/__main__.py", line 34, in <module>
    main()
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/__main__.py", line 31, in main
    root(prog_name="detection_rules")
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/main.py", line 225, in view_rule
    rule = RuleCollection().load_file(rule_file)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule_loader.py", line 276, in load_file
    return self.load_dict(obj, path=path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule_loader.py", line 253, in load_dict
    contents = TOMLRuleContents.from_dict(obj)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/mixins.py", line 109, in from_dict
    return schema.load(obj)
           ^^^^^^^^^^^^^^^^
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/marshmallow_dataclass/__init__.py", line 768, in load
    all_loaded = super().load(data, many=many, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/marshmallow/schema.py", line 719, in load
    return self._do_load(
           ^^^^^^^^^^^^^^
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/marshmallow/schema.py", line 876, in _do_load
    self._invoke_schema_validators(
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/marshmallow/schema.py", line 1179, in _invoke_schema_validators
    self._run_validator(
  File "/Users/stryker/.virtualenvs/detection_dev/lib/python3.11/site-packages/marshmallow/schema.py", line 771, in _run_validator
    validator_func(output, partial=partial, many=many)
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule.py", line 1138, in post_conversion_validation
    data.validate_query(metadata)
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule.py", line 591, in validate_query
    return validator.validate(self, meta)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule_validators.py", line 246, in validate
    raise ValueError(f"Error in both stack and integrations checks: {validation_checks}")
ValueError: Error in both stack and integrations checks: {'stack': EqlSchemaError('Error at line:4,column:3\nField not recognized for process event\n  event.type == "start" and process.name == "debugfs" and\n  process.args : "/dev/sd*" and not process.args == "-R" and\n  container.security_context.privileged == true\n  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\nstack: 8.9.0, beats: 8.9.0,ecs: 8.9.0, endgame: 8.4.0'), 'integrations': EqlSchemaError('Error at line:4,column:3\nField not recognized for process event\n  event.type == "start" and process.name == "debugfs" and\n  process.args : "/dev/sd*" and not process.args == "-R" and\n  container.security_context.privileged == true\n  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\nstack: 8.8.0, integration: None,ecs: 8.8.0, package: cloud_defend, package_version: 1.2.2')}
``` 

</p>
</details> 


<details><summary>Passing on privilege_escalation_debugfs_launc
hed_inside_a_privileged_container.toml  with minstack 8.10.0</summary>
<p>

```python
python -m detection_rules view-rule /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/integrations/cloud_defend/privilege_escalation_debugfs_lau
nched_inside_a_privileged_container.toml 
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

{
  "author": [
    "Elastic"
  ],
  "description": "This rule detects the use of the built-in Linux DebugFS utility from inside a privileged container. DebugFS is a special file system debugging utility which supports reading and writing directly from a hard drive device. When launched inside a privileged container, a container deployed with all the capabilities of the host machine, an attacker can access sensitive host level files which could be used for further privilege escalation and container escapes to the host machine.",
  "from": "now-6m",
  "index": [
    "logs-cloud_defend*"
  ],
  "interval": "5m",
  "language": "eql",
  "license": "Elastic License v2",
  "name": "File System Debugger Launched Inside a Privileged Container",
  "query": "process where event.module == \"cloud_defend\" and\n  event.type == \"start\" and process.name == \"debugfs\" and\n  process.args : \"/dev/sd*\" and not process.args == \"-R\" and\n  container.security_context.privileged == true\n",
  "references": [
    "https://cyberark.wistia.com/medias/ygbzkzx93q?wvideo=ygbzkzx93q",
    "https://book.hacktricks.xyz/linux-hardening/privilege-escalation/docker-security/docker-breakout-privilege-escalation#privileged"
  ],
  "related_integrations": [
    {
      "package": "cloud_defend",
      "version": "^1.0.5"
    }
  ],
  "required_fields": [
    {
      "ecs": true,
      "name": "container.security_context.privileged",
      "type": "boolean"
    },
    {
      "ecs": true,
      "name": "event.module",
      "type": "keyword"
    },
    {
      "ecs": true,
      "name": "event.type",
      "type": "keyword"
    },
    {
      "ecs": true,
      "name": "process.args",
      "type": "keyword"
    },
    {
      "ecs": true,
      "name": "process.name",
      "type": "keyword"
    }
  ],
  "risk_score": 47,
  "rule_id": "97697a52-4a76-4f0a-aa4f-25c178aae6eb",
  "severity": "medium",
  "tags": [
    "Data Source: Elastic Defend for Containers",
    "Domain: Container",
    "OS: Linux",
    "Use Case: Threat Detection",
    "Tactic: Privilege Escalation"
  ],
  "threat": [
    {
      "framework": "MITRE ATT&CK",
      "tactic": {
        "id": "TA0004",
        "name": "Privilege Escalation",
        "reference": "https://attack.mitre.org/tactics/TA0004/"
      },
      "technique": [
        {
          "id": "T1611",
          "name": "Escape to Host",
          "reference": "https://attack.mitre.org/techniques/T1611/"
        }
      ]
    }
  ],
  "timestamp_override": "event.ingested",
  "type": "eql",
  "version": 1
}
``` 

</p>
</details> 

Unit tests should all still pass as before.  However here are several example rules that fit the different cases:
1. rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
2. rules/integrations/beaconing/command_and_control_beaconing.toml
3. rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
4. rules/integrations/dga/command_and_control_ml_dga_activity_using_sunburst_domain.toml
5. rules/integrations/okta/persistence_stolen_credentials_used_to_login_to_okta_account_after_mfa_reset.toml
6. rules/integrations/azure/credential_access_azure_full_network_packet_capture_detected.toml

## Additional Information

Here is a Figma diagram to help understand our overall query validation process:

<img width="3716" alt="Query Validation" src="https://github.com/elastic/detection-rules/assets/1636709/43bf994c-01bb-46f0-88ee-d621e2d7b669">


