### PR TITLE
[New Rule] Network Connection via Sudo Binary

### DIFF
--- a/rules/linux/privilege_escalation_netcon_via_sudo_binary.toml
+++ b/rules/linux/privilege_escalation_netcon_via_sudo_binary.toml
@@ -1,0 +1,91 @@
+[metadata]
+creation_date = "2024/01/15"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2024/01/15"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects network connections initiated by the "sudo" binary. This behaviour is uncommon, and may occur in instances where
+reverse shell shellcode is injected into a process ran with elevated permissions via "sudo". Attackers may attempt to
+inject shellcode into processes running as root, to escalate privileges. 
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Suspicious Network Connection via Sudo Binary"
+risk_score = 47
+rule_id = "30e1e9f2-eb9c-439f-aff6-1e3068e99384"
+setup = """
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+
+"""
+severity = "medium"
+tags = [   
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Privilege Escalation",
+        "Data Source: Elastic Defend"
+        ]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+network where host.os.type == "linux" and event.action == "connection_attempted" and event.type == "start" and
+process.name == "sudo"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1055"
+name = "Process Injection"
+reference = "https://attack.mitre.org/techniques/T1055/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1055.008"
+name = "Ptrace System Calls"
+reference = "https://attack.mitre.org/techniques/T1055/008/"
+
+[[rule.threat.technique]]
+id = "T1548"
+name = "Abuse Elevation Control Mechanism"
+reference = "https://attack.mitre.org/techniques/T1548/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1548.003"
+name = "Sudo and Sudo Caching"
+reference = "https://attack.mitre.org/techniques/T1548/003/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/linux/privilege_escalation_netcon_via_sudo_binary.toml
+++ b/rules/linux/privilege_escalation_netcon_via_sudo_binary.toml
@@ -9,8 +9,8 @@ updated_date = "2024/01/15"
 [rule]
 author = ["Elastic"]
 description = """
-Detects network connections initiated by the "sudo" binary. This behaviour is uncommon, and may occur in instances where
-reverse shell shellcode is injected into a process ran with elevated permissions via "sudo". Attackers may attempt to
+Detects network connections initiated by the "sudo" binary. This behavior is uncommon and may occur in instances where
+reverse shell shellcode is injected into a process run with elevated permissions via "sudo". Attackers may attempt to
 inject shellcode into processes running as root, to escalate privileges. 
 """
 from = "now-9m"


### PR DESCRIPTION
## Summary
Detects network connections initiated by the "sudo" binary. This behavior is uncommon and may occur in instances where reverse shell shellcode is injected into a process run with elevated permissions via "sudo". Attackers may attempt to inject shellcode into processes running as root, to escalate privileges. 

## Detection
1 hit in telemetry last 365 days, seems to be suspicious behavior. 1 hit 365 days in my stack, related to process injection testing. 
```
network where host.os.type == "linux" and event.action == "connection_attempted" and event.type == "start" and
process.name == "sudo"
```

<img width="1573" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/9d60c83b-b021-498d-829f-8d6c3bef6d48">

