### PR TITLE
 [Rule Tuning]  Agent Spoofing - Multiple Hosts Using Same Agent

### DIFF
--- a/rules/cross-platform/defense_evasion_agent_spoofing_multiple_hosts.toml
+++ b/rules/cross-platform/defense_evasion_agent_spoofing_multiple_hosts.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/14"
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/14"
 
 [rule]
 author = ["Elastic"]
@@ -29,7 +29,7 @@ timestamp_override = "event.ingested"
 type = "threshold"
 
 query = '''
-event.agent_id_status:*
+event.agent_id_status:* and not tags:forwarded
 '''
 
 


### PR DESCRIPTION
This PR adds an exception for events tagged as "forwarded". These events don't contain information about the host running the agent, such as `host.id` or `host.name`. Certain integrations, including entity analytics, ingested EDR (eg M365 Defender) logs, and vulnerability management may populate these fields with details about the host or device in that event. 

An alert is triggered on each run after these events are ingested. Excluding forwarded events will reduce false positives.

<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues

Closes #3613 

## Summary

The rule's query has been tuned to exclude forwarded events.

## Contributor checklist

- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
