### PR TITLE
[Bug] Fix test_os_and_platform_in_query test and rules

### DIFF
--- a/rules/linux/execution_shell_via_child_tcp_utility_linux.toml
+++ b/rules/linux/execution_shell_via_child_tcp_utility_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/11/02"
+updated_date = "2024/05/17"
 
 [rule]
 author = ["Elastic"]
@@ -61,12 +61,13 @@ tags = [
 type = "eql"
 query = '''
 sequence by host.id, process.entity_id with maxspan=5s
-  [network where event.type == "start" and event.action in ("connection_attempted", "connection_accepted") and 
-   process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "socat") and destination.ip != null and 
-   not cidrmatch(destination.ip, "127.0.0.0/8", "169.254.0.0/16", "224.0.0.0/4", "::1")]
-  [process where event.type == "start" and event.action == "exec" and 
-   process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
-     (process.args : ("-i", "-l")) or (process.parent.name == "socat" and process.parent.args : "*exec*")
+  [network where event.type == "start" and host.os.type == "linux" and
+     event.action in ("connection_attempted", "connection_accepted") and
+     process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "socat") and destination.ip != null and
+     not cidrmatch(destination.ip, "127.0.0.0/8", "169.254.0.0/16", "224.0.0.0/4", "::1")]
+  [process where event.type == "start" and host.os.type == "linux" and event.action == "exec" and
+     process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
+       (process.args : ("-i", "-l")) or (process.parent.name == "socat" and process.parent.args : "*exec*")
    )]
 '''
 

--- a/rules/linux/execution_shell_via_tcp_cli_utility_linux.toml
+++ b/rules/linux/execution_shell_via_tcp_cli_utility_linux.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/11/02"
+updated_date = "2024/05/17"
 
 [rule]
 author = ["Elastic"]
@@ -59,12 +59,13 @@ tags = [
 type = "eql"
 query = '''
 sequence by host.id with maxspan=5s
-  [network where event.type == "start" and event.action in ("connection_attempted", "connection_accepted") and 
-   process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "socat") and destination.ip != null and 
-   not cidrmatch(destination.ip, "127.0.0.0/8", "169.254.0.0/16", "224.0.0.0/4", "::1")] by process.entity_id
-  [process where event.type == "start" and event.action in ("exec", "fork") and 
-   process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
-     (process.args : ("-i", "-l")) or (process.parent.name == "socat" and process.parent.args : "*exec*")
+  [network where event.type == "start" and host.os.type == "linux" and
+     event.action in ("connection_attempted", "connection_accepted") and
+     process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "socat") and destination.ip != null and
+     not cidrmatch(destination.ip, "127.0.0.0/8", "169.254.0.0/16", "224.0.0.0/4", "::1")] by process.entity_id
+  [process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "fork") and
+     process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
+       (process.args : ("-i", "-l")) or (process.parent.name == "socat" and process.parent.args : "*exec*")
    )] by process.parent.entity_id
 '''
 

--- a/rules/linux/persistence_kworker_file_creation.toml
+++ b/rules/linux/persistence_kworker_file_creation.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2024/02/21"
+updated_date = "2024/05/17"
 
 [transform]
 [[transform.osquery]]
@@ -175,10 +175,11 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where event.action in ("creation", "file_create_event") and process.name : "kworker*" and not (
-  (process.name : "kworker*kcryptd*") or 
-  (file.path : ("/var/log/*", "/var/crash/*", "/var/run/*", "/var/lib/systemd/coredump/*", "/var/spool/*"))
-)
+file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
+  process.name : "kworker*" and not (
+    (process.name : "kworker*kcryptd*") or
+    (file.path : ("/var/log/*", "/var/crash/*", "/var/run/*", "/var/lib/systemd/coredump/*", "/var/spool/*"))
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/persistence_message_of_the_day_execution.toml
+++ b/rules/linux/persistence_message_of_the_day_execution.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2024/02/21"
+updated_date = "2024/05/17"
 
 [transform]
 [[transform.osquery]]
@@ -157,8 +157,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where event.type == "start" and event.action : ("exec", "exec_event") and
-process.parent.executable : ("/etc/update-motd.d/*", "/usr/lib/update-notifier/*") and (
+process where event.type == "start" and host.os.type == "linux" and event.action : ("exec", "exec_event") and
+  process.parent.executable : ("/etc/update-motd.d/*", "/usr/lib/update-notifier/*") and (
   (process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
     (process.args : ("-i", "-l")) or (process.parent.name == "socat" and process.parent.args : "*exec*"))) or
   (process.name : ("nc", "ncat", "netcat", "nc.openbsd") and process.args_count >= 3 and 

--- a/rules/linux/persistence_suspicious_file_opened_through_editor.toml
+++ b/rules/linux/persistence_suspicious_file_opened_through_editor.toml
@@ -3,7 +3,7 @@ creation_date = "2023/07/25"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2024/02/22"
+updated_date = "2024/05/17"
 integration = ["endpoint"]
 
 [rule]
@@ -36,7 +36,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where event.action in ("creation", "file_create_event") and file.extension == "swp" and 
+file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
 file.path : (
   /* common interesting files and locations */
   "/etc/.shadow.swp", "/etc/.shadow-.swp", "/etc/.shadow~.swp", "/etc/.gshadow.swp", "/etc/.gshadow-.swp",

--- a/rules/linux/privilege_escalation_potential_bufferoverflow_attack.toml
+++ b/rules/linux/privilege_escalation_potential_bufferoverflow_attack.toml
@@ -3,7 +3,7 @@ creation_date = "2023/12/11"
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2023/12/11"
+updated_date = "2024/05/17"
 
 [rule]
 author = ["Elastic"]
@@ -41,7 +41,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "threshold"
 query = '''
-kibana.alert.rule.rule_id:5c81fc9d-1eae-437f-ba07-268472967013 and event.kind:signal
+kibana.alert.rule.rule_id:"5c81fc9d-1eae-437f-ba07-268472967013" and host.os.type:linux and event.kind:signal
 '''
 
 [[rule.threat]]

--- a/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
+++ b/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: process.Ext.effective_parent"
 min_stack_version = "8.7.0"
-updated_date = "2024/02/06"
+updated_date = "2024/05/17"
 
 [rule]
 author = ["Elastic"]
@@ -54,7 +54,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.action == "exec" and
+process where event.action == "exec" and host.os.type == "macos" and
  process.name : "osascript" and process.args : "-e" and process.command_line : ("*osascript*display*dialog*password*", "*osascript*display*dialog*passphrase*") and
  not (process.parent.executable : "/usr/bin/sudo" and process.command_line : "*Encryption Key Escrow*") and
  not (process.command_line : "*-e with timeout of 3600 seconds*" and user.id == "0" and process.parent.executable : "/bin/bash") and

--- a/rules/macos/credential_access_suspicious_web_browser_sensitive_file_access.toml
+++ b/rules/macos/credential_access_suspicious_web_browser_sensitive_file_access.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: file_access_events, process.Ext.effective_parent"
 min_stack_version = "8.11.0"
-updated_date = "2024/02/06"
+updated_date = "2024/05/17"
 
 [rule]
 author = ["Elastic"]
@@ -51,7 +51,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where event.action == "open" and process.executable != null and 
+file where event.action == "open" and host.os.type == "macos" and process.executable != null and
  file.name : ("cookies.sqlite", 
               "key?.db", 
               "logins.json", 

--- a/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
+++ b/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
-updated_date = "2024/02/06"
+updated_date = "2024/05/17"
 
 [rule]
 author = ["Elastic"]
@@ -55,7 +55,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where event.action == "extended_attributes_delete" and process.executable != null and
+file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
 (process.code_signature.trusted == false or process.code_signature.exists == false) and not
 process.executable : ("/usr/bin/xattr", 
                       "/System/*", 

--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: process.Ext.effective_parent"
 min_stack_version = "8.11.0"
-updated_date = "2024/05/10"
+updated_date = "2024/05/17"
 
 [rule]
 author = ["Elastic"]
@@ -52,7 +52,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where event.action == "exec" and
+process where event.action == "exec" and host.os.type == "macos" and
     process.parent.name: (
       "Microsoft Word",
       "Microsoft Outlook",

--- a/tests/test_specific_rules.py
+++ b/tests/test_specific_rules.py
@@ -51,7 +51,10 @@ class TestEndpointQuery(BaseRuleTest):
             err_msg = f"{self.rule_str(rule)} missing required field for endpoint rule"
             if "host.os.type" not in fields:
                 # Exception for Forwarded Events which contain Windows-only fields.
-                if rule.path.parent.name == "windows" and not any(field.startswith("winlog.") for field in fields):
+                if rule.path.parent.name == "windows":
+                    if not any(field.startswith("winlog.") for field in fields):
+                        self.assertIn("host.os.type", fields, err_msg)
+                else:
                     self.assertIn("host.os.type", fields, err_msg)
 
             # going to bypass this for now


### PR DESCRIPTION
## Issues
related to #2761 

## Summary
A bug was unintentionally introduced in #2761 where the `test_os_and_platform_in_query` was updated to only test on rules when they are `windows` _and do not_ include `winlog` fields, ignoring all other OS's. This fixes the logic and updates some rules that merged in the mean time without the `host.os.type` set.