### PR TITLE
[FR] Switch Default Behavior to not allow uppercase KQL Keywords 

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1405,7 +1405,7 @@ def get_unique_query_fields(rule: TOMLRule) -> List[str]:
 
         cfg = set_eql_config(rule.contents.metadata.get('min_stack_version'))
         with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions, eql.parser.skip_optimizations, cfg:
-            parsed = kql.parse(query, normalize_kql_keywords=True) if language == 'kuery' else eql.parse_query(query)
+            parsed = kql.parse(query) if language == 'kuery' else eql.parse_query(query)
 
         return sorted(set(str(f) for f in parsed if isinstance(f, (eql.ast.Field, kql.ast.Field))))
 

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -36,7 +36,7 @@ class KQLValidator(QueryValidator):
 
     @cached_property
     def ast(self) -> kql.ast.Expression:
-        return kql.parse(self.query, normalize_kql_keywords=True)
+        return kql.parse(self.query)
 
     @cached_property
     def unique_fields(self) -> List[str]:
@@ -80,7 +80,7 @@ class KQLValidator(QueryValidator):
                                                                     beats_version, ecs_version)
 
             try:
-                kql.parse(self.query, schema=schema, normalize_kql_keywords=True)
+                kql.parse(self.query, schema=schema)
             except kql.KqlParseError as exc:
                 message = exc.error_msg
                 trailer = err_trailer
@@ -135,7 +135,7 @@ class KQLValidator(QueryValidator):
 
             # Validate the query against the schema
             try:
-                kql.parse(self.query, schema=integration_schema, normalize_kql_keywords=True)
+                kql.parse(self.query, schema=integration_schema)
             except kql.KqlParseError as exc:
                 if exc.error_msg == "Unknown field":
                     field = extract_error_field(self.query, exc)

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -241,7 +241,7 @@ def convert_time_span(span: str) -> int:
 
 def evaluate(rule, events):
     """Evaluate a query against events."""
-    evaluator = kql.get_evaluator(kql.parse(rule.query, normalize_kql_keywords=True))
+    evaluator = kql.get_evaluator(kql.parse(rule.query))
     filtered = list(filter(evaluator, events))
     return filtered
 

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -67,7 +67,7 @@ class TestValidRules(BaseRuleTest):
                 )
             ):
                 source = rule.contents.data.query
-                tree = kql.parse(source, optimize=False, normalize_kql_keywords=True)
+                tree = kql.parse(source, optimize=False)
                 optimized = tree.optimize(recursive=True)
                 err_message = f'\n{self.rule_str(rule)} Query not optimized for rule\n' \
                               f'Expected: {optimized}\nActual: {source}'


### PR DESCRIPTION
## Issues
https://github.com/elastic/detection-rules/issues/3573

## Summary
We would like this uppercase conversion feature to be available for customers but internally we do not want it to be enabled by default. 


See https://github.com/elastic/detection-rules/pull/3568 for more context. There should be 6 instances where we use kql.parse for creating/importing/testing/validation that we wish to revert. The only remaining case we want to keep is the unit test to make sure conversion functions as expected. 


## Testing

1. Modify an existing `kuery` rule to use uppercase keywords.
E.g. modify the query for `rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml` to:
```toml
query = '''
event.dataset:gcp.audit AND event.action:(*.compute.firewalls.insert OR google.appengine.*.Firewall.Create*Rule)
'''
```
2. Run view rule for that rule.
E.g. ` python -m detection_rules view-rule rules/integrations/gcp/defense_evasion_gcp_firewall_rule_created.toml`
3. Run Unit Tests 
4. Create a rule using ` python -m detection_rules create-rule` with capital keywords
E.g. `event.dataset:gcp.audit AND event.action:(*.compute.firewalls.insert OR google.appengine.*.Firewall.Create*Rule)` 
5. Import a kuery rule with capital keywords via `python -m detection_rules import-rules` 
E.g. 
[20240314T190337L.ndjson.txt](https://github.com/elastic/detection-rules/files/14845809/20240314T190337L.ndjson.txt)

If all of these fail, then the behavior has been reverted successfully. 