### PR TITLE
[Rule Tuning] Fixing index in `Attempt to Retrieve User Data from AWS EC2 Instance`

### DIFF
--- a/rules_building_block/discovery_userdata_request_from_ec2_instance.toml
+++ b/rules_building_block/discovery_userdata_request_from_ec2_instance.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.9.0"
-updated_date = "2024/04/14"
+updated_date = "2024/06/10"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ gather sensitive data from the instance or to identify potential vulnerabilities
 does not generate an alert on its own, but serves as a signal for anomalous activity.
 """
 from = "now-119m"
-index = ["filebeat-*", "logs.aws.cloudtrail-*"]
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 interval = "60m"
 language = "kuery"
 license = "Elastic License v2"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
* https://github.com/elastic/sdh-protections/issues/490

## Summary
Per SDH, `Attempt to Retrieve User Data from AWS EC2 Instance` had an incorrect index mapping for AWS Cloudtrail data. Instead of `logs.aws.cloudtrail-*`, it should have been `logs-aws.cloudtrail-*`. I have verified all of the other AWS rules did not have this issue.