### PR TITLE
[New Rule] AWS GetCallerIdentity API Called for the First Time

### DIFF
--- a/rules/integrations/aws/discovery_new_terms_sts_getcalleridentity.toml
+++ b/rules/integrations/aws/discovery_new_terms_sts_getcalleridentity.toml
@@ -1,0 +1,124 @@
+[metadata]
+creation_date = "2024/05/24"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2024/05/24"
+
+[rule]
+author = ["Elastic"]
+description = """
+An adversary with access to a set of compromised credentials may attempt to verify that the credentials are valid and 
+determine what account they are using. This rule looks for the first time an identity has called the 
+STS `GetCallerIdentity` API operation in the last 15 days, which may be an indicator of compromised credentials. 
+A legitimate user would not need to call this operation as they should know the account they are using.
+"""
+false_positives = [
+    """
+    Verify whether the user identity should be using the STS `GetCallerIdentity` API operation. 
+    If known behavior is causing false positives, it can be exempted from the rule.
+    """,
+]
+from = "now-60m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS GetCallerIdentity API Called for the First Time"
+note = """## Triage and analysis
+
+### Investigating AWS GetCallerIdentity API Called for the First Time
+
+AWS Security Token Service (AWS STS) is a service that enables you to request temporary, limited-privilege credentials for users.
+The `GetCallerIdentity` function returns details about the IAM user or role owning the credentials used to call the operation. 
+No permissions are required to run this operation and the same information is returned even when access is denied.
+This rule looks for use of the `GetCallerIdentity` operation. This is a [New Terms](https://www.elastic.co/guide/en/security/master/rules-ui-create.html#create-new-terms-rule) rule indicating this is the first time a specific user identity has called this operation within the last 15 days.
+
+#### Possible investigation steps
+
+- Identify the account and its role in the environment, a role belonging to a service like Lambda or an EC2 instance would be highly suspicious.
+- Identify the applications or users that should use this account.
+- Investigate other alerts associated with the account during the past 48 hours.
+- Investigate abnormal values in the `user_agent.original` field by comparing them with the intended and authorized usage and historical data. Suspicious user agent values include non-SDK, AWS CLI, custom user agents, etc.
+- Assess whether this behavior is prevalent in the environment by looking for similar occurrences involving other users.
+- Contact the account owner and confirm whether they are aware of this activity.
+- Considering the source IP address and geolocation of the user who issued the command:
+    - Do they look normal for the calling user?
+    - If the source is an EC2 IP address, is it associated with an EC2 instance in one of your accounts or is the source IP from an EC2 instance that's not under your control?
+    - If it is an authorized EC2 instance, is the activity associated with normal behavior for the instance role or roles? Are there any other alerts or signs of suspicious activity involving this instance?
+- Review IAM permission policies for the user identity.
+- If you suspect the account has been compromised, scope potentially compromised assets by tracking servers, services, and data accessed by the account in the last 24 hours.
+
+### False positive analysis
+
+- False positives may occur due to the intended usage of the service. Tuning is needed in order to have higher confidence. Consider adding exceptions — preferably with a combination of user agent and IP address conditions.
+
+### Response and remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+- Disable or limit the account during the investigation and response.
+- Identify the possible impact of the incident and prioritize accordingly; the following actions can help you gain context:
+    - Identify the account role in the cloud environment.
+    - Assess the criticality of affected services and servers.
+    - Work with your IT team to identify and minimize the impact on users.
+    - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
+    - Identify any regulatory or legal ramifications related to this activity.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Rotate secrets or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Check if unauthorized new users were created, remove unauthorized new accounts, and request password resets for other IAM users.
+- Consider enabling multi-factor authentication for users.
+- Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
+- Implement security best practices [outlined](https://aws.amazon.com/premiumsupport/knowledge-center/security-best-practices/) by AWS.
+- Take the actions needed to return affected systems, data, or services to their normal operational levels.
+- Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+
+## Setup
+
+The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
+references = [
+    "https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html",
+    "https://www.secureworks.com/research/detecting-the-use-of-stolen-aws-lambda-credentials",
+    "https://detectioninthe.cloud/ttps/discovery/get_caller_identity/",
+]
+risk_score = 47
+rule_id = "30fbf4db-c502-4e68-a239-2e99af0f70da"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS STS",
+    "Use Case: Identity and Access Audit",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "new_terms"
+
+query = '''
+event.dataset:"aws.cloudtrail" and event.provider:"sts.amazonaws.com" and event.action:"GetCallerIdentity"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1087"
+name = "Account Discovery"
+reference = "https://attack.mitre.org/techniques/T1087/"
+[[rule.threat.technique.subtechnique]]
+id = "T1087.004"
+name = "Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1087/004/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["aws.cloudtrail.user_identity.arn"]
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-15d"
+

--- a/rules/integrations/aws/discovery_new_terms_sts_getcalleridentity.toml
+++ b/rules/integrations/aws/discovery_new_terms_sts_getcalleridentity.toml
@@ -71,7 +71,7 @@ This rule looks for use of the `GetCallerIdentity` operation. This is a [New Ter
 - Take the actions needed to return affected systems, data, or services to their normal operational levels.
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
-
+"""
 references = [
     "https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html",
     "https://www.secureworks.com/research/detecting-the-use-of-stolen-aws-lambda-credentials",

--- a/rules/integrations/aws/discovery_new_terms_sts_getcalleridentity.toml
+++ b/rules/integrations/aws/discovery_new_terms_sts_getcalleridentity.toml
@@ -23,7 +23,7 @@ index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
-name = "AWS GetCallerIdentity API Called for the First Time"
+name = "AWS STS GetCallerIdentity API Called for the First Time"
 note = """## Triage and analysis
 
 ### Investigating AWS GetCallerIdentity API Called for the First Time
@@ -51,6 +51,7 @@ This rule looks for use of the `GetCallerIdentity` operation. This is a [New Ter
 ### False positive analysis
 
 - False positives may occur due to the intended usage of the service. Tuning is needed in order to have higher confidence. Consider adding exceptions — preferably with a combination of user agent and IP address conditions.
+- Automation workflows that rely on the results from this API request may also generate false-positives. We recommend adding exceptions related to the `user.name` or `aws.cloudtrail.user_identity.arn` values to ignore these.
 
 ### Response and remediation
 
@@ -71,9 +72,6 @@ This rule looks for use of the `GetCallerIdentity` operation. This is a [New Ter
 - Identify the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
 
-## Setup
-
-The AWS Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."""
 references = [
     "https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html",
     "https://www.secureworks.com/research/detecting-the-use-of-stolen-aws-lambda-credentials",
@@ -120,5 +118,5 @@ field = "new_terms_fields"
 value = ["aws.cloudtrail.user_identity.arn"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
-value = "now-15d"
+value = "now-10d"
 


### PR DESCRIPTION
## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
+ https://github.com/elastic/ia-trade-team/issues/346 

## Summary
Identifies the use of `sts:GetCallerIdentity` API function. This is equivalent to `whoami` in linux and provides the caller with the user identity information for the set of credentials being used. A legitimate user would likely not need to make this call as they know who they are, and this is especially suspicious behavior coming from a service like Lambda or an EC2 instance role. `GetCallerIdentity` does not require any permissions as it returns the same information even when explicit deny policies  are in place that deny access to the API. For this reason I've decided not to include `event.outcome: success` as part of the query.

This is a new_terms rule as some operations may need to call the GetCallerIdentity function as part of their authorization process. For example, an AWS EKS token, the authentication token used when communicating with the Kubernetes API server, includes a pre-signed AWS API request for `sts:GetCallerIdentity` which allows the [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) to determine the AWS Identity and attached permissions for each request. 

![image](https://github.com/elastic/detection-rules/assets/59296946/a210f48a-7673-440d-a05d-92abbd051e86)


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
