### PR TITLE
[New Rule] Executable Masquerading as Kernel Process

### DIFF
--- a/rules/linux/defense_evasion_kthreadd_masquerading.toml
+++ b/rules/linux/defense_evasion_kthreadd_masquerading.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2024/02/01"
-integration = ["endpoint"]
+integration = ["endpoint", "auditd_manager"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
@@ -14,7 +14,7 @@ as kthreadd and kworker typically do not have process.executable fields associat
 hide their malicious programs by masquerading as legitimate kernel processes.  
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-auditd_manager.auditd-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Executable Masquerading as Kernel Process"
@@ -61,8 +61,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.action in ("exec", "exec_event") and event.type == "start" and
-process.name : ("kworker*", "kthread*") and process.executable != null
+process where host.os.type == "linux" and event.action in ("exec", "exec_event", "executed") and
+event.type == "start" and process.name : ("kworker*", "kthread*") and process.executable != null
 '''
 
 [[rule.threat]]

--- a/rules/linux/defense_evasion_kthreadd_masquerading.toml
+++ b/rules/linux/defense_evasion_kthreadd_masquerading.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2024/02/01"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
@@ -14,7 +14,7 @@ as kthreadd and kworker typically do not have process.executable fields associat
 hide their malicious programs by masquerading as legitimate kernel processes.  
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Executable Masquerading as Kernel Process"
@@ -61,8 +61,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.action in ("exec", "exec_event", "executed") and
-event.type == "start" and process.name : ("kworker*", "kthread*") and process.executable != null
+process where host.os.type == "linux" and event.action in ("exec", "exec_event") and event.type == "start" and
+process.name : ("kworker*", "kthread*") and process.executable != null
 '''
 
 [[rule.threat]]

--- a/rules/linux/defense_evasion_kthreadd_masquerading.toml
+++ b/rules/linux/defense_evasion_kthreadd_masquerading.toml
@@ -14,7 +14,7 @@ as kthreadd and kworker typically do not have process.executable fields associat
 hide their malicious programs by masquerading as legitimate kernel processes.  
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Executable Masquerading as Kernel Process"
@@ -55,12 +55,13 @@ tags = [
         "OS: Linux",
         "Use Case: Threat Detection",
         "Tactic: Defense Evasion",
-        "Data Source: Elastic Defend"
+        "Data Source: Elastic Defend",
+        "Data Source: Elastic Endgame"
         ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and
+process where host.os.type == "linux" and event.action in ("exec", "exec_event") and event.type == "start" and
 process.name : ("kworker*", "kthread*") and process.executable != null
 '''
 

--- a/rules/linux/defense_evasion_kthreadd_masquerading.toml
+++ b/rules/linux/defense_evasion_kthreadd_masquerading.toml
@@ -1,10 +1,10 @@
 [metadata]
-creation_date = "2023/08/29"
+creation_date = "2024/02/01"
 integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/12/12"
+updated_date = "2024/02/01"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_kthreadd_masquerading.toml
+++ b/rules/linux/defense_evasion_kthreadd_masquerading.toml
@@ -1,0 +1,88 @@
+[metadata]
+creation_date = "2023/08/29"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/12/12"
+
+[rule]
+author = ["Elastic"]
+description = """
+Monitors for kernel processes with associated process executable fields that are not empty. Unix kernel processes such 
+as kthreadd and kworker typically do not have process.executable fields associated to them. Attackers may attempt to
+hide their malicious programs by masquerading as legitimate kernel processes.  
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Executable Masquerading as Kernel Process"
+references = [
+    "https://sandflysecurity.com/blog/linux-stealth-rootkit-malware-with-edr-evasion-analyzed/",
+]
+risk_score = 21
+rule_id = "202829f6-0271-4e88-b882-11a655c590d4"
+setup = """
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+
+"""
+severity = "low"
+tags = [
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Defense Evasion",
+        "Data Source: Elastic Defend"
+        ]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and
+process.name : ("kworker*", "kthread*") and process.executable != null
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1564"
+name = "Hide Artifacts"
+reference = "https://attack.mitre.org/techniques/T1564/"
+
+[[rule.threat.technique]]
+id = "T1036"
+name = "Masquerading"
+reference = "https://attack.mitre.org/techniques/T1036/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1036.004"
+name = "Masquerade Task or Service"
+reference = "https://attack.mitre.org/techniques/T1036/004/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"


### PR DESCRIPTION
## Summary
Monitors for kernel processes with associated process executable fields that are not empty. Unix kernel processes such  as kthreadd and kworker typically do not have process.executable fields associated to them. Attackers may attempt to hide their malicious programs by masquerading as legitimate kernel processes.  