### PR TITLE
Update Minstack versions for SentinelOne rules

### DIFF
--- a/rules/windows/collection_email_powershell_exchange_mailbox.toml
+++ b/rules/windows/collection_email_powershell_exchange_mailbox.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/12/15"
 integration = ["endpoint", "windows", "system", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_port_forwarding_added_registry.toml
+++ b/rules/windows/command_and_control_port_forwarding_added_registry.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/25"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_rdp_tunnel_plink.toml
+++ b/rules/windows/command_and_control_rdp_tunnel_plink.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/10/14"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/command_and_control_screenconnect_childproc.toml
+++ b/rules/windows/command_and_control_screenconnect_childproc.toml
@@ -2,10 +2,9 @@
 creation_date = "2024/03/27"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
-
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
+++ b/rules/windows/credential_access_domain_backup_dpapi_private_keys.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/08/13"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_kirbi_file.toml
+++ b/rules/windows/credential_access_kirbi_file.toml
@@ -2,9 +2,9 @@
 creation_date = "2023/08/23"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/08/31"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
@@ -2,9 +2,9 @@
 creation_date = "2023/01/17"
 integration = ["windows", "endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
+++ b/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/25"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
+++ b/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/08/24"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_persistence_account_tokenfilterpolicy.toml
+++ b/rules/windows/defense_evasion_persistence_account_tokenfilterpolicy.toml
@@ -2,9 +2,9 @@
 creation_date = "2022/11/01"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
+++ b/rules/windows/defense_evasion_suspicious_zoom_child_process.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/09/03"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/execution_command_shell_started_by_unusual_process.toml
+++ b/rules/windows/execution_command_shell_started_by_unusual_process.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/08/21"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
+++ b/rules/windows/initial_access_suspicious_ms_outlook_child_process.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows", "system", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/persistence_appcertdlls_registry.toml
+++ b/rules/windows/persistence_appcertdlls_registry.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/11/18"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_local_scheduled_job_creation.toml
+++ b/rules/windows/persistence_local_scheduled_job_creation.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/03/15"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_system_shells_via_services.toml
+++ b/rules/windows/persistence_system_shells_via_services.toml
@@ -2,9 +2,9 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows", "system", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/persistence_via_bits_job_notify_command.toml
+++ b/rules/windows/persistence_via_bits_job_notify_command.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/12/04"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/persistence_webshell_detection.toml
+++ b/rules/windows/persistence_webshell_detection.toml
@@ -2,9 +2,9 @@
 creation_date = "2021/08/24"
 integration = ["endpoint", "windows", "system", "sentinel_one_cloud_funnel"]
 maturity = "production"
-min_stack_comments = "SentinelOne integration package minimum version for validation."
-min_stack_version = "8.11.0"
-updated_date = "2024/05/16"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+min_stack_version = "8.13.0"
+updated_date = "2024/06/11"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues
Double Bump in Version Lock https://github.com/elastic/detection-rules/pull/3776

## Summary

- Follow steps of `How do I Fix double version bumps for related integrations rules` in [FAQ](https://github.com/elastic/ia-trade-team/wiki/Detection-Rules-Releasing-v2#faq)
- Update Min stack version for all affected rules
- SentinelOne integration version changed across versions documented [here](https://github.com/elastic/detection-rules/pull/3777#issuecomment-2160672392)
