### PR TITLE
[New Rule] Suspicious Network Connection via systemd

### DIFF
--- a/rules/linux/persistence_systemd_netcon.toml
+++ b/rules/linux/persistence_systemd_netcon.toml
@@ -63,7 +63,7 @@ query = '''
 sequence by host.id with maxspan=5s
   [process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and
    process.parent.name == "systemd" and process.name in (
-     "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "python*", "php*", "perl", "ruby", "lua*", "*awk"
+     "python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk"
    )
   ] by process.entity_id
   [network where host.os.type == "linux" and event.action == "connection_attempted" and event.type == "start"

--- a/rules/linux/persistence_systemd_netcon.toml
+++ b/rules/linux/persistence_systemd_netcon.toml
@@ -1,0 +1,110 @@
+[metadata]
+creation_date = "2024/02/01"
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2024/02/01"
+integration = ["endpoint"]
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects suspicious network events executed by systemd, potentially indicating persistence through a systemd backdoor. 
+Systemd is a system and service manager for Linux operating systems, used to initialize and manage system processes.
+Attackers can backdoor systemd for persistence by creating or modifying systemd unit files to execute malicious scripts
+or commands, or by replacing legitimate systemd binaries with compromised ones, ensuring that their malicious code is
+automatically executed at system startup or during certain system events.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Suspicious Network Connection via systemd"
+risk_score = 47
+rule_id = "f3818c85-2207-4b51-8a28-d70fb156ee87"
+setup = """
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+
+"""
+severity = "medium"
+tags = [
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Persistence",
+        "Tactic: Command and Control",
+        "Tactic: Defense Evasion",
+        "Data Source: Elastic Defend"
+        ]
+type = "eql"
+query = '''
+sequence by host.id with maxspan=5s
+  [process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and
+   process.parent.name == "systemd" and process.name in (
+     "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "python*", "php*", "perl", "ruby", "lua*", "*awk"
+   )
+  ] by process.entity_id
+  [network where host.os.type == "linux" and event.action == "connection_attempted" and event.type == "start"
+  ] by process.parent.entity_id
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1543.002"
+name = "Systemd Service"
+reference = "https://attack.mitre.org/techniques/T1543/002/"
+
+[[rule.threat.technique]]
+id = "T1574"
+name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/linux/persistence_systemd_netcon.toml
+++ b/rules/linux/persistence_systemd_netcon.toml
@@ -9,7 +9,7 @@ integration = ["endpoint"]
 [rule]
 author = ["Elastic"]
 description = """
-Detects suspicious network events executed by systemd, potentially indicating persistence through a systemd backdoor. 
+Detects suspicious network events executed by systemd, potentially indicating persistence through a systemd backdoor.
 Systemd is a system and service manager for Linux operating systems, used to initialize and manage system processes.
 Attackers can backdoor systemd for persistence by creating or modifying systemd unit files to execute malicious scripts
 or commands, or by replacing legitimate systemd binaries with compromised ones, ensuring that their malicious code is


### PR DESCRIPTION
## Summary
Detects suspicious network events executed by systemd, potentially indicating persistence through a systemd backdoor. Systemd is a system and service manager for Linux operating systems, used to initialize and manage system processes. Attackers can backdoor systemd for persistence by creating or modifying systemd unit files to execute malicious scripts or commands, or by replacing legitimate systemd binaries with compromised ones, ensuring that their malicious code is automatically executed at system startup or during certain system events.

## Detection
0 FPs in telemetry / my own stack.
```
sequence by host.id with maxspan=5s
  [process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and
   process.parent.name == "systemd" and process.name in (
     "python*", "php*", "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk"
   )
  ] by process.entity_id
  [network where host.os.type == "linux" and event.action == "connection_attempted" and event.type == "start"
  ] by process.parent.entity_id
```
<img width="1727" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/1c351963-b0b0-402d-984c-3974af60adb8">
