### PR TITLE
fix typo  in lateral_movement_remote_services.toml

### DIFF
--- a/rules/windows/lateral_movement_remote_services.toml
+++ b/rules/windows/lateral_movement_remote_services.toml
@@ -36,7 +36,7 @@ authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.resu
 author = ["Elastic"]
 description = """
 Identifies remote execution of Windows services over remote procedure call (RPC). This could be indicative of lateral
-movement, but will be noisy if commonly done by administrators."
+movement, but will be noisy if commonly done by administrators.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*", "winlogbeat-*", "logs-windows.sysmon_operational-*"]


### PR DESCRIPTION


## Summary
fix typo in rule, the extra quote was getting rendered 


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? yes
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? yes
