### PR TITLE
[New Rule] Executable Bit Set for rc.local/rc.common

### DIFF
--- a/rules/linux/persistence_rc_local_common_executable_bit_set.toml
+++ b/rules/linux/persistence_rc_local_common_executable_bit_set.toml
@@ -1,0 +1,90 @@
+[metadata]
+creation_date = "2024/06/03"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/06/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule monitors for the addition of an executable bit of the `/etc/rc.local` or `/etc/rc.common` files. These files
+are used to start custom applications, services, scripts or commands during start-up. They require executable
+permissions to be executed on boot. An alert of this rule is an indicator that this method is being set up within
+your environment. This method has mostly been replaced by Systemd. However, through the `systemd-rc-local-generator`,
+these files can be converted to services that run at boot. Adversaries may alter these files to execute malicious code
+at start-up, and gain persistence onto the system.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*", "endgame-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Executable Bit Set for rc.local/rc.common"
+references = [
+    "https://www.intezer.com/blog/malware-analysis/hiddenwasp-malware-targeting-linux-systems/",
+    "https://pberba.github.io/security/2022/02/06/linux-threat-hunting-for-persistence-initialization-scripts-and-shell-configuration/#8-boot-or-logon-initialization-scripts-rc-scripts",
+    "https://www.cyberciti.biz/faq/how-to-enable-rc-local-shell-script-on-systemd-while-booting-linux-system/",
+]
+risk_score = 47
+rule_id = "94418745-529f-4259-8d25-a713a6feb6ae"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Data Source: Elastic Endgame",
+    "Data Source: Elastic Defend"
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process.args in ("/etc/rc.local", "/etc/rc.common") and (
+  (process.name == "chmod" and process.args : ("*+x*", "1*", "3*", "5*", "7*")) or
+  (process.name == "install" and process.args : "-m*" and process.args : ("*7*", "*5*", "*3*", "*1*"))
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1037"
+name = "Boot or Logon Initialization Scripts"
+reference = "https://attack.mitre.org/techniques/T1037/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1037.004"
+name = "RC Scripts"
+reference = "https://attack.mitre.org/techniques/T1037/004/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"

--- a/rules/linux/persistence_rc_local_common_executable_bit_set.toml
+++ b/rules/linux/persistence_rc_local_common_executable_bit_set.toml
@@ -64,7 +64,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
 process.args in ("/etc/rc.local", "/etc/rc.common") and (
   (process.name == "chmod" and process.args : ("*+x*", "1*", "3*", "5*", "7*")) or
   (process.name == "install" and process.args : "-m*" and process.args : ("*7*", "*5*", "*3*", "*1*"))


### PR DESCRIPTION
## Summary
Research related to this PR is conducted and documented in https://github.com/elastic/ia-trade-team/issues/374. This issue also contains the query + validation aspect.

This PR:

- Adds a new rule that detects the setting of the executable bit for the `/etc/rc.local` and `/etc/rc.common` files for the file owner. 

<img width="1907" alt="image" src="https://github.com/elastic/detection-rules/assets/78494512/24213264-02e4-40cb-bed6-6334d9f1b38e">

No hits last 90d in telemetry. 