### PR TITLE
[Rule Tuning] Update Performance Note in `Account Password Reset Remotely` and Backport to 8.3

### DIFF
--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -4,7 +4,7 @@ integration = ["system", "windows"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/12/14"
+updated_date = "2024/04/18"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,11 @@ index = ["winlogbeat-*", "logs-system.security*", "logs-windows.forwarded*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Account Password Reset Remotely"
-note = "This rule may cause medium to high performance impact due to logic scoping all remote Windows logon activity."
+note = """
+
+## Performance
+This rule may cause medium to high performance impact due to logic scoping all remote Windows logon activity.
+"""
 references = [
     "https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4724",
     "https://stealthbits.com/blog/manipulating-user-passwords-with-mimikatz/",
@@ -36,7 +40,7 @@ sequence by winlog.computer_name with maxspan=1m
   [authentication where event.action == "logged-in" and
     /* event 4624 need to be logged */
     winlog.logon.type : "Network" and event.outcome == "success" and source.ip != null and
-    source.ip != "127.0.0.1" and source.ip != "::1" and 
+    source.ip != "127.0.0.1" and source.ip != "::1" and
     not winlog.event_data.TargetUserName : ("svc*", "PIM_*", "_*_", "*-*-*", "*$")] by winlog.event_data.TargetLogonId
    /* event 4724 need to be logged */
   [iam where event.action == "reset-password" and


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/330

## Summary
This PR updated the performance note for this rule. This change should backport to 8.3 and thus return the rule to a specific state across all branches, while resolving the version lock issue mentioned in the issue above.
