### PR TITLE
[Bug] Add explicit format preserver

### DIFF
--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -77,10 +77,10 @@ class NonformattedField(str):
 def preserve_formatting_for_fields(data: OrderedDict, fields_to_preserve: list) -> OrderedDict:
     """Preserve formatting for specified nested fields in an action."""
 
-    def apply_preservation(target: OrderedDict, keys: list):
+    def apply_preservation(target: OrderedDict, keys: list) -> None:
         """Apply NonformattedField preservation based on keys path."""
         for key in keys[:-1]:
-            # Iterate to the  key, diving into nested dictionaries
+            # Iterate to the key, diving into nested dictionaries
             if key in target and isinstance(target[key], dict):
                 target = target[key]
             else:

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -74,6 +74,31 @@ class NonformattedField(str):
     """Non-formatting class."""
 
 
+def preserve_formatting_for_fields(data: OrderedDict, fields_to_preserve: list) -> OrderedDict:
+    """Preserve formatting for specified nested fields in an action."""
+
+    def apply_preservation(target: OrderedDict, keys: list):
+        """Apply NonformattedField preservation based on keys path."""
+        for key in keys[:-1]:
+            # Iterate to the  key, diving into nested dictionaries
+            if key in target and isinstance(target[key], dict):
+                target = target[key]
+            else:
+                # Cannot preserve formatting for missing or non-dict intermediate
+                return
+
+        final_key = keys[-1]
+        if final_key in target:
+            # Apply NonformattedField to the target field if it exists
+            target[final_key] = NonformattedField(target[final_key])
+
+    for field_path in fields_to_preserve:
+        keys = field_path.split('.')
+        apply_preservation(data, keys)
+
+    return data
+
+
 class RuleTomlEncoder(toml.TomlEncoder):
     """Generate a pretty form of toml."""
 
@@ -185,6 +210,11 @@ def toml_write(rule_contents, outfile=None):
 
         for k in sorted(list(_contents)):
             v = _contents.pop(k)
+
+            if k == 'actions':
+                # explicitly preserve formatting for message field in actions
+                preserved_fields = ["params.message"]
+                v = [preserve_formatting_for_fields(action, preserved_fields) for action in v]
 
             if isinstance(v, dict):
                 bottom[k] = OrderedDict(sorted(v.items()))


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

Resolves #2418

## Summary

- Adds a new method `preserve_formatting_for_fields` that can traverse nested dictionaries and mark as a `NonformattedField` so that newlines and whitespaces are preserved. The method is meant to be abstracted enough to support preserving any field by passing in as a dotted notation.
- Preserves the `action.params.message` field.

## Testing
- Run the importer with the sample file: `python -m detection_rules import-rules /Users/stryker/Downloads/rules_export_mail.ndjson` [rules_export_mail.ndjson.txt](https://github.com/elastic/detection-rules/files/14839897/rules_export_mail.ndjson.txt). The `message` field should preserve newlines in the action.

