### PR TITLE
Fix nodeenv version dependancy

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -98,6 +98,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip cache purge
           pip install .[dev]
 
       - name: Prune non-${{matrix.target_branch}} rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 	"detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana"
 ]
 [project.optional-dependencies]
-dev = ["pep8-naming==0.13.0", "PyGithub==2.2.0", "flake8==7.0.0", "pyflakes==3.2.0", "pytest>=8.1.1", "pre-commit==3.6.2"]
+dev = ["pep8-naming==0.13.0", "PyGithub==2.2.0", "flake8==7.0.0", "pyflakes==3.2.0", "pytest>=8.1.1", "nodeenv==1.8.0", "pre-commit==3.6.2"]
 
 [project.urls]
 "Homepage" = "https://github.com/elastic/detection-rules"


### PR DESCRIPTION
## Issues
 - Failures https://github.com/elastic/detection-rules/actions/runs/9286062166/job/25551938923

## Summary

Seems to be an issue with package versions of nodeenv1.9.0 which stopped coupling up setuptools along with. 
We have the following dependency 
- Collecting nodeenv>=0.11.1 (from pre-commit==3.6.2->detection_rules==0.1.0)
- The previous installations nodeenv-1.8.0-py2.py3-none-any.whl.metadata  got in [setuptools](https://github.com/elastic/detection-rules/actions/runs/9275165818/job/25519208988) 
- Collecting setuptools (from nodeenv>=0.11.1->pre-commit==3.6.2->detection_rules==0.1.0)
- Now recent runs are using nodeenv-1.9.0-py2.py3-none-any.whl.metadata (21 kB) which does not bundle this up!
- Fix nodeenv to previous known version 1.8.0
