### PR TITLE
[FR] Update _event_sort to use datetime instead of time

### DIFF
--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -214,7 +214,7 @@ def event_sort(events, timestamp='@timestamp', date_format='%Y-%m-%dT%H:%M:%S.%f
 
         return t
 
-    def _event_sort(event):
+    def _event_sort(event: dict) -> datetime:
         """Calculates the sort key for an event as a datetime object."""
         t = round_microseconds(event[timestamp])
 

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -16,7 +16,6 @@ import json
 import os
 import shutil
 import subprocess
-import time
 import zipfile
 from dataclasses import is_dataclass, astuple
 from datetime import datetime, date

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -216,11 +216,11 @@ def event_sort(events, timestamp='@timestamp', date_format='%Y-%m-%dT%H:%M:%S.%f
         return t
 
     def _event_sort(event):
-        """Calculates the sort key for an event."""
+        """Calculates the sort key for an event as a datetime object."""
         t = round_microseconds(event[timestamp])
 
-        # Return the timestamp in seconds, adjusted for microseconds and then scaled to milliseconds
-        return (time.mktime(time.strptime(t, date_format)) + int(t.split('.')[-1][:-1]) / 1000) * 1000
+        # Return the timestamp as a datetime object for comparison
+        return datetime.strptime(t, date_format)
 
     return sorted(events, key=_event_sort, reverse=not asc)
 


### PR DESCRIPTION
## Issues
https://github.com/elastic/ia-trade-team/issues/245

## Summary
This PR updates the event sorting to use datetime objects instead of direct numeric comparison. Python 3 supports direct comparison and sorting of datetime objects. 


## Testing
Run the `collect-events` command with an RTA against an Elastic stack with a host with the Elastic agent running.

Example command: 

```shell
python -m detection_rules es --cloud-id <CLOUD_ID> collect-events --rta-name <RTA_NAME> <HOST_ID>
```

When doing this make sure to execute the RTA on the host as well in order to generate some events to capture. 

<details><summary>Example Output</summary>
<p>
On development machine

```shell

> python -m detection_rules es --cloud-id <CLOUD_ID> collect-events --rta-name adobe_hijack <HOST_ID>

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

es_user: <username>
es_password: 
Press any key once detonation is complete ...
1 events saved to: /home/forteea1/Code/elastic/detection-rules/unit_tests/data/true_positives/adobe_hijack/endpoint.jsonl
31 events saved to: /home/forteea1/Code/elastic/detection-rules/unit_tests/data/true_positives/adobe_hijack/metricbeat.jsonl
```

On target host machine:

```shell
python -m rta -n adobe_hijack
```

</p>
</details> 