### PR TITLE
Fix minstack version for 0365 in azure integration rules

### DIFF
--- a/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/09/01"
 integration = ["azure", "o365"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2023/06/22"
+min_stack_comments = "Breaking change at 8.8.0 for Microsoft 365 Integration."
+min_stack_version = "8.8.0"
+updated_date = "2024/04/22"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues
Identified during https://github.com/elastic/ia-trade-team/issues/330

## Summary
- Similar to https://github.com/elastic/detection-rules/pull/3565
- Microsoft 365 integration has breaking change in 8.80 and one of azure rules uses that integration.
- This change address the minstack version fix to avoid double bump. 


## View Rule Details.

Until Versions 8.3-->8.7 for the rule "rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml"

```
  "related_integrations": [
    {
      "integration": "activitylogs",
      "package": "azure",
      "version": "^1.0.0"
    },
    {
      "package": "azure",
      "version": "^1.0.0"
    },
    {
      "package": "o365",
      "version": "^1.3.0"
    }
  ],
  ```
From versions 8.8-->8.13  for the rule "rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml"

```
"related_integrations": [
    {
      "integration": "activitylogs",
      "package": "azure",
      "version": "^1.0.0"
    },
    {
      "package": "azure",
      "version": "^1.0.0"
    },
    {
      "package": "o365",
      "version": "^2.0.0"
    }
    ```