### PR TITLE
[FR] [DAC] Add index_or_dataview Property

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -65,7 +65,7 @@ def filter_rule(rule: TOMLRule, config_filter: dict, exclude_fields: Optional[di
         unique_fields = get_unique_query_fields(rule)
 
         for index, fields in exclude_fields.items():
-            if unique_fields and (rule.contents.data.index == index or index == 'any'):
+            if unique_fields and (rule.contents.data.index_or_dataview == index or index == 'any'):
                 if set(unique_fields) & set(fields):
                     return False
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -703,7 +703,9 @@ class QueryRuleData(BaseRuleData):
     @cached_property
     def index_or_dataview(self) -> list[str]:
         """Return the index or dataview depending on which is set. If neither returns empty list."""
-        return self.index or [self.dataview] if self.dataview is not None else []
+        index = getattr(self, 'index', None)
+        dataview = getattr(self, 'dataview', None)
+        return index or [dataview] if dataview is not None else []
 
     @cached_property
     def validator(self) -> Optional[QueryValidator]:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -703,9 +703,12 @@ class QueryRuleData(BaseRuleData):
     @cached_property
     def index_or_dataview(self) -> list[str]:
         """Return the index or dataview depending on which is set. If neither returns empty list."""
-        index = getattr(self, 'index', None)
-        dataview = getattr(self, 'dataview', None)
-        return index or [dataview] if dataview is not None else []
+        if self.index is not None:
+            return self.index
+        elif self.dataview is not None:
+            return [self.dataview]
+        else:
+            return []
 
     @cached_property
     def validator(self) -> Optional[QueryValidator]:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -701,6 +701,13 @@ class QueryRuleData(BaseRuleData):
     alert_suppression: Optional[AlertSuppressionMapping] = field(metadata=dict(metadata=dict(min_compat="8.8")))
 
     @cached_property
+    def index_or_dataview(self) -> list[str]:
+        """Return the index or dataview depending on which is set."""
+        if self.index is not None:
+            return self.index
+        return [self.dataview]
+
+    @cached_property
     def validator(self) -> Optional[QueryValidator]:
         if self.language == "kuery":
             return KQLValidator(self.query)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -702,10 +702,8 @@ class QueryRuleData(BaseRuleData):
 
     @cached_property
     def index_or_dataview(self) -> list[str]:
-        """Return the index or dataview depending on which is set."""
-        if self.index is not None:
-            return self.index
-        return [self.dataview]
+        """Return the index or dataview depending on which is set. If neither returns empty list."""
+        return self.index or [self.dataview] if self.dataview is not None else []
 
     @cached_property
     def validator(self) -> Optional[QueryValidator]:

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -147,7 +147,7 @@ class KQLValidator(QueryValidator):
             ecs_version = mapping['ecs']
             err_trailer = f'stack: {stack_version}, beats: {beats_version}, ecs: {ecs_version}'
 
-            beat_types, beat_schema, schema = self.get_beats_schema(data.index or [],
+            beat_types, beat_schema, schema = self.get_beats_schema(data.index_or_dataview or [],
                                                                     beats_version, ecs_version)
 
             try:
@@ -195,12 +195,12 @@ class KQLValidator(QueryValidator):
             stack_version = integration_schema_data["stack_version"]
 
             # Add non-ecs-schema fields
-            for index_name in data.index:
+            for index_name in data.index_or_dataview:
                 integration_schema.update(**ecs.flatten(ecs.get_index_schema(index_name)))
 
             # Add custom schema fields for appropriate stack version
             if data.index and CUSTOM_RULES_DIR:
-                for index_name in data.index:
+                for index_name in data.index_or_dataview:
                     integration_schema.update(**ecs.flatten(ecs.get_custom_index_schema(index_name, stack_version)))
 
             # Add endpoint schema fields for multi-line fields
@@ -338,9 +338,9 @@ class EQLValidator(QueryValidator):
             err_trailer = f'stack: {stack_version}, beats: {beats_version},' \
                           f'ecs: {ecs_version}, endgame: {endgame_version}'
 
-            beat_types, beat_schema, schema = self.get_beats_schema(data.index or [],
+            beat_types, beat_schema, schema = self.get_beats_schema(data.index_or_dataview or [],
                                                                     beats_version, ecs_version)
-            endgame_schema = self.get_endgame_schema(data.index or [], endgame_version)
+            endgame_schema = self.get_endgame_schema(data.index_or_dataview or [], endgame_version)
             eql_schema = ecs.KqlSchema2Eql(schema)
 
             # validate query against the beats and eql schema
@@ -389,13 +389,13 @@ class EQLValidator(QueryValidator):
             stack_version = integration_schema_data["stack_version"]
 
             # add non-ecs-schema fields for edge cases not added to the integration
-            if data.index:
-                for index_name in data.index:
+            if data.index_or_dataview:
+                for index_name in data.index_or_dataview:
                     integration_schema.update(**ecs.flatten(ecs.get_index_schema(index_name)))
 
             # Add custom schema fields for appropriate stack version
-            if data.index and CUSTOM_RULES_DIR:
-                for index_name in data.index:
+            if data.index_or_dataview and CUSTOM_RULES_DIR:
+                for index_name in data.index_or_dataview:
                     integration_schema.update(**ecs.flatten(ecs.get_custom_index_schema(index_name, stack_version)))
 
             # add endpoint schema fields for multi-line fields

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -147,7 +147,7 @@ class KQLValidator(QueryValidator):
             ecs_version = mapping['ecs']
             err_trailer = f'stack: {stack_version}, beats: {beats_version}, ecs: {ecs_version}'
 
-            beat_types, beat_schema, schema = self.get_beats_schema(data.index_or_dataview or [],
+            beat_types, beat_schema, schema = self.get_beats_schema(data.index_or_dataview,
                                                                     beats_version, ecs_version)
 
             try:
@@ -338,9 +338,9 @@ class EQLValidator(QueryValidator):
             err_trailer = f'stack: {stack_version}, beats: {beats_version},' \
                           f'ecs: {ecs_version}, endgame: {endgame_version}'
 
-            beat_types, beat_schema, schema = self.get_beats_schema(data.index_or_dataview or [],
+            beat_types, beat_schema, schema = self.get_beats_schema(data.index_or_dataview,
                                                                     beats_version, ecs_version)
-            endgame_schema = self.get_endgame_schema(data.index_or_dataview or [], endgame_version)
+            endgame_schema = self.get_endgame_schema(data.index_or_dataview, endgame_version)
             eql_schema = ecs.KqlSchema2Eql(schema)
 
             # validate query against the beats and eql schema


### PR DESCRIPTION
## Issues
https://github.com/elastic/detection-rules/issues/3697

## Summary

This PR adds a property to `QueryRuleData` that allows you to use either index or data view depending on which one is set. This PR is dependent on a validation update to main that prevents both indexes and data views from being set. 

Please review and merge https://github.com/elastic/detection-rules/pull/3830 first and backport this to DAC-Feature before reviewing this PR. **Update: 3830 is now Merged.**

Note: There are a few remaining `data.index` calls that do not appear to support using this property. For example, in `validate_eql`  this update is not supported as `data.index` is used as an index parameter to the `self.es_client.eql.search` function call which does not support data views. 

## Testing

Make a package using `make` to make sure the new property fills the requirements of the updated function calls that used to use `.index`.  