### PR TITLE
[Tuning] Remote Scheduled Task Creation via RPC

### DIFF
--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -4,7 +4,7 @@ integration = ["system", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/12/14"
+updated_date = "2024/02/01"
 
 [rule]
 author = ["Elastic"]
@@ -53,7 +53,8 @@ type = "eql"
 timestamp_override = "event.ingested"
 
 query = '''
-iam where event.action == "scheduled-task-created" and winlog.event_data.RpcCallClientLocality : "0"
+iam where event.action == "scheduled-task-created" and 
+ winlog.event_data.RpcCallClientLocality : "0" and winlog.event_data.ClientProcessId : "0"
 '''
 
 


### PR DESCRIPTION
https://github.com/elastic/detection-rules/issues/3417 

added `winlog.event_data.ClientProcessId:"0"` to resolve FPs related to default value of 0 for `winlog.event_data.RpcCallClientLocality : "0"`