### PR TITLE
[Rule Tuning] Reverting `Account Password Reset Remotely` To Previous Version

### DIFF
--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/10/18"
 integration = ["system", "windows"]
 maturity = "production"
-min_stack_comments = "Forking rule to resolve double bump version issue."
-min_stack_version = "8.13.0"
-updated_date = "2024/04/18"
+min_stack_comments = "New fields added: required_fields, related_integrations, setup"
+min_stack_version = "8.3.0"
+updated_date = "2023/12/14"
 
 [rule]
 author = ["Elastic"]
@@ -18,11 +18,7 @@ index = ["winlogbeat-*", "logs-system.security*", "logs-windows.forwarded*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Account Password Reset Remotely"
-note = """
-
-## Performance
-This rule may cause medium to high performance impact due to scoping all remote Windows logon activity within the first sequence. This rule by default will be noisy if not scoped to custom privileged accounts. If noisy, duplicate the rule and replace the `TargetUserName` or `TargetSid` filters with your own naming convention and accounts of interest.
-"""
+note = "This rule may cause medium to high performance impact due to logic scoping all remote Windows logon activity."
 references = [
     "https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4724",
     "https://stealthbits.com/blog/manipulating-user-passwords-with-mimikatz/",
@@ -40,7 +36,7 @@ sequence by winlog.computer_name with maxspan=1m
   [authentication where event.action == "logged-in" and
     /* event 4624 need to be logged */
     winlog.logon.type : "Network" and event.outcome == "success" and source.ip != null and
-    source.ip != "127.0.0.1" and source.ip != "::1" and
+    source.ip != "127.0.0.1" and source.ip != "::1" and 
     not winlog.event_data.TargetUserName : ("svc*", "PIM_*", "_*_", "*-*-*", "*$")] by winlog.event_data.TargetLogonId
    /* event 4724 need to be logged */
   [iam where event.action == "reset-password" and
@@ -81,3 +77,4 @@ reference = "https://attack.mitre.org/techniques/T1531/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
+


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/330

## Summary
This PR reverts the `Account Password Reset Remotely` rule to the version merged correctly in [7a4f1224dc8c0146b28f21ee87b88d8b685fb0e8](https://github.com/elastic/detection-rules/commit/7a4f1224dc8c0146b28f21ee87b88d8b685fb0e8).

This is the last correct version of the rule that was merged in from #3335 for tuning.

## Testing
From this branch, I ran `view-rule` which showed version 114, then checked out 8.3 and ran the same command to receive the same version, 114. Originally, these versions were split. 
