### PR TITLE
[Bug] Update Sort Parameter

### DIFF
--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -336,7 +336,7 @@ class CollectRtaEvents(CollectEvents):
     def run(self, dsl, indexes, start_time):
         """Collect the events."""
         results = self.search(dsl, language='dsl', index=indexes, start_time=start_time, end_time='now', size=5000,
-                              sort='@timestamp:asc')
+                              sort=[{'@timestamp': {'order': 'asc'}}])
         events = self._group_events_by_type(results)
         return RtaEvents(events)
 


### PR DESCRIPTION

## Issues
https://github.com/elastic/detection-rules/issues/3530

## Summary

This PR updates the sort parameter so that the `collect-events` command functions correctly with  the `elasticsearch` 8.12 python library. See issue for more background/context info. 

## Testing

Run collect events and make sure you can collect data. If data is collected, the test is successful. 

```shell
endpoint-rules on  2356-fr-add-host-family-to-data-path [?] via  v3.8.10 (venv) on  eric.forte took 20s 
❯ python -m endpoint_rules es --cloud-id <cloud_id> collect-events --rta-name bitsadmin_execution <host_id>

███████╗███╗   ██╗██████╗ ██████╗  ██████╗ ██╗███╗   ██╗████████╗
██╔════╝████╗  ██║██╔══██╗██╔══██╗██╔═══██╗██║████╗  ██║╚══██╔══╝
█████╗  ██╔██╗ ██║██║  ██║██████╔╝██║   ██║██║██╔██╗ ██║   ██║
██╔══╝  ██║╚██╗██║██║  ██║██╔═══╝ ██║   ██║██║██║╚██╗██║   ██║
███████╗██║ ╚████║██████╔╝██║     ╚██████╔╝██║██║ ╚████║   ██║
╚══════╝╚═╝  ╚═══╝╚═════╝ ╚═╝      ╚═════╝ ╚═╝╚═╝  ╚═══╝   ╚═╝
        ██████╗ ██╗   ██╗██╗     ███████╗███████╗
        ██╔══██╗██║   ██║██║     ██╔════╝██╔════╝
        ██████╔╝██║   ██║██║     █████╗  ███████╗
        ██╔══██╗██║   ██║██║     ██╔══╝  ╚════██║
        ██║  ██║╚██████╔╝███████╗███████╗███████║
        ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚══════╝╚══════╝

es_user: eric.forte
es_password: 
Press any key once detonation is complete ...
149 events saved to: /tmp/init_tmp/endpoint-rules/unit_tests/data/true_positives/bitsadmin_execution/windows/endpoint.ndjson
32 events saved to: /tmp/init_tmp/endpoint-rules/unit_tests/data/true_positives/bitsadmin_execution/windows/metricbeat.ndjson
2 events saved to: /tmp/init_tmp/endpoint-rules/unit_tests/data/true_positives/bitsadmin_execution/windows/filebeat.ndjson

```
