### PR TITLE
[Rule Tuning] Potential AWS S3 Bucket Ransomware Note Uploaded 

### DIFF
--- a/rules/integrations/aws/impact_s3_bucket_object_uploaded_with_ransom_extension.toml
+++ b/rules/integrations/aws/impact_s3_bucket_object_uploaded_with_ransom_extension.toml
@@ -4,7 +4,7 @@ integration = ["aws"]
 maturity = "production"
 min_stack_comments = "AWS integration breaking changes, bumping version to ^2.0.0"
 min_stack_version = "8.13.0"
-updated_date = "2024/06/05"
+updated_date = "2024/07/01"
 
 [rule]
 author = ["Elastic"]
@@ -95,7 +95,7 @@ from logs-aws.cloudtrail-*
 | dissect aws.cloudtrail.request_parameters "%{?ignore_values}key=%{object_name}}"
 
 // regex on common ransomware note extensions
-| where object_name rlike "(.*).(ransom|lock|crypt|enc|readme|how_to_decrypt|decrypt_instructions|recovery|datarescue)"
+| where object_name rlike "(.*)(ransom|lock|crypt|enc|readme|how_to_decrypt|decrypt_instructions|recovery|datarescue)(.*)"
 
 // aggregate by S3 bucket, resource and object name
 | stats note_upload_count = count(*) by tls.client.server_name, aws.cloudtrail.user_identity.arn, object_name

--- a/rules/integrations/aws/impact_s3_bucket_object_uploaded_with_ransom_extension.toml
+++ b/rules/integrations/aws/impact_s3_bucket_object_uploaded_with_ransom_extension.toml
@@ -96,6 +96,7 @@ from logs-aws.cloudtrail-*
 
 // regex on common ransomware note extensions
 | where object_name rlike "(.*)(ransom|lock|crypt|enc|readme|how_to_decrypt|decrypt_instructions|recovery|datarescue)(.*)"
+    and not object_name rlike "(.*)(AWSLogs|CloudTrail|access-logs)(.*)"
 
 // aggregate by S3 bucket, resource and object name
 | stats note_upload_count = count(*) by tls.client.server_name, aws.cloudtrail.user_identity.arn, object_name


### PR DESCRIPTION
## Issues
* https://github.com/elastic/ia-trade-team/issues/272

## Summary
Tunes the 'Potential AWS S3 Bucket Ransomware Note Uploaded' rule by removing the extension `.` from the ES|QL WHERE clause. During testing from https://rhinosecuritylabs.com/aws/s3-ransomware-part-1-attack-vector/, Isai noticed that since we do not filter for `.txt`, this rule did not fire, however `ransom` was in the file name. Therefore the changes will allow these very specific encryption strings to be allowed within the file name or extension.

Telemetry was referenced to determine if any additional tuning was necessary, however global alerts for this rule have not been observed yet. 