### PR TITLE
Linux Rule Tuning

### DIFF
--- a/rules/linux/defense_evasion_chattr_immutable_file.toml
+++ b/rules/linux/defense_evasion_chattr_immutable_file.toml
@@ -76,7 +76,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and user.name == "root" and
+process where host.os.type == "linux" and event.type == "start" and user.id == "0" and
   process.executable : "/usr/bin/chattr" and process.args : ("-*i*", "+*i*") and
   not process.parent.executable: ("/lib/systemd/systemd", "/usr/local/uems_agent/bin/*", "/usr/lib/systemd/systemd") and
   not process.parent.name in ("systemd", "cf-agent", "ntpdate", "xargs", "px", "preinst", "auth")

--- a/rules/linux/defense_evasion_chattr_immutable_file.toml
+++ b/rules/linux/defense_evasion_chattr_immutable_file.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/12/12"
+updated_date = "2024/01/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/persistence_etc_file_creation.toml
+++ b/rules/linux/persistence_etc_file_creation.toml
@@ -202,7 +202,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where host.os.type == "linux" and event.type in ("creation", "file_create_event") and user.name == "root" and
+file where host.os.type == "linux" and event.type in ("creation", "file_create_event") and user.id == "0" and
 file.path : ("/etc/ld.so.conf.d/*", "/etc/cron.d/*", "/etc/sudoers.d/*", "/etc/rc.d/init.d/*", "/etc/systemd/system/*",
 "/usr/lib/systemd/system/*") and not (
   (process.executable : (

--- a/rules/linux/persistence_etc_file_creation.toml
+++ b/rules/linux/persistence_etc_file_creation.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/12/13"
+updated_date = "2024/01/11"
 
 [transform]
 [[transform.osquery]]


### PR DESCRIPTION
## Issues
Found while Testing rules for https://github.com/elastic/endpoint-rules/issues/3228

## Summary

- Two of the Linux Rules user users.name == "root" as a query criteria in them
    - File made Immutable by Chattr
    - Suspicious File Creation in /etc for Persistence
- While testing for some behaviours in issue mentioned I found not all instances user.name is enumerated as "root" on one of the test systems it is enumerated as  "r00t". This would mean the query would not identify such edge cases.
- Hence I have changed the query to use user.id=="0" instead which provides correct results for both the queries

![image](https://github.com/elastic/detection-rules/assets/91139415/527c1488-c85d-4348-80bc-fcff80d27fb3)

![image](https://github.com/elastic/detection-rules/assets/91139415/6fdfa093-5a13-4ef9-a1ad-4aed48f30d04)



## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
