### PR TITLE
[Bug] Update Rule Formatter

### DIFF
--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -164,6 +164,9 @@ def toml_write(rule_contents, outfile=None):
     """Write rule in TOML."""
     def write(text, nl=True):
         if outfile:
+            # Transform instances of \ to \\ as calling write will convert \\ to \.
+            # This will ensure that the output file has the correct number of backslashes.
+            text = text.replace("\\", "\\\\")
             outfile.write(text)
             if nl:
                 outfile.write(u"\n")

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -164,9 +164,6 @@ def toml_write(rule_contents, outfile=None):
     """Write rule in TOML."""
     def write(text, nl=True):
         if outfile:
-            # Transform instances of \ to \\ as calling write will convert \\ to \.
-            # This will ensure that the output file has the correct number of backslashes.
-            text = text.replace("\\", "\\\\")
             outfile.write(text)
             if nl:
                 outfile.write(u"\n")
@@ -218,6 +215,11 @@ def toml_write(rule_contents, outfile=None):
                 # explicitly preserve formatting for message field in actions
                 preserved_fields = ["params.message"]
                 v = [preserve_formatting_for_fields(action, preserved_fields) for action in v]
+
+            if k == 'note' and isinstance(v, str):
+                # Transform instances of \ to \\ as calling write will convert \\ to \.
+                # This will ensure that the output file has the correct number of backslashes.
+                v = v.replace("\\", "\\\\")
 
             if isinstance(v, dict):
                 bottom[k] = OrderedDict(sorted(v.items()))


### PR DESCRIPTION
## Issues
https://github.com/elastic/detection-rules/issues/3667

## Summary

This updates the rule formatter to handle backslashes correctly.

Prior to this fix running the `python -m detection_rules dev attack update-rules` command would cause the following breaking change in `rules/windows/privilege_escalation_group_policy_iniscript.toml` to the note section.

Breaking Change:
```
The scripts are stored in the following paths:
  - `<GPOPath>\Machine\Scripts\`
  - `<GPOPath>\User\Scripts\`
```

Running the command with the current update results in:
```
The scripts are stored in the following paths:
  - `<GPOPath>\\Machine\\Scripts\\`
  - `<GPOPath>\\User\\Scripts\\`
```

Which is the desired behavior.
