### PR TITLE
[Rule Tuning] Tune exceptions for M365 Brute Force User Attempt

### DIFF
--- a/rules/integrations/o365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
+++ b/rules/integrations/o365/credential_access_microsoft_365_brute_force_user_account_attempt.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/30"
 integration = ["o365"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/05/24"
 
 [rule]
 author = ["Elastic", "Willem D'Haese", "Austin Songer"]
@@ -41,7 +41,9 @@ query = '''
 event.dataset:o365.audit and event.provider:(AzureActiveDirectory or Exchange) and
   event.category:authentication and event.action:(UserLoginFailed or PasswordLogonInitialAuthUsingPassword) and
   not o365.audit.LogonError:(UserAccountNotFound or EntitlementGrantsNotFound or UserStrongAuthEnrollmentRequired or
-                             UserStrongAuthClientAuthNRequired or InvalidReplyTo)
+                             UserStrongAuthClientAuthNRequired or InvalidReplyTo or SsoArtifactExpiredDueToConditionalAccess or
+                             PasswordResetRegistrationRequiredInterrupt or SsoUserAccountNotFoundInResourceTenant or
+                             UserStrongAuthExpired)
 '''
 
 


### PR DESCRIPTION
## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
Closes #3694 

## Summary

The query rule has been updated to exclude a logon error for non-existing users via SSO, an interrupt requiring registration in self-service password reset, and two high volume logon errors related to Conditional Access Policy expiration.

## Contributor checklist

x Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
x Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
