### PR TITLE
[Rule Tuning] Suspicious Antimalware Scan Interface DLL

### DIFF
--- a/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
@@ -4,7 +4,7 @@ integration = ["windows", "endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/08/30"
+updated_date = "2024/02/06"
 
 [transform]
 [[transform.osquery]]
@@ -108,7 +108,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where host.os.type == "windows" and event.action != "deletion" and file.path != null and
+file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
  file.name : ("amsi.dll", "amsi") and not file.path : ("?:\\Windows\\system32\\amsi.dll", "?:\\Windows\\Syswow64\\amsi.dll", "?:\\$WINDOWS.~BT\\NewOS\\Windows\\WinSXS\\*", "?:\\$WINDOWS.~BT\\NewOS\\Windows\\servicing\\LCU\\*", "?:\\$WINDOWS.~BT\\Work\\*\\*", "?:\\Windows\\SoftwareDistribution\\Download\\*")
 '''
 


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/sdh-protections/issues/467

## Summary

Replaces `event.action` condition with `event.type` to exclude sysmon file deletion FPs.