### PR TITLE
[FR] Bundle KQL & Kibana libs into base dependencies

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -99,7 +99,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[dev]
-          pip install lib/kql lib/kibana
 
       - name: Prune non-${{matrix.target_branch}} rules
         env:

--- a/.github/workflows/get-target-branches.yml
+++ b/.github/workflows/get-target-branches.yml
@@ -26,7 +26,6 @@ jobs:
           python -m pip install --upgrade pip
           pip cache purge
           pip install .[dev]
-          pip install lib/kql lib/kibana
 
       - id: get-branch-list
         run: |

--- a/.github/workflows/lock-versions.yml
+++ b/.github/workflows/lock-versions.yml
@@ -36,7 +36,6 @@ jobs:
           python -m pip install --upgrade pip
           pip cache purge
           pip install .[dev]
-          pip install lib/kql lib/kibana
 
       - name: Build release package
         run: |

--- a/.github/workflows/manual-backport.yml
+++ b/.github/workflows/manual-backport.yml
@@ -55,7 +55,6 @@ jobs:
           python -m pip install --upgrade pip
           pip cache purge
           pip install .[dev]
-          pip install lib/kql lib/kibana
 
       - name: Prune non-"${{github.event.inputs.target_branch}}" rules
         env:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,7 +24,6 @@ jobs:
         python -m pip install --upgrade pip
         pip cache purge
         pip install .[dev]
-        pip install lib/kql lib/kibana
 
     - name: Python Lint
       run: |

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -48,7 +48,6 @@ jobs:
           python -m pip install --upgrade pip
           pip cache purge
           pip install .[dev]
-          pip install lib/kql lib/kibana
 
       - name: Build Integration Docs
         env:

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -84,7 +84,6 @@ jobs:
             python -m pip install --upgrade pip
             pip cache purge
             pip install .[dev]
-            pip install lib/kql lib/kibana
 
         - name: Bump prebuilt rules package version
           env:

--- a/CLI.md
+++ b/CLI.md
@@ -43,7 +43,7 @@ Using the environment variable `DR_BYPASS_TAGS_VALIDATION` will bypass the Detec
 
 ## Importing rules into the repo
 
-You can import rules into the repo using the `create-rule` or `import-rules` commands. Both of these commands will
+You can import rules into the repo using the `create-rule` or `import-rules-to-repo` commands. Both of these commands will
 require that the rules are schema-compliant and able to pass full validation. The biggest benefit to using these
 commands is that they will strip[*](#note) additional fields[**](#note-2) and prompt for missing required
 fields.
@@ -76,10 +76,10 @@ and will accept any valid rule in the following formats:
 * yaml (yup)
 * ndjson (as long as it contains only a single rule and has the extension `.ndjson` or `.jsonl`)
 
-#### `import-rules`
+#### `import-rules-to-repo`
 
 ```console
-Usage: detection_rules import-rules [OPTIONS] [INPUT_FILE]...
+Usage: detection_rules import-rules-to-repo [OPTIONS] [INPUT_FILE]...
 
   Import rules from json, toml, yaml, or Kibana exported rule file(s).
 
@@ -269,22 +269,23 @@ Alternatively, rules can be exported into a consolidated ndjson file which can b
 directly.
 
 ```console
-Usage: detection_rules export-rules [OPTIONS]
+Usage: detection_rules export-rules-from-repo [OPTIONS]
 
   Export rule(s) into an importable ndjson file.
 
 Options:
   -f, --rule-file FILE
-  -d, --directory DIRECTORY       Recursively export rules from a directory
+  -d, --directory DIRECTORY       Recursively load rules from a directory
   -id, --rule-id TEXT
-  -o, --outfile FILE              Name of file for exported rules
+  -o, --outfile PATH              Name of file for exported rules
   -r, --replace-id                Replace rule IDs with new IDs before export
-  --stack-version [7.8|7.9|7.10|7.11|7.12]
+  --stack-version [7.10|7.11|7.12|7.13|7.14|7.15|7.16|7.8|7.9|8.0|8.1|8.10|8.11|8.12|8.13|8.2|8.3|8.4|8.5|8.6|8.7|8.8|8.9]
                                   Downgrade a rule version to be compatible
                                   with older instances of Kibana
   -s, --skip-unsupported          If `--stack-version` is passed, skip rule
                                   types which are unsupported (an error will
                                   be raised otherwise)
+  --include-metadata              Add metadata to the exported rules
   -h, --help                      Show this message and exit.
 ```
 
@@ -336,7 +337,7 @@ Options:
 Example usage of a successful upload:
 
 ```
-python -m detection_rules kibana import-rules -f test-export-rules/credential_access_NEW_RULE.toml        
+python -m detection_rules kibana import-rules -f test-export-rules/credential_access_NEW_RULE.toml
 
 █▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
 █  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
@@ -375,7 +376,7 @@ python -m detection_rules kibana import-rules -f test-export-rules/credential_ac
 
 The rule loader detects a collision in name and fails as intended:
 ```
-python -m detection_rules kibana import-rules -d test-export-rules                               
+python -m detection_rules kibana import-rules -d test-export-rules
 
 █▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
 █  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
@@ -533,7 +534,7 @@ web_application_suspicious_activity_unauthorized_method.toml.toml
 Output of the `_errors.txt` file:
 
 ```
-cat test-export-rules/_errors.txt 
+cat test-export-rules/_errors.txt
 - Stolen Credentials Used to Login to Okta Account After MFA Reset - {'_schema': ['Setup header found in both note and setup fields.']}
 - First Occurrence of Okta User Session Started via Proxy - {'rule': [ValidationError({'type': ['Must be equal to eql.'], 'language': ['Must be equal to eql.']}), ValidationError({'type': ['Must be equal to esql.'], 'language': ['Must be equal to esql.']}), ValidationError({'type': ['Must be equal to threshold.'], 'threshold': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to threat_match.'], 'threat_mapping': ['Missing data for required field.'], 'threat_index': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to machine_learning.'], 'anomaly_threshold': ['Missing data for required field.'], 'machine_learning_job_id': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to query.']}), ValidationError({'new_terms': ['Missing data for required field.']})]}
 - ESQL test: cmd child of Explorer - {'rule': [ValidationError({'type': ['Must be equal to eql.'], 'threat': {0: {'tactic': {'reference': ['String does not match expected pattern.']}, 'technique': {0: {'reference': ['String does not match expected pattern.']}}}}, 'language': ['Must be equal to eql.']}), ValidationError({'threat': {0: {'tactic': {'reference': ['String does not match expected pattern.']}, 'technique': {0: {'reference': ['String does not match expected pattern.']}}}}}), ValidationError({'type': ['Must be equal to threshold.'], 'threat': {0: {'tactic': {'reference': ['String does not match expected pattern.']}, 'technique': {0: {'reference': ['String does not match expected pattern.']}}}}, 'threshold': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to threat_match.'], 'threat': {0: {'tactic': {'reference': ['String does not match expected pattern.']}, 'technique': {0: {'reference': ['String does not match expected pattern.']}}}}, 'threat_mapping': ['Missing data for required field.'], 'threat_index': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to machine_learning.'], 'threat': {0: {'tactic': {'reference': ['String does not match expected pattern.']}, 'technique': {0: {'reference': ['String does not match expected pattern.']}}}}, 'anomaly_threshold': ['Missing data for required field.'], 'machine_learning_job_id': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to query.'], 'threat': {0: {'tactic': {'reference': ['String does not match expected pattern.']}, 'technique': {0: {'reference': ['String does not match expected pattern.']}}}}}), ValidationError({'type': ['Must be equal to new_terms.'], 'threat': {0: {'tactic': {'reference': ['String does not match expected pattern.']}, 'technique': {0: {'reference': ['String does not match expected pattern.']}}}}, 'new_terms': ['Missing data for required field.']})]}
@@ -552,7 +553,7 @@ Unknown field
 data_stream.dataset:osquery_manager.result and osquery_meta.counter>0 and osquery_meta.type:diff and osquery.last_run_code:0 and osquery_meta.action:removed
                                                                           ^^^^^^^^^^^^^^^^^
 stack: 8.9.0, beats: 8.9.0, ecs: 8.9.0
-- name - {'rule': [ValidationError({'type': ['Must be equal to eql.'], 'language': ['Must be equal to eql.']}), ValidationError({'type': ['Must be equal to esql.'], 'language': ['Must be equal to esql.']}), ValidationError({'type': ['Must be equal to threshold.'], 'threshold': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to threat_match.'], 'threat_mapping': ['Missing data for required field.'], 'threat_index': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to machine_learning.'], 'anomaly_threshold': ['Missing data for required field.'], 'machine_learning_job_id': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to query.']}), ValidationError({'new_terms': ['Missing data for required field.']})]}(venv312) ➜  detection-rules-fork git:(refresh-kibana-module-with-new-APIs) ✗ 
+- name - {'rule': [ValidationError({'type': ['Must be equal to eql.'], 'language': ['Must be equal to eql.']}), ValidationError({'type': ['Must be equal to esql.'], 'language': ['Must be equal to esql.']}), ValidationError({'type': ['Must be equal to threshold.'], 'threshold': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to threat_match.'], 'threat_mapping': ['Missing data for required field.'], 'threat_index': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to machine_learning.'], 'anomaly_threshold': ['Missing data for required field.'], 'machine_learning_job_id': ['Missing data for required field.']}), ValidationError({'type': ['Must be equal to query.']}), ValidationError({'new_terms': ['Missing data for required field.']})]}(venv312) ➜  detection-rules-fork git:(refresh-kibana-module-with-new-APIs) ✗
 ```
 
 

--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,9 @@ clean:
 	rm -rf $(VENV) *.egg-info .eggs .egg htmlcov build dist packages .build .tmp .tox __pycache__  lib/kql/build lib/kibana/build lib/kql/*.egg-info lib/kibana/*.egg-info
 
 .PHONY: deps
-deps: $(VENV) install-packages
+deps: $(VENV)
 	@echo "Installing all dependencies..."
 	$(PIP) install .[dev]
-
-.PHONY: install-packages
-install-packages:
-	@echo "Installing kql and kibana packages..."
-	$(PIP) install lib/kql lib/kibana
 
 .PHONY: pytest
 pytest: $(VENV) deps

--- a/README.md
+++ b/README.md
@@ -76,16 +76,17 @@ Collecting Click==7.0
   Downloading Click-7.0-py2.py3-none-any.whl (81 kB)
      |████████████████████████████████| 81 kB 2.6 MB/s
 ...
-pip3 install packages/kibana packages/kql
 ```
 
-Note: The `kibana` and `kql` packages are not available on PyPI and must be installed from the `packages` directory or `git`.
+Note: The `kibana` and `kql` packages are not available on PyPI and must be installed from the `lib` directory.
 
 ```console
+
+# Install from the repository
 pip3 install git+https://github.com/elastic/detection-rules.git#subdirectory=kibana
 pip3 install git+https://github.com/elastic/detection-rules.git#subdirectory=kql
 
-# or locally
+# Or locally for development
 pip3 install lib/kibana lib/kql
 ```
 

--- a/detection_rules/etc/test_cli.bash
+++ b/detection_rules/etc/test_cli.bash
@@ -15,7 +15,7 @@ echo "Viewing rule: threat_intel_indicator_match_address.toml"
 python -m detection_rules view-rule rules/cross-platform/threat_intel_indicator_match_address.toml
 
 echo "Exporting rule by ID: 0a97b20f-4144-49ea-be32-b540ecc445de"
-python -m detection_rules export-rules --rule-id 0a97b20f-4144-49ea-be32-b540ecc445de
+python -m detection_rules export-rules-from-repo --rule-id 0a97b20f-4144-49ea-be32-b540ecc445de
 
 echo "Updating rule data schemas"
 python -m detection_rules dev schemas update-rule-data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,9 @@ dependencies = [
 	"typing-inspect==0.9.0",
 	"typing-extensions==4.10.0",
 	"XlsxWriter~=3.2.0",
-	"semver==3.0.2"
+	"semver==3.0.2",
+	"detection-rules-kql @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql",
+	"detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana"
 ]
 [project.optional-dependencies]
 dev = ["pep8-naming==0.13.0", "PyGithub==2.2.0", "flake8==7.0.0", "pyflakes==3.2.0", "pytest>=8.1.1", "pre-commit==3.6.2"]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Related to https://github.com/elastic/detection-rules/pull/3514

## Summary

Instead of bundling kql/kibana packages separately, add the packages to the code pyproject.toml using the git+ url.

Note: This implies that kql/kibana will pull from `main` git. For local development you will need to uninstall the git version and install locally for testing/dev. 

## Bug Fixes

Updates the test cli script to use the new export command.

## Testing

- CI should pass
- `make test-cli` and `make test-remote-cli` should pass.
- `make` should work as expected.


<details><summary>Make output</summary>
<p>

```
➜  detection-rules git:(main) ✗ make
python3.12 -m pip install --upgrade pip setuptools
Looking in indexes: https://pypi.org/simple, https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/simple
Requirement already satisfied: pip in /opt/homebrew/lib/python3.12/site-packages (24.0)
Requirement already satisfied: setuptools in /opt/homebrew/lib/python3.12/site-packages (69.5.1)
python3.12 -m venv ./env/detection-rules-build
Installing all dependencies...
./env/detection-rules-build/bin/pip install .[dev]
Looking in indexes: https://pypi.org/simple, https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/simple
Processing /Users/stryker/workspace/ElasticGitHub/detection-rules
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting detection-rules-kql@ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql (from detection_rules==0.1.0)
  Cloning https://github.com/elastic/detection-rules.git to /private/var/folders/ng/zlptgm9552j2dhj_xzy0r32h0000gn/T/pip-install-jiz0oey6/detection-rules-kql_1959cedeaf7944c8a9b42e8a1928568b
  Running command git clone --filter=blob:none --quiet https://github.com/elastic/detection-rules.git /private/var/folders/ng/zlptgm9552j2dhj_xzy0r32h0000gn/T/pip-install-jiz0oey6/detection-rules-kql_1959cedeaf7944c8a9b42e8a1928568b
  Resolved https://github.com/elastic/detection-rules.git to commit 1fb58e1b6147045c944b7f37f16a884ce7e97bf1
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting detection-rules-kibana@ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana (from detection_rules==0.1.0)
  Cloning https://github.com/elastic/detection-rules.git to /private/var/folders/ng/zlptgm9552j2dhj_xzy0r32h0000gn/T/pip-install-jiz0oey6/detection-rules-kibana_9e495f8a3d4c4df8b604689c7f8362c0
  Running command git clone --filter=blob:none --quiet https://github.com/elastic/detection-rules.git /private/var/folders/ng/zlptgm9552j2dhj_xzy0r32h0000gn/T/pip-install-jiz0oey6/detection-rules-kibana_9e495f8a3d4c4df8b604689c7f8362c0
  Resolved https://github.com/elastic/detection-rules.git to commit 1fb58e1b6147045c944b7f37f16a884ce7e97bf1
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting Click~=8.1.7 (from detection_rules==0.1.0)
  Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
Collecting elasticsearch~=8.12.1 (from detection_rules==0.1.0)
  Using cached elasticsearch-8.12.1-py3-none-any.whl.metadata (5.3 kB)
Collecting eql==0.9.19 (from detection_rules==0.1.0)
  Using cached eql-0.9.19-py2.py3-none-any.whl.metadata (3.7 kB)
Collecting jsl==0.2.4 (from detection_rules==0.1.0)
  Using cached jsl-0.2.4-py3-none-any.whl
Collecting jsonschema>=4.21.1 (from detection_rules==0.1.0)
  Using cached jsonschema-4.22.0-py3-none-any.whl.metadata (8.2 kB)
Collecting marko==2.0.3 (from detection_rules==0.1.0)
  Using cached marko-2.0.3-py3-none-any.whl.metadata (4.6 kB)
Collecting marshmallow-dataclass~=8.6.0 (from marshmallow-dataclass[union]~=8.6.0->detection_rules==0.1.0)
  Using cached marshmallow_dataclass-8.6.1-py3-none-any.whl.metadata (12 kB)
Collecting marshmallow-jsonschema~=0.13.0 (from detection_rules==0.1.0)
  Using cached marshmallow_jsonschema-0.13.0-py3-none-any.whl.metadata (7.5 kB)
Collecting marshmallow-union~=0.1.15 (from detection_rules==0.1.0)
  Using cached marshmallow_union-0.1.15.post1-py2.py3-none-any.whl.metadata (2.9 kB)
Collecting marshmallow~=3.21.1 (from detection_rules==0.1.0)
  Using cached marshmallow-3.21.2-py3-none-any.whl.metadata (7.1 kB)
Collecting pytoml==0.1.21 (from detection_rules==0.1.0)
  Using cached pytoml-0.1.21-py2.py3-none-any.whl.metadata (2.0 kB)
Collecting PyYAML~=6.0.1 (from detection_rules==0.1.0)
  Using cached PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl.metadata (2.1 kB)
Collecting requests~=2.31.0 (from detection_rules==0.1.0)
  Using cached requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
Collecting toml==0.10.2 (from detection_rules==0.1.0)
  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
Collecting typing-inspect==0.9.0 (from detection_rules==0.1.0)
  Using cached typing_inspect-0.9.0-py3-none-any.whl.metadata (1.5 kB)
Collecting typing-extensions==4.10.0 (from detection_rules==0.1.0)
  Using cached typing_extensions-4.10.0-py3-none-any.whl.metadata (3.0 kB)
Collecting XlsxWriter~=3.2.0 (from detection_rules==0.1.0)
  Using cached XlsxWriter-3.2.0-py3-none-any.whl.metadata (2.6 kB)
Collecting semver==3.0.2 (from detection_rules==0.1.0)
  Using cached semver-3.0.2-py3-none-any.whl.metadata (5.0 kB)
Collecting lark-parser~=0.12.0 (from eql==0.9.19->detection_rules==0.1.0)
  Using cached https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/lark-parser/0.12.0/lark_parser-0.12.0-py2.py3-none-any.whl (103 kB)
Collecting mypy-extensions>=0.3.0 (from typing-inspect==0.9.0->detection_rules==0.1.0)
  Using cached mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
Collecting pep8-naming==0.13.0 (from detection_rules==0.1.0)
  Using cached pep8_naming-0.13.0-py3-none-any.whl.metadata (6.5 kB)
Collecting PyGithub==2.2.0 (from detection_rules==0.1.0)
  Using cached PyGithub-2.2.0-py3-none-any.whl.metadata (3.8 kB)
Collecting flake8==7.0.0 (from detection_rules==0.1.0)
  Using cached flake8-7.0.0-py2.py3-none-any.whl.metadata (3.8 kB)
Collecting pyflakes==3.2.0 (from detection_rules==0.1.0)
  Using cached pyflakes-3.2.0-py2.py3-none-any.whl.metadata (3.5 kB)
Collecting pytest>=8.1.1 (from detection_rules==0.1.0)
  Using cached pytest-8.2.0-py3-none-any.whl.metadata (7.5 kB)
Collecting pre-commit==3.6.2 (from detection_rules==0.1.0)
  Using cached pre_commit-3.6.2-py2.py3-none-any.whl.metadata (1.3 kB)
Collecting mccabe<0.8.0,>=0.7.0 (from flake8==7.0.0->detection_rules==0.1.0)
  Using cached mccabe-0.7.0-py2.py3-none-any.whl.metadata (5.0 kB)
Collecting pycodestyle<2.12.0,>=2.11.0 (from flake8==7.0.0->detection_rules==0.1.0)
  Using cached pycodestyle-2.11.1-py2.py3-none-any.whl.metadata (4.5 kB)
Collecting cfgv>=2.0.0 (from pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached cfgv-3.4.0-py2.py3-none-any.whl.metadata (8.5 kB)
Collecting identify>=1.0.0 (from pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached identify-2.5.36-py2.py3-none-any.whl.metadata (4.4 kB)
Collecting nodeenv>=0.11.1 (from pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached nodeenv-1.8.0-py2.py3-none-any.whl.metadata (21 kB)
Collecting virtualenv>=20.10.0 (from pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached virtualenv-20.26.1-py3-none-any.whl.metadata (4.4 kB)
Collecting pynacl>=1.4.0 (from PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl.metadata (8.7 kB)
Collecting pyjwt>=2.4.0 (from pyjwt[crypto]>=2.4.0->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached PyJWT-2.8.0-py3-none-any.whl.metadata (4.2 kB)
Collecting urllib3>=1.26.0 (from PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached urllib3-2.2.1-py3-none-any.whl.metadata (6.4 kB)
Collecting Deprecated (from PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached Deprecated-1.2.14-py2.py3-none-any.whl.metadata (5.4 kB)
Collecting elastic-transport<9,>=8 (from elasticsearch~=8.12.1->detection_rules==0.1.0)
  Using cached elastic_transport-8.13.0-py3-none-any.whl.metadata (3.7 kB)
Collecting attrs>=22.2.0 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached attrs-23.2.0-py3-none-any.whl.metadata (9.5 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached jsonschema_specifications-2023.12.1-py3-none-any.whl.metadata (3.0 kB)
Collecting referencing>=0.28.4 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached referencing-0.35.1-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.7.1 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached rpds_py-0.18.1-cp312-cp312-macosx_11_0_arm64.whl.metadata (4.1 kB)
Collecting packaging>=17.0 (from marshmallow~=3.21.1->detection_rules==0.1.0)
  Using cached packaging-24.0-py3-none-any.whl.metadata (3.2 kB)
Collecting typeguard<4.0.0,>=2.4.1 (from marshmallow-dataclass[union]~=8.6.0->detection_rules==0.1.0)
  Using cached typeguard-3.0.2-py3-none-any.whl.metadata (3.7 kB)
Collecting iniconfig (from pytest>=8.1.1->detection_rules==0.1.0)
  Using cached iniconfig-2.0.0-py3-none-any.whl.metadata (2.6 kB)
Collecting pluggy<2.0,>=1.5 (from pytest>=8.1.1->detection_rules==0.1.0)
  Using cached pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
Collecting charset-normalizer<4,>=2 (from requests~=2.31.0->detection_rules==0.1.0)
  Using cached charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl.metadata (33 kB)
Collecting idna<4,>=2.5 (from requests~=2.31.0->detection_rules==0.1.0)
  Using cached idna-3.7-py3-none-any.whl.metadata (9.9 kB)
Collecting certifi>=2017.4.17 (from requests~=2.31.0->detection_rules==0.1.0)
  Using cached certifi-2024.2.2-py3-none-any.whl.metadata (2.2 kB)
Collecting setuptools (from nodeenv>=0.11.1->pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached setuptools-69.5.1-py3-none-any.whl.metadata (6.2 kB)
Collecting cryptography>=3.4.0 (from pyjwt[crypto]>=2.4.0->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached cryptography-42.0.7-cp39-abi3-macosx_10_12_universal2.whl.metadata (5.3 kB)
Collecting cffi>=1.4.1 (from pynacl>=1.4.0->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (1.5 kB)
Collecting distlib<1,>=0.3.7 (from virtualenv>=20.10.0->pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached distlib-0.3.8-py2.py3-none-any.whl.metadata (5.1 kB)
Collecting filelock<4,>=3.12.2 (from virtualenv>=20.10.0->pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached filelock-3.14.0-py3-none-any.whl.metadata (2.8 kB)
Collecting platformdirs<5,>=3.9.1 (from virtualenv>=20.10.0->pre-commit==3.6.2->detection_rules==0.1.0)
  Using cached platformdirs-4.2.1-py3-none-any.whl.metadata (11 kB)
Collecting wrapt<2,>=1.10 (from Deprecated->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (6.6 kB)
Collecting pycparser (from cffi>=1.4.1->pynacl>=1.4.0->PyGithub==2.2.0->detection_rules==0.1.0)
  Using cached pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
Using cached eql-0.9.19-py2.py3-none-any.whl (105 kB)
Using cached marko-2.0.3-py3-none-any.whl (42 kB)
Using cached pytoml-0.1.21-py2.py3-none-any.whl (8.5 kB)
Using cached semver-3.0.2-py3-none-any.whl (17 kB)
Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
Using cached typing_extensions-4.10.0-py3-none-any.whl (33 kB)
Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
Using cached flake8-7.0.0-py2.py3-none-any.whl (57 kB)
Using cached pep8_naming-0.13.0-py3-none-any.whl (8.5 kB)
Using cached pre_commit-3.6.2-py2.py3-none-any.whl (204 kB)
Using cached pyflakes-3.2.0-py2.py3-none-any.whl (62 kB)
Using cached PyGithub-2.2.0-py3-none-any.whl (350 kB)
Using cached click-8.1.7-py3-none-any.whl (97 kB)
Using cached elasticsearch-8.12.1-py3-none-any.whl (432 kB)
Using cached jsonschema-4.22.0-py3-none-any.whl (88 kB)
Using cached marshmallow-3.21.2-py3-none-any.whl (49 kB)
Using cached marshmallow_dataclass-8.6.1-py3-none-any.whl (18 kB)
Using cached marshmallow_jsonschema-0.13.0-py3-none-any.whl (11 kB)
Using cached marshmallow_union-0.1.15.post1-py2.py3-none-any.whl (4.6 kB)
Using cached pytest-8.2.0-py3-none-any.whl (339 kB)
Using cached PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl (165 kB)
Using cached requests-2.31.0-py3-none-any.whl (62 kB)
Using cached XlsxWriter-3.2.0-py3-none-any.whl (159 kB)
Using cached attrs-23.2.0-py3-none-any.whl (60 kB)
Using cached certifi-2024.2.2-py3-none-any.whl (163 kB)
Using cached cfgv-3.4.0-py2.py3-none-any.whl (7.2 kB)
Using cached charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl (119 kB)
Using cached elastic_transport-8.13.0-py3-none-any.whl (64 kB)
Using cached identify-2.5.36-py2.py3-none-any.whl (98 kB)
Using cached idna-3.7-py3-none-any.whl (66 kB)
Using cached jsonschema_specifications-2023.12.1-py3-none-any.whl (18 kB)
Using cached mccabe-0.7.0-py2.py3-none-any.whl (7.3 kB)
Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
Using cached nodeenv-1.8.0-py2.py3-none-any.whl (22 kB)
Using cached packaging-24.0-py3-none-any.whl (53 kB)
Using cached pluggy-1.5.0-py3-none-any.whl (20 kB)
Using cached pycodestyle-2.11.1-py2.py3-none-any.whl (31 kB)
Using cached PyJWT-2.8.0-py3-none-any.whl (22 kB)
Using cached PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl (349 kB)
Using cached referencing-0.35.1-py3-none-any.whl (26 kB)
Using cached rpds_py-0.18.1-cp312-cp312-macosx_11_0_arm64.whl (323 kB)
Using cached typeguard-3.0.2-py3-none-any.whl (30 kB)
Using cached urllib3-2.2.1-py3-none-any.whl (121 kB)
Using cached virtualenv-20.26.1-py3-none-any.whl (3.9 MB)
Using cached Deprecated-1.2.14-py2.py3-none-any.whl (9.6 kB)
Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Using cached cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl (177 kB)
Using cached cryptography-42.0.7-cp39-abi3-macosx_10_12_universal2.whl (5.9 MB)
Using cached distlib-0.3.8-py2.py3-none-any.whl (468 kB)
Using cached filelock-3.14.0-py3-none-any.whl (12 kB)
Using cached platformdirs-4.2.1-py3-none-any.whl (17 kB)
Using cached wrapt-1.16.0-cp312-cp312-macosx_11_0_arm64.whl (38 kB)
Using cached setuptools-69.5.1-py3-none-any.whl (894 kB)
Using cached pycparser-2.22-py3-none-any.whl (117 kB)
Building wheels for collected packages: detection_rules, detection-rules-kibana, detection-rules-kql
  Building wheel for detection_rules (pyproject.toml) ... done
  Created wheel for detection_rules: filename=detection_rules-0.1.0-py3-none-any.whl size=33961778 sha256=db9703fc0d8c132873aa5b3bc1b174cfa697fca17129a1081881c40a18ec6b33
  Stored in directory: /Users/stryker/Library/Caches/pip/wheels/21/c6/ab/8e432f1a2900ee2a465d751436987791213ddef360666b4436
  Building wheel for detection-rules-kibana (pyproject.toml) ... done
  Created wheel for detection-rules-kibana: filename=detection_rules_kibana-0.2.0-py3-none-any.whl size=9325 sha256=b298730fbd86efdaaadd082926dba0d0b2e98c9d54938f7d53c2ab194938c59a
  Stored in directory: /private/var/folders/ng/zlptgm9552j2dhj_xzy0r32h0000gn/T/pip-ephem-wheel-cache-k337tsu3/wheels/08/96/aa/385e2ed061d591561ceb888c9cc4321cda2494a338957e581e
  Building wheel for detection-rules-kql (pyproject.toml) ... done
  Created wheel for detection-rules-kql: filename=detection_rules_kql-0.1.7-py3-none-any.whl size=16336 sha256=99ca2a17dd04d1b1c3f07cf78d0c1bc02d3e3999c8d0e82916aa0a6d440ad944
  Stored in directory: /private/var/folders/ng/zlptgm9552j2dhj_xzy0r32h0000gn/T/pip-ephem-wheel-cache-k337tsu3/wheels/c7/d2/87/aadf9d1987eecf9ca470145b5d3a08c6ba65c43738212f5c8c
Successfully built detection_rules detection-rules-kibana detection-rules-kql
Installing collected packages: pytoml, lark-parser, jsl, distlib, XlsxWriter, wrapt, urllib3, typing-extensions, typeguard, toml, setuptools, semver, rpds-py, PyYAML, pyjwt, pyflakes, pycparser, pycodestyle, pluggy, platformdirs, packaging, mypy-extensions, mccabe, marko, iniconfig, idna, identify, filelock, eql, Click, charset-normalizer, cfgv, certifi, attrs, virtualenv, typing-inspect, requests, referencing, pytest, nodeenv, marshmallow, flake8, elastic-transport, detection-rules-kql, Deprecated, cffi, pynacl, pre-commit, pep8-naming, marshmallow-union, marshmallow-jsonschema, marshmallow-dataclass, jsonschema-specifications, elasticsearch, cryptography, jsonschema, detection-rules-kibana, PyGithub, detection_rules
Successfully installed Click-8.1.7 Deprecated-1.2.14 PyGithub-2.2.0 PyYAML-6.0.1 XlsxWriter-3.2.0 attrs-23.2.0 certifi-2024.2.2 cffi-1.16.0 cfgv-3.4.0 charset-normalizer-3.3.2 cryptography-42.0.7 detection-rules-kibana-0.2.0 detection-rules-kql-0.1.7 detection_rules-0.1.0 distlib-0.3.8 elastic-transport-8.13.0 elasticsearch-8.12.1 eql-0.9.19 filelock-3.14.0 flake8-7.0.0 identify-2.5.36 idna-3.7 iniconfig-2.0.0 jsl-0.2.4 jsonschema-4.22.0 jsonschema-specifications-2023.12.1 lark-parser-0.12.0 marko-2.0.3 marshmallow-3.21.2 marshmallow-dataclass-8.6.1 marshmallow-jsonschema-0.13.0 marshmallow-union-0.1.15.post1 mccabe-0.7.0 mypy-extensions-1.0.0 nodeenv-1.8.0 packaging-24.0 pep8-naming-0.13.0 platformdirs-4.2.1 pluggy-1.5.0 pre-commit-3.6.2 pycodestyle-2.11.1 pycparser-2.22 pyflakes-3.2.0 pyjwt-2.8.0 pynacl-1.5.0 pytest-8.2.0 pytoml-0.1.21 referencing-0.35.1 requests-2.31.0 rpds-py-0.18.1 semver-3.0.2 setuptools-69.5.1 toml-0.10.2 typeguard-3.0.2 typing-extensions-4.10.0 typing-inspect-0.9.0 urllib3-2.2.1 virtualenv-20.26.1 wrapt-1.16.0
RELEASE: 
./env/detection-rules-build/bin/python -m detection_rules dev build-release --generate-navigator
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building package 8.14
 - 5 rules excluded from package
Rule changes detected!
 - 21 changed rules
 - 5 new rules
 - 0 newly deprecated rules
run `build-release --update-version-lock` to update version.lock.json and deprecated_rules.json
Package saved to: /Users/stryker/workspace/ElasticGitHub/detection-rules/releases/8.14
loaded security_detection_engine manifests from the following package versions: ['8.13.6', '8.13.5', '8.13.4', '8.13.3', '8.13.2', '8.13.1', '8.12.11', '8.12.10', '8.12.9', '8.12.8', '8.12.7', '8.12.6', '8.12.5', '8.12.4', '8.12.3', '8.12.2', '8.12.1', '8.11.15', '8.11.14', '8.11.13', '8.11.12', '8.11.11', '8.11.10', '8.11.9', '8.11.8', '8.11.7', '8.11.6', '8.11.5', '8.11.4', '8.11.3', '8.11.2', '8.11.1', '8.10.18', '8.10.17', '8.10.16', '8.10.15', '8.10.14', '8.10.13', '8.10.12', '8.10.11', '8.10.10', '8.10.9', '8.10.8', '8.10.7', '8.10.6', '8.10.5', '8.10.4', '8.10.3', '8.10.2', '8.10.1', '8.9.15', '8.9.14', '8.9.13', '8.9.12', '8.9.11', '8.9.10', '8.9.9', '8.9.8', '8.9.7', '8.9.6', '8.9.5', '8.9.4', '8.9.3', '8.9.2', '8.9.1', '8.8.15', '8.8.14', '8.8.13', '8.8.12', '8.8.11', '8.8.10', '8.8.9', '8.8.8', '8.8.7', '8.8.6', '8.8.5', '8.8.4', '8.8.3', '8.8.2', '8.8.1', '8.7.13', '8.7.12', '8.7.11', '8.7.10', '8.7.9', '8.7.8', '8.7.7', '8.7.6', '8.7.5', '8.7.4', '8.7.3', '8.7.2', '8.7.1', '8.6.10', '8.6.9', '8.6.8', '8.6.7', '8.6.6', '8.6.5', '8.6.4', '8.6.3', '8.6.2', '8.6.1', '8.5.8', '8.5.7', '8.5.6', '8.5.5', '8.5.4', '8.5.3', '8.5.2', '8.5.1', '8.4.5', '8.4.4', '8.4.3', '8.4.2', '8.4.1', '8.3.4', '8.3.3', '8.3.2', '8.3.1', '8.2.1', '8.1.1', '1.0.2', '1.0.1']
[+] Adding historical rules from 8.13.6 package
- sha256: 787329066dc81b28ab9db56c054bcdd32f12db5792af6bc3497ac783ee026ac7
- 1101 rules included
rm -rf dist
mkdir dist
cp -r releases/*/*.zip dist/
```


</p>
</details> 

[3662_output.txt](https://github.com/elastic/detection-rules/files/15299192/3662_output.txt)

