### PR TITLE
Fix minstack version for 0365 prod rules

### DIFF
--- a/rules/integrations/o365/collection_microsoft_365_new_inbox_rule.toml
+++ b/rules/integrations/o365/collection_microsoft_365_new_inbox_rule.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/03/29"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic", "Gary Blackwell", "Austin Songer"]

--- a/rules/integrations/o365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
+++ b/rules/integrations/o365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/30"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2024/01/17"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic", "Willem D'Haese", "Austin Songer"]

--- a/rules/integrations/o365/credential_access_microsoft_365_potential_password_spraying_attack.toml
+++ b/rules/integrations/o365/credential_access_microsoft_365_potential_password_spraying_attack.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/12/01"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2024/01/05"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/credential_access_user_excessive_sso_logon_errors.toml
+++ b/rules/integrations/o365/credential_access_user_excessive_sso_logon_errors.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/17"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2024/01/05"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/o365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_exchange_dlp_policy_removed.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/20"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_exchange_malware_filter_policy_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/19"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_exchange_malware_filter_rule_mod.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/19"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_exchange_safe_attach_rule_disabled.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/19"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/defense_evasion_microsoft_365_mailboxauditbypassassociation.toml
+++ b/rules/integrations/o365/defense_evasion_microsoft_365_mailboxauditbypassassociation.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/01/13"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
+++ b/rules/integrations/o365/exfiltration_microsoft_365_exchange_transport_rule_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/18"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
+++ b/rules/integrations/o365/exfiltration_microsoft_365_exchange_transport_rule_mod.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/19"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/impact_microsoft_365_potential_ransomware_activity.toml
+++ b/rules/integrations/o365/impact_microsoft_365_potential_ransomware_activity.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/07/15"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/o365/impact_microsoft_365_unusual_volume_of_file_deletion.toml
+++ b/rules/integrations/o365/impact_microsoft_365_unusual_volume_of_file_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/07/15"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/o365/initial_access_microsoft_365_abnormal_clientappid.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_abnormal_clientappid.toml
@@ -1,10 +1,10 @@
 [metadata]
 creation_date = "2023/07/18"
-maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup, New Term"
-min_stack_version = "8.6.0"
 integration = ["o365"]
-updated_date = "2023/07/18"
+maturity = "production"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_exchange_anti_phish_policy_deletion.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/19"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_exchange_anti_phish_rule_mod.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/19"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_exchange_safelinks_disabled.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/18"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/initial_access_microsoft_365_user_restricted_from_sending_email.toml
+++ b/rules/integrations/o365/initial_access_microsoft_365_user_restricted_from_sending_email.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/07/15"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Austin Songer"]

--- a/rules/integrations/o365/initial_access_o365_user_reported_phish_malware.toml
+++ b/rules/integrations/o365/initial_access_o365_user_reported_phish_malware.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/01/12"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/lateral_movement_malware_uploaded_onedrive.toml
+++ b/rules/integrations/o365/lateral_movement_malware_uploaded_onedrive.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/01/10"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/lateral_movement_malware_uploaded_sharepoint.toml
+++ b/rules/integrations/o365/lateral_movement_malware_uploaded_sharepoint.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/01/10"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
+++ b/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/17"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/o365/persistence_microsoft_365_exchange_dkim_signing_config_disabled.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_exchange_dkim_signing_config_disabled.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/18"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/persistence_microsoft_365_exchange_management_role_assignment.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_exchange_management_role_assignment.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/20"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/persistence_microsoft_365_global_administrator_role_assign.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_global_administrator_role_assign.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/01/06"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/persistence_microsoft_365_teams_custom_app_interaction_allowed.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_teams_custom_app_interaction_allowed.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/30"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/persistence_microsoft_365_teams_external_access_enabled.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_teams_external_access_enabled.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/30"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/persistence_microsoft_365_teams_guest_access_enabled.toml
+++ b/rules/integrations/o365/persistence_microsoft_365_teams_guest_access_enabled.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/20"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/o365/privilege_escalation_new_or_modified_federation_domain.toml
+++ b/rules/integrations/o365/privilege_escalation_new_or_modified_federation_domain.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/05/17"
 integration = ["o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/02"
 
 [rule]
 author = ["Austin Songer"]


### PR DESCRIPTION
## Issues
Double version bumop found in lock versions https://github.com/elastic/detection-rules/pull/3564

## Summary

- Fix the minstack version for breaking changes in o365 integration.
- Identified new minstack as 8.8.0 

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
