### PR TITLE
[ Rule Tuning ] Correct the provider for AWS Route Table Created and AWS Route Table Modified or Deleted

### DIFF
--- a/rules/integrations/aws/persistence_route_table_created.toml
+++ b/rules/integrations/aws/persistence_route_table_created.toml
@@ -39,7 +39,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:cloudtrail.amazonaws.com and event.action:(CreateRoute or CreateRouteTable) and
+event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and event.action:(CreateRoute or CreateRouteTable) and
 event.outcome:success
 '''
 

--- a/rules/integrations/aws/persistence_route_table_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_route_table_modified_or_deleted.toml
@@ -43,7 +43,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:cloudtrail.amazonaws.com and event.action:(ReplaceRoute or ReplaceRouteTableAssociation or
+event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and event.action:(ReplaceRoute or ReplaceRouteTableAssociation or
 DeleteRouteTable or DeleteRoute or DisassociateRouteTable) and event.outcome:success
 '''
 


### PR DESCRIPTION

<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

Closes #3498 
Closes #3499 

## Summary

The rules _AWS Route Table Created_ and _AWS Route Table Modified or Deleted_ are using the wrong `event.provider`, this PR correct the `event.provider` from `cloudtrail.amazonaws.com` to `ec2.amazonaws.com`


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
