### PR TITLE
[FR] Add python3.12 setup in backport workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -90,6 +90,11 @@ jobs:
           # Move it to the staging area
           git reset --soft HEAD^
 
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/manual-backport.yml
+++ b/.github/workflows/manual-backport.yml
@@ -45,6 +45,11 @@ jobs:
           # Move it to the staging area
           git reset --soft HEAD^
 
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Related to https://github.com/elastic/detection-rules/pull/3492

## Summary

Adds the python3.12 setup similar to our other GitHub action workflows.

This should address the backport [failure](https://github.com/elastic/detection-rules/actions/runs/8289288269/job/22685462343) that recently occurred.
