### PR TITLE
[New Rule] Resource Accessing AWS Systems Manager SecureString Parameters with Decryption Flag

### DIFF
--- a/rules/integrations/aws/credential_access_retrieve_secure_string_parameters_via_ssm.toml
+++ b/rules/integrations/aws/credential_access_retrieve_secure_string_parameters_via_ssm.toml
@@ -1,0 +1,86 @@
+[metadata]
+creation_date = "2024/04/12"
+integration = ["aws"]
+maturity = "production"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
+updated_date = "2024/04/12"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects the first occurrence of a user identity accessing AWS Systems Manager (SSM) SecureStrin` parameters using the
+GetParameter or GetParameters API actions with credentials in the request parameters. This could indicate that the user
+is accessing sensitive information. This rule focuses solely on SecureStrings in AWS Systems Manager (SSM) parameters.
+SecureStrings are encrypted using an AWS Key Management Service (KMS) key. When a user accesses a SecureString
+parameter, they can specify whether the parameter should be decrypted. If the user specifies that the parameter should
+be decrypted, the decrypted value is returned in the response. This rule detects when a user accesses a SecureString
+parameter with the `withDecryption` parameter set to true. This is a
+[NewTerms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that
+detects the first occurrence of a specific AWS ARN accessing SecureString parameters with decryption within the last 15
+days.
+"""
+false_positives = [
+    """
+    Users may legitimately access AWS Systems Manager (SSM) parameters using the GetParameter, GetParameters, or
+    DescribeParameters API actions with credentials in the request parameters. Ensure that the user has a legitimate
+    reason to access the parameters and that the credentials are secured.
+    """,
+]
+from = "now-60m"
+index = ["filebeat-*", "logs-aws.cloudtrail*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License v2"
+name = "First Occurrence of Resource Accessing AWS Systems Manager SecureString Parameters with Decryption Flag"
+references = [
+    "https://docs.aws.amazon.com/vsts/latest/userguide/systemsmanager-getparameter.html",
+    "https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html",
+]
+risk_score = 47
+rule_id = "a00681e3-9ed6-447c-ab2c-be648821c622"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS Systems Manager",
+    "Tactic: Credential Access",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "new_terms"
+
+query = '''
+event.dataset: "aws.cloudtrail"
+    and event.provider: "ssm.amazonaws.com" and event.action: (GetParameters or GetParameter) and event.outcome: success
+    and aws.cloudtrail.request_parameters: *withDecryption=true*
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1555"
+name = "Credentials from Password Stores"
+reference = "https://attack.mitre.org/techniques/T1555/"
+[[rule.threat.technique.subtechnique]]
+id = "T1555.006"
+name = "Cloud Secrets Management Stores"
+reference = "https://attack.mitre.org/techniques/T1555/006/"
+
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["aws.cloudtrail.user_identity.arn"]
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-15d"
+
+


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/323

## Summary

Detects the first occurrence of a user identity accessing AWS Systems Manager (SSM) SecureString parameters using the GetParameter or GetParameters API actions with credentials in the request parameters. This could indicate that the user is accessing sensitive information.

This rule focuses solely on SecureStrings in AWS Systems Manager (SSM) parameters. SecureStrings are encrypted using an AWS Key Management Service (KMS) key. When a user accesses a SecureString parameter, they can specify whether the parameter should be decrypted. If the user specifies that the parameter should be decrypted, the decrypted value is returned in the response.

This rule detects when a user accesses a SecureString parameter with the `withDecryption` parameter set to true. This is a [NewTerms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that detects the first occurrence of a specific AWS ARN accessing SecureString parameters with decryption within the last 15 days.

References:
* https://docs.aws.amazon.com/vsts/latest/userguide/systemsmanager-getparameter.html
* https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html
