### PR TITLE
[Rule Tuning]: Fix threat_index and filters in Rapid7 CVE rule

### DIFF
--- a/rules/integrations/aws/privilege_escalation_sts_assumerole_usage.toml
+++ b/rules/integrations/aws/privilege_escalation_sts_assumerole_usage.toml
@@ -2,6 +2,8 @@
 creation_date = "2021/05/17"
 integration = ["aws"]
 maturity = "production"
+min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
+min_stack_version = "8.9.0"
 updated_date = "2024/05/21"
 
 [rule]
@@ -34,7 +36,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.dataset:aws.cloudtrail and event.provider:sts.amazonaws.com and event.action:AssumedRole and
+event.dataset:aws.cloudtrail and event.provider:sts.amazonaws.com and event.action:AssumeRole and
 aws.cloudtrail.user_identity.session_context.session_issuer.type:Role and event.outcome:success
 '''
 

--- a/rules/threat_intel/threat_intel_rapid7_threat_command.toml
+++ b/rules/threat_intel/threat_intel_rapid7_threat_command.toml
@@ -76,7 +76,7 @@ tags = [
     "Use Case: Asset Visibility",
     "Use Case: Continuous Monitoring",
 ]
-threat_index = ["logs-ti_rapid7_threat_command_latest.ioc"]
+threat_index = ["logs-ti_rapid7_threat_command_latest.vulnerability"]
 threat_indicator_path = "rapid7.tc.vulnerability"
 threat_language = "kuery"
 threat_query = """
@@ -90,16 +90,16 @@ vulnerability.id : *
 '''
 
 
-[[rule.threat_filters]]
+[[rule.filters]]
 
-[rule.threat_filters."$state"]
+[rule.filters."$state"]
 store = "appState"
-[rule.threat_filters.meta]
+[rule.filters.meta]
 disabled = false
 key = "rapid7.tc.vulnerability.id"
 negate = true
 type = "exists"
-[rule.threat_filters.query.exists]
+[rule.filters.query.exists]
 field = "rapid7.tc.vulnerability.id"
 [[rule.threat_mapping]]
 

--- a/rules/threat_intel/threat_intel_rapid7_threat_command.toml
+++ b/rules/threat_intel/threat_intel_rapid7_threat_command.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/05/29"
 integration = ["ti_rapid7_threat_command"]
 maturity = "production"
-updated_date = "2024/06/12"
+updated_date = "2024/06/20"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->

## Issues
<!-- Link to related issues. Use closing keywords when appropriate -->
The existing Rapid7 CVEs rule is querying on wrong `threat_index` and `filters`.

## Summary
1. The `threat_index` value is updated to `logs-ti_rapid7_threat_command_latest.vulnerability` which represents the index for storing vulnerabilities. Previously, the rule was pointing at `logs-ti_rapid7_threat_command_latest.ioc` which represents threat indicators.
2. Fixes the `filters` as they are wrongly applied to `threat_filters` as per https://github.com/elastic/integrations/issues/7360#issuecomment-2138798243.


## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
