### PR TITLE
[FR] Add support for Threshold Alert Suppression

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -641,10 +641,10 @@ class ThresholdQueryRuleData(QueryRuleData):
     class ThresholdMapping(MarshmallowDataclassMixin):
         @dataclass(frozen=True)
         class ThresholdCardinality:
-            field: Optional[Union[str, List[str]]]
+            field: str
             value: definitions.ThresholdValue
 
-        field: str
+        field: definitions.CardinalityFields
         value: definitions.ThresholdValue
         cardinality: Optional[List[ThresholdCardinality]]
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -235,7 +235,7 @@ class AlertSuppressionMapping(MarshmallowDataclassMixin, StackCompatMixin):
 class ThresholdAlertSuppression:
     """Mapping to alert suppression."""
 
-    duration: Optional[AlertSuppressionDuration]
+    duration: AlertSuppressionDuration
 
 
 @dataclass(frozen=True)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -644,7 +644,7 @@ class ThresholdQueryRuleData(QueryRuleData):
             field: Optional[Union[str, List[str]]]
             value: definitions.ThresholdValue
 
-        field: definitions.CardinalityFields
+        field: str
         value: definitions.ThresholdValue
         cardinality: Optional[List[ThresholdCardinality]]
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -622,7 +622,7 @@ class QueryRuleData(BaseRuleData):
         """Custom validation for query rule type and subclasses."""
         # alert suppression is only valid for query rule type and not any of its subclasses
         if data.get('alert_suppression') and data['type'] not in ('query', 'threshold'):
-            raise ValidationError("Alert suppression is only valid for query rule type.")
+            raise ValidationError("Alert suppression is only valid for query and threshold rule types.")
 
 
 @dataclass(frozen=True)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -232,7 +232,7 @@ class AlertSuppressionMapping(MarshmallowDataclassMixin, StackCompatMixin):
 
 
 @dataclass(frozen=True)
-class ThresholdAlertSuppression(MarshmallowDataclassMixin, StackCompatMixin):
+class ThresholdAlertSuppression:
     """Mapping to alert suppression."""
 
     duration: Optional[AlertSuppressionDuration]

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -126,12 +126,12 @@ EXPECTED_RULE_TAGS = [
     'Use Case: UEBA',
     'Use Case: Vulnerability'
 ]
-
+NonEmptyStr = NewType('NonEmptyStr', str, validate=validate.Length(min=1))
 MACHINE_LEARNING_PACKAGES = ['LMD', 'DGA', 'DED', 'ProblemChild', 'Beaconing']
-
+AlertSuppressionGroupBy = NewType('AlertSuppressionGroupBy', List[NonEmptyStr], validate=validate.Length(min=1, max=3))
 AlertSuppressionMissing = NewType('AlertSuppressionMissing', str,
                                   validate=validate.OneOf(['suppress', 'doNotSuppress']))
-NonEmptyStr = NewType('NonEmptyStr', str, validate=validate.Length(min=1))
+AlertSuppressionValue = NewType("AlertSupressionValue", int, validate=validate.Range(min=1))
 TimeUnits = Literal['s', 'm', 'h']
 BranchVer = NewType('BranchVer', str, validate=validate.Regexp(BRANCH_PATTERN))
 CardinalityFields = NewType('CardinalityFields', List[NonEmptyStr], validate=validate.Length(min=0, max=3))

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1231,7 +1231,6 @@ class TestAlertSuppression(BaseRuleTest):
                     min_stack_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
                 else:
                     min_stack_version = Version.parse(min_stack_version)
-
                 integration_tag = rule.contents.metadata.get("integration")
                 ecs_version = get_stack_schemas()[str(min_stack_version)]['ecs']
                 beats_version = get_stack_schemas()[str(min_stack_version)]['beats']

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1216,21 +1216,11 @@ class TestAlertSuppression(BaseRuleTest):
     """Test rule alert suppression."""
 
     @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.8.0"),
-                     "Test only applicable to 8.6+ stacks for rule alert suppression feature.")
-    def test_group_length(self):
-        """Test to ensure the rule alert suppression group_by does not exceed 3 elements."""
-        for rule in self.production_rules:
-            if rule.contents.data.get('alert_suppression'):
-                group_length = len(rule.contents.data.alert_suppression.group_by)
-                if group_length > 3:
-                    self.fail(f'{self.rule_str(rule)} has rule alert suppression with more than 3 elements.')
-
-    @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.8.0"),
                      "Test only applicable to 8.8+ stacks for rule alert suppression feature.")
     def test_group_field_in_schemas(self):
         """Test to ensure the fields are defined is in ECS/Beats/Integrations schema."""
         for rule in self.production_rules:
-            if rule.contents.data.get('alert_suppression'):
+            if rule.contents.data.get('type') == 'query' and rule.contents.data.get('alert_suppression'):
                 group_by_fields = rule.contents.data.alert_suppression.group_by
                 min_stack_version = rule.contents.metadata.get("min_stack_version")
                 if min_stack_version is None:

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1232,10 +1232,6 @@ class TestAlertSuppression(BaseRuleTest):
                 else:
                     min_stack_version = Version.parse(min_stack_version)
 
-                if min_stack_version < Version.parse("8.12.0") and rule_type == 'threshold':
-                    self.fail(f"{self.rule_str(rule)} threshold rule with alert suppression requires \
-                              min_stack_version 8.12")
-
                 integration_tag = rule.contents.metadata.get("integration")
                 ecs_version = get_stack_schemas()[str(min_stack_version)]['ecs']
                 beats_version = get_stack_schemas()[str(min_stack_version)]['beats']


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

Resolves #3393

## Summary

Adds support for alert supression with threshold rules. The changes predominately mirror logic added in [171423](https://github.com/elastic/kibana/pull/171423) with some tweaks to better align:

- Broke out `AlertSuppressionDuration` to be reused across rule multiple schema data classes (similar to implementation upstream).
- Added a dedicated definition for `AlertSuppressionGroupBy` to enforce limitations, and removed `test_group_length` duplicative unit test
- Updates the unit test to check minstack (8.12) for the feature


### Testing

1. Try importing rules exported from Kibana `python -m detection_rules import-rules`. Note: the default importer skips optional fields like alert suppression, so you'll have to make adjustments for this.

    Three combinations in the [Archive.zip](https://github.com/elastic/detection-rules/files/14186906/Archive.zip) based on the kibana PR (make sure the query is updated, e.g. `process.name: "test"`):
    - Suppression is not enabled, threshold fields not selected
    - Suppression is enabled, threshold fields selected
    - Suppression is not enabled, threshold fields selected

2. Try importing toml files created back into Kibana. 

    First use the export command, then load import the rule using the UI. 
    ```bash
    
    python -m detection_rules export-rules --rule-id 6ed78d6c-0992-42c4-bcfd-813bd833fb77
    Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json
    
    █▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
    █  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
    █▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█
    
    Exported 1 rules into /Users/stryker/workspace/ElasticGitHub/detection-rules/exports/20240206T170157L.ndjson
    ```