### PR TITLE
[Rule Tuning] Agent Spoofing

### DIFF
--- a/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
+++ b/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
@@ -1,13 +1,13 @@
 [metadata]
 creation_date = "2021/07/14"
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/05/31"
 
 [rule]
 author = ["Elastic"]
 description = """
-Detects events that have a mismatch on the expected event agent ID. The status "agent_id_mismatch" occurs when the
-expected agent ID associated with the API key does not match the actual agent ID in an event. This could indicate
+Detects events that have a mismatch on the expected event agent ID. The status "agent_id_mismatch/mismatch" occurs when
+the expected agent ID associated with the API key does not match the actual agent ID in an event. This could indicate
 attempts to spoof events in order to masquerade actual activity to evade detection.
 """
 false_positives = [
@@ -29,20 +29,18 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.agent_id_status:agent_id_mismatch
+event.agent_id_status:(agent_id_mismatch or mismatch)
 '''
-
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1036"
 name = "Masquerading"
 reference = "https://attack.mitre.org/techniques/T1036/"
 
-
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-


### PR DESCRIPTION
## Summary
This PR adds `mismatch` to the `event.agent_id_status` field within the query, as newer Elastic agents no longer mark this as `agent_id_mismatch`. 

This is checked with the LS data, and would've flagged the rogue host. 

<img width="343" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/aa05cc03-f6b6-47d8-99d8-ec9fc42b9064">
