### PR TITLE
[Rule Tuning] SMTP on Port 26/TCP

### DIFF
--- a/rules/network/command_and_control_port_26_activity.toml
+++ b/rules/network/command_and_control_port_26_activity.toml
@@ -4,7 +4,7 @@ integration = ["network_traffic"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/08/17"
+updated_date = "2024/03/18"
 
 [rule]
 author = ["Elastic"]

--- a/rules/network/command_and_control_port_26_activity.toml
+++ b/rules/network/command_and_control_port_26_activity.toml
@@ -36,8 +36,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-(event.dataset: network_traffic.flow or (event.category: (network or network_traffic))) and
-    network.transport:tcp and (destination.port:26 or (event.dataset:zeek.smtp and destination.port:26))
+(event.dataset: (network_traffic.flow or zeek.smtp) or event.category:(network or network_traffic)) and network.transport:tcp and destination.port:26
 '''
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

N/A

## Summary

Tunes the rule to remove the branch of the query where event.dataset matched two different datasets.

### Additional Context:

See [slack convo](https://elastic.slack.com/archives/C02USDK55AQ/p1710780645002749).