### PR TITLE
Update collection_microsoft_365_new_inbox_rule.toml

### DIFF
--- a/rules/integrations/o365/collection_microsoft_365_new_inbox_rule.toml
+++ b/rules/integrations/o365/collection_microsoft_365_new_inbox_rule.toml
@@ -43,13 +43,8 @@ type = "query"
 
 query = '''
 event.dataset:o365.audit and event.provider:Exchange and
-event.category:web and event.action:("New-InboxRule" or "Set-InboxRule") and
-    (
-        o365.audit.Parameters.ForwardTo:* or
-        o365.audit.Parameters.ForwardAsAttachmentTo:* or
-        o365.audit.Parameters.RedirectTo:*
-    )
-    and event.outcome:success
+event.category:web and event.action:("New-InboxRule" or "Set-InboxRule")
+and event.outcome:success
 '''
 
 


### PR DESCRIPTION
## Summary
Not all events have these fields. This caused a legitimate security event to evade detection, so I suggest they are simply removed as the logic works without these fields.
