### PR TITLE
Remove unwanted backticks

### DIFF
--- a/rules/integrations/dga/command_and_control_ml_dga_activity_using_sunburst_domain.toml
+++ b/rules/integrations/dga/command_and_control_ml_dga_activity_using_sunburst_domain.toml
@@ -42,7 +42,6 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 - In the query bar, search for Domain Generation Algorithm Detection and select the integration to see more details about it.
 - Follow the instructions under the **Installation** section.
 - For this rule to work, complete the instructions through **Configure the ingest pipeline**.
-``` 
 """
 severity = "critical"
 tags = [

--- a/rules/integrations/dga/command_and_control_ml_dga_high_sum_probability.toml
+++ b/rules/integrations/dga/command_and_control_ml_dga_high_sum_probability.toml
@@ -44,7 +44,6 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 - In the query bar, search for Domain Generation Algorithm Detection and select the integration to see more details about it.
 - Follow the instructions under the **Installation** section.
 - For this rule to work, complete the instructions through **Add preconfigured anomaly detection jobs**.
-```
 
 ### Anomaly Detection Setup
 Before you can enable this rule, you'll need to enable the corresponding Anomaly Detection job. 

--- a/rules/integrations/dga/command_and_control_ml_dns_request_high_dga_probability.toml
+++ b/rules/integrations/dga/command_and_control_ml_dns_request_high_dga_probability.toml
@@ -42,7 +42,6 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 - In the query bar, search for Domain Generation Algorithm Detection and select the integration to see more details about it.
 - Follow the instructions under the **Installation** section.
 - For this rule to work, complete the instructions through **Configure the ingest pipeline**.
-```
 """
 severity = "low"
 tags = [

--- a/rules/integrations/dga/command_and_control_ml_dns_request_predicted_to_be_a_dga_domain.toml
+++ b/rules/integrations/dga/command_and_control_ml_dns_request_predicted_to_be_a_dga_domain.toml
@@ -42,7 +42,6 @@ The DGA Detection integration consists of an ML-based framework to detect DGA ac
 - In the query bar, search for Domain Generation Algorithm Detection and select the integration to see more details about it.
 - Follow the instructions under the **Installation** section.
 - For this rule to work, complete the instructions through **Configure the ingest pipeline**.
-```
 """
 severity = "low"
 tags = [

--- a/rules/integrations/problemchild/defense_evasion_ml_suspicious_windows_event.toml
+++ b/rules/integrations/problemchild/defense_evasion_ml_suspicious_windows_event.toml
@@ -42,7 +42,6 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 - In the query bar, search for Living off the Land Attack Detection and select the integration to see more details about it.
 - Follow the instructions under the **Installation** section.
 - For this rule to work, complete the instructions through **Configure the ingest pipeline**.
-```
 """
 severity = "low"
 tags = [

--- a/rules/integrations/problemchild/defense_evasion_ml_suspicious_windows_event_high_probability.toml
+++ b/rules/integrations/problemchild/defense_evasion_ml_suspicious_windows_event_high_probability.toml
@@ -42,7 +42,6 @@ The LotL Attack Detection integration detects living-off-the-land activity in Wi
 - In the query bar, search for Living off the Land Attack Detection and select the integration to see more details about it.
 - Follow the instructions under the **Installation** section.
 - For this rule to work, complete the instructions through **Configure the ingest pipeline**.
-```
 """
 severity = "low"
 tags = [


### PR DESCRIPTION
## Issues
Related to Security Doc Build [Failures](https://buildkite.com/elastic/docs-build-pr/builds/86313#018fc9b4-90ac-4f7e-a68f-1980f1a9df67)

## Summary
- There is a [rouge backtick](https://github.com/elastic/detection-rules/pull/3652/files#diff-a4e0110b58dfb4ebe75271a82820d74da69044bc480c0d3307a34a012cc8ca65L69) that is left when the rule tuning went in as part of [PR](https://github.com/elastic/detection-rules/pull/3652) for DGA Rules. 
- This caused the invalid references and we have cleaned this up in the documents.
- This PR corrects those backticks
