### PR TITLE
[Rule Tuning] LSASS Process Access via Windows API

### DIFF
--- a/rules/windows/credential_access_lsass_openprocess_api.toml
+++ b/rules/windows/credential_access_lsass_openprocess_api.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/03/02"
 integration = ["endpoint", "m365_defender"]
 maturity = "production"
-updated_date = "2024/06/25"
+updated_date = "2024/06/27"
 
 [transform]
 [[transform.osquery]]
@@ -120,7 +120,9 @@ type = "eql"
 query = '''
 api where host.os.type == "windows" and 
   process.Ext.api.name in ("OpenProcess", "OpenThread") and Target.process.name : "lsass.exe" and 
-  not process.executable : (
+  not 
+  (
+    process.executable : (
         "?:\\ProgramData\\GetSupportService*\\Updates\\Update_*.exe",
         "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
         "?:\\Program Files (x86)\\Asiainfo Security\\OfficeScan Client\\NTRTScan.exe",
@@ -157,6 +159,7 @@ api where host.os.type == "windows" and
         "?:\\Windows\\System32\\RtkAudUService64.exe",
         "?:\\Windows\\System32\\wbem\\WmiPrvSE.exe",
         "?:\\Windows\\SysWOW64\\wbem\\WmiPrvSE.exe"
+    ) and not ?process.code_signature.trusted == false
   )
 '''
 


### PR DESCRIPTION
## Summary

Re-introduces the code signature check with a different approach + optional field.

Context: https://elastic.slack.com/archives/C02USDK55AQ/p1719415974247789?thread_ts=1719410796.090999&cid=C02USDK55AQ