### PR TITLE
[New Rule] Okta Credential Stuffing and Password Spraying Identification via Source, Device Token and Actor

### DIFF
--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
@@ -26,6 +26,7 @@ note = """## Triage and analysis
 This rule detects when a certain threshold of Okta user authentication events are reported for multiple users from the same client address. Adversaries may attempt to launch a credential stuffing attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts. Note that Okta does not log unrecognized usernames supplied during authentication attempts, so this rule may not detect all credential stuffing attempts or may indicate a targeted attack.
 
 #### Possible investigation steps:
+Since this is an ES|QL rule, the `okta.actor.alternate_id` and `okta.client.ip` values can be used to pivot into the raw authentication events related to this activity.
 - Identify the users involved in this action by examining the `okta.actor.id`, `okta.actor.type`, `okta.actor.alternate_id`, and `okta.actor.display_name` fields.
 - Determine the device client used for these actions by analyzing `okta.client.ip`, `okta.client.user_agent.raw_user_agent`, `okta.client.zone`, `okta.client.device`, and `okta.client.id` fields.
 - Review the `okta.security_context.is_proxy` field to determine if the device is a proxy.
@@ -91,8 +92,9 @@ FROM logs-okta*
     BY okta.client.ip, okta.actor.alternate_id
 | WHERE
     source_auth_count > 5
+| SORT
+    source_auth_count DESC
 '''
-
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
@@ -86,7 +86,8 @@ query = '''
 FROM logs-okta*
 | WHERE
     event.dataset == "okta.system"
-    AND event.action RLIKE "user\\.authentication(.*)" OR event.action == "user.session.start"
+    AND (event.action RLIKE "user\\.authentication(.*)" OR event.action == "user.session.start")
+    AND okta.outcome.reason == "INVALID_CREDENTIALS"
 | STATS
     source_auth_count = COUNT_DISTINCT(okta.actor.id)
     BY okta.client.ip, okta.actor.alternate_id

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
@@ -9,7 +9,7 @@ updated_date = "2024/06/17"
 [rule]
 author = ["Elastic"]
 description = """
-Detects when a high number of Okta user authentication events are reported for multiple users in a short time frame. Adversaries may attempt to launch a credential stuffing or password spraying attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts.
+Detects when a certain threshold of Okta user authentication events are reported for multiple users from the same client address. Adversaries may attempt to launch a credential stuffing or password spraying attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts.
 """
 false_positives = [
     "Users may share an endpoint related to work or personal use in which separate Okta accounts are used.",
@@ -19,12 +19,12 @@ from = "now-9m"
 index = ["filebeat-*", "logs-okta*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "Multiple Okta User Authentication Events with Same Device Token Hash"
+name = "Multiple Okta User Authentication Events with Client Address"
 note = """## Triage and analysis
 
-### Investigating Multiple Okta User Authentication Events with Same Device Token Hash
+### Investigating Multiple Okta User Authentication Events with Client Address
 
-This rule detects when a high number of Okta user authentication events are reported for multiple users in a short time frame. Adversaries may attempt to launch a credential stuffing attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts. Note that Okta does not log unrecognized usernames supplied during authentication attempts, so this rule may not detect all credential stuffing attempts or may indicate a targeted attack.
+This rule detects when a certain threshold of Okta user authentication events are reported for multiple users from the same client address. Adversaries may attempt to launch a credential stuffing attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts. Note that Okta does not log unrecognized usernames supplied during authentication attempts, so this rule may not detect all credential stuffing attempts or may indicate a targeted attack.
 
 #### Possible investigation steps:
 - Identify the users involved in this action by examining the `okta.actor.id`, `okta.actor.type`, `okta.actor.alternate_id`, and `okta.actor.display_name` fields.
@@ -38,6 +38,7 @@ This rule detects when a high number of Okta user authentication events are repo
 - Review the `okta.event_type` field to determine the type of authentication event that occurred.
     - If the event type is `user.authentication.sso`, the user may have legitimately started a session via a proxy for security or privacy reasons.
     - If the event type is `user.authentication.password`, the user may be using a proxy to access multiple accounts for password spraying.
+    - If the event type is `user.session.start`, the source may have attempted to establish a session via the Okta authentication API.
 - Examine the `okta.outcome.result` field to determine if the authentication was successful.
 - Review the past activities of the actor(s) involved in this action by checking their previous actions.
 - Evaluate the actions that happened just before and after this event in the `okta.event_type` field to help understand the full context of the activity.
@@ -71,10 +72,10 @@ references = [
     "https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection",
     "https://www.okta.com/resources/whitepaper-how-adaptive-mfa-can-help-in-mitigating-brute-force-attacks/"
 ]
-risk_score = 47
+risk_score = 23
 rule_id = "50887ba8-7ff7-11ee-a038-f661ea17fbcd"
 setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
-severity = "medium"
+severity = "low"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]
 timestamp_override = "event.ingested"
 type = "threshold"
@@ -83,14 +84,12 @@ query = '''
 FROM logs-okta*
 | WHERE
     event.dataset == "okta.system"
-    AND event.action RLIKE "user\\.authentication(.*)"
-    AND okta.debug_context.debug_data.dt_hash != "-"
+    AND event.action RLIKE "user\\.authentication(.*)" OR event.action == "user.session.start"
 | STATS
-    target_auth_count = COUNT_DISTINCT(okta.actor.id)
-    BY okta.debug_context.debug_data.dt_hash, okta.actor.alternate_id
+    source_auth_count = COUNT_DISTINCT(okta.actor.id)
+    BY okta.client.ip, okta.actor.alternate_id
 | WHERE
-    target_auth_count > 20
-| SORT target_auth_count DESC
+    source_auth_count > 5
 '''
 
 

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
@@ -64,6 +64,8 @@ This rule detects when a certain threshold of Okta user authentication events ar
         - Reset passwords and reset MFA for the user.
 - If this is a false positive, consider adding the `okta.debug_context.debug_data.dt_hash` field to the `exceptions` list in the rule.
     - This will prevent future occurrences of this event for this device from triggering the rule.
+    - Alternatively adding `okta.client.ip` or a CIDR range to the `exceptions` list can prevent future occurrences of this event from triggering the rule.
+        - This should be done with caution as it may prevent legitimate alerts from being generated.
 """
 references = [
     "https://support.okta.com/help/s/article/How-does-the-Device-Token-work?language=en_US",
@@ -73,7 +75,7 @@ references = [
     "https://www.okta.com/resources/whitepaper-how-adaptive-mfa-can-help-in-mitigating-brute-force-attacks/"
 ]
 risk_score = 23
-rule_id = "50887ba8-7ff7-11ee-a038-f661ea17fbcd"
+rule_id = "94e734c0-2cda-11ef-84e1-f661ea17fbce"
 setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
 severity = "low"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
@@ -74,7 +74,7 @@ references = [
     "https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection",
     "https://www.okta.com/resources/whitepaper-how-adaptive-mfa-can-help-in-mitigating-brute-force-attacks/"
 ]
-risk_score = 23
+risk_score = 21
 rule_id = "94e734c0-2cda-11ef-84e1-f661ea17fbce"
 setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
 severity = "low"

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
@@ -2,9 +2,9 @@
 creation_date = "2024/06/17"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "ES|QL rule type is still in technical preview as of 8.13, however this rule was tested successfully"
+min_stack_comments = "ES|QL rule type becomes available in 8.13.0 as technical preview."
 min_stack_version = "8.13.0"
-updated_date = "2024/06/17"
+updated_date = "2024/06/20"
 
 [rule]
 author = ["Elastic"]
@@ -86,7 +86,7 @@ query = '''
 FROM logs-okta*
 | WHERE
     event.dataset == "okta.system"
-    AND (event.action RLIKE "user\\.authentication(.*)" OR event.action == "user.session.start")
+    AND (event.action == "user.session.start" OR event.action RLIKE "user\\.authentication(.*)")
     AND okta.outcome.reason == "INVALID_CREDENTIALS"
 | STATS
     source_auth_count = COUNT_DISTINCT(okta.actor.id)

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_from_single_source.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/17"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_comments = "ES|QL rule type is still in technical preview as of 8.13, however this rule was tested successfully"
 min_stack_version = "8.13.0"
 updated_date = "2024/06/17"
 
@@ -16,8 +16,7 @@ false_positives = [
     "Shared systems such as Kiosks and conference room computers may be used by multiple users.",
 ]
 from = "now-9m"
-index = ["filebeat-*", "logs-okta*"]
-language = "kuery"
+language = "esql"
 license = "Elastic License v2"
 name = "Multiple Okta User Authentication Events with Client Address"
 note = """## Triage and analysis
@@ -80,7 +79,7 @@ setup = "The Okta Fleet integration, Filebeat module, or similarly structured da
 severity = "low"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]
 timestamp_override = "event.ingested"
-type = "threshold"
+type = "esql"
 
 query = '''
 FROM logs-okta*

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
@@ -83,7 +83,7 @@ query = '''
 FROM logs-okta*
 | WHERE
     event.dataset == "okta.system"
-    AND event.action RLIKE "user\\.authentication(.*)"
+    AND (event.action RLIKE "user\\.authentication(.*)" OR event.action == "user.session.start")
     AND okta.debug_context.debug_data.dt_hash != "-"
     AND okta.outcome.reason == "INVALID_CREDENTIALS"
 | STATS

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
@@ -72,7 +72,7 @@ references = [
     "https://www.okta.com/resources/whitepaper-how-adaptive-mfa-can-help-in-mitigating-brute-force-attacks/"
 ]
 risk_score = 47
-rule_id = "50887ba8-7ff7-11ee-a038-f661ea17fbcd"
+rule_id = "95b99adc-2cda-11ef-84e1-f661ea17fbce"
 setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
 severity = "medium"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
@@ -2,9 +2,9 @@
 creation_date = "2024/06/17"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "ES|QL rule type is still in technical preview as of 8.13, however this rule was tested successfully"
+min_stack_comments = "ES|QL rule type becomes available in 8.13.0 as technical preview."
 min_stack_version = "8.13.0"
-updated_date = "2024/06/17"
+updated_date = "2024/06/20"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/17"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_comments = "ES|QL rule type is still in technical preview as of 8.13, however this rule was tested successfully"
 min_stack_version = "8.13.0"
 updated_date = "2024/06/17"
 
@@ -16,8 +16,7 @@ false_positives = [
     "Shared systems such as Kiosks and conference room computers may be used by multiple users.",
 ]
 from = "now-9m"
-index = ["filebeat-*", "logs-okta*"]
-language = "kuery"
+language = "esql"
 license = "Elastic License v2"
 name = "Multiple Okta User Authentication Events with Same Device Token Hash"
 note = """## Triage and analysis
@@ -77,7 +76,7 @@ setup = "The Okta Fleet integration, Filebeat module, or similarly structured da
 severity = "medium"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]
 timestamp_override = "event.ingested"
-type = "threshold"
+type = "esql"
 
 query = '''
 FROM logs-okta*

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
@@ -85,6 +85,7 @@ FROM logs-okta*
     event.dataset == "okta.system"
     AND event.action RLIKE "user\\.authentication(.*)"
     AND okta.debug_context.debug_data.dt_hash != "-"
+    AND okta.outcome.reason == "INVALID_CREDENTIALS"
 | STATS
     target_auth_count = COUNT_DISTINCT(okta.actor.id)
     BY okta.debug_context.debug_data.dt_hash, okta.actor.alternate_id

--- a/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
+++ b/rules/integrations/okta/credential_access_okta_authentication_for_multiple_users_with_the_same_device_token_hash.toml
@@ -71,10 +71,10 @@ references = [
     "https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection",
     "https://www.okta.com/resources/whitepaper-how-adaptive-mfa-can-help-in-mitigating-brute-force-attacks/"
 ]
-risk_score = 47
+risk_score = 21
 rule_id = "95b99adc-2cda-11ef-84e1-f661ea17fbce"
 setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
-severity = "medium"
+severity = "low"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/integrations/okta/credential_access_okta_credential_stuffing_by_unique_device.toml
+++ b/rules/integrations/okta/credential_access_okta_credential_stuffing_by_unique_device.toml
@@ -1,0 +1,122 @@
+[metadata]
+creation_date = "2024/06/17"
+integration = ["okta"]
+maturity = "production"
+min_stack_comments = "Breaking change in Okta integration bumping version to ^2.0.0"
+min_stack_version = "8.13.0"
+updated_date = "2024/06/17"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when a high number of Okta user authentication events are reported for multiple users in a short time frame. Adversaries may attempt to launch a credential stuffing or password spraying attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts.
+"""
+false_positives = [
+    "Users may share an endpoint related to work or personal use in which separate Okta accounts are used.",
+    "Shared systems such as Kiosks and conference room computers may be used by multiple users.",
+]
+from = "now-9m"
+index = ["filebeat-*", "logs-okta*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Multiple Okta User Authentication Events with Same Device Token Hash"
+note = """## Triage and analysis
+
+### Investigating Multiple Okta User Authentication Events with Same Device Token Hash
+
+This rule detects when a high number of Okta user authentication events are reported for multiple users in a short time frame. Adversaries may attempt to launch a credential stuffing attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts. Note that Okta does not log unrecognized usernames supplied during authentication attempts, so this rule may not detect all credential stuffing attempts or may indicate a targeted attack.
+
+#### Possible investigation steps:
+- Identify the users involved in this action by examining the `okta.actor.id`, `okta.actor.type`, `okta.actor.alternate_id`, and `okta.actor.display_name` fields.
+- Determine the device client used for these actions by analyzing `okta.client.ip`, `okta.client.user_agent.raw_user_agent`, `okta.client.zone`, `okta.client.device`, and `okta.client.id` fields.
+- Review the `okta.security_context.is_proxy` field to determine if the device is a proxy.
+    - If the device is a proxy, this may indicate that a user is using a proxy to access multiple accounts for password spraying.
+- With the list of `okta.actor.alternate_id` values, review `event.outcome` results to determine if the authentication was successful.
+    - If the authentication was successful for any user, pivoting to `event.action` values for those users may provide additional context.
+- With Okta end users identified, review the `okta.debug_context.debug_data.dt_hash` field.
+    - Historical analysis should indicate if this device token hash is commonly associated with the user.
+- Review the `okta.event_type` field to determine the type of authentication event that occurred.
+    - If the event type is `user.authentication.sso`, the user may have legitimately started a session via a proxy for security or privacy reasons.
+    - If the event type is `user.authentication.password`, the user may be using a proxy to access multiple accounts for password spraying.
+- Examine the `okta.outcome.result` field to determine if the authentication was successful.
+- Review the past activities of the actor(s) involved in this action by checking their previous actions.
+- Evaluate the actions that happened just before and after this event in the `okta.event_type` field to help understand the full context of the activity.
+    - This may help determine the authentication and authorization actions that occurred between the user, Okta and application.
+
+### False positive analysis:
+- A user may have legitimately started a session via a proxy for security or privacy reasons.
+- Users may share an endpoint related to work or personal use in which separate Okta accounts are used.
+    - Architecturally, this shared endpoint may leverage a proxy for security or privacy reasons.
+    - Shared systems such as Kiosks and conference room computers may be used by multiple users.
+    - Shared working spaces may have a single endpoint that is used by multiple users.
+
+### Response and remediation:
+- Review the profile of the users involved in this action to determine if proxy usage may be expected.
+- If the user is legitimate and the authentication behavior is not suspicious based on device analysis, no action is required.
+- If the user is legitimate but the authentication behavior is suspicious, consider resetting passwords for the users involves and enabling multi-factor authentication (MFA).
+    - If MFA is already enabled, consider resetting MFA for the users.
+- If any of the users are not legitimate, consider deactivating the user's account.
+- Conduct a review of Okta policies and ensure they are in accordance with security best practices.
+- Check with internal IT teams to determine if the accounts involved recently had MFA reset at the request of the user.
+    - If so, confirm with the user this was a legitimate request.
+    - If so and this was not a legitimate request, consider deactivating the user's account temporarily.
+        - Reset passwords and reset MFA for the user.
+- If this is a false positive, consider adding the `okta.debug_context.debug_data.dt_hash` field to the `exceptions` list in the rule.
+    - This will prevent future occurrences of this event for this device from triggering the rule.
+"""
+references = [
+    "https://developer.okta.com/docs/reference/api/system-log/",
+    "https://developer.okta.com/docs/reference/api/event-types/",
+    "https://www.elastic.co/security-labs/testing-okta-visibility-and-detection-dorothy",
+    "https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection",
+    "https://www.okta.com/resources/whitepaper-how-adaptive-mfa-can-help-in-mitigating-brute-force-attacks/"
+]
+risk_score = 47
+rule_id = "50887ba8-7ff7-11ee-a038-f661ea17fbcd"
+setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
+severity = "medium"
+tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]
+timestamp_override = "event.ingested"
+type = "threshold"
+
+query = '''
+FROM logs-okta*
+| WHERE
+    event.dataset == "okta.system"
+    AND event.action RLIKE "user\\.authentication(.*)"
+    AND okta.debug_context.debug_data.dt_hash != "-"
+| STATS
+    target_auth_count = COUNT_DISTINCT(okta.actor.id)
+    BY okta.debug_context.debug_data.dt_hash, okta.actor.alternate_id
+| WHERE
+    target_auth_count > 20
+| SORT target_auth_count DESC
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+    [[rule.threat.technique.subtechnique]]
+    id = "T1110.003"
+    name = "Password Spraying"
+    reference = "https://attack.mitre.org/techniques/T1110/003/"
+
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+    [[rule.threat.technique.subtechnique]]
+    id = "T1110.004"
+    name = "Credential Stuffing"
+    reference = "https://attack.mitre.org/techniques/T1110/004/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/integrations/okta/credential_access_okta_multiple_device_token_hashes_for_single_user.toml
+++ b/rules/integrations/okta/credential_access_okta_multiple_device_token_hashes_for_single_user.toml
@@ -86,8 +86,9 @@ query = '''
 FROM logs-okta*
 | WHERE
     event.dataset == "okta.system"
-    AND event.action RLIKE "user\\.authentication(.*)" OR event.action == "user.session.start"
+    AND (event.action RLIKE "user\\.authentication(.*)" OR event.action == "user.session.start")
     AND okta.debug_context.debug_data.request_uri == "/api/v1/authn"
+    AND okta.outcome.reason == "INVALID_CREDENTIALS"
 | STATS
     source_auth_count = COUNT_DISTINCT(okta.debug_context.debug_data.dt_hash)
     BY okta.client.ip, okta.actor.alternate_id

--- a/rules/integrations/okta/credential_access_okta_multiple_device_token_hashes_for_single_user.toml
+++ b/rules/integrations/okta/credential_access_okta_multiple_device_token_hashes_for_single_user.toml
@@ -74,10 +74,10 @@ references = [
     "https://sec.okta.com/articles/2023/08/cross-tenant-impersonation-prevention-and-detection",
     "https://www.okta.com/resources/whitepaper-how-adaptive-mfa-can-help-in-mitigating-brute-force-attacks/"
 ]
-risk_score = 47
+risk_score = 21
 rule_id = "23f18264-2d6d-11ef-9413-f661ea17fbce"
 setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
-severity = "medium"
+severity = "low"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/integrations/okta/credential_access_okta_multiple_device_token_hashes_for_single_user.toml
+++ b/rules/integrations/okta/credential_access_okta_multiple_device_token_hashes_for_single_user.toml
@@ -2,9 +2,9 @@
 creation_date = "2024/06/17"
 integration = ["okta"]
 maturity = "production"
-min_stack_comments = "ES|QL rule type is still in technical preview as of 8.13, however this rule was tested successfully"
+min_stack_comments = "ES|QL rule type becomes available in 8.13.0 as technical preview."
 min_stack_version = "8.13.0"
-updated_date = "2024/06/17"
+updated_date = "2024/06/20"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/okta/credential_access_okta_multiple_device_token_hashes_for_single_user.toml
+++ b/rules/integrations/okta/credential_access_okta_multiple_device_token_hashes_for_single_user.toml
@@ -9,7 +9,7 @@ updated_date = "2024/06/17"
 [rule]
 author = ["Elastic"]
 description = """
-Detects when a high number of Okta user authentication events are reported for multiple users in a short time frame. Adversaries may attempt to launch a credential stuffing or password spraying attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts.
+Detects when an Okta client address has a certain threshold of Okta user authentication events with multiple device token hashes generated for single user authentication. Adversaries may attempt to launch a credential stuffing or password spraying attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts.
 """
 false_positives = [
     "Users may share an endpoint related to work or personal use in which separate Okta accounts are used.",
@@ -18,15 +18,15 @@ false_positives = [
 from = "now-9m"
 language = "esql"
 license = "Elastic License v2"
-name = "Multiple Okta User Authentication Events with Same Device Token Hash"
+name = "High Number of Okta Device Token Cookies Generated for Authentication"
 note = """## Triage and analysis
 
-### Investigating Multiple Okta User Authentication Events with Same Device Token Hash
+### Investigating High Number of Okta Device Token Cookies Generated for Authentication
 
-This rule detects when a high number of Okta user authentication events are reported for multiple users in a short time frame. Adversaries may attempt to launch a credential stuffing attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts. Note that Okta does not log unrecognized usernames supplied during authentication attempts, so this rule may not detect all credential stuffing attempts or may indicate a targeted attack.
+This rule detects when a certain threshold of Okta user authentication events are reported for multiple users from the same client address. Adversaries may attempt to launch a credential stuffing attack from the same device by using a list of known usernames and passwords to gain unauthorized access to user accounts. Note that Okta does not log unrecognized usernames supplied during authentication attempts, so this rule may not detect all credential stuffing attempts or may indicate a targeted attack.
 
 #### Possible investigation steps:
-- Since this is an ES|QL rule, the `okta.actor.alternate_id` and `okta.debug_context.debug_data.dt_hash` values can be used to pivot into the raw authentication events related to this activity.
+- Since this is an ES|QL rule, the `okta.actor.alternate_id` and `okta.client.ip` values can be used to pivot into the raw authentication events related to this activity.
 - Identify the users involved in this action by examining the `okta.actor.id`, `okta.actor.type`, `okta.actor.alternate_id`, and `okta.actor.display_name` fields.
 - Determine the device client used for these actions by analyzing `okta.client.ip`, `okta.client.user_agent.raw_user_agent`, `okta.client.zone`, `okta.client.device`, and `okta.client.id` fields.
 - Review the `okta.security_context.is_proxy` field to determine if the device is a proxy.
@@ -38,6 +38,7 @@ This rule detects when a high number of Okta user authentication events are repo
 - Review the `okta.event_type` field to determine the type of authentication event that occurred.
     - If the event type is `user.authentication.sso`, the user may have legitimately started a session via a proxy for security or privacy reasons.
     - If the event type is `user.authentication.password`, the user may be using a proxy to access multiple accounts for password spraying.
+    - If the event type is `user.session.start`, the source may have attempted to establish a session via the Okta authentication API.
 - Examine the `okta.outcome.result` field to determine if the authentication was successful.
 - Review the past activities of the actor(s) involved in this action by checking their previous actions.
 - Evaluate the actions that happened just before and after this event in the `okta.event_type` field to help understand the full context of the activity.
@@ -63,6 +64,8 @@ This rule detects when a high number of Okta user authentication events are repo
         - Reset passwords and reset MFA for the user.
 - If this is a false positive, consider adding the `okta.debug_context.debug_data.dt_hash` field to the `exceptions` list in the rule.
     - This will prevent future occurrences of this event for this device from triggering the rule.
+    - Alternatively adding `okta.client.ip` or a CIDR range to the `exceptions` list can prevent future occurrences of this event from triggering the rule.
+        - This should be done with caution as it may prevent legitimate alerts from being generated.
 """
 references = [
     "https://support.okta.com/help/s/article/How-does-the-Device-Token-work?language=en_US",
@@ -72,7 +75,7 @@ references = [
     "https://www.okta.com/resources/whitepaper-how-adaptive-mfa-can-help-in-mitigating-brute-force-attacks/"
 ]
 risk_score = 47
-rule_id = "95b99adc-2cda-11ef-84e1-f661ea17fbce"
+rule_id = "23f18264-2d6d-11ef-9413-f661ea17fbce"
 setup = "The Okta Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule."
 severity = "medium"
 tags = ["Use Case: Identity and Access Audit", "Data Source: Okta", "Tactic: Credential Access"]
@@ -83,15 +86,15 @@ query = '''
 FROM logs-okta*
 | WHERE
     event.dataset == "okta.system"
-    AND event.action RLIKE "user\\.authentication(.*)"
-    AND okta.debug_context.debug_data.dt_hash != "-"
+    AND event.action RLIKE "user\\.authentication(.*)" OR event.action == "user.session.start"
+    AND okta.debug_context.debug_data.request_uri == "/api/v1/authn"
 | STATS
-    target_auth_count = COUNT_DISTINCT(okta.actor.id)
-    BY okta.debug_context.debug_data.dt_hash, okta.actor.alternate_id
+    source_auth_count = COUNT_DISTINCT(okta.debug_context.debug_data.dt_hash)
+    BY okta.client.ip, okta.actor.alternate_id
 | WHERE
-    target_auth_count > 20
+    source_auth_count >= 30
 | SORT
-    target_auth_count DESC
+    source_auth_count DESC
 '''
 
 


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/271

## Summary
This pull request adds new threat detection rules for Okta data that identify potential credential stuffing or password spraying attempt by adversaries. These rules leverage ES|QL to aggregate specific attributes of the authentication requests that should identify anomalies based on high counts.

These rules focus primarily on authentication via Okta's API endpoint `/api/v1/authn` which adversaries often use to test stolen credentials from infostealers or third-party markets. 

#### Additional Information
- Okta's Device Token Hash (`okta.debug_context.debug_data.dt_hash`) is a cookie used to identify client devices, and once an authenticated session is established, remains persistent for the lifetime of the session. However, if a request is invalid, a new device token hash cookie will be generated.
- We do not limit the activity to successful due to the nature of credential stuffing and password spraying where we need to properly account for both failed and successful.
- Okta will not log authentication attempts for accounts it does not recognize, therefore if these fire and are not FP it could be targeted as the adversary needs to know the Okta domain for the customer as well
- Low priority has been assigned to these rules because of how common credential stuffing and password spraying are, as well as these not indicating a compromised user, but rather an attempt externally








