### PR TITLE
[New Rule] Potential Windows Session Hijacking via CcmExec

### DIFF
--- a/rules/windows/defense_evasion_sccm_scnotification_dll.toml
+++ b/rules/windows/defense_evasion_sccm_scnotification_dll.toml
@@ -1,0 +1,49 @@
+[metadata]
+creation_date = "2024/04/17"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2024/04/17"
+
+[rule]
+author = ["Elastic"]
+description = """
+This detection rule identifies when 'SCNotification.exe' loads an untrusted DLL, which is a potential indicator of an
+attacker attempt to hijack/impersonate a Windows user session.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.library-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Windows Session Hijacking via CcmExec"
+references = [
+    "https://cloud.google.com/blog/topics/threat-intelligence/windows-session-hijacking-via-ccmexec",
+    "https://mayfly277.github.io/posts/SCCM-LAB-part0x3/#impersonate-users---revshell-connected-users"
+]
+risk_score = 47
+rule_id = "e7357fec-6e9c-41b9-b93d-6e4fc40c7d47"
+severity = "medium"
+tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Defense Evasion", "Data Source: Elastic Defend"]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+library where host.os.type == "windows" and process.name : "SCNotification.exe" and
+  dll.Ext.relative_file_creation_time < 86400 and dll.code_signature.status != "trusted"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1574"
+name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/windows/defense_evasion_sccm_scnotification_dll.toml
+++ b/rules/windows/defense_evasion_sccm_scnotification_dll.toml
@@ -30,7 +30,7 @@ type = "eql"
 
 query = '''
 library where host.os.type == "windows" and process.name : "SCNotification.exe" and
-  dll.Ext.relative_file_creation_time < 86400 and dll.code_signature.status != "trusted"
+  (dll.Ext.relative_file_creation_time < 86400 or dll.Ext.relative_file_name_modify_time <= 500) and dll.code_signature.status != "trusted"
 '''
 
 


### PR DESCRIPTION
## Issues

Related to https://github.com/elastic/ia-trade-team/issues/325

## Summary

This detection rule identifies when 'SCNotification.exe' loads an untrusted DLL, which is a potential indicator of an
attacker attempt to hijack/impersonate a Windows user session.
