### PR TITLE
[Rule Tuning] Direct Outbound SMB Connection

### DIFF
--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"

--- a/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
+++ b/rules/windows/lateral_movement_direct_outbound_smb_connection.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2024/01/03"
+updated_date = "2024/01/22"
 
 [transform]
 [[transform.osquery]]
@@ -41,7 +41,7 @@ connections are established by the kernel. Processes making 445/tcp connections 
 suspicious user-level processes moving laterally.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.*", "logs-windows.*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Direct Outbound SMB Connection"
@@ -104,14 +104,8 @@ query = '''
 sequence by process.entity_id with maxspan=2m
   [process where host.os.type == "windows" and event.type == "start" and process.pid != 4 and 
    not user.id : ("S-1-5-19", "S-1-5-20") and 
-   not (process.code_signature.trusted == true and not process.code_signature.subject_name : ("Famatech Corp.", "Insecure.Com LLC")) and 
-   not (process.name : "powershell.exe" and process.args : "?:\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Downloads\\PSScript_*.ps1") and 
-   not (process.executable : "?:\\EnterpriseCare\\tools\\*\\bin\\java.exe" and process.args : "com.*.launcher.Invoker") and
-   not (process.executable : "?:\\Docusnap*\\Tools\\*\\nmap.exe" and process.args : "smb-os-discovery.nse") and
-   not process.executable :
-              ("?:\\Program Files\\*.exe",
-               "?:\\Program Files (x86)\\*.exe", 
-               "?:\\Windows\\ProPatches\\Installation\\InstallationSandbox*\\stdeploy.exe")]
+   not (process.code_signature.trusted == true and not process.code_signature.subject_name : "Microsoft *") and 
+   not (process.name : "powershell.exe" and process.args : "?:\\ProgramData\\Microsoft\\Windows Defender Advanced Threat Protection\\Downloads\\PSScript_*.ps1")]
   [network where host.os.type == "windows" and destination.port == 445 and process.pid != 4 and
      not cidrmatch(destination.ip, "127.0.0.1", "::1")]
 until [process where host.os.type == "windows" and event.type == "end"]


### PR DESCRIPTION
## Summary

* Drops Sysmon support as we are using process code signature fields.
* Limits the query to unsigned or MS-signed executables.
