### PR TITLE
[Bug] Support spaces with capital letters

### DIFF
--- a/lib/kibana/kibana/__init__.py
+++ b/lib/kibana/kibana/__init__.py
@@ -8,7 +8,7 @@
 from .connector import Kibana
 from .resources import RuleResource, Signal
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __all__ = (
     "Kibana",
     "RuleResource",

--- a/lib/kibana/kibana/connector.py
+++ b/lib/kibana/kibana/connector.py
@@ -89,7 +89,7 @@ class Kibana(object):
         # If a space is defined update the URL accordingly
         uri = uri.lstrip('/')
         if self.space:
-            uri = "s/{}/{}".format(self.space, uri)
+            uri = "s/{}/{}".format(self.space.lower(), uri)
         return f"{self.kibana_url}/{uri}"
 
     def request(self, method, uri, params=None, data=None, raw_data=None, error=True, verbose=True, raw=False,

--- a/lib/kibana/kibana/connector.py
+++ b/lib/kibana/kibana/connector.py
@@ -11,8 +11,8 @@ import sys
 import threading
 import uuid
 from typing import List, Optional, Union
-from urllib.parse import urljoin
 
+from urllib.parse import urljoin
 import requests
 from elasticsearch import Elasticsearch
 
@@ -87,20 +87,11 @@ class Kibana(object):
     def url(self, uri):
         """Get the full URL given a URI."""
         assert self.kibana_url is not None
-        normalized_uri = uri.lstrip('/')
-
-        # Construct the space path if a space is defined
+        # If a space is defined update the URL accordingly
+        uri = uri.lstrip('/')
         if self.space:
-            space_path = f"s/{self.space.lower()}/"
-            full_path = urljoin(space_path, normalized_uri)
-        else:
-            full_path = normalized_uri
-
-        # Ensure the base Kibana URL ends with a '/' to correctly form a base URL for urljoin
-        if not self.kibana_url.endswith('/'):
-            self.kibana_url += '/'
-
-        return urljoin(self.kibana_url, full_path)
+            uri = "s/{}/{}".format(self.space.lower(), uri)
+        return f"{self.kibana_url}/{uri}"
 
     def request(self, method, uri, params=None, data=None, raw_data=None, error=True, verbose=True, raw=False,
                 **kwargs) -> Optional[Union[requests.Response, dict]]:

--- a/lib/kibana/kibana/connector.py
+++ b/lib/kibana/kibana/connector.py
@@ -11,6 +11,7 @@ import sys
 import threading
 import uuid
 from typing import List, Optional, Union
+from urllib.parse import urljoin
 
 import requests
 from elasticsearch import Elasticsearch
@@ -86,11 +87,20 @@ class Kibana(object):
     def url(self, uri):
         """Get the full URL given a URI."""
         assert self.kibana_url is not None
-        # If a space is defined update the URL accordingly
-        uri = uri.lstrip('/')
+        normalized_uri = uri.lstrip('/')
+
+        # Construct the space path if a space is defined
         if self.space:
-            uri = "s/{}/{}".format(self.space.lower(), uri)
-        return f"{self.kibana_url}/{uri}"
+            space_path = f"s/{self.space.lower()}/"
+            full_path = urljoin(space_path, normalized_uri)
+        else:
+            full_path = normalized_uri
+
+        # Ensure the base Kibana URL ends with a '/' to correctly form a base URL for urljoin
+        if not self.kibana_url.endswith('/'):
+            self.kibana_url += '/'
+
+        return urljoin(self.kibana_url, full_path)
 
     def request(self, method, uri, params=None, data=None, raw_data=None, error=True, verbose=True, raw=False,
                 **kwargs) -> Optional[Union[requests.Response, dict]]:

--- a/lib/kibana/pyproject.toml
+++ b/lib/kibana/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection-rules-kibana"
-version = "0.2.0"
+version = "0.2.1"
 description = "Kibana API utilities for Elastic Detection Rules"
 license = {text = "Elastic License v2"}
 keywords = ["Elastic", "Kibana", "Detection Rules", "Security", "Elasticsearch"]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
N/A

## Summary

When trying to import / export rules to Kibana with spaces, the `space` in the url is lowercased.

If you create a space called `DEV` the url will have `s/dev`. To support this, we need to ensure we're supplying the lowercased version of the space to match the `URL identifier`.

## Testing

Try to import and export rules with a space name that is capitalized and lowercased URL identifier:

- `python -m detection_rules kibana --space devs import-rules --directory mikas_dir/rules/`
- `python -m detection_rules kibana --space dev export-rules -d mikas_dir/rules/`

![Screenshot 2024-05-16 at 8 15 20 PM](https://github.com/elastic/detection-rules/assets/1636709/32b1ed31-fd1a-43e3-8fcf-43a2b77b52af)
![Screenshot 2024-05-16 at 8 39 16 PM](https://github.com/elastic/detection-rules/assets/1636709/a4476c1e-566a-4698-b7a8-68732e65d4f4)
