### PR TITLE
[Rule Tuning] Host Files System Changes via Windows Subsystem for Linux

### DIFF
--- a/rules/windows/defense_evasion_wsl_filesystem.toml
+++ b/rules/windows/defense_evasion_wsl_filesystem.toml
@@ -13,7 +13,7 @@ Detects files creation and modification on the host system from the the Windows 
 Adversaries may enable and use WSL for Linux to avoid detection.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*", "endgame-*"]
+index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Host Files System Changes via Windows Subsystem for Linux"

--- a/rules/windows/defense_evasion_wsl_filesystem.toml
+++ b/rules/windows/defense_evasion_wsl_filesystem.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/12"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2023/06/22"
+updated_date = "2024/01/22"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 


### PR DESCRIPTION
## Summary

Drops endgame support, the query uses `process.entity_id`, which is not populated by Endgame.