### PR TITLE
[Bug] Remove Leftover KQL Normalize Code from Unit Test

### DIFF
--- a/tests/kuery/test_lint.py
+++ b/tests/kuery/test_lint.py
@@ -34,12 +34,6 @@ class LintTests(unittest.TestCase):
             with self.assertRaises(kql.KqlParseError):
                 kql.parse(q)
 
-        for q in queries:
-            # Test query successfully converts and parses
-            parsed_query = kql.parse(q, normalize_kql_keywords=True)
-            # Test that the parsed query is not equal to the original query, that the transformation was applied
-            self.assertNotEqual(str(parsed_query), q, f"Parsed query {parsed_query} matches the original {q}")
-
     def test_lint_precedence(self):
         self.validate("a:b or (c:d and e:f)", "a:b or c:d and e:f")
         self.validate("(a:b and (c:d or e:f))", "a:b and (c:d or e:f)")


### PR DESCRIPTION
## Summary
It seems the following code may have unintentionally been left behind from this [addition](https://github.com/elastic/detection-rules/commit/1566c29bae09d782e54c20516675e7021a44ffd7#diff-55c5843aa394d49b9e8ea7076d4ddb7e2a350c8a1e4ae185f6892371d95bbcd4). As a result, `test_lint` fails when running unit tests.

The code was reverted in this [PR](https://github.com/elastic/detection-rules/commit/fbb6df506e64d1fc118a912420eaac43969373cd), but not from `LintTests.test_upper_tokens`.

When running unit tests on a branch created from main, I receive the following error:
<img width="1059" alt="Screenshot 2024-04-14 at 8 07 14 PM" src="https://github.com/elastic/detection-rules/assets/99630311/2b34a9b8-01a9-4f8e-b098-e59d4684c1ab">

