### PR TITLE
[Tuning] Event.dataset removal & Tag Addition

### DIFF
--- a/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_ftp_bruteforce.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/11/02"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -60,16 +60,22 @@ However, if more advanced configuration is required to detect specific behavior,
 
 """
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
+tags = [
+        "Data Source: Auditd Manager",
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Credential Access"
+        ]
 type = "eql"
 query = '''
 sequence by host.id, auditd.data.addr, related.user with maxspan=5s
-  [authentication where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
-   event.action == "authenticated" and auditd.data.terminal == "ftp" and event.outcome == "failure" and 
-   auditd.data.addr != null and auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] with runs=10
-  [authentication where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
-   event.action  == "authenticated" and auditd.data.terminal == "ftp" and event.outcome == "success" and 
-   auditd.data.addr != null and auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] | tail 1
+  [authentication where host.os.type == "linux" and event.action == "authenticated" and
+   auditd.data.terminal == "ftp" and event.outcome == "failure" and auditd.data.addr != null and
+   auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] with runs=10
+  [authentication where host.os.type == "linux" and event.action  == "authenticated" and
+   auditd.data.terminal == "ftp" and event.outcome == "success" and auditd.data.addr != null and
+   auditd.data.addr != "0.0.0.0" and auditd.data.addr != "::"] | tail 1
 '''
 
 [[rule.threat]]

--- a/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_rdp_bruteforce.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/11/02"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -60,14 +60,20 @@ However, if more advanced configuration is required to detect specific behavior,
 
 """
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Credential Access"]
+tags = [
+        "Data Source: Auditd Manager",
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Credential Access"
+        ]
 type = "eql"
 query = '''
 sequence by host.id, related.user with maxspan=5s
-  [authentication where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
-   event.action == "authenticated" and auditd.data.terminal : "*rdp*" and event.outcome == "failure"] with runs=10
-  [authentication where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
-   event.action  == "authenticated" and auditd.data.terminal : "*rdp*" and event.outcome == "success"] | tail 1
+  [authentication where host.os.type == "linux" and event.action == "authenticated" and
+   auditd.data.terminal : "*rdp*" and event.outcome == "failure"] with runs=10
+  [authentication where host.os.type == "linux" and event.action  == "authenticated" and
+   auditd.data.terminal : "*rdp*" and event.outcome == "success"] | tail 1
 '''
 
 [[rule.threat]]

--- a/rules/linux/discovery_pspy_process_monitoring_detected.toml
+++ b/rules/linux/discovery_pspy_process_monitoring_detected.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/11/02"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -48,13 +48,18 @@ However, if more advanced configuration is required to detect specific behavior,
 
 """
 severity = "low"
-tags = ["Domain: Endpoint", "OS: Linux", "Use Case: Threat Detection", "Tactic: Discovery"]
+tags = [
+        "Data Source: Auditd Manager",
+        "Domain: Endpoint",
+        "OS: Linux",
+        "Use Case: Threat Detection",
+        "Tactic: Discovery"
+        ]
 type = "eql"
 query = '''
 sequence by process.pid, host.id with maxspan=5s
-[ file where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
-  auditd.data.syscall == "openat" and file.path == "/proc" and auditd.data.a0 : ("ffffffffffffff9c", "ffffff9c") and 
-  auditd.data.a2 : ("80000", "88000") ] with runs=10
+  [file where host.os.type == "linux" and auditd.data.syscall == "openat" and file.path == "/proc" and
+   auditd.data.a0 : ("ffffffffffffff9c", "ffffff9c") and auditd.data.a2 : ("80000", "88000") ] with runs=10
 '''
 
 [[rule.threat]]

--- a/rules/linux/execution_shell_via_meterpreter_linux.toml
+++ b/rules/linux/execution_shell_via_meterpreter_linux.toml
@@ -75,7 +75,7 @@ sample by host.id, process.pid, user.id
   [file where host.os.type == "linux" and auditd.data.syscall == "open" and auditd.data.a2 == "1b6" and file.path == "/etc/passwd"]
   [file where host.os.type == "linux" and auditd.data.syscall == "open" and auditd.data.a2 == "1b6" and file.path == "/proc/net/route"]
   [file where host.os.type == "linux" and auditd.data.syscall == "open" and auditd.data.a2 == "1b6" and file.path == "/proc/net/ipv6_route"]
-  [file where host.os.type == "linux" and auditd.data.syscall == "open" and xwauditd.data.a2 == "1b6" and file.path == "/proc/net/if_inet6"]
+  [file where host.os.type == "linux" and auditd.data.syscall == "open" and auditd.data.a2 == "1b6" and file.path == "/proc/net/if_inet6"]
 '''
 
 [[rule.threat]]

--- a/rules/linux/execution_shell_via_meterpreter_linux.toml
+++ b/rules/linux/execution_shell_via_meterpreter_linux.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "The sampling feature within EQL was introduced in 8.6.0"
 min_stack_version = "8.6.0"
-updated_date = "2023/11/02"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -61,6 +61,7 @@ However, if more advanced configuration is required to detect specific behavior,
 """
 severity = "medium"
 tags = [
+        "Data Source: Auditd Manager",
         "Domain: Endpoint",
         "OS: Linux",
         "Use Case: Threat Detection",
@@ -70,16 +71,11 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 sample by host.id, process.pid, user.id
-[file where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and auditd.data.syscall == "open" and 
-  auditd.data.a2 == "1b6" and file.path == "/etc/machine-id"]
-[file where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and auditd.data.syscall == "open" and
-  auditd.data.a2 == "1b6" and file.path == "/etc/passwd"]
-[file where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and auditd.data.syscall == "open" and 
-  auditd.data.a2 == "1b6" and file.path == "/proc/net/route"]
-[file where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and auditd.data.syscall == "open" and
-  auditd.data.a2 == "1b6" and file.path == "/proc/net/ipv6_route"]
-[file where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and auditd.data.syscall == "open" and
-  auditd.data.a2 == "1b6" and file.path == "/proc/net/if_inet6"]
+  [file where host.os.type == "linux" and auditd.data.syscall == "open" and auditd.data.a2 == "1b6" and file.path == "/etc/machine-id"]
+  [file where host.os.type == "linux" and auditd.data.syscall == "open" and auditd.data.a2 == "1b6" and file.path == "/etc/passwd"]
+  [file where host.os.type == "linux" and auditd.data.syscall == "open" and auditd.data.a2 == "1b6" and file.path == "/proc/net/route"]
+  [file where host.os.type == "linux" and auditd.data.syscall == "open" and auditd.data.a2 == "1b6" and file.path == "/proc/net/ipv6_route"]
+  [file where host.os.type == "linux" and auditd.data.syscall == "open" and xwauditd.data.a2 == "1b6" and file.path == "/proc/net/if_inet6"]
 '''
 
 [[rule.threat]]

--- a/rules/linux/execution_shell_via_udp_cli_utility_linux.toml
+++ b/rules/linux/execution_shell_via_udp_cli_utility_linux.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "The sampling feature within EQL was introduced in 8.6.0"
 min_stack_version = "8.6.0"
-updated_date = "2023/11/02"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -62,6 +62,7 @@ However, if more advanced configuration is required to detect specific behavior,
 """
 severity = "medium"
 tags = [
+    "Data Source: Auditd Manager",
     "Domain: Endpoint",
     "OS: Linux",
     "Use Case: Threat Detection",
@@ -71,19 +72,22 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 sample by host.id, process.pid, process.parent.pid
-[process where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
- auditd.data.syscall == "execve" and process.name : ("bash", "dash", "sh", "tcsh",
- "csh", "zsh", "ksh", "fish", "perl", "python*", "nc", "ncat", "netcat", "php*", "ruby",
- "openssl", "awk", "telnet", "lua*", "socat")]
-[process where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
- auditd.data.syscall == "socket" and process.name : ("bash", "dash", "sh", "tcsh", "csh",
- "zsh", "ksh", "fish", "perl", "python*", "nc", "ncat", "netcat", "php*", "ruby", "openssl",
- "awk", "telnet", "lua*", "socat") and auditd.data.a0 == "2" and auditd.data.a1 : ("2", "802")]
-[network where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
- auditd.data.syscall == "connect" and process.name : ("bash", "dash", "sh", "tcsh", "csh",
- "zsh", "ksh", "fish", "perl", "python*", "nc", "ncat", "netcat", "php*", "ruby", "openssl",
- "awk", "telnet", "lua*", "socat") and network.direction == "egress" and destination.ip != null and 
- destination.ip != "127.0.0.1" and destination.ip != "127.0.0.53" and destination.ip != "::1"]
+  [process where host.os.type == "linux" and auditd.data.syscall == "execve" and process.name : (
+     "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "perl", "python*", "nc", "ncat", "netcat", "php*",
+     "ruby", "openssl", "awk", "telnet", "lua*", "socat"
+   )
+  ]
+  [process where host.os.type == "linux" and auditd.data.syscall == "socket" and process.name : (
+     "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "perl", "python*", "nc", "ncat", "netcat", "php*",
+     "ruby", "openssl", "awk", "telnet", "lua*", "socat"
+   ) and
+   auditd.data.a0 == "2" and auditd.data.a1 : ("2", "802")]
+[network where host.os.type == "linux" and auditd.data.syscall == "connect" and process.name : (
+   "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "perl", "python*", "nc", "ncat", "netcat", "php*",
+   "ruby", "openssl", "awk", "telnet", "lua*", "socat"
+ ) and
+ network.direction == "egress" and destination.ip != null and destination.ip != "127.0.0.1" and
+ destination.ip != "127.0.0.53" and destination.ip != "::1"]
 '''
 
 [[rule.threat]]

--- a/rules/linux/persistence_kernel_driver_load_by_non_root.toml
+++ b/rules/linux/persistence_kernel_driver_load_by_non_root.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2024/01/10"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -50,6 +50,7 @@ However, if more advanced configuration is required to detect specific behavior,
 """
 severity = "medium"
 tags = [
+        "Data Source: Auditd Manager",
         "Domain: Endpoint",
         "OS: Linux",
         "Use Case: Threat Detection",
@@ -59,8 +60,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-driver where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
-event.action == "loaded-kernel-module" and auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
+driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
+auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 '''
 
 [[rule.threat]]

--- a/rules/linux/privilege_escalation_suspicious_chown_fowner_elevation.toml
+++ b/rules/linux/privilege_escalation_suspicious_chown_fowner_elevation.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "auditd_manager"]
 maturity = "production"
 min_stack_comments = "Linux effective and permitted process capability data sources were added in version 8.11.0"
 min_stack_version = "8.11.0"
-updated_date = "2024/01/08"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -49,6 +49,7 @@ However, if more advanced configuration is required to detect specific behavior,
 """
 severity = "medium"
 tags = [
+        "Data Source: Auditd Manager",
         "Domain: Endpoint",
         "OS: Linux",
         "Use Case: Threat Detection",
@@ -61,14 +62,14 @@ sequence by host.id, process.pid with maxspan=1s
   [process where host.os.type == "linux" and event.action == "exec" and event.type == "start" and
    process.name != null and process.thread.capabilities.effective : ("CAP_CHOWN", "CAP_FOWNER") and
    process.command_line : ("*sudoers*", "*passwd*", "*shadow*", "*/root/*") and user.id != "0"]
-  [file where event.dataset == "auditd_manager.auditd" and host.os.type == "linux" and
-   event.action == "changed-file-ownership-of" and event.type == "change" and event.outcome == "success" and
-   file.path in (
+  [file where host.os.type == "linux" and event.action == "changed-file-ownership-of" and event.type == "change" and
+   event.outcome == "success" and file.path in (
      "/etc/passwd",
      "/etc/shadow",
      "/etc/sudoers",
      "/root/.ssh/*"
-   ) and user.id != "0"]
+   ) and user.id != "0"
+  ]
 '''
 
 [[rule.threat]]

--- a/rules/linux/privilege_escalation_suspicious_passwd_file_write.toml
+++ b/rules/linux/privilege_escalation_suspicious_passwd_file_write.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "auditd_manager"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2024/01/22"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -71,6 +71,7 @@ However, if more advanced configuration is required to detect specific behavior,
 """
 severity = "medium"
 tags = [
+        "Data Source: Auditd Manager",
         "Domain: Endpoint",
         "OS: Linux",
         "Use Case: Threat Detection",
@@ -82,8 +83,8 @@ query = '''
 sequence by host.id, process.parent.pid with maxspan=1m
   [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
    process.name == "openssl" and process.args == "passwd" and user.id != "0"]
-  [file where event.dataset == "auditd_manager.auditd" and host.os.type == "linux" and file.path == "/etc/passwd" and
-  process.parent.pid != 1 and not auditd.data.a2 == "80000" and event.outcome == "success" and user.id != "0"]
+  [file where host.os.type == "linux" and file.path == "/etc/passwd" and process.parent.pid != 1 and
+   not auditd.data.a2 == "80000" and event.outcome == "success" and user.id != "0"]
 '''
 
 [[rule.threat]]

--- a/rules_building_block/discovery_kernel_module_enumeration_via_proc.toml
+++ b/rules_building_block/discovery_kernel_module_enumeration_via_proc.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "Multiple field support in the New Terms rule type was added in Elastic 8.6"
 min_stack_version = "8.6.0"
-updated_date = "2023/10/19"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -47,6 +47,7 @@ Add the newly installed `auditd manager` to an agent policy, and deploy the agen
 """
 severity = "low"
 tags = [
+        "Data Source: Auditd Manager",
         "OS: Linux",
         "Use Case: Threat Detection",
         "Tactic: Discovery",

--- a/rules_building_block/discovery_linux_modprobe_enumeration.toml
+++ b/rules_building_block/discovery_linux_modprobe_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "Multiple field support in the New Terms rule type was added in Elastic 8.6"
 min_stack_version = "8.6.0"
-updated_date = "2023/12/18"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -46,6 +46,7 @@ Add the newly installed `auditd manager` to an agent policy, and deploy the agen
 """
 severity = "low"
 tags = [
+        "Data Source: Auditd Manager",
         "OS: Linux",
         "Use Case: Threat Detection",
         "Tactic: Discovery",

--- a/rules_building_block/discovery_linux_sysctl_enumeration.toml
+++ b/rules_building_block/discovery_linux_sysctl_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "Multiple field support in the New Terms rule type was added in Elastic 8.6"
 min_stack_version = "8.6.0"
-updated_date = "2023/12/18"
+updated_date = "2024/12/19"
 
 [rule]
 author = ["Elastic"]
@@ -46,6 +46,7 @@ Add the newly installed `auditd manager` to an agent policy, and deploy the agen
 """
 severity = "low"
 tags = [
+        "Data Source: Auditd Manager",
         "OS: Linux",
         "Use Case: Threat Detection",
         "Tactic: Discovery",

--- a/rules_building_block/discovery_suspicious_proc_enumeration.toml
+++ b/rules_building_block/discovery_suspicious_proc_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/10/19"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -44,6 +44,7 @@ Add the newly installed `auditd manager` to an agent policy, and deploy the agen
 """
 severity = "low"
 tags = [
+    "Data Source: Auditd Manager",
     "OS: Linux",
     "Use Case: Threat Detection",
     "Tactic: Discovery", 

--- a/rules_building_block/persistence_kernel_driver_load.toml
+++ b/rules_building_block/persistence_kernel_driver_load.toml
@@ -5,7 +5,7 @@ integration = ["auditd_manager"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/10/26"
+updated_date = "2024/02/19"
 
 [rule]
 author = ["Elastic"]
@@ -46,6 +46,7 @@ Add the newly installed `auditd manager` to an agent policy, and deploy the agen
 """
 severity = "low"
 tags = [
+        "Data Source: Auditd Manager",
         "Domain: Endpoint",
         "OS: Linux",
         "Use Case: Threat Detection",
@@ -56,8 +57,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-driver where host.os.type == "linux" and event.dataset == "auditd_manager.auditd" and 
-event.action == "loaded-kernel-module" and auditd.data.syscall in ("init_module", "finit_module")
+driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
+auditd.data.syscall in ("init_module", "finit_module")
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary
This PR removes the event.dataset == "auditd_manager.auditd" entries from the Auditd Manager rules. Additionally, it adds the "Data Source: Auditd Manager" tag to the tag list. The reasoning behind this is documented in https://github.com/elastic/detection-rules/pull/3430. 