### PR TITLE
[FR] Add required-fields option to import-rules

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -81,9 +81,10 @@ and will accept any valid rule in the following formats:
 ```console
 Usage: detection_rules import-rules [OPTIONS] [INPUT_FILE]...
 
-  Import rules from json, toml, or Kibana exported rule file(s).
+  Import rules from json, toml, yaml, or Kibana exported rule file(s).
 
 Options:
+  --required-only            Only prompt for required fields
   -d, --directory DIRECTORY  Load files from a directory
   -h, --help                 Show this message and exit.
 ```

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -114,7 +114,7 @@ def import_rules(input_file, required_only, directory):
     for contents in rule_contents:
         base_path = contents.get('name') or contents.get('rule', {}).get('name')
         base_path = name_to_filename(base_path) if base_path else base_path
-        rule_path = Path(RULES_DIR, base_path) if base_path else None
+        rule_path = os.path.join(RULES_DIR, base_path) if base_path else None
         additional = ['index'] if not contents.get('data_view_id') else ['data_view_id']
         rule_prompt(rule_path, required_only=required_only, save=True, verbose=True,
                     additional_required=additional, **contents)

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -94,8 +94,9 @@ def generate_rules_index(ctx: click.Context, query, overwrite, save_files=True):
 
 @root.command('import-rules')
 @click.argument('input-file', type=click.Path(dir_okay=False, exists=True), nargs=-1, required=False)
+@click.option('--required-only', is_flag=True, help='Only prompt for required fields')
 @click.option('--directory', '-d', type=click.Path(file_okay=False, exists=True), help='Load files from a directory')
-def import_rules(input_file, directory):
+def import_rules(input_file, required_only, directory):
     """Import rules from json, toml, yaml, or Kibana exported rule file(s)."""
     rule_files = glob.glob(os.path.join(directory, '**', '*.*'), recursive=True) if directory else []
     rule_files = sorted(set(rule_files + list(input_file)))
@@ -113,9 +114,10 @@ def import_rules(input_file, directory):
     for contents in rule_contents:
         base_path = contents.get('name') or contents.get('rule', {}).get('name')
         base_path = name_to_filename(base_path) if base_path else base_path
-        rule_path = os.path.join(RULES_DIR, base_path) if base_path else None
+        rule_path = Path(RULES_DIR, base_path) if base_path else None
         additional = ['index'] if not contents.get('data_view_id') else ['data_view_id']
-        rule_prompt(rule_path, required_only=True, save=True, verbose=True, additional_required=additional, **contents)
+        rule_prompt(rule_path, required_only=required_only, save=True, verbose=True,
+                    additional_required=additional, **contents)
 
 
 @root.command('build-limited-rules')


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

None, but related to several PRs testing import rules features.

## Summary

While testing other PRs, I had to manually change this line just to fully test fields that are not required. 

- This exposes a required-only option to the import-rules CLI so that the default isn't set to not import required fields. 
- Updates the CLI.md
- ⚠️ NOTE: This is a breaking change which will prompt users for fields if the `--required-only` flag is not supplied.

## Testing

- If the CI passes, this should be g2g
- Test the import command with the new field:

<details><summary>Import-Rules CLI</summary>
<p>

```bash
(detection-rules-build) ➜  detection-rules git:(update_import_rules) ✗ python -m detection_rules import-rules /Users/stryker/Downloads/rules_export\(2\).ndjson
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/exchange_mailbox_export_via_powershell.toml
actions (multi, comma separated): 
alert_suppression: 
building_block_type: 
data_view_id: 
exceptions_list (multi, comma separated): 
meta: 
risk_score_mapping (multi, comma separated): 
rule_name_override: 
setup: 
severity_mapping (multi, comma separated): 
add mitre tactic? [y/N]: 
throttle: 
timeline_id: 
timeline_title: 
(detection-rules-build) ➜  detection-rules git:(update_import_rules) ✗ python -m detection_rules import-rules /Users/stryker/Downloads/rules_export\(2\).ndjson --required-only

Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/exchange_mailbox_export_via_powershell.toml
(detection-rules-build) ➜  detection-rules git:(update_import_rules) ✗ 
```

</p>
</details> 