### PR TITLE
Add filebeat-* index pattern to rules based on system.auth dataset

### DIFF
--- a/rules/linux/credential_access_potential_linux_ssh_bruteforce_external.toml
+++ b/rules/linux/credential_access_potential_linux_ssh_bruteforce_external.toml
@@ -14,7 +14,7 @@ a short time interval. Adversaries will often brute force login attempts across 
 password, in an attempt to gain access to these accounts.
 """
 from = "now-9m"
-index = ["logs-system.auth-*"]
+index = ["filebeat-*", "logs-system.auth-*"]
 language = "eql"
 license = "Elastic License v2"
 max_signals = 5

--- a/rules/linux/credential_access_potential_linux_ssh_bruteforce_internal.toml
+++ b/rules/linux/credential_access_potential_linux_ssh_bruteforce_internal.toml
@@ -14,7 +14,7 @@ a short time interval. Adversaries will often brute force login attempts across 
 password, in an attempt to gain access to these accounts.
 """
 from = "now-9m"
-index = ["logs-system.auth-*"]
+index = ["filebeat-*", "logs-system.auth-*"]
 language = "eql"
 license = "Elastic License v2"
 max_signals = 5

--- a/rules/linux/credential_access_potential_successful_linux_ssh_bruteforce.toml
+++ b/rules/linux/credential_access_potential_successful_linux_ssh_bruteforce.toml
@@ -13,7 +13,7 @@ Identifies multiple SSH login failures followed by a successful one from the sam
 to login into multiple users with a common or known password to gain access to accounts.
 """
 from = "now-9m"
-index = ["auditbeat-*", "logs-system.auth-*"]
+index = ["auditbeat-*",  "filebeat-*", "logs-system.auth-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Successful SSH Brute Force Attack"

--- a/rules/linux/persistence_linux_group_creation.toml
+++ b/rules/linux/persistence_linux_group_creation.toml
@@ -29,7 +29,7 @@ description = """
 Identifies attempts to create a new group. Attackers may create new groups to establish persistence on a system.
 """
 from = "now-9m"
-index = ["logs-system.auth-*"]
+index = ["filebeat-*", "logs-system.auth-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Linux Group Creation"

--- a/rules/linux/persistence_linux_user_account_creation.toml
+++ b/rules/linux/persistence_linux_user_account_creation.toml
@@ -29,7 +29,7 @@ description = """
 Identifies attempts to create new users. Attackers may add new users to establish persistence on a system.
 """
 from = "now-9m"
-index = ["logs-system.auth-*"]
+index = ["filebeat-*", "logs-system.auth-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Linux User Account Creation"


### PR DESCRIPTION
## Issues

- #3559 

## Summary

Add the filebeat-* index pattern to the rules that use the `system.auth` dataset. These rules already contain a "Filebeat setup" section, which is useless if the `filebeat-*` index is not considered during searches. 


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? ✅ 
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)? ✅ 
