### PR TITLE
[FR] Update Python Dependency Versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ lint: $(VENV) deps
 test: $(VENV) lint pytest
 
 .PHONY: test-cli
-test-cli:
+test-cli: $(VENV)
 	@echo "Running detection-rules CLI tests..."
 	@echo "Refreshing redirect mappings in ATT&CK"
 	@$(PYTHON) -m detection_rules dev attack refresh-redirect-mappings
@@ -74,7 +74,7 @@ test-cli:
 	@echo "Building limited rules for stack version 8.12"
 	@$(PYTHON) -m detection_rules build-limited-rules --stack-version "8.12" --output-file "output_file.ndjson"
 	@echo "Building limited rules for stack version 8.12 with custom rules"
-	@$(PYTHON) -m detection_rules generate-rules-index
+	@$(PYTHON) -m detection_rules generate-rules-index --overwrite
 	@echo "Building manifests for integrations"
 	@$(PYTHON) -m detection_rules dev integrations build-manifests -i endpoint
 	@echo "Building schemas for integrations"

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ test-cli:
 	@$(PYTHON) -m detection_rules dev attack refresh-redirect-mappings
 	@echo "Viewing rule: threat_intel_indicator_match_address.toml"
 	@$(PYTHON) -m detection_rules view-rule rules/cross-platform/threat_intel_indicator_match_address.toml
-	@echo "Exporting rule by ID: 8f6eb3b6-e9f2-4c10-a72b-cf48b4e90c2d"
-	@$(PYTHON) -m detection_rules export-rules --rule-id 8f6eb3b6-e9f2-4c10-a72b-cf48b4e90c2d
+	@echo "Exporting rule by ID: 0a97b20f-4144-49ea-be32-b540ecc445de"
+	@$(PYTHON) -m detection_rules export-rules --rule-id 0a97b20f-4144-49ea-be32-b540ecc445de
 	@echo "Updating rule data schemas"
 	@$(PYTHON) -m detection_rules dev schemas update-rule-data
 	@echo "Validating rule: execution_github_new_event_action_for_pat.toml"

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,43 @@ lint: $(VENV) deps
 .PHONY: test
 test: $(VENV) lint pytest
 
+.PHONY: test-cli
+test-cli:
+	@echo "Running detection-rules CLI tests..."
+	@echo "Refreshing redirect mappings in ATT&CK"
+	@$(PYTHON) -m detection_rules dev attack refresh-redirect-mappings
+	@echo "Viewing rule: threat_intel_indicator_match_address.toml"
+	@$(PYTHON) -m detection_rules view-rule rules/cross-platform/threat_intel_indicator_match_address.toml
+	@echo "Exporting rule by ID: 8f6eb3b6-e9f2-4c10-a72b-cf48b4e90c2d"
+	@$(PYTHON) -m detection_rules export-rules --rule-id 8f6eb3b6-e9f2-4c10-a72b-cf48b4e90c2d
+	@echo "Updating rule data schemas"
+	@$(PYTHON) -m detection_rules dev schemas update-rule-data
+	@echo "Validating rule: execution_github_new_event_action_for_pat.toml"
+	@$(PYTHON) -m detection_rules validate-rule rules_building_block/execution_github_new_event_action_for_pat.toml
+	@echo "Checking licenses"
+	@$(PYTHON) -m detection_rules dev license-check
+	@echo "Building release and updating version lock"
+	@$(PYTHON) -m detection_rules dev build-release --update-version-lock
+	@echo "Refreshing ATT&CK data"
+	@$(PYTHON) -m detection_rules dev attack refresh-data
+	@echo "Updating rules with latest ATT&CK data"
+	@$(PYTHON) -m detection_rules dev attack update-rules
+	@echo "Getting target branches"
+	@$(PYTHON) -m detection_rules dev utils get-branches
+	@echo "Showing latest compatible version for security_detection_engine with stack version 8.12.0"
+	@$(PYTHON) -m detection_rules dev integrations show-latest-compatible --package endpoint --stack_version 8.12.0
+	@echo "Building limited rules for stack version 8.12"
+	@$(PYTHON) -m detection_rules build-limited-rules --stack-version "8.12" --output-file "output_file.ndjson"
+	@echo "Building limited rules for stack version 8.12 with custom rules"
+	@$(PYTHON) -m detection_rules generate-rules-index
+	@echo "Building manifests for integrations"
+	@$(PYTHON) -m detection_rules dev integrations build-manifests -i endpoint
+	@echo "Building schemas for integrations"
+	@$(PYTHON) -m detection_rules dev integrations build-schemas -i endpoint
+	@echo "Detection-rules CLI tests completed!"
+
+
+
 .PHONY: release
 release: deps
 	@echo "RELEASE: $(app_name)"

--- a/lib/kibana/pyproject.toml
+++ b/lib/kibana/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "requests>=2.25,<3.0",
-    "elasticsearch~=8.1",
+    "elasticsearch~=8.12.1",
 ]
 
 [project.urls]

--- a/lib/kql/pyproject.toml
+++ b/lib/kql/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "eql==0.9.19",
-    "lark-parser>=0.11.1",
+    "lark-parser>=0.12.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,28 +19,28 @@ classifiers = [
   "Topic :: Utilities"
 ]
 dependencies = [
-  	"Click~=8.1.0",
-	"elasticsearch~=8.1",
+  	"Click~=8.1.7",
+	"elasticsearch~=8.12.1",
 	"eql==0.9.19",
 	"jsl==0.2.4",
-	"jsonschema>=3.2.0",
-	"marko==2.0.1",
-	"marshmallow-dataclass[union]~=8.5.12",
-	"marshmallow-jsonschema~=0.12.0",
+	"jsonschema>=4.21.1",
+	"marko==2.0.3",
+	"marshmallow-dataclass[union]~=8.6.0",
+	"marshmallow-jsonschema~=0.13.0",
 	"marshmallow-union~=0.1.15",
-	"marshmallow~=3.13.0",
+	"marshmallow~=3.21.1",
 	"pywin32 ; platform_system=='Windows'",
 	"pytoml==0.1.21",
 	"PyYAML~=6.0.1",
-	"requests~=2.27",
-	"toml==0.10.0",
-	"typing-inspect==0.8.0",
-	"typing-extensions==4.8.0",
-	"XlsxWriter~=1.3.6",
-	"semver==3.0.0-dev.4"
+	"requests~=2.31.0",
+	"toml==0.10.2",
+	"typing-inspect==0.9.0",
+	"typing-extensions==4.10.0",
+	"XlsxWriter~=3.2.0",
+	"semver==3.0.2"
 ]
 [project.optional-dependencies]
-dev = ["pep8-naming==0.7.0", "PyGithub==1.55", "flake8==7.0.0", "pyflakes==3.2.0", "pytest>=3.6", "pre-commit==2.20.0"]
+dev = ["pep8-naming==0.13.0", "PyGithub==2.2.0", "flake8==7.0.0", "pyflakes==3.2.0", "pytest>=8.1.1", "pre-commit==3.6.2"]
 
 [project.urls]
 "Homepage" = "https://github.com/elastic/detection-rules"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

Related to https://github.com/elastic/detection-rules/pull/3492#discussion_r1524099958

## Summary

- Updates the python dependencies.
- Updates the makefile to add a `make test-cli` command to interate multiple commands, testing the CLI


### Testing


<details>
<summary>Installing Dependencies</summary>

```bash
➜  detection-rules git:(update_python_dependencies) ✗ make deps
python3.12 -m pip install --upgrade pip setuptools
Looking in indexes: https://pypi.org/simple, https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/simple
Requirement already satisfied: pip in /opt/homebrew/lib/python3.12/site-packages (24.0)
Requirement already satisfied: setuptools in /opt/homebrew/lib/python3.12/site-packages (69.2.0)
python3.12 -m venv ./env/detection-rules-build
Installing kql and kibana packages...
./env/detection-rules-build/bin/pip install lib/kql lib/kibana
Looking in indexes: https://pypi.org/simple, https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/simple
Processing ./lib/kql
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Processing ./lib/kibana
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting eql==0.9.19 (from detection-rules-kql==0.1.6)
  Using cached eql-0.9.19-py2.py3-none-any.whl.metadata (3.7 kB)
Collecting lark-parser>=0.12.0 (from detection-rules-kql==0.1.6)
  Using cached https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/lark-parser/0.12.0/lark_parser-0.12.0-py2.py3-none-any.whl (103 kB)
Collecting requests<3.0,>=2.25 (from detection-rules-kibana==0.1.0)
  Using cached requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
Collecting elasticsearch~=8.12.1 (from detection-rules-kibana==0.1.0)
  Using cached elasticsearch-8.12.1-py3-none-any.whl.metadata (5.3 kB)
Collecting elastic-transport<9,>=8 (from elasticsearch~=8.12.1->detection-rules-kibana==0.1.0)
  Using cached elastic_transport-8.12.0-py3-none-any.whl.metadata (3.5 kB)
Collecting charset-normalizer<4,>=2 (from requests<3.0,>=2.25->detection-rules-kibana==0.1.0)
  Using cached charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl.metadata (33 kB)
Collecting idna<4,>=2.5 (from requests<3.0,>=2.25->detection-rules-kibana==0.1.0)
  Using cached idna-3.6-py3-none-any.whl.metadata (9.9 kB)
Collecting urllib3<3,>=1.21.1 (from requests<3.0,>=2.25->detection-rules-kibana==0.1.0)
  Using cached urllib3-2.2.1-py3-none-any.whl.metadata (6.4 kB)
Collecting certifi>=2017.4.17 (from requests<3.0,>=2.25->detection-rules-kibana==0.1.0)
  Using cached certifi-2024.2.2-py3-none-any.whl.metadata (2.2 kB)
Using cached eql-0.9.19-py2.py3-none-any.whl (105 kB)
Using cached elasticsearch-8.12.1-py3-none-any.whl (432 kB)
Using cached requests-2.31.0-py3-none-any.whl (62 kB)
Using cached certifi-2024.2.2-py3-none-any.whl (163 kB)
Using cached charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl (119 kB)
Using cached elastic_transport-8.12.0-py3-none-any.whl (59 kB)
Using cached idna-3.6-py3-none-any.whl (61 kB)
Using cached urllib3-2.2.1-py3-none-any.whl (121 kB)
Building wheels for collected packages: detection-rules-kql, detection-rules-kibana
  Building wheel for detection-rules-kql (pyproject.toml) ... done
  Created wheel for detection-rules-kql: filename=detection_rules_kql-0.1.6-py3-none-any.whl size=16157 sha256=3e93042a85ca17c444e18c6a90bb1470d2ccc3e4ff9faf8f1dc3ea2761a86197
  Stored in directory: /private/var/folders/ng/zlptgm9552j2dhj_xzy0r32h0000gn/T/pip-ephem-wheel-cache-v16kx695/wheels/7c/be/eb/f105f81d04c0575e48ab4ce963914f5c752b3b89fc58b3e94f
  Building wheel for detection-rules-kibana (pyproject.toml) ... done
  Created wheel for detection-rules-kibana: filename=detection_rules_kibana-0.1.0-py3-none-any.whl size=6835 sha256=d8f9675ee73f39e63bc7583d43662c5c6dfa674b12b954480e23de0fe7dccf04
  Stored in directory: /private/var/folders/ng/zlptgm9552j2dhj_xzy0r32h0000gn/T/pip-ephem-wheel-cache-v16kx695/wheels/2a/c1/12/5373374ecdfaec5b2aef4b10c88f87a24e8a45c85b746184b6
Successfully built detection-rules-kql detection-rules-kibana
Installing collected packages: lark-parser, urllib3, idna, eql, charset-normalizer, certifi, requests, elastic-transport, detection-rules-kql, elasticsearch, detection-rules-kibana
Successfully installed certifi-2024.2.2 charset-normalizer-3.3.2 detection-rules-kibana-0.1.0 detection-rules-kql-0.1.6 elastic-transport-8.12.0 elasticsearch-8.12.1 eql-0.9.19 idna-3.6 lark-parser-0.12.0 requests-2.31.0 urllib3-2.2.1
Installing all dependencies...
./env/detection-rules-build/bin/pip install .[dev]
Looking in indexes: https://pypi.org/simple, https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/simple
Processing /Users/stryker/workspace/ElasticGitHub/detection-rules
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting Click~=8.1.7 (from detection_rules==0.1.0)
  Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
Requirement already satisfied: elasticsearch~=8.12.1 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (8.12.1)
Requirement already satisfied: eql==0.9.19 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (0.9.19)
Collecting jsl==0.2.4 (from detection_rules==0.1.0)
  Using cached jsl-0.2.4-py3-none-any.whl
Collecting jsonschema>=4.21.1 (from detection_rules==0.1.0)
  Using cached jsonschema-4.21.1-py3-none-any.whl.metadata (7.8 kB)
Collecting marko==2.0.3 (from detection_rules==0.1.0)
  Using cached marko-2.0.3-py3-none-any.whl.metadata (4.6 kB)
Collecting marshmallow-dataclass~=8.6.0 (from marshmallow-dataclass[union]~=8.6.0->detection_rules==0.1.0)
  Using cached marshmallow_dataclass-8.6.0-py3-none-any.whl.metadata (12 kB)
Collecting marshmallow-jsonschema~=0.13.0 (from detection_rules==0.1.0)
  Using cached marshmallow_jsonschema-0.13.0-py3-none-any.whl.metadata (7.5 kB)
Collecting marshmallow-union~=0.1.15 (from detection_rules==0.1.0)
  Using cached marshmallow_union-0.1.15.post1-py2.py3-none-any.whl.metadata (2.9 kB)
Collecting marshmallow~=3.21.1 (from detection_rules==0.1.0)
  Using cached marshmallow-3.21.1-py3-none-any.whl.metadata (7.2 kB)
Collecting pytoml==0.1.21 (from detection_rules==0.1.0)
  Using cached pytoml-0.1.21-py2.py3-none-any.whl.metadata (2.0 kB)
Collecting PyYAML~=6.0.1 (from detection_rules==0.1.0)
  Using cached PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl.metadata (2.1 kB)
Requirement already satisfied: requests~=2.31.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (2.31.0)
Collecting toml==0.10.2 (from detection_rules==0.1.0)
  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
Collecting typing-inspect==0.9.0 (from detection_rules==0.1.0)
  Using cached typing_inspect-0.9.0-py3-none-any.whl.metadata (1.5 kB)
Collecting typing-extensions==4.10.0 (from detection_rules==0.1.0)
  Using cached typing_extensions-4.10.0-py3-none-any.whl.metadata (3.0 kB)
Collecting XlsxWriter~=3.2.0 (from detection_rules==0.1.0)
  Using cached XlsxWriter-3.2.0-py3-none-any.whl.metadata (2.6 kB)
Collecting semver==3.0.2 (from detection_rules==0.1.0)
  Using cached semver-3.0.2-py3-none-any.whl.metadata (5.0 kB)
Requirement already satisfied: lark-parser~=0.12.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from eql==0.9.19->detection_rules==0.1.0) (0.12.0)
Collecting mypy-extensions>=0.3.0 (from typing-inspect==0.9.0->detection_rules==0.1.0)
  Using cached mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
Collecting pep8-naming==0.13.0 (from detection_rules==0.1.0)
  Downloading pep8_naming-0.13.0-py3-none-any.whl.metadata (6.5 kB)
Collecting PyGithub==2.2.0 (from detection_rules==0.1.0)
  Using cached PyGithub-2.2.0-py3-none-any.whl.metadata (3.8 kB)
Collecting flake8==7.0.0 (from detection_rules==0.1.0)
  Using cached flake8-7.0.0-py2.py3-none-any.whl.metadata (3.8 kB)
Collecting pyflakes==3.2.0 (from detection_rules==0.1.0)
  Using cached pyflakes-3.2.0-py2.py3-none-any.whl.metadata (3.5 kB)
Collecting pytest>=8.1.1 (from detection_rules==0.1.0)
  Using cached pytest-8.1.1-py3-none-any.whl.metadata (7.6 kB)
Collecting pre-commit==3.6.2 (from detection_rules==0.1.0)
  Using cached pre_commit-3.6.2-py2.py3-none-any.whl.metadata (1.3 kB)
Collecting mccabe<0.8.0,>=0.7.0 (from flake8==7.0.0->detection_rules==0.1.0)
  Using cached mccabe-0.7.0-py2.py3-none-any.whl.metadata (5.0 kB)
Collecting pycodestyle<2.12.0,>=2.11.0 (from flake8==7.0.0->detection_rules==0.1.0)
  Using cached pycodestyle-2.11.1-py2.py3-none-any.whl.metadata (4.5 kB)
Collecting cfgv>=2.0.0 (from pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached cfgv-3.4.0-py2.py3-none-any.whl.metadata (8.5 kB)
Collecting identify>=1.0.0 (from pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached identify-2.5.35-py2.py3-none-any.whl.metadata (4.4 kB)
Collecting nodeenv>=0.11.1 (from pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached nodeenv-1.8.0-py2.py3-none-any.whl.metadata (21 kB)
Collecting virtualenv>=20.10.0 (from pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached virtualenv-20.25.1-py3-none-any.whl.metadata (4.4 kB)
Collecting pynacl>=1.4.0 (from PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl.metadata (8.7 kB)
Collecting pyjwt>=2.4.0 (from pyjwt[crypto]>=2.4.0->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached PyJWT-2.8.0-py3-none-any.whl.metadata (4.2 kB)
Requirement already satisfied: urllib3>=1.26.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from PyGithub==2.2.0->detection_rules==0.1.0) (2.2.1)
Collecting Deprecated (from PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached Deprecated-1.2.14-py2.py3-none-any.whl.metadata (5.4 kB)
Requirement already satisfied: elastic-transport<9,>=8 in ./env/detection-rules-build/lib/python3.12/site-packages (from elasticsearch~=8.12.1->detection_rules==0.1.0) (8.12.0)
Collecting attrs>=22.2.0 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached attrs-23.2.0-py3-none-any.whl.metadata (9.5 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached jsonschema_specifications-2023.12.1-py3-none-any.whl.metadata (3.0 kB)
Collecting referencing>=0.28.4 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached referencing-0.33.0-py3-none-any.whl.metadata (2.7 kB)
Collecting rpds-py>=0.7.1 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached rpds_py-0.18.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (4.1 kB)
Collecting packaging>=17.0 (from marshmallow~=3.21.1->detection_rules==0.1.0)
  Using cached packaging-24.0-py3-none-any.whl.metadata (3.2 kB)
Collecting typeguard<4.0.0,>=2.4.1 (from marshmallow-dataclass[union]~=8.6.0->detection_rules==0.1.0)
  Using cached typeguard-3.0.2-py3-none-any.whl.metadata (3.7 kB)
Collecting iniconfig (from pytest>=8.1.1->detection_rules==0.1.0)
  Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
Collecting pluggy<2.0,>=1.4 (from pytest>=8.1.1->detection_rules==0.1.0)
  Using cached pluggy-1.4.0-py3-none-any.whl.metadata (4.3 kB)
Requirement already satisfied: charset-normalizer<4,>=2 in ./env/detection-rules-build/lib/python3.12/site-packages (from requests~=2.31.0->detection_rules==0.1.0) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in ./env/detection-rules-build/lib/python3.12/site-packages (from requests~=2.31.0->detection_rules==0.1.0) (3.6)
Requirement already satisfied: certifi>=2017.4.17 in ./env/detection-rules-build/lib/python3.12/site-packages (from requests~=2.31.0->detection_rules==0.1.0) (2024.2.2)
Collecting setuptools (from nodeenv>=0.11.1->pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached setuptools-69.2.0-py3-none-any.whl.metadata (6.3 kB)
Collecting cryptography>=3.4.0 (from pyjwt[crypto]>=2.4.0->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached cryptography-42.0.5-cp39-abi3-macosx_10_12_universal2.whl.metadata (5.3 kB)
Collecting cffi>=1.4.1 (from pynacl>=1.4.0->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (1.5 kB)
Collecting distlib<1,>=0.3.7 (from virtualenv>=20.10.0->pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached distlib-0.3.8-py2.py3-none-any.whl.metadata (5.1 kB)
Collecting filelock<4,>=3.12.2 (from virtualenv>=20.10.0->pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached filelock-3.13.1-py3-none-any.whl.metadata (2.8 kB)
Collecting platformdirs<5,>=3.9.1 (from virtualenv>=20.10.0->pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached platformdirs-4.2.0-py3-none-any.whl.metadata (11 kB)
Collecting wrapt<2,>=1.10 (from Deprecated->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (6.6 kB)
Collecting pycparser (from cffi>=1.4.1->pynacl>=1.4.0->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/pycparser/2.21/pycparser-2.21-py2.py3-none-any.whl (118 kB)
Using cached marko-2.0.3-py3-none-any.whl (42 kB)
Using cached pytoml-0.1.21-py2.py3-none-any.whl (8.5 kB)
Using cached semver-3.0.2-py3-none-any.whl (17 kB)
Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
Using cached typing_extensions-4.10.0-py3-none-any.whl (33 kB)
Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
Using cached flake8-7.0.0-py2.py3-none-any.whl (57 kB)
Downloading pep8_naming-0.13.0-py3-none-any.whl (8.5 kB)
Using cached pre_commit-3.6.2-py2.py3-none-any.whl (204 kB)
Using cached pyflakes-3.2.0-py2.py3-none-any.whl (62 kB)
Using cached PyGithub-2.2.0-py3-none-any.whl (350 kB)
Using cached click-8.1.7-py3-none-any.whl (97 kB)
Using cached jsonschema-4.21.1-py3-none-any.whl (85 kB)
Using cached marshmallow-3.21.1-py3-none-any.whl (49 kB)
Using cached marshmallow_dataclass-8.6.0-py3-none-any.whl (17 kB)
Using cached marshmallow_jsonschema-0.13.0-py3-none-any.whl (11 kB)
Using cached marshmallow_union-0.1.15.post1-py2.py3-none-any.whl (4.6 kB)
Using cached pytest-8.1.1-py3-none-any.whl (337 kB)
Using cached PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl (165 kB)
Using cached XlsxWriter-3.2.0-py3-none-any.whl (159 kB)
Using cached attrs-23.2.0-py3-none-any.whl (60 kB)
Using cached cfgv-3.4.0-py2.py3-none-any.whl (7.2 kB)
Using cached identify-2.5.35-py2.py3-none-any.whl (98 kB)
Using cached jsonschema_specifications-2023.12.1-py3-none-any.whl (18 kB)
Using cached mccabe-0.7.0-py2.py3-none-any.whl (7.3 kB)
Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
Using cached nodeenv-1.8.0-py2.py3-none-any.whl (22 kB)
Using cached packaging-24.0-py3-none-any.whl (53 kB)
Using cached pluggy-1.4.0-py3-none-any.whl (20 kB)
Using cached pycodestyle-2.11.1-py2.py3-none-any.whl (31 kB)
Using cached PyJWT-2.8.0-py3-none-any.whl (22 kB)
Using cached PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl (349 kB)
Using cached referencing-0.33.0-py3-none-any.whl (26 kB)
Using cached rpds_py-0.18.0-cp312-cp312-macosx_11_0_arm64.whl (332 kB)
Using cached typeguard-3.0.2-py3-none-any.whl (30 kB)
Using cached virtualenv-20.25.1-py3-none-any.whl (3.8 MB)
Using cached Deprecated-1.2.14-py2.py3-none-any.whl (9.6 kB)
Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Using cached cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl (177 kB)
Using cached cryptography-42.0.5-cp39-abi3-macosx_10_12_universal2.whl (5.9 MB)
Using cached distlib-0.3.8-py2.py3-none-any.whl (468 kB)
Using cached filelock-3.13.1-py3-none-any.whl (11 kB)
Using cached platformdirs-4.2.0-py3-none-any.whl (17 kB)
Using cached wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl (38 kB)
Using cached setuptools-69.2.0-py3-none-any.whl (821 kB)
Building wheels for collected packages: detection_rules
  Building wheel for detection_rules (pyproject.toml) ... done
  Created wheel for detection_rules: filename=detection_rules-0.1.0-py3-none-any.whl size=33696221 sha256=8f9edce6781cf3063869997b7eb070b937598dcf3def0c43ba97ea29c82223d5
  Stored in directory: /Users/stryker/Library/Caches/pip/wheels/21/c6/ab/8e432f1a2900ee2a465d751436987791213ddef360666b4436
Successfully built detection_rules
Installing collected packages: pytoml, jsl, distlib, XlsxWriter, wrapt, typing-extensions, typeguard, toml, setuptools, semver, rpds-py, PyYAML, pyjwt, pyflakes, pycparser, pycodestyle, pluggy, platformdirs, packaging, mypy-extensions, mccabe, marko, iniconfig, identify, filelock, Click, cfgv, attrs, virtualenv, typing-inspect, referencing, pytest, nodeenv, marshmallow, flake8, Deprecated, cffi, pynacl, pre-commit, pep8-naming, marshmallow-union, marshmallow-jsonschema, marshmallow-dataclass, jsonschema-specifications, cryptography, jsonschema, PyGithub, detection_rules
Successfully installed Click-8.1.7 Deprecated-1.2.14 PyGithub-2.2.0 PyYAML-6.0.1 XlsxWriter-3.2.0 attrs-23.2.0 cffi-1.16.0 cfgv-3.4.0 cryptography-42.0.5 detection_rules-0.1.0 distlib-0.3.8 filelock-3.13.1 flake8-7.0.0 identify-2.5.35 iniconfig-2.0.0 jsl-0.2.4 jsonschema-4.21.1 jsonschema-specifications-2023.12.1 marko-2.0.3 marshmallow-3.21.1 marshmallow-dataclass-8.6.0 marshmallow-jsonschema-0.13.0 marshmallow-union-0.1.15.post1 mccabe-0.7.0 mypy-extensions-1.0.0 nodeenv-1.8.0 packaging-24.0 pep8-naming-0.13.0 platformdirs-4.2.0 pluggy-1.4.0 pre-commit-3.6.2 pycodestyle-2.11.1 pycparser-2.21 pyflakes-3.2.0 pyjwt-2.8.0 pynacl-1.5.0 pytest-8.1.1 pytoml-0.1.21 referencing-0.33.0 rpds-py-0.18.0 semver-3.0.2 setuptools-69.2.0 toml-0.10.2 typeguard-3.0.2 typing-extensions-4.10.0 typing-inspect-0.9.0 virtualenv-20.25.1 wrapt-1.16.0
```


</details>



<details>

<summary>Testing CLI Commands with make test-cli</summary>

```bash


```

</details>