### PR TITLE
[FR] Add --force flag to update-lock-versions

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -332,10 +332,10 @@ def prune_staging_area(target_stack_version: str, dry_run: bool, exception_list:
         change.revert(dry_run=dry_run)
 
 
-@dev_group.command("update-lock-versions")
-@click.argument("rule-ids", nargs=-1, required=False)
-@click.option("--force", is_flag=True, help="Force update without confirmation")
-def update_lock_versions(rule_ids, force):
+@dev_group.command('update-lock-versions')
+@click.argument('rule-ids', nargs=-1, required=False)
+@click.option('--force', is_flag=True, help='Force update without confirmation')
+def update_lock_versions(rule_ids: Tuple[str, ...], force: bool):
     """Update rule hashes in version.lock.json file without bumping version."""
     rules = RuleCollection.default()
 
@@ -345,7 +345,7 @@ def update_lock_versions(rule_ids, force):
         rules = rules.filter(production_filter)
 
     if not force and not click.confirm(
-        f"Are you sure you want to update hashes for {len(rules)} rules without a version bump?"
+        f'Are you sure you want to update hashes for {len(rules)} rules without a version bump?'
     ):
         return
 
@@ -353,7 +353,7 @@ def update_lock_versions(rule_ids, force):
     changed, new, _ = default_version_lock.manage_versions(rules, exclude_version_update=True, save_changes=True)
 
     if not changed:
-        click.echo("No hashes updated")
+        click.echo('No hashes updated')
 
     return changed
 

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -332,9 +332,10 @@ def prune_staging_area(target_stack_version: str, dry_run: bool, exception_list:
         change.revert(dry_run=dry_run)
 
 
-@dev_group.command('update-lock-versions')
-@click.argument('rule-ids', nargs=-1, required=False)
-def update_lock_versions(rule_ids):
+@dev_group.command("update-lock-versions")
+@click.argument("rule-ids", nargs=-1, required=False)
+@click.option("--force", is_flag=True, help="Force update without confirmation")
+def update_lock_versions(rule_ids, force):
     """Update rule hashes in version.lock.json file without bumping version."""
     rules = RuleCollection.default()
 
@@ -343,14 +344,16 @@ def update_lock_versions(rule_ids):
     else:
         rules = rules.filter(production_filter)
 
-    if not click.confirm(f'Are you sure you want to update hashes for {len(rules)} rules without a version bump?'):
+    if not force and not click.confirm(
+        f"Are you sure you want to update hashes for {len(rules)} rules without a version bump?"
+    ):
         return
 
     # this command may not function as expected anymore due to previous changes eliminating the use of add_new=False
     changed, new, _ = default_version_lock.manage_versions(rules, exclude_version_update=True, save_changes=True)
 
     if not changed:
-        click.echo('No hashes updated')
+        click.echo("No hashes updated")
 
     return changed
 


### PR DESCRIPTION

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->

## Summary

This PR adds a `--force` flag to lock versions to allow this command to be run in CI such that users can lock versions without needing to build a package. 

## Testing

` python -m detection_rules dev update-lock-versions --force` should not have a confirm prompt. 