### PR TITLE
[FR] Bump KQL Lib Version

### DIFF
--- a/lib/kql/pyproject.toml
+++ b/lib/kql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection-rules-kql"
-version = "0.1.6"
+version = "0.1.7"
 description = "Kibana Query Language parser for Elastic Detection Rules"
 license = {text = "Elastic License v2"}
 keywords = ["Elastic", "sour", "Detection Rules", "Security", "Elasticsearch", "kql"]


### PR DESCRIPTION

## Related PRs
https://github.com/elastic/detection-rules/pull/3574

## Summary

This PR bumps the KQL version due to recent updates to the KQL library (other PR should have had this bump in it). 
