### PR TITLE
[FR] [DAC] Use Rules Config Directories If None Specified 

### DIFF
--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -74,11 +74,13 @@ def multi_collection(f):
 
         rules = RuleCollection()
 
-        if not (directories or rule_id or rule_files):
+        if not (directories or rule_id or rule_files or DEFAULT_PREBUILT_RULES_DIRS + DEFAULT_PREBUILT_BBR_DIRS):
             client_error('Required: at least one of --rule-id, --rule-file, or --directory')
 
         rules.load_files(Path(p) for p in rule_files)
         rules.load_directories(Path(d) for d in directories)
+        if not rule_files and not directories:
+            rules.load_directories(Path(d) for d in DEFAULT_PREBUILT_RULES_DIRS + DEFAULT_PREBUILT_BBR_DIRS)
 
         if rule_id:
             rules.load_directories(DEFAULT_PREBUILT_RULES_DIRS + DEFAULT_PREBUILT_BBR_DIRS,


### PR DESCRIPTION
## Related Issue
https://github.com/elastic/detection-rules/pull/3654

## Summary

Small PR to add the default functionality of using the Rules config default directories if none are specified. 


## Testing 

Use `python -m detection_rules kibana import-rules --overwrite` to add or update a rule from your config in Kibana. 

![rule_update_example](https://github.com/elastic/detection-rules/assets/119343520/1a97d052-30df-496a-9c83-f9330b0ac89c)
