### PR TITLE
[Bug] Update Prebuilt Detection Rules Release Process

### DIFF
--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -51,7 +51,7 @@ jobs:
           run: |
             cd detection-rules
             COMMIT_HASH=$(git log --grep="Lock versions for releases" -1 --format="%H")
-            echo "::set-output name=commit_hash::$COMMIT_HASH"
+            echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
           shell: bash
 
     fleet-pr:
@@ -97,7 +97,7 @@ jobs:
             COMMIT_HASH: ${{ needs.extract-commit-hash.outputs.commit_hash }}
           run: |
             cd detection-rules
-            git checkout $COMMIT_HASH
+            git checkout ${{ env.COMMIT_HASH }}
 
         - name: Bump prebuilt rules package version
           env:

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -35,6 +35,7 @@ on:
 
 jobs:
     extract-commit-hash:
+      name: Extract version lock commit hash
       runs-on: ubuntu-latest
       outputs:
         commit_hash: ${{ steps.extract_commit_hash.outputs.commit_hash }}
@@ -51,7 +52,7 @@ jobs:
             echo "commit_hash=$(git log --grep='Lock versions for releases' -1 --format='%H')" >> $GITHUB_OUTPUT
 
     fleet-pr:
-      name: Fleet PR
+      name: Build package and create PR to integrations
       needs: extract-commit-hash
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -62,6 +62,7 @@ jobs:
         - name: Checkout commit hash
           run: |
             cd detection-rules
+            echo "Current branch is $GITHUB_REF"
             echo "Checking out commit hash $COMMIT_HASH"
             git checkout $COMMIT_HASH
 

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -35,7 +35,6 @@ on:
 
 jobs:
     extract-commit-hash:
-      name: Extract Commit Hash
       runs-on: ubuntu-latest
       outputs:
         commit_hash: ${{ steps.extract_commit_hash.outputs.commit_hash }}
@@ -45,14 +44,11 @@ jobs:
           with:
             path: detection-rules
             fetch-depth: 0
-
-        - name: Extract commit hash
-          id: extract_commit_hash
+        - id: extract_commit_hash
+          name: Extract commit hash
           run: |
             cd detection-rules
-            COMMIT_HASH=$(git log --grep="Lock versions for releases" -1 --format="%H")
-            echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
-          shell: bash
+            echo "commit_hash=$(git log --grep='Lock versions for releases' -1 --format='%H')" >> $GITHUB_OUTPUT
 
     fleet-pr:
       name: Fleet PR
@@ -66,12 +62,17 @@ jobs:
               if ('refs/heads/main' === '${{github.ref}}') {
                 core.setFailed('Forbidden branch')
               }
-
         - name: Checkout detection-rules
           uses: actions/checkout@v3
           with:
             path: detection-rules
             fetch-depth: 0
+
+        - name: Checkout commit hash
+          run: |
+            cd detection-rules
+            echo "Checking out commit hash ${{ needs.extract-commit-hash.outputs.commit_hash }}"
+            git checkout ${{ needs.extract-commit-hash.outputs.commit_hash }}
 
         - name: Checkout elastic/integrations
           uses: actions/checkout@v3
@@ -92,13 +93,6 @@ jobs:
             pip cache purge
             pip install .[dev]
 
-        - name: Checkout commit hash
-          env:
-            COMMIT_HASH: ${{ needs.extract-commit-hash.outputs.commit_hash }}
-          run: |
-            cd detection-rules
-            git checkout ${{ env.COMMIT_HASH }}
-
         - name: Bump prebuilt rules package version
           env:
             PACKAGE_MATURITY: "${{github.event.inputs.package_maturity}}"
@@ -111,19 +105,18 @@ jobs:
               --maturity $PACKAGE_MATURITY
 
         - name: Store release tag
-          if: ${{github.event.inputs.package_maturity}} == "ga"
-          id: packages-version
+          if: github.event.inputs.package_maturity == 'ga'
           run: |
             cd detection-rules
             output=$(cat detection_rules/etc/packages.yml | grep -oP '(?<=\sversion: )\S+')
-            echo "::set-output name=pkg_version::$output"
+            echo "pkg_version=$output" >> $GITHUB_ENV
 
         - name: Create release tag
-          if: ${{github.event.inputs.package_maturity}} == "ga"
-          env:
-            RELEASE_TAG: "integration-v${{ steps.packages-version.outputs.pkg_version }}"
+          if: github.event.inputs.package_maturity == 'ga'
           run: |
             cd detection-rules
+            RELEASE_TAG="integration-v${{ env.pkg_version }}"
+            echo "Creating release tag: $RELEASE_TAG"
             git tag $RELEASE_TAG
             git push origin $RELEASE_TAG
 

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -28,162 +28,144 @@ on:
         type: choice
         description: 'New Package'
         required: true
+        default: "true"
         options:
           - "true"
           - "false"
-      add_historical:
-        type: choice
-        description: 'Add Historical Rules'
-        required: true
-        options:
-          - "yes"
-          - "no"
-      commit_hash:
-        description: 'Commit hash'
-        required: true
 
 jobs:
-  check-commit:
-    name: Check Commit Hash
-    runs-on: ubuntu-latest
-    outputs:
-      is_locked_commit: ${{ steps.check_commit.outputs.check_message }}
-    steps:
-      - name: Checkout detection-rules
-        uses: actions/checkout@v3
-        with:
-          path: detection-rules
-          fetch-depth: 0
+    extract-commit-hash:
+      name: Extract Commit Hash
+      runs-on: ubuntu-latest
+      outputs:
+        commit_hash: ${{ steps.extract_commit_hash.outputs.commit_hash }}
+      steps:
+        - name: Checkout detection-rules
+          uses: actions/checkout@v3
+          with:
+            path: detection-rules
+            fetch-depth: 0
 
-      - name: Check commit message
-        id: check_commit
-        env:
-          COMMIT_HASH: "${{github.event.inputs.commit_hash}}"
-        run: |
-          cd detection-rules
-          COMMIT_MESSAGE=$(git show -s --format=%B $COMMIT_HASH | grep "Lock versions for releases" || true)
-          if [ -z "$COMMIT_MESSAGE" ]; then
-            echo "::set-output name=check_message::false"
-          else
-            echo "::set-output name=check_message::true"
-          fi
-        shell: bash
+        - name: Extract commit hash
+          id: extract_commit_hash
+          run: |
+            cd detection-rules
+            COMMIT_HASH=$(git log --grep="Lock versions for releases" -1 --format="%H")
+            echo "::set-output name=commit_hash::$COMMIT_HASH"
+          shell: bash
 
-  fleet-pr:
-    name: Fleet PR
-    needs: check-commit
-    if: needs.check-commit.outputs.is_locked_commit == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate the source branch
-        uses: actions/github-script@v3
-        with:
-          script: |
-            if ('refs/heads/main' === '${{github.ref}}') {
-              core.setFailed('Forbidden branch')
-            }
+    fleet-pr:
+      name: Fleet PR
+      needs: extract-commit-hash
+      runs-on: ubuntu-latest
+      steps:
+        - name: Validate the source branch
+          uses: actions/github-script@v3
+          with:
+            script: |
+              if ('refs/heads/main' === '${{github.ref}}') {
+                core.setFailed('Forbidden branch')
+              }
 
-      - name: Checkout detection-rules
-        uses: actions/checkout@v3
-        with:
-          path: detection-rules
-          fetch-depth: 0
+        - name: Checkout detection-rules
+          uses: actions/checkout@v3
+          with:
+            path: detection-rules
+            fetch-depth: 0
 
-      - name: Checkout elastic/integrations
-        uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
-          repository: ${{github.event.inputs.target_repo}}
-          path: integrations
+        - name: Checkout elastic/integrations
+          uses: actions/checkout@v3
+          with:
+            token: ${{ secrets.READ_WRITE_RELEASE_FLEET }}
+            repository: ${{github.event.inputs.target_repo}}
+            path: integrations
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
+        - name: Set up Python 3.8
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.8
 
-      - name: Install Python dependencies
-        run: |
-          cd detection-rules
-          python -m pip install --upgrade pip
-          pip cache purge
-          pip install .[dev]
+        - name: Install Python dependencies
+          run: |
+            cd detection-rules
+            python -m pip install --upgrade pip
+            pip cache purge
+            pip install .[dev]
 
-      - name: Checkout commit hash
-        env:
-          COMMIT_HASH: ${{github.event.inputs.commit_hash}}
-        run: |
-          cd detection-rules
-          git checkout $COMMIT_HASH
+        - name: Checkout commit hash
+          env:
+            COMMIT_HASH: ${{ needs.extract-commit-hash.outputs.commit_hash }}
+          run: |
+            cd detection-rules
+            git checkout $COMMIT_HASH
 
-      - name: Bump prebuilt rules package version
-        env:
-          PACKAGE_MATURITY: "${{github.event.inputs.package_maturity}}"
-          NEW_PACKAGE: "${{github.event.inputs.new_package}}"
-        run: |
-          cd detection-rules
-          python -m detection_rules dev bump-pkg-versions \
-            --patch-release                               \
-            --new-package $NEW_PACKAGE                    \
-            --maturity $PACKAGE_MATURITY
+        - name: Bump prebuilt rules package version
+          env:
+            PACKAGE_MATURITY: "${{github.event.inputs.package_maturity}}"
+            NEW_PACKAGE: "${{github.event.inputs.new_package}}"
+          run: |
+            cd detection-rules
+            python -m detection_rules dev bump-pkg-versions \
+              --patch-release                               \
+              --new-package $NEW_PACKAGE                    \
+              --maturity $PACKAGE_MATURITY
 
-      - name: Store release tag
-        if: ${{github.event.inputs.package_maturity}} == "ga"
-        id: packages-version
-        run: |
-          cd detection-rules
-          output=$(cat detection_rules/etc/packages.yml | grep -oP '(?<=\sversion: )\S+')
-          echo "::set-output name=pkg_version::$output"
+        - name: Store release tag
+          if: ${{github.event.inputs.package_maturity}} == "ga"
+          id: packages-version
+          run: |
+            cd detection-rules
+            output=$(cat detection_rules/etc/packages.yml | grep -oP '(?<=\sversion: )\S+')
+            echo "::set-output name=pkg_version::$output"
 
-      - name: Create release tag
-        if: ${{github.event.inputs.package_maturity}} == "ga"
-        env:
-          RELEASE_TAG: "integration-v${{ steps.packages-version.outputs.pkg_version }}"
-        run: |
-          cd detection-rules
-          git tag $RELEASE_TAG
-          git push origin $RELEASE_TAG
+        - name: Create release tag
+          if: ${{github.event.inputs.package_maturity}} == "ga"
+          env:
+            RELEASE_TAG: "integration-v${{ steps.packages-version.outputs.pkg_version }}"
+          run: |
+            cd detection-rules
+            git tag $RELEASE_TAG
+            git push origin $RELEASE_TAG
 
-      - name: Build release package
-        env:
-          HISTORICAL: "${{github.event.inputs.add_historical}}"
-        run: |
-          cd detection-rules
-          python -m detection_rules dev build-release --add-historical $HISTORICAL
+        - name: Build release package
+          run: |
+            cd detection-rules
+            python -m detection_rules dev build-release
 
-      - name: Set github config
-        run: |
-          git config --global user.email "72879786+protectionsmachine@users.noreply.github.com"
-          git config --global user.name "protectionsmachine"
+        - name: Set github config
+          run: |
+            git config --global user.email "72879786+protectionsmachine@users.noreply.github.com"
+            git config --global user.name "protectionsmachine"
 
-      - name: Setup go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '^1.20.1'
-          check-latest: true
+        - name: Setup go
+          uses: actions/setup-go@v3
+          with:
+            go-version: '^1.20.1'
+            check-latest: true
 
-      - name: Build elastic-package
-        run: |
-          go install github.com/elastic/elastic-package@latest
+        - name: Build elastic-package
+          run: |
+            go install github.com/elastic/elastic-package@latest
 
-      - name: Create the PR to Integrations
-        env:
-          DRAFT_ARGS: "${{startsWith(github.event.inputs.draft,'y') && '--draft' || ' '}}"
-          TARGET_REPO: "${{github.event.inputs.target_repo}}"
-          TARGET_BRANCH: "${{github.event.inputs.target_branch}}"
-          LOCAL_REPO: "../integrations"
-          GITHUB_TOKEN: "${{ secrets.READ_WRITE_RELEASE_FLEET }}"
-        run: |
-          cd detection-rules
-          python -m detection_rules dev integrations-pr \
-            $LOCAL_REPO                                 \
-            --github-repo $TARGET_REPO                  \
-            --base-branch $TARGET_BRANCH                \
-            --assign ${{github.actor}}                  \
-            $DRAFT_ARGS
+        - name: Create the PR to Integrations
+          env:
+            DRAFT_ARGS: "${{startsWith(github.event.inputs.draft,'y') && '--draft' || ' '}}"
+            TARGET_REPO: "${{github.event.inputs.target_repo}}"
+            TARGET_BRANCH: "${{github.event.inputs.target_branch}}"
+            LOCAL_REPO: "../integrations"
+            GITHUB_TOKEN: "${{ secrets.READ_WRITE_RELEASE_FLEET }}"
+          run: |
+            cd detection-rules
+            python -m detection_rules dev integrations-pr \
+              $LOCAL_REPO                                 \
+              --github-repo $TARGET_REPO                  \
+              --base-branch $TARGET_BRANCH                \
+              --assign ${{github.actor}}                  \
+              $DRAFT_ARGS
 
-      - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: release-files
-          path: |
-            detection-rules/releases
+        - name: Archive production artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: release-files
+            path: |
+              detection-rules/releases

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -52,7 +52,6 @@ jobs:
             fetch-depth: 0
 
         - name: Extract version lock commit hash
-          id: extract_commit_hash
           run: |
             cd detection-rules
             COMMIT_HASH=$(git log --grep='Lock versions for releases' -1 --format='%H')

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -34,26 +34,8 @@ on:
           - "false"
 
 jobs:
-    extract-commit-hash:
-      name: Extract version lock commit hash
-      runs-on: ubuntu-latest
-      outputs:
-        commit_hash: ${{ steps.extract_commit_hash.outputs.commit_hash }}
-      steps:
-        - name: Checkout detection-rules
-          uses: actions/checkout@v3
-          with:
-            path: detection-rules
-            fetch-depth: 0
-        - id: extract_commit_hash
-          name: Extract commit hash
-          run: |
-            cd detection-rules
-            echo "commit_hash=$(git log --grep='Lock versions for releases' -1 --format='%H')" >> $GITHUB_OUTPUT
-
     fleet-pr:
       name: Build package and create PR to integrations
-      needs: extract-commit-hash
       runs-on: ubuntu-latest
       steps:
         - name: Validate the source branch
@@ -69,11 +51,19 @@ jobs:
             path: detection-rules
             fetch-depth: 0
 
+        - name: Extract version lock commit hash
+          id: extract_commit_hash
+          run: |
+            cd detection-rules
+            COMMIT_HASH=$(git log --grep='Lock versions for releases' -1 --format='%H')
+            echo "COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
+            echo "Extracted commit hash: $COMMIT_HASH"
+
         - name: Checkout commit hash
           run: |
             cd detection-rules
-            echo "Checking out commit hash ${{ needs.extract-commit-hash.outputs.commit_hash }}"
-            git checkout ${{ needs.extract-commit-hash.outputs.commit_hash }}
+            echo "Checking out commit hash $COMMIT_HASH"
+            git checkout $COMMIT_HASH
 
         - name: Checkout elastic/integrations
           uses: actions/checkout@v3

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -227,7 +227,8 @@ def bump_versions(major_release: bool, minor_release: bool, patch_release: bool,
                 latest_patch_release_ver = latest_patch_release_ver.bump_patch()
             pkg_data["registry_data"]["version"] = str(latest_patch_release_ver.bump_prerelease("beta"))
 
-        if 'release' in pkg_data['registry_data']: pkg_data['registry_data']['release'] = maturity
+        if 'release' in pkg_data['registry_data']:
+            pkg_data['registry_data']['release'] = maturity
 
     click.echo(f"Kibana version: {pkg_data['name']}")
     click.echo(f"Package Kibana version: {pkg_data['registry_data']['conditions']['kibana.version']}")

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -86,7 +86,7 @@ def dev_group():
 @click.option('--update-version-lock', '-u', is_flag=True,
               help='Save version.lock.json file with updated rule versions in the package')
 @click.option('--generate-navigator', is_flag=True, help='Generate ATT&CK navigator files')
-@click.option('--add-historical', type=str, required=True, default="no",
+@click.option('--add-historical', type=str, required=True, default="yes",
               help='Generate historical package-registry files')
 @click.option('--update-message', type=str, help='Update message for new package')
 def build_release(config_file, update_version_lock: bool, generate_navigator: bool, add_historical: str,

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -118,12 +118,12 @@ def build_release(config_file, update_version_lock: bool, generate_navigator: bo
         historical_rules = sde.load_integration_assets(previous_pkg_version)
         historical_rules = sde.transform_legacy_assets(historical_rules)
 
-        docs = IntegrationSecurityDocsMDX(config['registry_data']['version'], Path(f'releases/{config["name"]}-docs'),
+        docs = IntegrationSecurityDocsMDX(registry_data['version'], Path(f'releases/{config["name"]}-docs'),
                                           True, historical_rules, package, note=update_message)
         docs.generate()
 
         click.echo(f'[+] Adding historical rules from {previous_pkg_version} package')
-        package.add_historical_rules(historical_rules, config['registry_data']['version'])
+        package.add_historical_rules(historical_rules, registry_data['version'])
 
     if verbose:
         package.get_package_hash(verbose=verbose)

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -221,13 +221,13 @@ def bump_versions(major_release: bool, minor_release: bool, patch_release: bool,
 
         if maturity == "ga":
             pkg_data["registry_data"]["version"] = str(latest_patch_release_ver.bump_patch())
-            pkg_data["registry_data"]["release"] = maturity
         else:
             # passing in true or false from GH actions; not using eval() for security purposes
             if new_package == "true":
                 latest_patch_release_ver = latest_patch_release_ver.bump_patch()
             pkg_data["registry_data"]["version"] = str(latest_patch_release_ver.bump_prerelease("beta"))
-            pkg_data["registry_data"]["release"] = maturity
+
+        if 'release' in pkg_data['registry_data']: pkg_data['registry_data']['release'] = maturity
 
     click.echo(f"Kibana version: {pkg_data['name']}")
     click.echo(f"Package Kibana version: {pkg_data['registry_data']['conditions']['kibana.version']}")

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -194,7 +194,7 @@ def bump_versions(major_release: bool, minor_release: bool, patch_release: bool,
     """Bump the versions"""
 
     pkg_data = load_etc_dump('packages.yml')['package']
-    kibana_ver = Version.parse(pkg_data['name'], optional_minor_and_patch=True)
+    kibana_ver = Version.parse(pkg_data["name"], optional_minor_and_patch=True)
     pkg_ver = Version.parse(pkg_data["registry_data"]["version"])
     pkg_kibana_ver = Version.parse(pkg_data["registry_data"]["conditions"]["kibana.version"].lstrip("^"))
     if major_release:


### PR DESCRIPTION
## Issues
* https://github.com/elastic/detection-rules/issues/3374

## Summary
This pull request fixes the Detection Rules release workflow and related CLI commands used. Below is a list of issues that were addressed and have more detailed information in the related issue.

- Automatic Locked Version Workflow Commit Hash Identification
- Incorrect use of branch version for determining previous release packages from EPR
- Add historical rules not default since the dropped support for 8.7 and previous 
- Integrations PR labeling and description updates

```[tasklist]
- [x] Fix/Update Release Meta Template in TRADE Repository
- [x] Review release-fleet workflow for updates and bugs
- [x] Adjust fleet package building to add historical rules by default
- [x] Adjust `packages.yml` in 8.10 branch so `kibana.version` is `8.10.1`
- [x] Update documentation for step to ask for backport branch in integrations if not available
- [x] Update `bump-pkg-versions` command to address schema failures
```

## Testing
Testing will be a big part of these updates. The importance of testing it to ensure these important steps work as intended:

- Locked Versions workflow commit is properly obtained and used after checking out protected branches
- When `bump-pkg-versions` CLI command is used, `packages.yml` reflects the accurate results; only distinguishable when integrations PR is created as it will reflect in the manifest

Example run: https://github.com/elastic/detection-rules/actions/runs/7791122549

Release Workflow Test:
1. Detection Rules repo > Actions
2. Select `release-fleet` > Run workflow
3. Change "User workflow from" from `main` to `bug-release-process-updates`
4. Leave default options
5. Select "run workflow"
6. Monitor workflow progress
7. Under `Build package and create PR to integrations` job > `Build package and create PR to integrations`; ensure that it checks out a version lock commit hash as shown below

<img width="808" alt="Screenshot 2024-02-05 at 4 35 15 PM" src="https://github.com/elastic/detection-rules/assets/99630311/922d55c5-8255-4d00-938d-d4ddf3af2a57">

9. Note that the `Build release package` step is expected to fail. This is because we are checking out a commit hash that is PRIOR to this PR. As a result, when the package builds, it will incorrectly add `release` to the manifest which is fixed [here](https://github.com/elastic/detection-rules/blob/c44eef633eb67f65527ecb2f4b4891ab4a5b4a9d/detection_rules/devtools.py#L230-L231).
