### PR TITLE
[FR] [DAC] Update default KQL parsing behavior to normalize keywords for custom rule directories.

### DIFF
--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -19,7 +19,6 @@ from .utils import cached, load_etc_dump, get_etc_path
 
 ROOT_DIR = Path(__file__).parent.parent
 CUSTOM_RULES_DIR = os.getenv('CUSTOM_RULES_DIR', None)
-NORMALIZE_KQL_KEYWORDS = os.getenv('NORMALIZE_KQL_KEYWORDS', None)
 
 
 @dataclass
@@ -190,6 +189,7 @@ class RulesConfig:
     bbr_rules_dirs: Optional[List[Path]] = field(default_factory=list)
     bypass_version_lock: bool = False
     exception_dir: Optional[Path] = None
+    normalize_kql_keywords: bool = True
 
     def __post_init__(self):
         """Perform post validation on packages.yaml file."""
@@ -271,6 +271,9 @@ def parse_rules_config(path: Optional[Path] = None) -> RulesConfig:
     # paths are relative
     if loaded.get('bbr_rules_dirs'):
         contents['bbr_rules_dirs'] = [base_dir.joinpath(d).resolve() for d in loaded.get('bbr_rules_dirs', [])]
+
+    # kql keyword normalization
+    contents['normalize_kql_keywords'] = loaded.get('normalize_kql_keywords', True)
 
     try:
         rules_config = RulesConfig(test_config=test_config, **contents)

--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -19,6 +19,7 @@ from .utils import cached, load_etc_dump, get_etc_path
 
 ROOT_DIR = Path(__file__).parent.parent
 CUSTOM_RULES_DIR = os.getenv('CUSTOM_RULES_DIR', None)
+NORMALIZE_KQL_KEYWORDS = os.getenv('NORMALIZE_KQL_KEYWORDS', None)
 
 
 @dataclass

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -33,6 +33,7 @@ from . import attack, rule_loader, utils
 from .beats import (download_beats_schema, download_latest_beats_schema,
                     refresh_main_schema)
 from .cli_utils import single_collection
+from .config import parse_rules_config
 from .docs import IntegrationSecurityDocs, IntegrationSecurityDocsMDX
 from .ecs import download_endpoint_schemas, download_schemas
 from .endgame import EndgameSchemaManager
@@ -50,7 +51,7 @@ from .packaging import (CURRENT_RELEASE_PATH, PACKAGE_FILE, RELEASE_DIR,
                         Package)
 from .rule import (AnyRuleData, BaseRuleData, DeprecatedRule, QueryRuleData,
                    RuleTransform, ThreatMapping, TOMLRule, TOMLRuleContents)
-from .rule_loader import RULES_CONFIG, RuleCollection, production_filter
+from .rule_loader import RuleCollection, production_filter
 from .schemas import definitions, get_stack_versions
 from .utils import dict_hash, get_etc_path, get_path, load_dump
 from .version_lock import VersionLockFile, loaded_version_lock
@@ -61,6 +62,7 @@ NAVIGATOR_URL = 'https://ela.st/detection-rules-navigator'
 NAVIGATOR_BADGE = (
     f'[![ATT&CK navigator coverage](https://img.shields.io/badge/ATT&CK-Navigator-red.svg)]({NAVIGATOR_URL})'
 )
+RULES_CONFIG = parse_rules_config()
 
 
 def get_github_token() -> Optional[str]:

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -17,6 +17,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch.client import AsyncSearchClient
 
 import kql
+from .config import parse_rules_config
 from .main import root
 from .misc import add_params, client_error, elasticsearch_options, get_elasticsearch_client, nested_get
 from .rule import TOMLRule
@@ -26,6 +27,7 @@ from .utils import format_command_options, normalize_timing_and_sort, unix_time_
 
 COLLECTION_DIR = get_path('collections')
 MATCH_ALL = {'bool': {'filter': [{'match_all': {}}]}}
+RULES_CONFIG = parse_rules_config()
 
 
 def add_range_to_dsl(dsl_filter, start_time, end_time='now'):
@@ -92,7 +94,7 @@ class RtaEvents:
         rule = RuleCollection.default().id_map.get(rule_id)
         assert rule is not None, f"Unable to find rule with ID {rule_id}"
         merged_events = combine_sources(*self.events.values())
-        filtered = evaluate(rule, merged_events)
+        filtered = evaluate(rule, merged_events, normalize_kql_keywords=RULES_CONFIG.normalize_kql_keywords)
 
         if filtered:
             sources = [e['agent']['type'] for e in filtered]

--- a/detection_rules/etc/_config.yaml
+++ b/detection_rules/etc/_config.yaml
@@ -8,7 +8,7 @@ files:
   packages: packages.yaml
   stack_schema_map: stack-schema-map.yaml
   version_lock: version.lock.json
-
+normalize_kql_keywords: False
 # Set the versioning strategy.
 # 1. Set to False to use version.lock.json file
 # 2. Set to True to either:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -26,7 +26,7 @@ from marshmallow import ValidationError, validates_schema
 import kql
 
 from . import beats, ecs, endgame, utils
-from .config import NORMALIZE_KQL_KEYWORDS, load_current_package_version, parse_rules_config
+from .config import load_current_package_version, parse_rules_config
 from .integrations import (find_least_compatible_version, get_integration_schema_fields,
                            load_integrations_manifests, load_integrations_schemas,
                            parse_datasets)
@@ -1526,7 +1526,7 @@ def get_unique_query_fields(rule: TOMLRule) -> List[str]:
 
         cfg = set_eql_config(rule.contents.metadata.get('min_stack_version'))
         with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions, eql.parser.skip_optimizations, cfg:
-            parsed = (kql.parse(query, normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
+            parsed = (kql.parse(query, normalize_kql_keywords=RULES_CONFIG.normalize_kql_keywords)
                       if language == 'kuery' else eql.parse_query(query))
         return sorted(set(str(f) for f in parsed if isinstance(f, (eql.ast.Field, kql.ast.Field))))
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -26,7 +26,7 @@ from marshmallow import ValidationError, validates_schema
 import kql
 
 from . import beats, ecs, endgame, utils
-from .config import CUSTOM_RULES_DIR, load_current_package_version, parse_rules_config
+from .config import NORMALIZE_KQL_KEYWORDS, load_current_package_version, parse_rules_config
 from .integrations import (find_least_compatible_version, get_integration_schema_fields,
                            load_integrations_manifests, load_integrations_schemas,
                            parse_datasets)
@@ -1526,7 +1526,7 @@ def get_unique_query_fields(rule: TOMLRule) -> List[str]:
 
         cfg = set_eql_config(rule.contents.metadata.get('min_stack_version'))
         with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions, eql.parser.skip_optimizations, cfg:
-            parsed = (kql.parse(query, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
+            parsed = (kql.parse(query, normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
                       if language == 'kuery' else eql.parse_query(query))
         return sorted(set(str(f) for f in parsed if isinstance(f, (eql.ast.Field, kql.ast.Field))))
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1526,8 +1526,8 @@ def get_unique_query_fields(rule: TOMLRule) -> List[str]:
 
         cfg = set_eql_config(rule.contents.metadata.get('min_stack_version'))
         with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions, eql.parser.skip_optimizations, cfg:
-            parsed = kql.parse(query, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None)) if language == 'kuery' else eql.parse_query(query)
-
+            parsed = (kql.parse(query, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
+                      if language == 'kuery' else eql.parse_query(query))
         return sorted(set(str(f) for f in parsed if isinstance(f, (eql.ast.Field, kql.ast.Field))))
 
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -26,7 +26,7 @@ from marshmallow import ValidationError, validates_schema
 import kql
 
 from . import beats, ecs, endgame, utils
-from .config import load_current_package_version, parse_rules_config
+from .config import CUSTOM_RULES_DIR, load_current_package_version, parse_rules_config
 from .integrations import (find_least_compatible_version, get_integration_schema_fields,
                            load_integrations_manifests, load_integrations_schemas,
                            parse_datasets)
@@ -1526,7 +1526,7 @@ def get_unique_query_fields(rule: TOMLRule) -> List[str]:
 
         cfg = set_eql_config(rule.contents.metadata.get('min_stack_version'))
         with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions, eql.parser.skip_optimizations, cfg:
-            parsed = kql.parse(query) if language == 'kuery' else eql.parse_query(query)
+            parsed = kql.parse(query, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None)) if language == 'kuery' else eql.parse_query(query)
 
         return sorted(set(str(f) for f in parsed if isinstance(f, (eql.ast.Field, kql.ast.Field))))
 

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -212,8 +212,8 @@ class KQLValidator(QueryValidator):
 
             # Validate the query against the schema
             try:
-                kql.parse(self.query, 
-                          schema=integration_schema, 
+                kql.parse(self.query,
+                          schema=integration_schema,
                           normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
             except kql.KqlParseError as exc:
                 if exc.error_msg == "Unknown field":

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -18,7 +18,7 @@ from semver import Version
 import kql
 
 from . import ecs, endgame
-from .config import CUSTOM_RULES_DIR, load_current_package_version
+from .config import CUSTOM_RULES_DIR, NORMALIZE_KQL_KEYWORDS, load_current_package_version
 from .integrations import (get_integration_schema_data,
                            load_integrations_manifests)
 from .rule import (EQLRuleData, QueryRuleData, QueryValidator, RuleMeta,
@@ -107,7 +107,7 @@ class KQLValidator(QueryValidator):
 
     @cached_property
     def ast(self) -> kql.ast.Expression:
-        return kql.parse(self.query, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
+        return kql.parse(self.query, normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
 
     @cached_property
     def unique_fields(self) -> List[str]:
@@ -151,7 +151,7 @@ class KQLValidator(QueryValidator):
                                                                     beats_version, ecs_version)
 
             try:
-                kql.parse(self.query, schema=schema, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
+                kql.parse(self.query, schema=schema, normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
             except kql.KqlParseError as exc:
                 message = exc.error_msg
                 trailer = err_trailer
@@ -212,7 +212,9 @@ class KQLValidator(QueryValidator):
 
             # Validate the query against the schema
             try:
-                kql.parse(self.query, schema=integration_schema, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
+                kql.parse(self.query, 
+                          schema=integration_schema, 
+                          normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
             except kql.KqlParseError as exc:
                 if exc.error_msg == "Unknown field":
                     field = extract_error_field(self.query, exc)

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -107,7 +107,7 @@ class KQLValidator(QueryValidator):
 
     @cached_property
     def ast(self) -> kql.ast.Expression:
-        return kql.parse(self.query)
+        return kql.parse(self.query, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
 
     @cached_property
     def unique_fields(self) -> List[str]:
@@ -151,7 +151,7 @@ class KQLValidator(QueryValidator):
                                                                     beats_version, ecs_version)
 
             try:
-                kql.parse(self.query, schema=schema)
+                kql.parse(self.query, schema=schema, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
             except kql.KqlParseError as exc:
                 message = exc.error_msg
                 trailer = err_trailer
@@ -212,7 +212,7 @@ class KQLValidator(QueryValidator):
 
             # Validate the query against the schema
             try:
-                kql.parse(self.query, schema=integration_schema)
+                kql.parse(self.query, schema=integration_schema, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
             except kql.KqlParseError as exc:
                 if exc.error_msg == "Unknown field":
                     field = extract_error_field(self.query, exc)

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -31,7 +31,7 @@ from eql.utils import load_dump, stream_json_lines
 import kql
 
 # Cannot import from detection_rules.config due to circular imports
-CUSTOM_RULES_DIR = os.getenv('CUSTOM_RULES_DIR', None)
+NORMALIZE_KQL_KEYWORDS = os.getenv('NORMALIZE_KQL_KEYWORDS', None)
 
 CURR_DIR = Path(__file__).resolve().parent
 ROOT_DIR = CURR_DIR.parent
@@ -245,7 +245,7 @@ def convert_time_span(span: str) -> int:
 
 def evaluate(rule, events):
     """Evaluate a query against events."""
-    evaluator = kql.get_evaluator(kql.parse(rule.query), normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
+    evaluator = kql.get_evaluator(kql.parse(rule.query), normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
     filtered = list(filter(evaluator, events))
     return filtered
 

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -30,6 +30,9 @@ from eql.utils import load_dump, stream_json_lines
 
 import kql
 
+# Cannot import from detection_rules.config due to circular imports
+CUSTOM_RULES_DIR = os.getenv('CUSTOM_RULES_DIR', None)
+
 CURR_DIR = Path(__file__).resolve().parent
 ROOT_DIR = CURR_DIR.parent
 ETC_DIR = ROOT_DIR / "detection_rules" / "etc"
@@ -242,7 +245,7 @@ def convert_time_span(span: str) -> int:
 
 def evaluate(rule, events):
     """Evaluate a query against events."""
-    evaluator = kql.get_evaluator(kql.parse(rule.query))
+    evaluator = kql.get_evaluator(kql.parse(rule.query), normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
     filtered = list(filter(evaluator, events))
     return filtered
 

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -30,8 +30,6 @@ from eql.utils import load_dump, stream_json_lines
 
 import kql
 
-# Cannot import from detection_rules.config due to circular imports
-NORMALIZE_KQL_KEYWORDS = os.getenv('NORMALIZE_KQL_KEYWORDS', None)
 
 CURR_DIR = Path(__file__).resolve().parent
 ROOT_DIR = CURR_DIR.parent
@@ -243,9 +241,9 @@ def convert_time_span(span: str) -> int:
     return eql.ast.TimeRange(amount, unit).as_milliseconds()
 
 
-def evaluate(rule, events):
+def evaluate(rule, events, normalize_kql_keywords: bool = False):
     """Evaluate a query against events."""
-    evaluator = kql.get_evaluator(kql.parse(rule.query), normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
+    evaluator = kql.get_evaluator(kql.parse(rule.query), normalize_kql_keywords=normalize_kql_keywords)
     filtered = list(filter(evaluator, events))
     return filtered
 

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -113,6 +113,7 @@ class RulesConfig:
     bbr_rules_dirs: Optional[List[Path]] = field(default_factory=list)
     bypass_version_lock: bool = False
     exception_dir: Optional[Path] = None
+    normalize_kql_keywords: bool = True
 
 # using the stack_schema_map
 RULES_CONFIG.stack_schema_map

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -19,7 +19,7 @@ from semver import Version
 
 import kql
 from detection_rules import attack
-from detection_rules.config import CUSTOM_RULES_DIR, load_current_package_version
+from detection_rules.config import NORMALIZE_KQL_KEYWORDS, load_current_package_version
 from detection_rules.integrations import (find_latest_compatible_version,
                                           load_integrations_manifests,
                                           load_integrations_schemas)
@@ -67,7 +67,7 @@ class TestValidRules(BaseRuleTest):
                 )
             ):
                 source = rule.contents.data.query
-                tree = kql.parse(source, optimize=False, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
+                tree = kql.parse(source, optimize=False, normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
                 optimized = tree.optimize(recursive=True)
                 err_message = f'\n{self.rule_str(rule)} Query not optimized for rule\n' \
                               f'Expected: {optimized}\nActual: {source}'

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -19,7 +19,7 @@ from semver import Version
 
 import kql
 from detection_rules import attack
-from detection_rules.config import NORMALIZE_KQL_KEYWORDS, load_current_package_version
+from detection_rules.config import load_current_package_version
 from detection_rules.integrations import (find_latest_compatible_version,
                                           load_integrations_manifests,
                                           load_integrations_schemas)
@@ -67,7 +67,7 @@ class TestValidRules(BaseRuleTest):
                 )
             ):
                 source = rule.contents.data.query
-                tree = kql.parse(source, optimize=False, normalize_kql_keywords=(NORMALIZE_KQL_KEYWORDS is not None))
+                tree = kql.parse(source, optimize=False, normalize_kql_keywords=RULES_CONFIG.normalize_kql_keywords)
                 optimized = tree.optimize(recursive=True)
                 err_message = f'\n{self.rule_str(rule)} Query not optimized for rule\n' \
                               f'Expected: {optimized}\nActual: {source}'

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -19,7 +19,7 @@ from semver import Version
 
 import kql
 from detection_rules import attack
-from detection_rules.config import load_current_package_version
+from detection_rules.config import CUSTOM_RULES_DIR, load_current_package_version
 from detection_rules.integrations import (find_latest_compatible_version,
                                           load_integrations_manifests,
                                           load_integrations_schemas)
@@ -67,7 +67,7 @@ class TestValidRules(BaseRuleTest):
                 )
             ):
                 source = rule.contents.data.query
-                tree = kql.parse(source, optimize=False)
+                tree = kql.parse(source, optimize=False, normalize_kql_keywords=(CUSTOM_RULES_DIR is not None))
                 optimized = tree.optimize(recursive=True)
                 err_message = f'\n{self.rule_str(rule)} Query not optimized for rule\n' \
                               f'Expected: {optimized}\nActual: {source}'

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -10,6 +10,7 @@ import warnings
 
 from . import get_data_files, get_fp_data_files
 from detection_rules.utils import combine_sources, evaluate, load_etc_dump
+from detection_rules.rule_loader import RULES_CONFIG
 from rta import get_available_tests
 from .base import BaseRuleTest
 
@@ -21,7 +22,7 @@ class TestMappings(BaseRuleTest):
 
     def evaluate(self, documents, rule, expected, msg):
         """KQL engine to evaluate."""
-        filtered = evaluate(rule, documents)
+        filtered = evaluate(rule, documents, RULES_CONFIG.normalize_kql_keywords)
         self.assertEqual(expected, len(filtered), msg)
         return filtered
 

--- a/tests/test_mappings.py
+++ b/tests/test_mappings.py
@@ -9,10 +9,13 @@ import unittest
 import warnings
 
 from . import get_data_files, get_fp_data_files
+from detection_rules.config import parse_rules_config
 from detection_rules.utils import combine_sources, evaluate, load_etc_dump
-from detection_rules.rule_loader import RULES_CONFIG
 from rta import get_available_tests
 from .base import BaseRuleTest
+
+
+RULES_CONFIG = parse_rules_config()
 
 
 class TestMappings(BaseRuleTest):


### PR DESCRIPTION
## Related Issue:
https://github.com/elastic/detection-rules/issues/3624

## Related PRs:
https://github.com/elastic/detection-rules/pull/3574

## Summary
This PR updates the default KQL parsing behavior when a custom rule directory is set. Now when the `NORMALIZE_KQL_KEYWORDS` environment variable is set, the normalization flag is set to `True`

## Testing

Make a custom KQL rule and modify the keyword to be upper case and test with view rule.

<details><summary>Example KQL Rule</summary>
<p>

```
[metadata]
creation_date = "2023/05/22"
maturity = "production"
updated_date = "2024/05/21"

[transform]
[[transform.osquery]]
label = "Osquery - Retrieve DNS Cache"
query = "SELECT * FROM dns_cache"

[[transform.osquery]]
label = "Osquery - Retrieve All Services"
query = "SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services"

[[transform.osquery]]
label = "Osquery - Retrieve Services Running on User Accounts"
query = """
SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE
NOT (user_account LIKE '%LocalSystem' OR user_account LIKE '%LocalService' OR user_account LIKE '%NetworkService' OR
user_account == null)
"""

[[transform.osquery]]
label = "Osquery - Retrieve Service Unsigned Executables with Virustotal Link"
query = """
SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid,
services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path =
authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != 'trusted'
"""


[rule]
author = ["Elastic"]
description = """
This rule is triggered when a hash indicator from the Threat Intel Filebeat module or integrations has a match against
an event that contains file hashes, such as antivirus alerts, process creation, library load, and file operation events.
"""
from = "now-65m"
index = ["auditbeat-*", "endgame-*", "filebeat-*", "logs-*", "winlogbeat-*"]
interval = "1h"
language = "kuery"
license = "Elastic License v2"
name = "Test Threat Intel Hash Indicator Match"
note = """## Triage and Analysis

fing the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
"""
references = [
    "https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-threatintel.html",
    "https://www.elastic.co/guide/en/security/master/es-threat-intel-integrations.html",
    "https://www.elastic.co/security/tip",
]
risk_score = 99
rule_id = "f62a0edd-4cf3-46fe-b5f2-58fd23db991e"
setup = """## Setup

This rule needs threat intelligence indicators to work.
Threat intelligence indicators can be collected using an [Elastic Agent integration](https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html#agent-ti-integration),
the [Threat Intel module](https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html#ti-mod-integration),
or a [custom integration](https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html#custom-ti-integration).

More information can be found [here](https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html).
"""
severity = "critical"
tags = ["OS: Windows", "Data Source: Elastic Endgame", "Rule Type: Indicator Match"]
threat_index = ["filebeat-*", "logs-ti_*"]
threat_indicator_path = "threat.indicator"
threat_language = "kuery"
threat_query = """
@timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and (threat.indicator.file.hash.*:* or
threat.indicator.file.pe.imphash:*) and not labels.is_ioc_transform_source:"true"
"""
timeline_id = "495ad7a7-316e-4544-8a0f-9c098daee76e"
timeline_title = "Generic Threat Match Timeline"
timestamp_override = "event.ingested"
type = "threat_match"

query = '''
file.hash.*:* OR process.hash.*:* or dll.hash.*:*
'''


[[rule.threat_filters]]

[rule.threat_filters."$state"]
store = "appState"
[rule.threat_filters.meta]
disabled = false
key = "event.category"
negate = false
type = "phrase"
[rule.threat_filters.meta.params]
query = "threat"
[rule.threat_filters.query.match_phrase]
"event.category" = "threat"
[[rule.threat_filters]]

[rule.threat_filters."$state"]
store = "appState"
[rule.threat_filters.meta]
disabled = false
key = "event.kind"
negate = false
type = "phrase"
[rule.threat_filters.meta.params]
query = "enrichment"
[rule.threat_filters.query.match_phrase]
"event.kind" = "enrichment"
[[rule.threat_filters]]

[rule.threat_filters."$state"]
store = "appState"
[rule.threat_filters.meta]
disabled = false
key = "event.type"
negate = false
type = "phrase"
[rule.threat_filters.meta.params]
query = "indicator"
[rule.threat_filters.query.match_phrase]
"event.type" = "indicator"
[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "file.hash.md5"
type = "mapping"
value = "threat.indicator.file.hash.md5"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "file.hash.sha1"
type = "mapping"
value = "threat.indicator.file.hash.sha1"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "file.hash.sha256"
type = "mapping"
value = "threat.indicator.file.hash.sha256"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "dll.hash.md5"
type = "mapping"
value = "threat.indicator.file.hash.md5"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "dll.hash.sha1"
type = "mapping"
value = "threat.indicator.file.hash.sha1"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "dll.hash.sha256"
type = "mapping"
value = "threat.indicator.file.hash.sha256"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "process.hash.md5"
type = "mapping"
value = "threat.indicator.file.hash.md5"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "process.hash.sha1"
type = "mapping"
value = "threat.indicator.file.hash.sha1"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "process.hash.sha256"
type = "mapping"
value = "threat.indicator.file.hash.sha256"



```

</p>
</details> 

<details><summary>Output</summary>
<p>

![normalize_kql_keywords](https://github.com/elastic/detection-rules/assets/119343520/b0cf7f50-403e-466f-923a-24db09da3174)


</p>
</details> 
