### PR TITLE
[FR] Bump KQL Version in Init

### DIFF
--- a/lib/kql/kql/__init__.py
+++ b/lib/kql/kql/__init__.py
@@ -13,7 +13,7 @@ from .evaluator import FilterGenerator
 from .kql2eql import KqlToEQL
 from .parser import lark_parse, KqlParser
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 __all__ = (
     "ast",
     "from_eql",


### PR DESCRIPTION
## Related PRs
https://github.com/elastic/detection-rules/pull/3574
https://github.com/elastic/detection-rules/pull/3575

## Summary

This PR bumps the KQL version due to recent updates to the KQL library (other PRs should have had this bump in it). 
