### PR TITLE
[Rule Tuning] Potential Modification of Accessibility Binaries

### DIFF
--- a/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
+++ b/rules/windows/persistence_priv_escalation_via_accessibility_features.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2023/10/23"
+updated_date = "2024/01/23"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 
@@ -119,6 +119,7 @@ type = "eql"
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
  process.parent.name : ("Utilman.exe", "winlogon.exe") and user.name == "SYSTEM" and
+ process.pe.original_file_name : "?*" and
  process.args :
     (
     "C:\\Windows\\System32\\osk.exe",


### PR DESCRIPTION
## Summary

Related: https://github.com/elastic/endpoint-dev/issues/14039

Adds a condition to check if `process.pe.original_file_name` is populated, to avoid FPs related to an endpoint bug where it is occasionally not populated.