### PR TITLE
Package Manifest changes to add capabilities

### DIFF
--- a/detection_rules/etc/packages.yaml
+++ b/detection_rules/etc/packages.yaml
@@ -11,6 +11,8 @@ package:
     conditions:
       elastic:
         subscription: basic
+        capabilities:
+          - security
       kibana.version: ^8.15.0
     description: Prebuilt detection rules for Elastic Security
     format_version: 3.0.0

--- a/detection_rules/schemas/registry_package.py
+++ b/detection_rules/schemas/registry_package.py
@@ -15,7 +15,7 @@ from ..mixins import MarshmallowDataclassMixin
 @dataclass
 class ConditionElastic:
     subscription: str
-    capabilities: List[str]
+    capabilities: Optional[List[str]]
 
 
 @dataclass

--- a/detection_rules/schemas/registry_package.py
+++ b/detection_rules/schemas/registry_package.py
@@ -15,6 +15,7 @@ from ..mixins import MarshmallowDataclassMixin
 @dataclass
 class ConditionElastic:
     subscription: str
+    capabilities: List[str]
 
 
 @dataclass


### PR DESCRIPTION
## Issues

- Related to https://github.com/elastic/integrations/pull/9938

## Summary

- Add security capability to package manifest to match to the changes https://github.com/elastic/integrations/pull/9938
- This should backport to 8.12 as we use to format version 3.0.0 and this capability is available from 2.10.0 https://github.com/elastic/package-spec/blob/db9a76d9534bca28a227d24543d80c5413c77ed6/spec/changelog.yml#L184
- We don't have to worry on packages 8.11 and below as this change is tightly coupled to RegistryPackageManifestV3 Data class.

