### PR TITLE
[Bug] Cleanup test_event_override unit test

### DIFF
--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -964,10 +964,6 @@ class TestRuleTiming(BaseRuleTest):
             # QueryRuleData should inheritenly ignore machine learning rules
             if isinstance(rule.contents.data, QueryRuleData):
                 rule_language = rule.contents.data.language
-                rule_integrations = rule.contents.metadata.get('integration')
-                if isinstance(rule_integrations, str):
-                    rule_integrations = [rule_integrations]
-                rule_query = rule.contents.data.get('query')
                 has_event_ingested = rule.contents.data.get('timestamp_override') == 'event.ingested'
                 rule_str = self.rule_str(rule, trailer=None)
 
@@ -975,7 +971,7 @@ class TestRuleTiming(BaseRuleTest):
                     # TODO: determine if we expand this to ES|QL
                     # ignores any rule that does not use EQL or KQL queries specifically
                     # this does not avoid rule types where variants of KQL are used (e.g. new terms)
-                    if rule_language not in ('eql', 'kuery') or "sequence" in rule_query:
+                    if rule_language not in ('eql', 'kuery') or rule.contents.data.is_sequence:
                         continue
                     else:
                         errors.append(f'{rule_str} - rule must have `timestamp_override: event.ingested`')


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
* https://github.com/elastic/detection-rules/issues/3394

## Summary
This PR fixes the `TestRuleTiming.test_event_override` unit test by doing the following:
- Removes `rule_integrations` variable as it is not used in the logic to determine if the `timestamp_override` field is necessary
- Removes `rule_query` since we are using `is_sequence()` method to determine if the EQL query uses sequences
- Changes `"sequence" in rule_query` to `rule.contents.data.is_sequence`

Note: While `is_sequence` is a method of `EQLRuleData`, it exists as an attribute of this object because `QueryRuleData` is inherited into these dataclass. We only run the rest of this unit test if the `rule.contents.data` is `QueryRuleData`.
