### PR TITLE
[Rule Tuning] Improve Compatibility in WIndows BBR Detection Rules 

### DIFF
--- a/rules_building_block/collection_files_staged_in_recycle_bin_root.toml
+++ b/rules_building_block/collection_files_staged_in_recycle_bin_root.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/24"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies files written to the root of the Recycle Bin folder instead of subdir
 the root of the Recycle Bin in preparation for exfiltration or to evade defenses.
 """
 from = "now-119m"
-index = ["logs-endpoint.events.file-*"]
+index = ["logs-endpoint.events.file-*", "logs-windows.sysmon_operational-*", "endgame-*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -27,6 +27,8 @@ tags = [
     "Tactic: Collection",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Elastic Endgame",
+    "Data Source: Sysmon"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/collection_outlook_email_archive.toml
+++ b/rules_building_block/collection_outlook_email_archive.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies commands containing references to Outlook data files extensions, whic
 access, or modification of these files.
 """
 from = "now-119m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-system.security*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -27,6 +27,8 @@ tags = [
     "Tactic: Collection",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/command_and_control_bitsadmin_activity.toml
+++ b/rules_building_block/command_and_control_bitsadmin_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Windows Background Intelligent Transfer Service (BITS) is a low-bandwidth, async
 Adversaries may abuse BITS to persist, download, execute, and even clean up after running malicious code.
 """
 from = "now-119m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-system.security*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -27,6 +27,8 @@ tags = [
     "Tactic: Command and Control",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/command_and_control_certutil_network_connection.toml
+++ b/rules_building_block/command_and_control_certutil_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/19"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 bypass_bbr_timing = true
 
 [transform]
@@ -70,7 +70,7 @@ Identifies certutil.exe making a network connection. Adversaries could abuse cer
 malware, from a remote URL.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.network-*", "logs-windows.sysmon_operational-*"]
+index = ["winlogbeat-*", "logs-endpoint.events.network-*", "logs-windows.sysmon_operational-*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Network Connection via Certutil"
@@ -135,7 +135,7 @@ references = [
 risk_score = 21
 rule_id = "3838e0e3-1850-4850-a411-2e8c5ba40ba8"
 severity = "low"
-tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Command and Control", "Resources: Investigation Guide", "Data Source: Elastic Defend", "Data Source: Sysmon"]
+tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Command and Control", "Resources: Investigation Guide", "Data Source: Elastic Defend", "Data Source: Sysmon", "Data Source: Elastic Endgame"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules_building_block/credential_access_win_private_key_access.toml
+++ b/rules_building_block/credential_access_win_private_key_access.toml
@@ -2,14 +2,14 @@
 creation_date = "2023/08/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
 building_block_type = "default"
 description = "Attackers may try to access private keys, e.g. ssh, in order to gain further authenticated access to the environment.\n"
 from = "now-119m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-system.security*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -24,6 +24,8 @@ tags = [
     "Tactic: Credential Access",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/defense_evasion_cmd_copy_binary_contents.toml
+++ b/rules_building_block/defense_evasion_cmd_copy_binary_contents.toml
@@ -2,14 +2,14 @@
 creation_date = "2023/08/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
 building_block_type = "default"
 description = "Attackers may abuse cmd.exe commands to reassemble binary fragments into a malicious payload.\n"
 from = "now-119m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-system.security*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -25,6 +25,8 @@ tags = [
     "Tactic: Execution",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/defense_evasion_cmstp_execution.toml
+++ b/rules_building_block/defense_evasion_cmstp_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/24"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ service profiles, which accept installation information file (INF) files. Advers
 execution of malicious code by supplying INF files that contain malicious commands.
 """
 from = "now-119m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-system.security*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -29,6 +29,8 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/defense_evasion_service_path_registry.toml
+++ b/rules_building_block/defense_evasion_service_path_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/29"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies attempts to modify a service path by an unusual process. Attackers ma
 for persistence or privilege escalation.
 """
 from = "now-119m"
-index = ["logs-endpoint.events.registry-*", "endgame-*"]
+index = ["logs-endpoint.events.registry-*", "endgame-*", "logs-windows.sysmon_operational-*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -28,6 +28,7 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/defense_evasion_services_exe_path.toml
+++ b/rules_building_block/defense_evasion_services_exe_path.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/29"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies attempts to modify a service path setting using sc.exe. Attackers may
 persistence or privilege escalation.
 """
 from = "now-119m"
-index = ["logs-endpoint.events.process-*", "endgame-*"]
+index = ["logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-system.security*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -28,6 +28,8 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/discovery_files_dir_systeminfo_via_cmd.toml
+++ b/rules_building_block/discovery_files_dir_systeminfo_via_cmd.toml
@@ -3,7 +3,7 @@ bypass_bbr_timing = true
 creation_date = "2022/11/01"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ Identifies the execution of discovery commands to enumerate system information, 
 Command Shell.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.*", "logs-endpoint.events.process-*"]
+index = ["winlogbeat-*", "logs-windows.*", "logs-endpoint.events.process-*", "endgame-*", "logs-system.security*"]
 language = "eql"
 license = "Elastic License v2"
 name = "System Information Discovery via Windows Command Shell"
@@ -64,6 +64,7 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/discovery_windows_system_information_discovery.toml
+++ b/rules_building_block/discovery_windows_system_information_discovery.toml
@@ -3,7 +3,7 @@ bypass_bbr_timing = true
 creation_date = "2023/07/06"
 integration = ["windows", "endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ Detects the execution of commands used to discover information about the system,
 compromising a system to gain situational awareness.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.process-*", "logs-windows.*", "endgame-*"]
+index = ["winlogbeat-*", "logs-endpoint.events.process-*", "logs-windows.*", "endgame-*", "logs-system.security*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Windows System Information Discovery"

--- a/rules_building_block/execution_settingcontent_ms_file_creation.toml
+++ b/rules_building_block/execution_settingcontent_ms_file_creation.toml
@@ -3,7 +3,7 @@ bypass_bbr_timing = true
 creation_date = "2023/08/24"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +13,7 @@ Identifies the suspicious creation of SettingContents-ms files, which have been 
 execution while evading defenses.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.file-*"]
+index = ["logs-endpoint.events.file-*", "logs-windows.sysmon_operational-*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Creation of SettingContent-ms Files"
@@ -28,6 +28,8 @@ tags = [
     "Tactic: Execution",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules_building_block/lateral_movement_wmic_remote.toml
+++ b/rules_building_block/lateral_movement_wmic_remote.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/24"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Identifies the use of wmic.exe to run commands on remote hosts. While this can b
 attackers can abuse this built-in utility to achieve lateral movement.
 """
 from = "now-119m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-system.security*"]
 interval = "60m"
 language = "eql"
 license = "Elastic License v2"
@@ -27,6 +27,8 @@ tags = [
     "Tactic: Lateral Movement",
     "Data Source: Elastic Defend",
     "Rule Type: BBR",
+    "Data Source: Sysmon",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/detection-rules/issues/3661

## Summary

Adds compatibility (where possible) to Security Logs, Sysmon, and Endgame in Windows BBRs.