### PR TITLE
[Rule Tuning] Tighten AWS Index Patterns and Add AWS Service Tags

### DIFF
--- a/rules/integrations/aws/collection_cloudtrail_logging_created.toml
+++ b/rules/integrations/aws/collection_cloudtrail_logging_created.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/credential_access_aws_iam_assume_role_brute_force.toml
+++ b/rules/integrations/aws/credential_access_aws_iam_assume_role_brute_force.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2024/01/05"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ used to delegate access to users or services. An adversary may attempt to enumer
 role exists before attempting to assume or hijack the discovered role.
 """
 from = "now-20m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS IAM Brute Force of Assume Role Policy"

--- a/rules/integrations/aws/credential_access_iam_user_addition_to_group.toml
+++ b/rules/integrations/aws/credential_access_iam_user_addition_to_group.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/credential_access_new_terms_secretsmanager_getsecretvalue.toml
+++ b/rules/integrations/aws/credential_access_new_terms_secretsmanager_getsecretvalue.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2024/03/07"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Nick Jones", "Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws.cloudtrail*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/credential_access_root_console_failure_brute_force.toml
+++ b/rules/integrations/aws/credential_access_root_console_failure_brute_force.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2024/01/05"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-20m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Management Console Brute Force of Root User Identity"

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_config_service_rule_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_config_service_rule_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/integrations/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_elasticache_security_group_creation.toml
+++ b/rules/integrations/aws/defense_evasion_elasticache_security_group_creation.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -18,7 +18,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_elasticache_security_group_modified_or_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_elasticache_security_group_modified_or_deleted.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -18,7 +18,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_escalation_aws_suspicious_saml_activity.toml
+++ b/rules/integrations/aws/defense_evasion_escalation_aws_suspicious_saml_activity.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-25m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS SAML Activity"

--- a/rules/integrations/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_s3_bucket_configuration_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_s3_bucket_configuration_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_waf_acl_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/exfiltration_ec2_full_network_packet_capture_detected.toml
+++ b/rules/integrations/aws/exfiltration_ec2_full_network_packet_capture_detected.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/exfiltration_ec2_snapshot_change_activity.toml
+++ b/rules/integrations/aws/exfiltration_ec2_snapshot_change_activity.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/exfiltration_ec2_vm_export_failure.toml
+++ b/rules/integrations/aws/exfiltration_ec2_vm_export_failure.toml
@@ -4,7 +4,8 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
+
 [rule]
 author = ["Elastic", "Austin Songer"]
 description = """
@@ -19,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/exfiltration_rds_snapshot_export.toml
+++ b/rules/integrations/aws/exfiltration_rds_snapshot_export.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/exfiltration_rds_snapshot_restored.toml
+++ b/rules/integrations/aws/exfiltration_rds_snapshot_restored.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -20,7 +20,7 @@ false_positives = [
     should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS RDS Snapshot Restored"

--- a/rules/integrations/aws/impact_aws_eventbridge_rule_disabled_or_deleted.toml
+++ b/rules/integrations/aws/impact_aws_eventbridge_rule_disabled_or_deleted.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-20m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EventBridge Rule Disabled or Deleted"

--- a/rules/integrations/aws/impact_cloudtrail_logging_updated.toml
+++ b/rules/integrations/aws/impact_cloudtrail_logging_updated.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -76,7 +76,7 @@ references = [
 risk_score = 21
 rule_id = "3e002465-876f-4f04-b016-84ef48ce7e5d"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Log Auditing", "Resources: Investigation Guide", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS Cloudtrail", "Use Case: Log Auditing", "Resources: Investigation Guide", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -81,7 +81,7 @@ references = [
 risk_score = 47
 rule_id = "68a7a5a5-a2fc-4a76-ba9f-26849de881b4"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Log Auditing", "Resources: Investigation Guide", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS CloudWatch", "Use Case: Log Auditing", "Resources: Investigation Guide", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -85,6 +85,7 @@ tags = [
     "Domain: Cloud",
     "Data Source: AWS",
     "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudWatch",
     "Use Case: Log Auditing",
     "Tactic: Impact",
     "Resources: Investigation Guide",

--- a/rules/integrations/aws/impact_ec2_disable_ebs_encryption.toml
+++ b/rules/integrations/aws/impact_ec2_disable_ebs_encryption.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -36,7 +36,7 @@ references = [
 risk_score = 47
 rule_id = "bb9b13b2-1700-48a8-a750-b43b0a72ab69"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS EC2", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/impact_efs_filesystem_or_mount_deleted.toml
+++ b/rules/integrations/aws/impact_efs_filesystem_or_mount_deleted.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -75,7 +75,7 @@ references = [
 risk_score = 47
 rule_id = "d8fc1cca-93ed-43c1-bbb6-c0dd3eff2958"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Resources: Investigation Guide", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS IAM", "Resources: Investigation Guide", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/impact_iam_group_deletion.toml
+++ b/rules/integrations/aws/impact_iam_group_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -35,7 +35,7 @@ references = [
 risk_score = 21
 rule_id = "867616ec-41e5-4edc-ada2-ab13ab45de8a"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS IAM", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/impact_kms_cmk_disabled_or_scheduled_for_deletion.toml
+++ b/rules/integrations/aws/impact_kms_cmk_disabled_or_scheduled_for_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Xavier Pich"]
@@ -22,7 +22,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -37,7 +37,7 @@ references = [
 risk_score = 47
 rule_id = "6951f15e-533c-4a60-8014-a3c3ab851a1b"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Log Auditing", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS KMS", "Use Case: Log Auditing", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/impact_rds_group_deletion.toml
+++ b/rules/integrations/aws/impact_rds_group_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -18,7 +18,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -30,7 +30,7 @@ references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Del
 risk_score = 21
 rule_id = "863cdf31-7fd3-41cf-a185-681237ea277b"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS RDS", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -39,7 +39,7 @@ references = [
 risk_score = 47
 rule_id = "9055ece6-2689-4224-a0e0-b04881e1f8ad"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Asset Visibility", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS RDS", "Use Case: Asset Visibility", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/impact_rds_instance_cluster_stoppage.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_stoppage.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -34,7 +34,7 @@ references = [
 risk_score = 47
 rule_id = "ecf2b32c-e221-4bd4-aa3b-c7d59b3bc01d"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Asset Visibility", "Tactic: Impact"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS RDS", "Use Case: Asset Visibility", "Tactic: Impact"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/initial_access_console_login_root.toml
+++ b/rules/integrations/aws/initial_access_console_login_root.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -69,6 +69,7 @@ tags = [
     "Domain: Cloud",
     "Data Source: AWS",
     "Data Source: Amazon Web Services",
+    "Data Source: AWS Signin",
     "Use Case: Identity and Access Audit",
     "Resources: Investigation Guide",
     "Tactic: Initial Access"

--- a/rules/integrations/aws/initial_access_password_recovery.toml
+++ b/rules/integrations/aws/initial_access_password_recovery.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -32,7 +32,7 @@ references = ["https://www.cadosecurity.com/an-ongoing-aws-phishing-campaign/"]
 risk_score = 21
 rule_id = "69c420e8-6c9e-4d28-86c0-8a2be2d1e78c"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Identity and Access Audit", "Tactic: Initial Access"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS Signin", "Use Case: Identity and Access Audit", "Tactic: Initial Access"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/initial_access_via_system_manager.toml
+++ b/rules/integrations/aws/initial_access_via_system_manager.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -83,6 +83,7 @@ tags = [
     "Domain: Cloud",
     "Data Source: AWS",
     "Data Source: Amazon Web Services",
+    "Data Source: AWS SSM",
     "Use Case: Log Auditing",
     "Tactic: Initial Access",
     "Resources: Investigation Guide",

--- a/rules/integrations/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/integrations/aws/persistence_ec2_network_acl_creation.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -37,7 +37,7 @@ references = [
 risk_score = 21
 rule_id = "39144f38-5284-4f8e-a2ae-e3fd628d90b0"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Network Security Monitoring", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS EC2", "Use Case: Network Security Monitoring", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_ec2_security_group_configuration_change_detection.toml
+++ b/rules/integrations/aws/persistence_ec2_security_group_configuration_change_detection.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-30m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -33,7 +33,7 @@ references = ["https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-securi
 risk_score = 21
 rule_id = "29052c19-ff3e-42fd-8363-7be14d7c5469"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Network Security Monitoring", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS EC2", "Use Case: Network Security Monitoring", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_iam_group_creation.toml
+++ b/rules/integrations/aws/persistence_iam_group_creation.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -35,7 +35,7 @@ references = [
 risk_score = 21
 rule_id = "169f3a93-efc7-4df2-94d6-0d9438c310d1"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Identity and Access Audit", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS IAM", "Use Case: Identity and Access Audit", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_rds_cluster_creation.toml
+++ b/rules/integrations/aws/persistence_rds_cluster_creation.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -37,7 +37,7 @@ references = [
 risk_score = 21
 rule_id = "e14c5fd7-fdd7-49c2-9e5b-ec49d817bc8d"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Asset Visibility", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS RDS", "Use Case: Asset Visibility", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_rds_group_creation.toml
+++ b/rules/integrations/aws/persistence_rds_group_creation.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -29,7 +29,7 @@ references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Cre
 risk_score = 21
 rule_id = "378f9024-8a0c-46a5-aa08-ce147ac73a4e"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS RDS", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_rds_instance_creation.toml
+++ b/rules/integrations/aws/persistence_rds_instance_creation.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -29,7 +29,7 @@ references = ["https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Cre
 risk_score = 21
 rule_id = "f30f3443-4fbb-4c27-ab89-c3ad49d62315"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Asset Visibility", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS RDS", "Use Case: Asset Visibility", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_redshift_instance_creation.toml
+++ b/rules/integrations/aws/persistence_redshift_instance_creation.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -33,7 +33,7 @@ references = ["https://docs.aws.amazon.com/redshift/latest/APIReference/API_Crea
 risk_score = 21
 rule_id = "015cca13-8832-49ac-a01b-a396114809f6"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Asset Visibility", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS Redshift", "Use Case: Asset Visibility", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_route_53_domain_transfer_lock_disabled.toml
+++ b/rules/integrations/aws/persistence_route_53_domain_transfer_lock_disabled.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -35,7 +35,7 @@ references = [
 risk_score = 21
 rule_id = "12051077-0124-4394-9522-8f4f4db1d674"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Asset Visibility", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS Route53", "Use Case: Asset Visibility", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_route_53_domain_transferred_to_another_account.toml
+++ b/rules/integrations/aws/persistence_route_53_domain_transferred_to_another_account.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -18,7 +18,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -30,7 +30,7 @@ references = ["https://docs.aws.amazon.com/Route53/latest/APIReference/API_Opera
 risk_score = 21
 rule_id = "2045567e-b0af-444a-8c0b-0b6e2dae9e13"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Asset Visibility", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services",  "Data Source: AWS Route53", "Use Case: Asset Visibility", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_route_53_hosted_zone_associated_with_a_vpc.toml
+++ b/rules/integrations/aws/persistence_route_53_hosted_zone_associated_with_a_vpc.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -17,7 +17,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -29,7 +29,7 @@ references = ["https://docs.aws.amazon.com/Route53/latest/APIReference/API_Assoc
 risk_score = 21
 rule_id = "e3c27562-709a-42bd-82f2-3ed926cced19"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Asset Visibility", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services",  "Data Source: AWS Route53", "Use Case: Asset Visibility", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_route_table_created.toml
+++ b/rules/integrations/aws/persistence_route_table_created.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -18,7 +18,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -34,7 +34,7 @@ references = [
 risk_score = 21
 rule_id = "e12c0318-99b1-44f2-830c-3a38a43207ca"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Network Security Monitoring", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services",  "Data Source: AWS Route53", "Use Case: Network Security Monitoring", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/persistence_route_table_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_route_table_modified_or_deleted.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -18,7 +18,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -38,7 +38,7 @@ references = [
 risk_score = 21
 rule_id = "e7cd5982-17c8-4959-874c-633acde7d426"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Network Security Monitoring", "Tactic: Persistence"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services",  "Data Source: AWS Route53", "Use Case: Network Security Monitoring", "Tactic: Persistence"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/privilege_escalation_root_login_without_mfa.toml
+++ b/rules/integrations/aws/privilege_escalation_root_login_without_mfa.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -74,6 +74,7 @@ tags = [
     "Domain: Cloud",
     "Data Source: AWS",
     "Data Source: Amazon Web Services",
+    "Data Source: AWS Route53",
     "Use Case: Identity and Access Audit",
     "Resources: Investigation Guide",
     "Tactic: Privilege Escalation"

--- a/rules/integrations/aws/privilege_escalation_sts_assumerole_usage.toml
+++ b/rules/integrations/aws/privilege_escalation_sts_assumerole_usage.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -13,7 +13,7 @@ Identifies the use of AssumeRole. AssumeRole returns a set of temporary security
 AWS resources. An adversary could use those credentials to move laterally and escalate privileges.
 """
 false_positives = ["Automated processes that use Terraform may lead to false positives."]
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Security Token Service (STS) AssumeRole Usage"
@@ -24,7 +24,7 @@ references = ["https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRol
 risk_score = 21
 rule_id = "93075852-b0f5-4b8b-89c3-a226efae5726"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Identity and Access Audit", "Tactic: Privilege Escalation"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Data Source: AWS STS", "Use Case: Identity and Access Audit", "Tactic: Privilege Escalation"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/privilege_escalation_sts_getsessiontoken_abuse.toml
+++ b/rules/integrations/aws/privilege_escalation_sts_getsessiontoken_abuse.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Austin Songer"]
@@ -19,7 +19,7 @@ false_positives = [
     be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS STS GetSessionToken Abuse"
@@ -30,7 +30,7 @@ references = ["https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessio
 risk_score = 21
 rule_id = "b45ab1d2-712f-4f01-a751-df3826969807"
 severity = "low"
-tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services", "Use Case: Identity and Access Audit", "Tactic: Privilege Escalation"]
+tags = ["Domain: Cloud", "Data Source: AWS", "Data Source: Amazon Web Services",  "Data Source: AWS STS", "Use Case: Identity and Access Audit", "Tactic: Privilege Escalation"]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/aws/privilege_escalation_updateassumerolepolicy.toml
+++ b/rules/integrations/aws/privilege_escalation_updateassumerolepolicy.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.9.0"
-updated_date = "2023/10/24"
+updated_date = "2024/04/14"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     """,
 ]
 from = "now-60m"
-index = ["filebeat-*", "logs-aws*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
@@ -75,6 +75,7 @@ tags = [
     "Domain: Cloud",
     "Data Source: AWS",
     "Data Source: Amazon Web Services",
+    "Data Source: AWS STS",
     "Use Case: Identity and Access Audit",
     "Resources: Investigation Guide",
     "Tactic: Privilege Escalation"


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/323

## Summary
This PR tightens the index patterns for all AWS non-ML detection rules. At this time, our entire AWS ruleset, aside from ML rules, were scoped to `logs-aws*`, however, they all rely on CloudTrail logs as noted in the queries by `aws.cloudtrail`. Thus can we restrict the index patterns to `logs-aws.cloudtrail-*`.

Additionally, the `event.provider` for each rule indicates which AWS service these logs are expected from within the cloudtrail trail itself. As a result, it will be more simple to filter detection rules by an AWS service that a customer may be using rather than AWS entirely. Note that the acronym's were used for these tags.
