### PR TITLE
[FR] [DAC] Add exceptions importing from ndjson

### DIFF
--- a/detection_rules/exception.py
+++ b/detection_rules/exception.py
@@ -3,21 +3,27 @@
 # 2.0; you may not use this file except in compliance with the Elastic License
 # 2.0.
 """Rule exceptions data."""
+import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import List, Optional, Union
 
-from marshmallow import validates_schema, ValidationError
+import toml
+from marshmallow import ValidationError, validates_schema
 
 from .mixins import MarshmallowDataclassMixin
+from .rule import TOMLRuleContents
 from .schemas import definitions
 
+TIME_NOW = time.strftime("%Y/%m/%d")
 
 # https://www.elastic.co/guide/en/security/current/exceptions-api-overview.html
+
 
 @dataclass(frozen=True)
 class ExceptionMeta(MarshmallowDataclassMixin):
     """Data stored in an exception's [metadata] section of TOML."""
+
     creation_date: definitions.Date
     rule_id: definitions.UUIDString
     rule_name: str
@@ -32,6 +38,7 @@ class ExceptionMeta(MarshmallowDataclassMixin):
 @dataclass(frozen=True)
 class BaseExceptionItemEntry(MarshmallowDataclassMixin):
     """Shared object between nested and non-nested exception items."""
+
     field: str
     type: definitions.ExceptionEntryType
 
@@ -39,21 +46,24 @@ class BaseExceptionItemEntry(MarshmallowDataclassMixin):
 @dataclass(frozen=True)
 class NestedExceptionItemEntry(BaseExceptionItemEntry, MarshmallowDataclassMixin):
     """Nested exception item entry."""
-    entries: List['ExceptionItemEntry']
+
+    entries: List["ExceptionItemEntry"]
 
     @validates_schema
     def validate_nested_entry(self, data: dict, **kwargs):
         """More specific validation."""
-        if data.get('list') is not None:
-            raise ValidationError('Nested entries cannot define a list')
+        if data.get("list") is not None:
+            raise ValidationError("Nested entries cannot define a list")
 
 
 @dataclass(frozen=True)
 class ExceptionItemEntry(BaseExceptionItemEntry, MarshmallowDataclassMixin):
     """Exception item entry."""
+
     @dataclass(frozen=True)
     class ListObject:
         """List object for exception item entry."""
+
         id: definitions.UUIDString
         type: definitions.EsDataTypes
 
@@ -64,64 +74,68 @@ class ExceptionItemEntry(BaseExceptionItemEntry, MarshmallowDataclassMixin):
     @validates_schema
     def validate_entry(self, data: dict, **kwargs):
         """Validate the entry based on its type."""
-        value = data.get('value', '')
-        if data['type'] in ('exists', 'list') and value is not None:
+        value = data.get("value", "")
+        if data["type"] in ("exists", "list") and value is not None:
             raise ValidationError(f'Entry of type {data["type"]} cannot have a value')
-        elif data['type'] in ('match', 'wildcard') and not isinstance(value, str):
+        elif data["type"] in ("match", "wildcard") and not isinstance(value, str):
             raise ValidationError(f'Entry of type {data["type"]} must have a string value')
-        elif data['type'] == 'match_any' and not isinstance(value, list):
+        elif data["type"] == "match_any" and not isinstance(value, list):
             raise ValidationError(f'Entry of type {data["type"]} must have a list of strings as a value')
 
 
 @dataclass(frozen=True)
 class ExceptionItem(MarshmallowDataclassMixin):
     """Base exception item."""
-    @dataclass(frozen=True)
-    class Comment:
-        """Comment object for exception item."""
-        comment: str
 
-    comments: List[Optional[Comment]]
-    description: str
-    entries: List[Union[ExceptionItemEntry, NestedExceptionItemEntry]]
-    list_id: str
-    item_id: Optional[str]  # api sets field when not provided
-    meta: Optional[dict]
-    name: str
-    namespace_type: Optional[definitions.ExceptionNamespaceType]  # defaults to "single" if not provided
-    tags: Optional[List[str]]
-    type: Literal['simple']
+    field: str
+    operator: str
+    type: str
+    value: str
 
 
 @dataclass(frozen=True)
 class EndpointException(ExceptionItem, MarshmallowDataclassMixin):
     """Endpoint exception item."""
+
     _tags: List[definitions.ExceptionItemEndpointTags]
 
     @validates_schema
     def validate_endpoint(self, data: dict, **kwargs):
         """Validate the endpoint exception."""
-        for entry in data['entries']:
-            if entry['operator'] == "excluded":
+        for entry in data["entries"]:
+            if entry["operator"] == "excluded":
                 raise ValidationError("Endpoint exceptions cannot have an `excluded` operator")
 
 
 @dataclass(frozen=True)
 class DetectionException(ExceptionItem, MarshmallowDataclassMixin):
     """Detection exception item."""
+
     expire_time: Optional[str]  # fields.DateTime]  # maybe this is isoformat?
 
 
 @dataclass(frozen=True)
 class ExceptionContainer(MarshmallowDataclassMixin):
     """Exception container."""
+
     description: str
-    list_id: Optional[str]
-    meta: Optional[dict]
+    id: str
+    list_id: str
     name: str
+    entries: List[DetectionException]  # Union[DetectionException, EndpointException]]
+
+    os_types: Optional[List[str]]
     namespace_type: Optional[definitions.ExceptionNamespaceType]
+    _version: Optional[str]
     tags: Optional[List[str]]
     type: definitions.ExceptionContainerType
+    comments: Optional[List[str]]
+    created_at: Optional[str]
+    created_by: Optional[str]
+    updated_at: Optional[str]
+    updated_by: Optional[str]
+    item_id: Optional[str]  # api sets field when not provided
+    tie_breaker_id: Optional[str]
 
     def to_rule_entry(self) -> dict:
         """Returns a dict of the format required in rule.exception_list."""
@@ -130,29 +144,55 @@ class ExceptionContainer(MarshmallowDataclassMixin):
 
 
 @dataclass(frozen=True)
-class Data(MarshmallowDataclassMixin):
-    """Data stored in an exception's [exception] section of TOML."""
-    container: ExceptionContainer
-    items: List[DetectionException]  # Union[DetectionException, EndpointException]]
-
-
-@dataclass(frozen=True)
 class TOMLExceptionContents(MarshmallowDataclassMixin):
     """Data stored in an exception file."""
+
     metadata: ExceptionMeta
-    exceptions: List[Data]
+    exceptions: List[ExceptionContainer]
+
+    @classmethod
+    def from_rule_contents(
+        cls,
+        rule: TOMLRuleContents,
+        exception_data: List[dict],
+        creation_date: str = TIME_NOW,
+        updated_date: str = TIME_NOW,
+    ) -> "TOMLExceptionContents":
+        """Create a TOMLExceptionContents from a kibana rule resource."""
+        metadata = {
+            "creation_date": rule.metadata.creation_date,
+            "rule_id": rule.id,
+            "rule_name": rule.name,
+            "updated_date": rule.metadata.updated_date,
+        }
+        contents = cls.from_dict({"metadata": metadata, "exceptions": exception_data})
+        return contents
 
 
 @dataclass(frozen=True)
 class TOMLException:
     """TOML exception object."""
+
     contents: TOMLExceptionContents
     path: Optional[Path] = None
 
     @property
-    def name(self):
+    def rule_name(self):
+        """Return the exception name."""
         return self.contents.metadata.rule_name
 
     @property
-    def id(self):
+    def rule_id(self):
+        """Return the exception ID."""
         return self.contents.metadata.rule_id
+
+    def save_toml(self):
+        """Save the exception to a TOML file."""
+        assert self.path is not None, f"Can't save exception {self.contents.name} without a path"
+        # Check if self.path has a .toml extension
+        path = self.path
+        if path.suffix != ".toml":
+            # If it doesn't, add one
+            path = path.with_suffix(".toml")
+        with path.open("w") as f:
+            toml.dump(self.contents.to_dict(), f)

--- a/detection_rules/exception.py
+++ b/detection_rules/exception.py
@@ -178,12 +178,12 @@ class TOMLException:
 
     @property
     def rule_name(self):
-        """Return the exception name."""
+        """Return the rule name."""
         return self.contents.metadata.rule_name
 
     @property
     def rule_id(self):
-        """Return the exception ID."""
+        """Return the rule ID."""
         return self.contents.metadata.rule_id
 
     def save_toml(self):

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -168,7 +168,9 @@ def kibana_export_rules(
             raise
 
         exported.append(rule)
-        exceptions.append(exception)
+
+        if export_exceptions:
+            exceptions.append(exception)
 
     saved = []
     for rule in exported:

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -148,6 +148,7 @@ def kibana_export_rules(
             rule_name = rulename_to_filename(contents.data.name, tactic_name=first_tactic)
             rule = TOMLRule(contents=contents, path=directory / f'{rule_name}')
 
+            exception = None
             if contents.data.get("exceptions_list") and export_exceptions:
                 for exception_obj in rule_resource.get("exceptions_list", []):
                     with kibana:
@@ -169,7 +170,7 @@ def kibana_export_rules(
 
         exported.append(rule)
 
-        if export_exceptions:
+        if export_exceptions and exception:
             exceptions.append(exception)
 
     saved = []

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -152,7 +152,7 @@ ExceptionEntryOperator = Literal['included', 'excluded']
 ExceptionEntryType = Literal['match', 'match_any', 'exists', 'list', 'wildcard', 'nested']
 ExceptionNamespaceType = Literal['single', 'agnostic']
 ExceptionItemEndpointTags = Literal['endpoint', 'os:windows', 'os:linux', 'os:macos']
-ExceptionContainerType = Literal['detection', 'endpoint', 'rule_default']
+ExceptionContainerType = Literal['detection', 'endpoint', 'rule_default', 'simple']
 FilterLanguages = Literal["eql", "esql", "kuery", "lucene"]
 Interval = NewType('Interval', str, validate=validate.Regexp(INTERVAL_PATTERN))
 InvestigateProviderQueryType = Literal["phrase", "range"]

--- a/lib/kibana/kibana/resources.py
+++ b/lib/kibana/kibana/resources.py
@@ -103,6 +103,7 @@ class ResourceIterator(object):
 
 class RuleResource(BaseResource):
     BASE_URI = "/api/detection_engine/rules"
+    EXCEPTION_LIST_URI = '/api/exception_lists/_find'
 
     @staticmethod
     def _add_internal_filter(is_internal: bool, params: dict) -> dict:
@@ -249,6 +250,14 @@ class RuleResource(BaseResource):
         successful_rule_ids = [r for r in rule_ids if r not in error_rule_ids]
         rule_resources = cls.export_rules(successful_rule_ids) if successful_rule_ids else []
         return response, successful_rule_ids, rule_resources
+
+    @classmethod
+    def export_exception_list(cls, exception_list_id) -> List[dict]:
+        """Export an exception list from Kibana using the list id API."""
+        url_items = f'/api/exception_lists/items/_find?list_id={exception_list_id}'
+        response = Kibana.current().get(url_items, raw=True)
+        items_data = response.json().get('data', [])
+        return items_data
 
     @classmethod
     def export_rules(cls, rule_ids: Optional[List[str]] = None,


### PR DESCRIPTION
# Note

This PR is an old PR that is now replaced by: https://github.com/elastic/detection-rules/pull/3869

## Issues
https://github.com/elastic/detection-rules/issues/3674

## Summary

This PR adds support for exporting exception lists from Kibana that are attached to rules that we export. This is accomplished by adding a small method `export_exception_list` to our Kibana library's resource.py file containing the definition of a rules resource. At this time we are not supporting managing exceptions/exception lists outside of rules. Meaning, every exception list needs to be tied to a rule. The purpose of this feature is to add support for importing and exporting rules that make use of exception lists to Kibana instances that do not have those lists already available. 

This PR is the export part of that functionality.
**Note:** the prior exception list logic does not support importing to Kibana. This PR contains only the export logic, a separate PR will be needed to support importing into Kibana. 

<details><summary>Details</summary>
<p>

Current output if you attempt to import rules with exceptions list (the exceptions list does not get moved with the rule).

```
2 rule(s) failed to import!
 - 794d2fc0-ecd0-4963-99da-fd587666b80d: (400) Rule with rule_id: "794d2fc0-ecd0-4963-99da-fd587666b80d" references a non existent exception list of list_id: "1ce8efca-877d-4d4a-a069-6d41aa77e0d9". Reference has been removed.
 - 7c22a9d2-5910-4da2-92af-7ff7481bd0f7: (400) Rule with rule_id: "7c22a9d2-5910-4da2-92af-7ff7481bd0f7" references a non existent exception list of list_id: "ad78032a-6730-44c1-8ec3-129ff1dc2ad9". Reference has been removed.

```

</p>
</details> 

**Additional note:** while it may be desirable to also provide support for pulling exception lists when one has a .ndjson export from Kibana, this may be blocked by https://github.com/elastic/detection-rules/issues/3863. 

### Kibana API Docs

https://www.elastic.co/guide/en/security/current/exceptions-api-get-item.html
https://www.elastic.co/guide/en/security/current/exceptions-api-create-container.html

## Testing

To test this code:
1.  Create a rule with one or more exceptions in the Kibana API. 

<details><summary>Details</summary>
<p>

![image](https://github.com/elastic/detection-rules/assets/119343520/1ca6344e-c940-4a11-8ab5-98e5eba1149b)


</p>
</details>  

2. Next, run the export rules command with the new `-e` flag to also export the exceptions. 
Example Command: ` python -m detection_rules kibana export-rules -d custom_rules/rules -s -sv -e`
**Note:** Depending on how many custom rules you have in your Kibana instance, your numbers may be slightly different. 

<details><summary>Expected Output</summary>
<p>

detection-rules on  3674-frdac-add-exceptions-importing-from-ndjson [!?] is  v0.1.0 via  v3.12.4 (detection-rules-build) on  eric.forte took 2s 
❯ python -m detection_rules kibana export-rules -d custom_rules/rules -s -sv -e
Loaded config file: /home/forteea1/Code/clean_mains/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

8 rules exported
8 rules converted
2 exceptions exported
8 saved to custom_rules/rules


</p>
</details> 


3. Check to see if your exception toml file exists in the `exceptions/` folder in your custom rules directory.

<details><summary>Example Exception File Contents</summary>
<p>

```toml
[[exceptions]]
description = "Exception list item"
id = "8d1c6de2-12bf-442d-9b52-00bc99bfcea2"
list_id = "ad78032a-6730-44c1-8ec3-129ff1dc2ad9"
name = "FakeRoot"
os_types = []
namespace_type = "single"
_version = "WzQ3NTY0LDJd"
tags = []
type = "simple"
comments = []
created_at = "2024-07-01T17:50:11.181Z"
created_by = "3610252053"
updated_at = "2024-07-01T17:50:11.181Z"
updated_by = "3610252053"
item_id = "d6a0e21c-bf41-4758-a522-cca5df3a2332"
tie_breaker_id = "e1e84f62-b36f-4608-9778-1e4ca29539ae"
[[exceptions.entries]]
field = "process.name"
operator = "included"
type = "match"
value = "FakeRoot"


[[exceptions]]
description = "Exception list item"
id = "49f9966c-9fb4-4d8a-8bed-8e7bfcdafbc5"
list_id = "ad78032a-6730-44c1-8ec3-129ff1dc2ad9"
name = "Pid not One"
os_types = []
namespace_type = "single"
_version = "WzQ3NTY1LDJd"
tags = []
type = "simple"
comments = []
created_at = "2024-07-01T19:35:20.071Z"
created_by = "3610252053"
updated_at = "2024-07-01T19:35:20.071Z"
updated_by = "3610252053"
item_id = "970945dd-71d5-4128-89a8-7e8689326a19"
tie_breaker_id = "db323af7-5564-4a42-8d8e-81f933c5cef1"
[[exceptions.entries]]
field = "Effective_process.pid"
operator = "included"
type = "match"
value = "1"


[metadata]
creation_date = "2024/07/03"
rule_id = "7c22a9d2-5910-4da2-92af-7ff7481bd0f7"
rule_name = "Test Exception List"
updated_date = "2024/07/03"


```

</p>
</details> 

<details><summary>Example Rule File Toml (in rules directory of custom rules dir) that is attached to the above exception list</summary>
<p>

```toml
[metadata]
creation_date = "2024/07/03"
maturity = "production"
updated_date = "2024/07/03"

[rule]
actions = []
author = ["Elastic"]
description = "Test Exception List"
enabled = true
false_positives = []
filters = []
from = "now-18060s"
index = [
    "apm-*-transaction*",
    "auditbeat-*",
    "endgame-*",
    "filebeat-*",
    "logs-*",
    "packetbeat-*",
    "traces-apm*",
    "winlogbeat-*",
    "-*elastic-cloud-logs-*",
]
interval = "5h"
language = "eql"
license = ""
max_signals = 100
name = "Test Exception List"
references = []
related_integrations = []
required_fields = []
risk_score = 21
risk_score_mapping = []
rule_id = "7c22a9d2-5910-4da2-92af-7ff7481bd0f7"
setup = ""
severity = "low"
severity_mapping = []
tags = []
threat = []
to = "now"
type = "eql"

query = '''
process where true
'''


[[rule.exceptions_list]]
id = "222e1466-6dee-49ed-bb40-b7791891dc90"
list_id = "ad78032a-6730-44c1-8ec3-129ff1dc2ad9"
namespace_type = "single"
type = "rule_default"

[rule.meta]
from = "1m"
kibana_siem_app_url = "https://dev-deployment-2c684a.kb.us-central1.gcp.cloud.es.io:9243/app/security"


```

</p>
</details> 