### PR TITLE
[FR] Added Modify URL Preload Function

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from urllib.parse import urlparse
 from uuid import uuid4
 
 import eql
@@ -21,7 +22,7 @@ import marshmallow
 from semver import Version
 from marko.block import Document as MarkoDocument
 from marko.ext.gfm import gfm
-from marshmallow import ValidationError, validates_schema
+from marshmallow import ValidationError, pre_load, validates_schema
 
 import kql
 
@@ -174,6 +175,14 @@ class BaseThreatEntry:
     id: str
     name: str
     reference: str
+
+    @pre_load()
+    def modify_url(self, data: Dict[str, Any], **kwargs):
+        """Modify the URL."""
+        if urlparse(data["reference"]).scheme:
+            if not data["reference"].endswith("/"):
+                data["reference"] += "/"
+        return data
 
 
 @dataclass(frozen=True)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -178,7 +178,7 @@ class BaseThreatEntry:
 
     @pre_load()
     def modify_url(self, data: Dict[str, Any], **kwargs):
-        """Modify the URL."""
+        """Modify the URL to support MITRE ATT&CK URLS with and without trailing forward slash."""
         if urlparse(data["reference"]).scheme:
             if not data["reference"].endswith("/"):
                 data["reference"] += "/"


### PR DESCRIPTION

## Issues
https://github.com/elastic/detection-rules/issues/3843

## Summary

This PR addresses an issue where MITRE Updated the format in which the URLs were supplied for the MITRE ATT&CK Framework. Originally they were supplied with a trailing `/` and now they are supplied without it. Given that we will want to support rules under both older and newer versions of MITRE ATT&CK, the proposed solution is to add a pre-load check which will modify the reference URLs to match the required schema. 

## Testing

Create a rule in Kibana and add MITRE ATT&CK information. Prior to this fix, using the DAC export rules command would result in schema errors in any rules with MITRE ATT&CK information. Now the rule should export successfully. 

Example Run:

<details><summary>Details</summary>
<p>

![rules_export_fix](https://github.com/elastic/detection-rules/assets/119343520/cbd0906e-3864-49f9-af84-4fd19ad22d67)

Example Rule:

```toml

[metadata]
creation_date = "2024/07/01"
maturity = "production"
updated_date = "2024/07/01"

[rule]
actions = []
author = []
description = "test"
enabled = false
exceptions_list = []
false_positives = []
filters = []
from = "now-18060s"
index = [
    "apm-*-transaction*",
    "auditbeat-*",
    "endgame-*",
    "filebeat-*",
    "logs-*",
    "packetbeat-*",
    "traces-apm*",
    "winlogbeat-*",
    "-*elastic-cloud-logs-*",
]
interval = "5h"
language = "eql"
license = ""
max_signals = 100
name = "Test Rule Less Threat"
references = []
related_integrations = []
required_fields = []
risk_score = 21
risk_score_mapping = []
rule_id = "6559f7d2-56d9-49b1-9426-76caf2f8ab04"
setup = ""
severity = "low"
severity_mapping = []
tags = []
to = "now"
type = "eql"

query = '''
process where true
'''


[[rule.threat]]
framework = "MITRE ATT&CK"
technique = []

[rule.threat.tactic]
id = "TA0005"
name = "Defense Evasion"
reference = "https://attack.mitre.org/tactics/TA0005/"

[rule.meta]
from = "1m"
kibana_siem_app_url = "https://dev-deployment-2c684a.kb.us-central1.gcp.cloud.es.io:9243/s/customer/app/security"


```

</p>
</details> 