### PR TITLE
Fix MITRE Attack details for v15.1.0

### DIFF
--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -126,7 +126,7 @@ reference = "https://attack.mitre.org/techniques/T1574/010/"
 
 [[rule.threat.technique]]
 id = "T1554"
-name = "Compromise Client Software Binary"
+name = "Compromise Host Software Binary"
 reference = "https://attack.mitre.org/techniques/T1554/"
 
 

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/03/28"
+updated_date = "2024/06/04"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 


### PR DESCRIPTION
## Issues
Unit Test Failures in 8.10 - https://github.com/elastic/detection-rules/actions/runs/9369285587/job/25793406644

## Summary
- The MITRE attack details was not back ported for rules/windows/persistence_adobe_hijack_persistence.toml. The Rule is min stacked to 8.11.0 in [main](https://github.com/elastic/detection-rules/blob/main/rules/windows/persistence_adobe_hijack_persistence.toml)
```
commit 2dfc2ecbb098fc8f1d58262b7373d71e2ecff24b (HEAD -> 8.10, origin/8.10)
Author: shashank-elastic <91139415+shashank-elastic@users.noreply.github.com>
Date:   Tue Jun 4 20:14:58 2024 +0530

    Refresh MITRE Attack v15.1.0 (#3725)
    
    Removed changes from:
    - rules/windows/persistence_adobe_hijack_persistence.toml
    
    (selectively cherry picked from commit e357a2c050753b2657d7c5317204b8dce63d826b)
```

So this PR corrects the MITRE details according to the new version v15.1.0
