### PR TITLE
[FR] Add support for investigation_fields

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -245,6 +245,7 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
     @dataclass(frozen=True)
     class InvestigationFields:
         field_names: List[definitions.NonEmptyStr]
+
     @dataclass
     class RequiredFields:
         name: definitions.NonEmptyStr

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -242,7 +242,7 @@ class ThresholdAlertSuppression:
 class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
     """Base rule data."""
 
-    @dataclass(frozen=True)
+    @dataclass
     class InvestigationFields:
         field_names: List[definitions.NonEmptyStr]
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -240,6 +240,11 @@ class ThresholdAlertSuppression:
 
 @dataclass(frozen=True)
 class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
+    """Base rule data."""
+
+    @dataclass(frozen=True)
+    class InvestigationFields:
+        field_names: List[definitions.NonEmptyStr]
     @dataclass
     class RequiredFields:
         name: definitions.NonEmptyStr
@@ -264,6 +269,7 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
     # trailing `_` required since `from` is a reserved word in python
     from_: Optional[str] = field(metadata=dict(data_key="from"))
     interval: Optional[definitions.Interval]
+    investigation_fields: Optional[InvestigationFields] = field(metadata=dict(metadata=dict(min_compat="8.11")))
     max_signals: Optional[definitions.MaxSignals]
     meta: Optional[Dict[str, Any]]
     name: definitions.RuleName


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Resolves https://github.com/elastic/detection-rules/issues/3135
Resolves https://github.com/elastic/detection-rules/issues/3224

## Summary

- Add's support for the new field `investigation_fields` completed in 8.11 with min_compat set to 8.11
- Original feature was added [here](https://github.com/elastic/kibana/pull/163235) in 8.10 but updated later [here](https://github.com/elastic/kibana/pull/164133) in 8.11
- Added @yctercero who implemented the feature upstream for review
- Didn't add any downgrade functionality since we didn't implement the breaking change included in 8.10
- Note: I did not add validation on the field values. I suspect this will be expensive to do in the data class validation. We could potentially add a unit test that loads all the schemas, but we may run into the same issue here. 


## Testing

- Unit test should all pass
- Made sure imports/exports of the new field worked.
- Tested the test-cli makefile command [make_test_cli.txt](https://github.com/elastic/detection-rules/files/14807483/make_test_cli.txt)
- This file was exported from Kibana and tested with the importer:  [rules_export-16.ndjson.txt](https://github.com/elastic/detection-rules/files/14806861/rules_export-16.ndjson.txt)
<details><summary>Import Testing</summary>
<p>

<img width="1112" alt="Screenshot 2024-03-29 at 12 09 05 PM" src="https://github.com/elastic/detection-rules/assets/1636709/49d7475f-0fb0-47fa-b8a3-eeabc92043f5">

<img width="593" alt="Screenshot 2024-03-29 at 12 14 15 PM" src="https://github.com/elastic/detection-rules/assets/1636709/15a2fd9c-f0ba-4df6-923d-054f5de60c12">

<img width="819" alt="Screenshot 2024-03-29 at 1 09 27 PM" src="https://github.com/elastic/detection-rules/assets/1636709/c511ee08-db58-40bb-b795-4be1017d1d6c">

</p>
</details> 


<details><summary>Sample NDJSON from TOML</summary>
<p>

```json
{"actions": [{"action_type_id": ".email", "frequency": {"notifyWhen": "onActiveAlert", "summary": true}, "group": "default", "id": "elastic-cloud-email", "params": {"message": "Rule {{context.rule.name}} generated {{state.signals_count}} alerts. my double space newline here ### My header newline More stuff here.", "subject": "my test subject", "to": ["all@test.org"]}, "uuid": "6a2023af-5854-4dae-86dd-4c26b78315cb"}], "author": ["me"], "data_view_id": "logs-*", "description": "ere add aims aewerdas", "filters": [{"$state": {"store": "appState"}, "meta": {"disabled": false, "field": "Effective_process.pid", "index": "logs-*", "key": "Effective_process.pid", "negate": false, "params": {"query": "0"}, "type": "phrase"}, "query": {"match_phrase": {"Effective_process.pid": "0"}}}], "from": "now-360s", "interval": "5m", "investigation_fields": {"field_names": ["Effective_process.pid", "Responses.action.key.values.actions", "Target.process.Ext.dll.code_signature.subject_name"]}, "language": "eql", "max_signals": 100, "meta": {"from": "1m", "kibana_siem_app_url": ""}, "name": "test investigation_fields", "query": "process where true\n", "risk_score": 21, "rule_id": "8f6eb3b6-e9f2-4c10-a72b-cf48b4e90c2e", "severity": "low", "to": "now", "type": "eql", "version": 1}
```


</p>
</details> 

<details><summary>Sample TOML</summary>
<p>

I added additional metadata needed to pass unit tests.

```
[metadata]
creation_date = "2024/03/29"
maturity = "production"
updated_date = "2024/03/29"
min_stack_comments = "New fields added: investigation_fields"
min_stack_version = "8.11.0"

[rule]
author = ["Elastic"]
data_view_id = "logs-*"
description = "ere add aims aewerdas"
from = "now-360s"
interval = "5m"
language = "eql"
license = "Elastic License v2"
max_signals = 100
name = "test investigation_fields"
risk_score = 21
rule_id = "8f6eb3b6-e9f2-4c10-a72b-cf48b4eeec2e"
severity = "low"
tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Privilege Escalation"]
to = "now"
type = "eql"
timestamp_override = "event.ingested"
query = '''
process where true and host.os.type: "windows"
'''

[rule.investigation_fields]
field_names = [
    "Effective_process.pid",
    "Responses.action.key.values.actions",
    "Target.process.Ext.dll.code_signature.subject_name",
]

[[rule.threat]]
framework = "MITRE ATT&CK"
[[rule.threat.technique]]
id = "T1134"
name = "Access Token Manipulation"
reference = "https://attack.mitre.org/techniques/T1134/"


[rule.threat.tactic]
id = "TA0004"
name = "Privilege Escalation"
reference = "https://attack.mitre.org/tactics/TA0004/"
```

</p>
</details> 