### PR TITLE
[Bug] Normalize Hunting Index Link Generation

### DIFF
--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -29,15 +29,15 @@ class Hunt:
 
     author: str
     description: str
-    integration: List[str]
+    integration: list[str]
     uuid: str
     name: str
-    language: List[str]
+    language: list[str]
     license: str
-    query: List[str]
-    notes: Optional[List[str]] = field(default_factory=list)
-    mitre: Optional[List[str]] = field(default_factory=list)
-    references: Optional[List[str]] = field(default_factory=list)
+    query: list[str]
+    notes: Optional[list[str]] = field(default_factory=list)
+    mitre: Optional[list[str]] = field(default_factory=list)
+    references: Optional[list[str]] = field(default_factory=list)
 
 
 def load_toml(contents: str) -> Hunt:

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -1,3 +1,10 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+"""Lightweight builtin toml-markdown converter."""
+
 import os
 import tomllib
 import urllib3

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -63,7 +63,7 @@ def validate_link(link: str):
         raise ValueError(f"Invalid link: {link}")
 
 
-def generate_integration_links(integrations: List[str]) -> List[str]:
+def generate_integration_links(integrations: list[str]) -> list[str]:
     base_url = 'https://docs.elastic.co/integrations'
     generated = []
     for integration in integrations:

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -87,7 +87,7 @@ def convert_toml_to_markdown(hunt_config: Hunt, file_path: Path) -> str:
     markdown += f"- **UUID:** `{hunt_config.uuid}`\n"
     markdown += f"- **Integration:** {', '.join(generate_integration_links(hunt_config.integration))}\n"
     markdown += f"- **Language:** `{hunt_config.language}`\n".replace("'", "").replace('"', "")
-    markdown += f"- **Source File:** [{hunt_config.name}]({(Path('../queries') / file_path.name).as_posix()})"
+    markdown += f"- **Source File:** [{hunt_config.name}]({(Path('../queries') / file_path.name).as_posix()})\n"
     markdown += "\n## Query\n\n"
     for query in hunt_config.query:
         markdown += f"```sql\n{query}```\n\n"

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -87,7 +87,7 @@ def convert_toml_to_markdown(hunt_config: Hunt, file_path: Path) -> str:
     markdown += f"- **UUID:** `{hunt_config.uuid}`\n"
     markdown += f"- **Integration:** {', '.join(generate_integration_links(hunt_config.integration))}\n"
     markdown += f"- **Language:** `{hunt_config.language}`\n".replace("'", "").replace('"', "")
-    markdown += f"- **Source File:** [{hunt_config.name}]({Path('../queries') / file_path.name})"
+    markdown += f"- **Source File:** [{hunt_config.name}]({(Path('../queries') / file_path.name).as_posix()})"
     markdown += "\n## Query\n\n"
     for query in hunt_config.query:
         markdown += f"```sql\n{query}```\n\n"

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -87,22 +87,22 @@ def convert_toml_to_markdown(hunt_config: Hunt, file_path: Path) -> str:
     markdown += f"- **Description:** {hunt_config.description}\n"
     markdown += f"- **UUID:** `{hunt_config.uuid}`\n"
     markdown += f"- **Integration:** {', '.join(generate_integration_links(hunt_config.integration))}\n"
-    markdown += f"- **Language:** `{hunt_config.language}`\n\n".replace("'", "").replace('"', "")
-    markdown += "## Query\n\n"
+    markdown += f"- **Language:** `{hunt_config.language}`\n".replace("'", "").replace('"', "")
+    markdown += f"- **Source File:** [{hunt_config.name}]({Path('../queries') / file_path.name})"
+    markdown += "\n## Query\n\n"
     for query in hunt_config.query:
         markdown += f"```sql\n{query}```\n\n"
 
     if hunt_config.notes:
         markdown += "## Notes\n\n" + "\n".join(f"- {note}" for note in hunt_config.notes)
     if hunt_config.mitre:
-        markdown += "\n## MITRE ATT&CK Techniques\n\n" + "\n".join(
+        markdown += "\n\n## MITRE ATT&CK Techniques\n\n" + "\n".join(
             f"- [{tech}]({ATLAS_URL if tech.startswith('AML') else ATTACK_URL}"
             f"{tech.replace('.', '/') if tech.startswith('T') else tech})"
             for tech in hunt_config.mitre
         )
     if hunt_config.references:
-        markdown += "\n## References\n\n" + "\n".join(f"- {ref}" for ref in hunt_config.references)
-        markdown += f"\n- [{hunt_config.name}]({Path('../queries') / file_path.name})"
+        markdown += "\n\n## References\n\n" + "\n".join(f"- {ref}" for ref in hunt_config.references)
 
     markdown += f"\n\n## License\n\n- `{hunt_config.license}`\n"
     return markdown

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -86,7 +86,7 @@ def convert_toml_to_markdown(hunt_config: Hunt, file_path: Path) -> str:
     markdown += f"- **Author:** {hunt_config.author}\n"
     markdown += f"- **Description:** {hunt_config.description}\n"
     markdown += f"- **UUID:** `{hunt_config.uuid}`\n"
-    markdown += f"- **Integration:** {", ".join(generate_integration_links(hunt_config.integration))}\n"
+    markdown += f"- **Integration:** {', '.join(generate_integration_links(hunt_config.integration))}\n"
     markdown += f"- **Language:** `{hunt_config.language}`\n\n".replace("'", "").replace('"', "")
     markdown += "## Query\n\n"
     for query in hunt_config.query:
@@ -134,7 +134,7 @@ def process_toml_files(base_path: Path) -> None:
         index_content += f"\n\n## {folder}\n"
         for file_path, rule_name, language in sorted(files):
             index_path = f"./{str(file_path).replace(os.path.sep, '/')}"
-            index_content += f"- [{rule_name}]({index_path}) ({", ".join(language)})\n"
+            index_content += f"- [{rule_name}]({index_path}) ({', '.join(language)})\n"
 
     # Write the index file at the base directory level
     index_path = base_path / "index.md"

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -5,7 +5,6 @@
 
 """Lightweight builtin toml-markdown converter."""
 
-import os
 import tomllib
 import urllib3
 from dataclasses import dataclass, field
@@ -125,7 +124,7 @@ def process_toml_files(base_path: Path) -> None:
                 markdown_path.parent.mkdir(parents=True, exist_ok=True)
                 markdown_path.write_text(markdown_content, encoding="utf-8")
                 print(f"Markdown generated: {markdown_path}")
-                relative_path = os.path.normpath(markdown_path.relative_to(base_path))
+                relative_path = markdown_path.relative_to(base_path)
                 folder_name = platform_dir.name
                 directories.setdefault(folder_name, []).append((relative_path, hunt_config.name, hunt_config.language))
 
@@ -133,8 +132,8 @@ def process_toml_files(base_path: Path) -> None:
     for folder, files in sorted(directories.items()):
         index_content += f"\n\n## {folder}\n"
         for file_path, rule_name, language in sorted(files):
-            index_path = f"./{str(file_path).replace(os.path.sep, '/')}"
-            index_content += f"- [{rule_name}]({index_path}) ({', '.join(language)})\n"
+            index_path = f"./{file_path.as_posix()}"
+            index_content += f"- [{rule_name}]({index_path}) ({", ".join(language)})\n"
 
     # Write the index file at the base directory level
     index_path = base_path / "index.md"

--- a/hunting/index.md
+++ b/hunting/index.md
@@ -43,6 +43,7 @@ Here are the queries currently available:
 
 
 ## macos
+- [Low Occurrence of Suspicious Launch Agent or Launch Daemon](./macos/docs/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.md) (ES|QL)
 - [Suspicious Network Connections by Unsigned Mach-O](./macos/docs/suspicious_network_connections_by_unsigned_macho.md) (ES|QL)
 
 
@@ -70,7 +71,6 @@ Here are the queries currently available:
 - [PE File Transfer via SMB_Admin Shares by Agent or User](./windows/docs/pe_file_transfer_via_smb_admin_shares_by_agent.md) (ES|QL)
 - [Persistence via Run Key with Low Occurrence Frequency](./windows/docs/persistence_via_run_key_with_low_occurrence_frequency.md) (ES|QL)
 - [Persistence via Startup with Low Occurrence Frequency by Unique Host](./windows/docs/persistence_via_startup_with_low_occurrence_frequency.md) (ES|QL)
-- [Low Occurrence of Suspicious Launch Agent or Launch Daemon](./windows/docs/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.md) (ES|QL)
 - [Egress Network Connections with Total Bytes Greater than Threshold](./windows/docs/potential_exfiltration_by_process_total_egress_bytes.md) (ES|QL)
 - [Rundll32 Execution Aggregated by Command Line](./windows/docs/rundll32_execution_aggregated_by_cmdline.md) (ES|QL)
 - [Scheduled tasks Creation by Action via Registry](./windows/docs/scheduled_task_creation_by_action_via_registry.md) (ES|QL)

--- a/hunting/linux/docs/command_and_control_via_network_connections_with_low_occurrence_frequency_for_unique_agents.md
+++ b/hunting/linux/docs/command_and_control_via_network_connections_with_low_occurrence_frequency_for_unique_agents.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Network Connections with Low Occurrence Frequency for Unique Agent ID](../queries/command_and_control_via_network_connections_with_low_occurrence_frequency_for_unique_agents.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/command_and_control_via_network_connections_with_low_occurrence_frequency_for_unique_agents.md
+++ b/hunting/linux/docs/command_and_control_via_network_connections_with_low_occurrence_frequency_for_unique_agents.md
@@ -10,7 +10,7 @@
 - **UUID:** `ecd84bc7-32ae-474b-93a8-d1d9736c3464`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Network Connections with Low Occurrence Frequency for Unique Agent ID](../queries/command_and_control_via_network_connections_with_low_occurrence_frequency_for_unique_agents.toml)
 ## Query
 
 ```sql
@@ -68,6 +68,7 @@ destination.ip IS NOT null and not CIDR_MATCH(destination.ip, "127.0.0.0/8", "16
 - Excludes common internal IP ranges to minimize false positives.
 - Accounts for known low-frequency legitimate binaries (LoLBins) to reduce noise.
 - Identifies suspicious directories where processes are executed from, which can indicate malicious activity.
+
 ## MITRE ATT&CK Techniques
 
 - [T1071.001](https://attack.mitre.org/techniques/T1071/001)

--- a/hunting/linux/docs/command_and_control_via_unusual_file_downloads_from_source_addresses.md
+++ b/hunting/linux/docs/command_and_control_via_unusual_file_downloads_from_source_addresses.md
@@ -10,7 +10,7 @@
 - **UUID:** `0d061fad-cf35-43a6-b9b7-986c348bf182`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Unusual File Downloads from Source Addresses](../queries/command_and_control_via_unusual_file_downloads_from_source_addresses.toml)
 ## Query
 
 ```sql
@@ -29,6 +29,7 @@ from logs-endpoint.events.process-*
 - Monitors for potentially suspicious file downloads, which are often seen in malicious activities.
 - Uses process command line counting in conjunction with host counting to minimize false positives caused by legitimate downloads.
 - The process command line count threshold is set to <= 10, and the host count threshold is set to <= 5 to balance detection and noise.
+
 ## MITRE ATT&CK Techniques
 
 - [T1071.001](https://attack.mitre.org/techniques/T1071/001)

--- a/hunting/linux/docs/command_and_control_via_unusual_file_downloads_from_source_addresses.md
+++ b/hunting/linux/docs/command_and_control_via_unusual_file_downloads_from_source_addresses.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Unusual File Downloads from Source Addresses](../queries/command_and_control_via_unusual_file_downloads_from_source_addresses.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/defense_evasion_via_capitalized_process_execution.md
+++ b/hunting/linux/docs/defense_evasion_via_capitalized_process_execution.md
@@ -10,7 +10,7 @@
 - **UUID:** `9d485892-1ca2-464b-9e4e-6b21ab379b9a`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Defense Evasion via Capitalized Process Execution](../queries/defense_evasion_via_capitalized_process_execution.toml)
 ## Query
 
 ```sql
@@ -31,6 +31,7 @@ from logs-endpoint.events.process-*
 - Detects processes that have two or more consecutive capital letters within their names, with optional digits.
 - This technique is often used in malicious payloads, such as Metasploit payloads, to evade detection.
 - Included a process count of <= 3 and a host count of <= 3 to eliminate common processes across different hosts.
+
 ## MITRE ATT&CK Techniques
 
 - [T1036.004](https://attack.mitre.org/techniques/T1036/004)

--- a/hunting/linux/docs/defense_evasion_via_capitalized_process_execution.md
+++ b/hunting/linux/docs/defense_evasion_via_capitalized_process_execution.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Defense Evasion via Capitalized Process Execution](../queries/defense_evasion_via_capitalized_process_execution.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/defense_evasion_via_hidden_process_execution.md
+++ b/hunting/linux/docs/defense_evasion_via_hidden_process_execution.md
@@ -10,7 +10,7 @@
 - **UUID:** `00461198-9a2d-4823-b4cc-f3d1b5c17935`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Hidden Process Execution](../queries/defense_evasion_via_hidden_process_execution.toml)
 ## Query
 
 ```sql
@@ -29,6 +29,7 @@ from logs-endpoint.events.process-*
 
 - Included only hidden files, excluding hidden directories, as hidden directories are common in Unix.
 - Included a process or parent process count of <= 3, and a host count of <= 3 to eliminate common processes across different hosts.
+
 ## MITRE ATT&CK Techniques
 
 - [T1036.004](https://attack.mitre.org/techniques/T1036/004)

--- a/hunting/linux/docs/defense_evasion_via_hidden_process_execution.md
+++ b/hunting/linux/docs/defense_evasion_via_hidden_process_execution.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Hidden Process Execution](../queries/defense_evasion_via_hidden_process_execution.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/defense_evasion_via_multi_dot_process_execution.md
+++ b/hunting/linux/docs/defense_evasion_via_multi_dot_process_execution.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Potential Defense Evasion via Multi-Dot Process Execution](../queries/defense_evasion_via_multi_dot_process_execution.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/defense_evasion_via_multi_dot_process_execution.md
+++ b/hunting/linux/docs/defense_evasion_via_multi_dot_process_execution.md
@@ -10,7 +10,7 @@
 - **UUID:** `11810497-8ce3-4960-9777-9d0e97052682`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Potential Defense Evasion via Multi-Dot Process Execution](../queries/defense_evasion_via_multi_dot_process_execution.toml)
 ## Query
 
 ```sql
@@ -28,6 +28,7 @@ from logs-endpoint.events.process-*
 
 - This query identifies processes with executables containing three or more consecutive dots in their names.
 - The process count threshold of <= 10 can be adjusted based on the environment's baseline activity.
+
 ## MITRE ATT&CK Techniques
 
 - [T1036.004](https://attack.mitre.org/techniques/T1036/004)

--- a/hunting/linux/docs/excessive_ssh_network_activity_unique_destinations.md
+++ b/hunting/linux/docs/excessive_ssh_network_activity_unique_destinations.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Excessive SSH Network Activity to Unique Destinations](../queries/excessive_ssh_network_activity_unique_destinations.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/excessive_ssh_network_activity_unique_destinations.md
+++ b/hunting/linux/docs/excessive_ssh_network_activity_unique_destinations.md
@@ -10,7 +10,7 @@
 - **UUID:** `223f812c-a962-4d58-961d-134d8f8b15da`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Excessive SSH Network Activity to Unique Destinations](../queries/excessive_ssh_network_activity_unique_destinations.toml)
 ## Query
 
 ```sql
@@ -30,6 +30,7 @@ from logs-endpoint.events.network-*
 - Monitors network connections to port 22 (SSH) and counts the number of unique destination IP addresses per host and user.
 - A high number of unique destinations can indicate suspicious activity such as discovery or lateral movement.
 - The threshold of 10 unique destinations can be adjusted to suit the environment's baseline activity.
+
 ## MITRE ATT&CK Techniques
 
 - [T1021.004](https://attack.mitre.org/techniques/T1021/004)

--- a/hunting/linux/docs/execution_uncommon_process_execution_from_suspicious_directory.md
+++ b/hunting/linux/docs/execution_uncommon_process_execution_from_suspicious_directory.md
@@ -10,7 +10,7 @@
 - **UUID:** `0ea47044-b161-4785-ba99-e11f46d6ac51`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Uncommon Process Execution from Suspicious Directory](../queries/execution_uncommon_process_execution_from_suspicious_directory.toml)
 ## Query
 
 ```sql
@@ -47,6 +47,7 @@ from logs-endpoint.events.process-*
 - Excluded /tmp, /var/tmp, /run, /var/run subdirectories to reduce noise.
 - Excluded /tmp, /var/tmp files starting or ending with digits to exclude real temporary files.
 - Included a process or parent process count of <= 3, and a host count of <= 3 to eliminate common processes across different hosts.
+
 ## MITRE ATT&CK Techniques
 
 - [T1036.004](https://attack.mitre.org/techniques/T1036/004)

--- a/hunting/linux/docs/execution_uncommon_process_execution_from_suspicious_directory.md
+++ b/hunting/linux/docs/execution_uncommon_process_execution_from_suspicious_directory.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Uncommon Process Execution from Suspicious Directory](../queries/execution_uncommon_process_execution_from_suspicious_directory.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/login_activity_by_source_address.md
+++ b/hunting/linux/docs/login_activity_by_source_address.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Logon Activity by Source IP](../queries/login_activity_by_source_address.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/login_activity_by_source_address.md
+++ b/hunting/linux/docs/login_activity_by_source_address.md
@@ -10,7 +10,7 @@
 - **UUID:** `95c1467d-d566-4645-b5f1-37a4b0093bb6`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Logon Activity by Source IP](../queries/login_activity_by_source_address.toml)
 ## Query
 
 ```sql
@@ -29,6 +29,7 @@ from logs-system.auth-*
 - Monitors authentication events and counts failed and successful logon attempts by source IP address.
 - A high number of failed logon attempts combined with a low number of successful logons and multiple distinct usernames can indicate a potential brute force or credential stuffing attack.
 - The thresholds for failed attempts, successful logons, and distinct usernames should be adjusted based on the environment's normal logon patterns.
+
 ## MITRE ATT&CK Techniques
 
 - [T1110](https://attack.mitre.org/techniques/T1110)

--- a/hunting/linux/docs/low_volume_external_network_connections_from_process.md
+++ b/hunting/linux/docs/low_volume_external_network_connections_from_process.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Volume External Network Connections from Process by Unique Agent](../queries/low_volume_external_network_connections_from_process.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/low_volume_external_network_connections_from_process.md
+++ b/hunting/linux/docs/low_volume_external_network_connections_from_process.md
@@ -10,7 +10,7 @@
 - **UUID:** `12526f14-5e35-4f5f-884c-96c6a353a544`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Volume External Network Connections from Process by Unique Agent](../queries/low_volume_external_network_connections_from_process.toml)
 ## Query
 
 ```sql
@@ -40,6 +40,7 @@ from logs-endpoint.events.network-*
 - Monitors for network connections attempted by processes that have a low occurrence frequency (five or fewer connections) and are seen by a unique agent.
 - Excludes common internal IP ranges to minimize false positives.
 - A separate query is included to specifically monitor low volume network connections initiated by the root user, as these can be particularly indicative of malicious activity.
+
 ## MITRE ATT&CK Techniques
 
 - [T1071.001](https://attack.mitre.org/techniques/T1071/001)

--- a/hunting/linux/docs/low_volume_gtfobins_external_network_connections.md
+++ b/hunting/linux/docs/low_volume_gtfobins_external_network_connections.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Volume GTFOBins External Network Connections](../queries/low_volume_gtfobins_external_network_connections.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/low_volume_gtfobins_external_network_connections.md
+++ b/hunting/linux/docs/low_volume_gtfobins_external_network_connections.md
@@ -10,7 +10,7 @@
 - **UUID:** `783d6091-b98d-45a8-a880-a07f112a8aa2`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Volume GTFOBins External Network Connections](../queries/low_volume_gtfobins_external_network_connections.toml)
 ## Query
 
 ```sql
@@ -36,6 +36,7 @@ destination.ip IS NOT null and not CIDR_MATCH(destination.ip, "10.0.0.0/8", "127
 - Excludes common internal IP ranges to minimize false positives.
 - Counts the occurrences of these connections by process name and limits to those seen infrequently (five or fewer connections).
 - This can help identify potentially malicious activity involving the exploitation of GTFOBins.
+
 ## MITRE ATT&CK Techniques
 
 - [T1219](https://attack.mitre.org/techniques/T1219)

--- a/hunting/linux/docs/low_volume_modifications_to_critical_system_binaries.md
+++ b/hunting/linux/docs/low_volume_modifications_to_critical_system_binaries.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Volume Modifications to Critical System Binaries by Unique Host](../queries/low_volume_modifications_to_critical_system_binaries.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/low_volume_modifications_to_critical_system_binaries.md
+++ b/hunting/linux/docs/low_volume_modifications_to_critical_system_binaries.md
@@ -10,7 +10,7 @@
 - **UUID:** `c7044817-d9a5-4755-abab-9059e50dab24`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Volume Modifications to Critical System Binaries by Unique Host](../queries/low_volume_modifications_to_critical_system_binaries.toml)
 ## Query
 
 ```sql
@@ -39,6 +39,7 @@ from logs-endpoint.events.file-*
 - Excludes modifications made by expected update processes such as package managers to reduce false positives.
 - Counts the number of unique files modified by each host and the number of modifications made.
 - Focuses on modifications made by unique hosts to detect unauthorized or suspicious changes.
+
 ## MITRE ATT&CK Techniques
 
 - [T1070.004](https://attack.mitre.org/techniques/T1070/004)

--- a/hunting/linux/docs/low_volume_process_injection_syscalls_by_executable.md
+++ b/hunting/linux/docs/low_volume_process_injection_syscalls_by_executable.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Volume Process Injection-Related Syscalls by Process Executable](../queries/low_volume_process_injection_syscalls_by_executable.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/low_volume_process_injection_syscalls_by_executable.md
+++ b/hunting/linux/docs/low_volume_process_injection_syscalls_by_executable.md
@@ -10,7 +10,7 @@
 - **UUID:** `c9931736-d5ec-4c89-b4d2-d71dcf5ca12a`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Volume Process Injection-Related Syscalls by Process Executable](../queries/low_volume_process_injection_syscalls_by_executable.toml)
 ## Query
 
 ```sql
@@ -28,6 +28,7 @@ from logs-auditd_manager.auditd-*, logs-auditd.log-*, auditbeat-*
 - Monitors for process injection-related syscalls such as ptrace and memfd_create.
 - Counts the occurrences of these syscalls by process executable to identify processes that make these syscalls infrequently.
 - Focuses on low volume occurrences to detect potential malicious activity related to process injection.
+
 ## MITRE ATT&CK Techniques
 
 - [T1055.001](https://attack.mitre.org/techniques/T1055/001)

--- a/hunting/linux/docs/persistence_reverse_bind_shells.md
+++ b/hunting/linux/docs/persistence_reverse_bind_shells.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
 - **Source File:** [Persistence Through Reverse/Bind Shells](../queries/persistence_reverse_bind_shells.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_reverse_bind_shells.md
+++ b/hunting/linux/docs/persistence_reverse_bind_shells.md
@@ -10,7 +10,7 @@
 - **UUID:** `7422faf1-ba51-49c3-b8ba-13759e6bcec4`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
-
+- **Source File:** [Persistence Through Reverse/Bind Shells](../queries/persistence_reverse_bind_shells.toml)
 ## Query
 
 ```sql
@@ -49,6 +49,7 @@ SELECT pid, address, port, socket, protocol, path FROM listening_ports
 - The third hunt query retrieves information about listening ports on the system.
 - Investigate strange or unexpected open sockets, processes, or listening ports on the system.
 - Use the information from each hunt to pivot and investigate further for potential reverse/bind shells.
+
 ## MITRE ATT&CK Techniques
 
 - [T1059.004](https://attack.mitre.org/techniques/T1059/004)

--- a/hunting/linux/docs/persistence_via_cron.md
+++ b/hunting/linux/docs/persistence_via_cron.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [Persistence via Cron](../queries/persistence_via_cron.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_cron.md
+++ b/hunting/linux/docs/persistence_via_cron.md
@@ -10,7 +10,7 @@
 - **UUID:** `e1cffb7c-4acf-4e7a-8d72-b8b7657cf7b8`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [Persistence via Cron](../queries/persistence_via_cron.toml)
 ## Query
 
 ```sql
@@ -101,6 +101,7 @@ SELECT * FROM crontab
 - Uses EVAL to tag potential persistence events and counts occurrences to identify unusual activity.
 - Monitors processes started by cron, fcron, or atd to detect potential persistence mechanisms.
 - OSQuery queries are provided to complement the detection by retrieving detailed file information and crontab entries.
+
 ## MITRE ATT&CK Techniques
 
 - [T1053.003](https://attack.mitre.org/techniques/T1053/003)

--- a/hunting/linux/docs/persistence_via_driver_load_with_low_occurrence_frequency.md
+++ b/hunting/linux/docs/persistence_via_driver_load_with_low_occurrence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `e1f59c9a-7a2a-4eb8-a524-97b16a041a4a`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Drivers Load with Low Occurrence Frequency](../queries/persistence_via_driver_load_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -29,6 +29,7 @@ from logs-auditd_manager.auditd-*, logs-auditd.log-*, auditbeat-*
 - Monitors for kernel modules loaded with syscall 'init_module' or 'finit_module', indicating driver load events.
 - Counts the occurrence of each driver across all hosts and identifies those seen only once on a single host within the past year.
 - Such rare driver loads can indicate potentially malicious activity or the presence of uncommon drivers.
+
 ## MITRE ATT&CK Techniques
 
 - [T1547.006](https://attack.mitre.org/techniques/T1547/006)

--- a/hunting/linux/docs/persistence_via_driver_load_with_low_occurrence_frequency.md
+++ b/hunting/linux/docs/persistence_via_driver_load_with_low_occurrence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Drivers Load with Low Occurrence Frequency](../queries/persistence_via_driver_load_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_git_hook_pager.md
+++ b/hunting/linux/docs/persistence_via_git_hook_pager.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [Git Hook/Pager Persistence](../queries/persistence_via_git_hook_pager.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_git_hook_pager.md
+++ b/hunting/linux/docs/persistence_via_git_hook_pager.md
@@ -10,7 +10,7 @@
 - **UUID:** `2d7bb29d-d53f-47ab-a0b4-1818adb91423`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [Git Hook/Pager Persistence](../queries/persistence_via_git_hook_pager.toml)
 ## Query
 
 ```sql
@@ -80,6 +80,7 @@ WHERE
 - Monitors processes started by Git hooks to detect suspicious activity related to Git configurations.
 - OSQuery query is provided to retrieve detailed file information related to Git configurations and hooks.
 - OSQuery has limited support for wildcard queries, therefore the query includes multiple LIKE conditions for directories. These can be increased and decreased based on the environment's Git configuration paths.
+
 ## MITRE ATT&CK Techniques
 
 - [T1546.004](https://attack.mitre.org/techniques/T1546/004)

--- a/hunting/linux/docs/persistence_via_message_of_the_day.md
+++ b/hunting/linux/docs/persistence_via_message_of_the_day.md
@@ -10,7 +10,7 @@
 - **UUID:** `5984a354-d76c-43e6-bdd9-228456f1b371`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [Persistence via Message-of-the-Day](../queries/persistence_via_message_of_the_day.toml)
 ## Query
 
 ```sql
@@ -70,6 +70,7 @@ ORDER BY
 - Uses EVAL to tag potential persistence events and counts occurrences to identify unusual activity.
 - Monitors processes started by motd scripts to detect potential persistence mechanisms.
 - OSQuery query is provided to complement the detection by retrieving detailed file information related to motd scripts.
+
 ## MITRE ATT&CK Techniques
 
 - [T1036.005](https://attack.mitre.org/techniques/T1036/005)

--- a/hunting/linux/docs/persistence_via_message_of_the_day.md
+++ b/hunting/linux/docs/persistence_via_message_of_the_day.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [Persistence via Message-of-the-Day](../queries/persistence_via_message_of_the_day.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_package_manager.md
+++ b/hunting/linux/docs/persistence_via_package_manager.md
@@ -10,7 +10,7 @@
 - **UUID:** `2d01a413-8d97-407a-8698-02dfc7119c97`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [Persistence via Packager Manager](../queries/persistence_via_package_manager.toml)
 ## Query
 
 ```sql
@@ -90,6 +90,7 @@ SELECT * FROM yum_sources
 - Uses EVAL to tag potential persistence events and counts occurrences to identify unusual activity.
 - Monitors processes started by package managers to detect suspicious activity related to package manager configurations.
 - OSQuery queries are provided to retrieve detailed file information related to package manager configurations, as well as sources for APT and YUM.
+
 ## MITRE ATT&CK Techniques
 
 - [T1546.004](https://attack.mitre.org/techniques/T1546/004)

--- a/hunting/linux/docs/persistence_via_package_manager.md
+++ b/hunting/linux/docs/persistence_via_package_manager.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [Persistence via Packager Manager](../queries/persistence_via_package_manager.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_rc_local.md
+++ b/hunting/linux/docs/persistence_via_rc_local.md
@@ -10,7 +10,7 @@
 - **UUID:** `a95f778f-2193-4a3d-bbbe-7b02d5740638`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [Persistence via rc.local/rc.common](../queries/persistence_via_rc_local.toml)
 ## Query
 
 ```sql
@@ -71,6 +71,7 @@ WHERE
 - Monitors processes started by rc.local and rc.common scripts to detect potential persistence mechanisms.
 - Syslog hunting query is provided to complement the detection by analyzing syslog entries related to rc.local and rc.common processes.
 - OSQuery queries are provided to retrieve systemd unit states, startup items, and detailed file information related to rc.local and rc.common.
+
 ## MITRE ATT&CK Techniques
 
 - [T1037.004](https://attack.mitre.org/techniques/T1037/004)

--- a/hunting/linux/docs/persistence_via_rc_local.md
+++ b/hunting/linux/docs/persistence_via_rc_local.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [Persistence via rc.local/rc.common](../queries/persistence_via_rc_local.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_shell_modification_persistence.md
+++ b/hunting/linux/docs/persistence_via_shell_modification_persistence.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [Shell Modification Persistence](../queries/persistence_via_shell_modification_persistence.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_shell_modification_persistence.md
+++ b/hunting/linux/docs/persistence_via_shell_modification_persistence.md
@@ -10,7 +10,7 @@
 - **UUID:** `20a02fad-2a09-44c0-a8ce-ce4502859c8a`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [Shell Modification Persistence](../queries/persistence_via_shell_modification_persistence.toml)
 ## Query
 
 ```sql
@@ -100,6 +100,7 @@ WHERE
 - Uses EVAL to tag potential persistence events and counts occurrences to identify unusual activity.
 - Monitors processes started by SSH daemons (sshd) to detect suspicious activity related to SSH logins.
 - OSQuery query is provided to retrieve detailed file information related to profile files.
+
 ## MITRE ATT&CK Techniques
 
 - [T1546.004](https://attack.mitre.org/techniques/T1546/004)

--- a/hunting/linux/docs/persistence_via_ssh_configurations_and_keys.md
+++ b/hunting/linux/docs/persistence_via_ssh_configurations_and_keys.md
@@ -10,7 +10,7 @@
 - **UUID:** `aa759db0-4499-42f2-9f2f-be3e00fdebfa`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
-
+- **Source File:** [Persistence via SSH Configurations and/or Keys](../queries/persistence_via_ssh_configurations_and_keys.toml)
 ## Query
 
 ```sql
@@ -58,6 +58,7 @@ WHERE
 - Monitors SSH keys, authorized_keys files, and SSH configuration files using OSQuery to detect potential unauthorized access or persistence techniques.
 - Lists detailed information about SSH files, including paths, owners, and permissions.
 - Requires additional data analysis and investigation into results to identify malicious or unauthorized SSH configurations and keys.
+
 ## MITRE ATT&CK Techniques
 
 - [T1098.004](https://attack.mitre.org/techniques/T1098/004)

--- a/hunting/linux/docs/persistence_via_ssh_configurations_and_keys.md
+++ b/hunting/linux/docs/persistence_via_ssh_configurations_and_keys.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
 - **Source File:** [Persistence via SSH Configurations and/or Keys](../queries/persistence_via_ssh_configurations_and_keys.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_systemd_timers.md
+++ b/hunting/linux/docs/persistence_via_systemd_timers.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [Persistence via Systemd (Timers)](../queries/persistence_via_systemd_timers.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_systemd_timers.md
+++ b/hunting/linux/docs/persistence_via_systemd_timers.md
@@ -10,7 +10,7 @@
 - **UUID:** `d2d24ad6-a315-4e05-a3f9-e205eb805df4`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [Persistence via Systemd (Timers)](../queries/persistence_via_systemd_timers.toml)
 ## Query
 
 ```sql
@@ -192,6 +192,7 @@ name LIKE "%.service" OR name LIKE  "%.timer"
 - Excludes common legitimate processes and file types to minimize false positives.
 - Uses EVAL to tag potential persistence events and counts occurrences to identify unusual activity.
 - OSQuery queries are provided to complement the detection by retrieving detailed file information and entries related to systemd services, timers, and generators.
+
 ## MITRE ATT&CK Techniques
 
 - [T1053.005](https://attack.mitre.org/techniques/T1053/005)

--- a/hunting/linux/docs/persistence_via_sysv_init.md
+++ b/hunting/linux/docs/persistence_via_sysv_init.md
@@ -10,6 +10,7 @@
 - **UUID:** `27d76f07-7dc4-49bc-b4a7-6d9a01de171f`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
+- **Source File:** [Persistence via System V Init](../queries/persistence_via_sysv_init.toml)
 
 ## Query
 
@@ -75,6 +76,7 @@ ORDER BY
 - Uses OSQuery to detect active System V Init services and retrieve detailed file information related to System V Init services.
 - Uses OSQuery to retrieve file information for files in /etc/init.d/.
 - Excludes common legitimate processes and file types to minimize false positives.
+
 ## MITRE ATT&CK Techniques
 
 - [T1037](https://attack.mitre.org/techniques/T1037)

--- a/hunting/linux/docs/persistence_via_udev.md
+++ b/hunting/linux/docs/persistence_via_udev.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [Persistence via Udev](../queries/persistence_via_udev.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_udev.md
+++ b/hunting/linux/docs/persistence_via_udev.md
@@ -10,7 +10,7 @@
 - **UUID:** `8d42a644-5b60-4165-a8f1-84d5bcdd4ade`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [Persistence via Udev](../queries/persistence_via_udev.toml)
 ## Query
 
 ```sql
@@ -90,6 +90,7 @@ ORDER BY
 - Uses EVAL to tag potential persistence events and counts occurrences to identify unusual activity.
 - Monitors processes started by Udevadm to detect suspicious activity related to Udev rules.
 - OSQuery query is provided to retrieve detailed file information related to Udev rules.
+
 ## MITRE ATT&CK Techniques
 
 - [T1547.010](https://attack.mitre.org/techniques/T1547/010)

--- a/hunting/linux/docs/persistence_via_unusual_system_binary_parent.md
+++ b/hunting/linux/docs/persistence_via_unusual_system_binary_parent.md
@@ -10,7 +10,7 @@
 - **UUID:** `d22cbe8f-c84d-4811-aa6d-f1ee00c806b2`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Unusual System Binary Parent (Potential System Binary Hijacking Attempt)](../queries/persistence_via_unusual_system_binary_parent.toml)
 ## Query
 
 ```sql
@@ -29,6 +29,7 @@ from logs-endpoint.events.process-*
 - Focuses on identifying unusual or suspicious child processes spawned by these common system binaries.
 - Uses stats to count occurrences and identify unusual activity by looking at the number of unique hosts and processes involved.
 - Requires additional data analysis and investigation into results to identify malicious or unauthorized use of system binaries.
+
 ## MITRE ATT&CK Techniques
 
 - [T1546.004](https://attack.mitre.org/techniques/T1546/004)

--- a/hunting/linux/docs/persistence_via_unusual_system_binary_parent.md
+++ b/hunting/linux/docs/persistence_via_unusual_system_binary_parent.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Unusual System Binary Parent (Potential System Binary Hijacking Attempt)](../queries/persistence_via_unusual_system_binary_parent.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_user_group_creation_modification.md
+++ b/hunting/linux/docs/persistence_via_user_group_creation_modification.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
 - **Source File:** [Privilege Escalation/Persistence via User/Group Creation and/or Modification](../queries/persistence_via_user_group_creation_modification.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/persistence_via_user_group_creation_modification.md
+++ b/hunting/linux/docs/persistence_via_user_group_creation_modification.md
@@ -10,7 +10,7 @@
 - **UUID:** `f00c9757-d21b-432c-90a6-8372f18075d0`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
-
+- **Source File:** [Privilege Escalation/Persistence via User/Group Creation and/or Modification](../queries/persistence_via_user_group_creation_modification.toml)
 ## Query
 
 ```sql
@@ -44,6 +44,7 @@ SELECT pid, username, name FROM processes p JOIN users u ON u.uid = p.uid ORDER 
 - Monitors changes to the shadow file and user/group information using OSQuery to detect potentially unauthorized access or privilege escalation attempts.
 - Lists detailed information about users, including authentication status and running processes.
 - Requires additional data analysis and investigation into results to identify malicious or unauthorized user and group modifications.
+
 ## MITRE ATT&CK Techniques
 
 - [T1136](https://attack.mitre.org/techniques/T1136)

--- a/hunting/linux/docs/persistence_via_xdg_autostart_modifications.md
+++ b/hunting/linux/docs/persistence_via_xdg_autostart_modifications.md
@@ -10,7 +10,7 @@
 - **UUID:** `8dcc2161-65e0-4448-a03a-1c4e0cbc9330`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
-
+- **Source File:** [XDG Persistence](../queries/persistence_via_xdg_autostart_modifications.toml)
 ## Query
 
 ```sql
@@ -124,6 +124,7 @@ WHERE
 - Uses EVAL to tag potential persistence events and counts occurrences to identify unusual activity.
 - Monitors processes started by common Linux desktop session managers to detect suspicious activity related to autostart entries.
 - OSQuery queries are provided to retrieve enabled XDG startup items and detailed file information related to autostart directories.
+
 ## MITRE ATT&CK Techniques
 
 - [T1547.001](https://attack.mitre.org/techniques/T1547/001)

--- a/hunting/linux/docs/persistence_via_xdg_autostart_modifications.md
+++ b/hunting/linux/docs/persistence_via_xdg_autostart_modifications.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL, SQL]`
 - **Source File:** [XDG Persistence](../queries/persistence_via_xdg_autostart_modifications.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/privilege_escalation_via_existing_sudoers.md
+++ b/hunting/linux/docs/privilege_escalation_via_existing_sudoers.md
@@ -10,7 +10,7 @@
 - **UUID:** `6e57e6a6-f150-405d-b8be-e4e666a3a86d`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
-
+- **Source File:** [Privilege Escalation Identification via Existing Sudoers File](../queries/privilege_escalation_via_existing_sudoers.toml)
 ## Query
 
 ```sql
@@ -22,6 +22,7 @@ SELECT * FROM sudoers
 - Lists all entries in the sudoers file using OSQuery to detect potentially unauthorized or suspicious rules.
 - Requires additional data analysis and investigation into results to identify malicious or misconfigured sudoers entries.
 - Focuses on monitoring and analyzing administrative privileges granted through the sudoers file.
+
 ## MITRE ATT&CK Techniques
 
 - [T1548.003](https://attack.mitre.org/techniques/T1548/003)

--- a/hunting/linux/docs/privilege_escalation_via_existing_sudoers.md
+++ b/hunting/linux/docs/privilege_escalation_via_existing_sudoers.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
 - **Source File:** [Privilege Escalation Identification via Existing Sudoers File](../queries/privilege_escalation_via_existing_sudoers.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/privilege_escalation_via_process_capabilities.md
+++ b/hunting/linux/docs/privilege_escalation_via_process_capabilities.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Process Capability Hunting](../queries/privilege_escalation_via_process_capabilities.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/privilege_escalation_via_process_capabilities.md
+++ b/hunting/linux/docs/privilege_escalation_via_process_capabilities.md
@@ -10,7 +10,7 @@
 - **UUID:** `6f67704d-e5b1-4613-912c-e2965660fe17`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Process Capability Hunting](../queries/privilege_escalation_via_process_capabilities.toml)
 ## Query
 
 ```sql
@@ -49,6 +49,7 @@ from logs-endpoint.events.process-*
 - Uses EVAL to tag potential privilege escalation events and counts occurrences to identify unusual activity.
 - Focuses on non-root users to detect potential privilege escalation attempts.
 - Requires additional data analysis and investigation into results to identify malicious or unauthorized use of process capabilities.
+
 ## MITRE ATT&CK Techniques
 
 - [T1548.001](https://attack.mitre.org/techniques/T1548/001)

--- a/hunting/linux/docs/privilege_escalation_via_segmentation_fault_and_buffer_overflow.md
+++ b/hunting/linux/docs/privilege_escalation_via_segmentation_fault_and_buffer_overflow.md
@@ -11,6 +11,7 @@
 - **Integration:** [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Segmentation Fault & Potential Buffer Overflow Hunting](../queries/privilege_escalation_via_segmentation_fault_and_buffer_overflow.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/privilege_escalation_via_segmentation_fault_and_buffer_overflow.md
+++ b/hunting/linux/docs/privilege_escalation_via_segmentation_fault_and_buffer_overflow.md
@@ -10,7 +10,7 @@
 - **UUID:** `3f3fd2b9-940c-4310-adb1-d8b7d726e281`
 - **Integration:** [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Segmentation Fault & Potential Buffer Overflow Hunting](../queries/privilege_escalation_via_segmentation_fault_and_buffer_overflow.toml)
 ## Query
 
 ```sql
@@ -41,6 +41,7 @@ from logs-system.syslog*
 - Counts occurrences of segfaults within a plain text message field to potentially detect buffer overflow attacks and unsuccessful process injection attempts.
 - Removes prepending spaces from syslog messages using EVAL to ensure consistent parsing.
 - Depending on the Syslog configuration, additional parsing may be required to extract the necessary fields from the message.
+
 ## MITRE ATT&CK Techniques
 
 - [T1203](https://attack.mitre.org/techniques/T1203)

--- a/hunting/linux/docs/privilege_escalation_via_suid_binaries.md
+++ b/hunting/linux/docs/privilege_escalation_via_suid_binaries.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
 - **Source File:** [OSQuery SUID Hunting](../queries/privilege_escalation_via_suid_binaries.toml)
+
 ## Query
 
 ```sql

--- a/hunting/linux/docs/privilege_escalation_via_suid_binaries.md
+++ b/hunting/linux/docs/privilege_escalation_via_suid_binaries.md
@@ -10,7 +10,7 @@
 - **UUID:** `2db642d2-621a-4183-88b5-b2659dc2c940`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[SQL]`
-
+- **Source File:** [OSQuery SUID Hunting](../queries/privilege_escalation_via_suid_binaries.toml)
 ## Query
 
 ```sql
@@ -56,6 +56,7 @@ f.type == "regular" AND
 - Lists all SUID binaries and provides detailed information about these files, including their paths, owners, and permissions.
 - Focuses on regular files owned by root with SUID or SGID bits set to identify potential privilege escalation vectors.
 - OSQuery has limited support for wildcard queries, therefore the query includes multiple LIKE conditions for directories. These can be increased and decreased, based on the environment
+
 ## MITRE ATT&CK Techniques
 
 - [T1548.001](https://attack.mitre.org/techniques/T1548/001)

--- a/hunting/llm/docs/aws_bedrock_dos_resource_exhaustion_detection.md
+++ b/hunting/llm/docs/aws_bedrock_dos_resource_exhaustion_detection.md
@@ -10,7 +10,7 @@
 - **UUID:** `00023411-192e-4472-90aa-da7562bc3f2a`
 - **Integration:** [aws_bedrock.invocation](https://docs.elastic.co/integrations/aws_bedrock)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [AWS Bedrock LLM Denial-of-Service or Resource Exhaustion](../queries/aws_bedrock_dos_resource_exhaustion_detection.toml)
 ## Query
 
 ```sql
@@ -34,14 +34,15 @@ from logs-aws_bedrock.invocation-*
 - Consider reviewing the context of high token requests to differentiate between legitimate heavy usage and potential abuse. Monitor the source of requests and patterns over time for better assessment.
 - Ensure logging and monitoring are correctly configured to capture detailed metrics on token usage. This will facilitate accurate detection and allow for a quick response to potential threats.
 - Collect evidence from logs that detail the timestamp, user ID, session information, and token counts for incidents flagged by this analytic. This information will be crucial for forensic analysis in the event of a security incident.
+
 ## MITRE ATT&CK Techniques
 
 - [AML.T0034](https://atlas.mitre.org/techniques/AML.T0034)
+
 ## References
 
 - https://www.elastic.co/security-labs/elastic-advances-llm-security
 - https://owasp.org/www-project-top-10-for-large-language-model-applications/
-- [AWS Bedrock LLM Denial-of-Service or Resource Exhaustion](../queries/aws_bedrock_dos_resource_exhaustion_detection.toml)
 
 ## License
 

--- a/hunting/llm/docs/aws_bedrock_dos_resource_exhaustion_detection.md
+++ b/hunting/llm/docs/aws_bedrock_dos_resource_exhaustion_detection.md
@@ -11,6 +11,7 @@
 - **Integration:** [aws_bedrock.invocation](https://docs.elastic.co/integrations/aws_bedrock)
 - **Language:** `[ES|QL]`
 - **Source File:** [AWS Bedrock LLM Denial-of-Service or Resource Exhaustion](../queries/aws_bedrock_dos_resource_exhaustion_detection.toml)
+
 ## Query
 
 ```sql

--- a/hunting/llm/docs/aws_bedrock_latency_anomalies_detection.md
+++ b/hunting/llm/docs/aws_bedrock_latency_anomalies_detection.md
@@ -10,7 +10,7 @@
 - **UUID:** `991b55c3-6327-4af6-8e0c-5d4870748369`
 - **Integration:** [aws_bedrock.invocation](https://docs.elastic.co/integrations/aws_bedrock)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [AWS Bedrock LLM Latency Anomalies](../queries/aws_bedrock_latency_anomalies_detection.toml)
 ## Query
 
 ```sql
@@ -29,14 +29,15 @@ from logs-aws_bedrock.invocation-*
 - Review the incidents flagged by this analytic to understand the context and potential sources of latency. This can include network configurations, resource allocation, or external network pressures.
 - Effective logging and monitoring setup are essential to capture relevant latency metrics accurately. Ensure system clocks and time syncing are properly configured to avoid false positives.
 - Gather comprehensive logs that detail the request and response timestamps, user IDs, and session details for thorough investigation and evidence collection in case of security incidents.
+
 ## MITRE ATT&CK Techniques
 
 - [AML.T0029](https://atlas.mitre.org/techniques/AML.T0029)
+
 ## References
 
 - https://www.elastic.co/security-labs/elastic-advances-llm-security
 - https://owasp.org/www-project-top-10-for-large-language-model-applications/
-- [AWS Bedrock LLM Latency Anomalies](../queries/aws_bedrock_latency_anomalies_detection.toml)
 
 ## License
 

--- a/hunting/llm/docs/aws_bedrock_latency_anomalies_detection.md
+++ b/hunting/llm/docs/aws_bedrock_latency_anomalies_detection.md
@@ -11,6 +11,7 @@
 - **Integration:** [aws_bedrock.invocation](https://docs.elastic.co/integrations/aws_bedrock)
 - **Language:** `[ES|QL]`
 - **Source File:** [AWS Bedrock LLM Latency Anomalies](../queries/aws_bedrock_latency_anomalies_detection.toml)
+
 ## Query
 
 ```sql

--- a/hunting/llm/docs/aws_bedrock_sensitive_content_refusal_detection.md
+++ b/hunting/llm/docs/aws_bedrock_sensitive_content_refusal_detection.md
@@ -10,6 +10,7 @@
 - **Integration:** [aws_bedrock.invocation](https://docs.elastic.co/integrations/aws_bedrock)
 - **Language:** `[ES|QL]`
 - **Source File:** [AWS Bedrock LLM Sensitive Content Refusals](../queries/aws_bedrock_sensitive_content_refusal_detection.toml)
+
 ## Query
 
 ```sql

--- a/hunting/llm/docs/aws_bedrock_sensitive_content_refusal_detection.md
+++ b/hunting/llm/docs/aws_bedrock_sensitive_content_refusal_detection.md
@@ -9,7 +9,7 @@
 - **UUID:** `11e33a8f-805b-4394-bee0-08ae8d78b025`
 - **Integration:** [aws_bedrock.invocation](https://docs.elastic.co/integrations/aws_bedrock)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [AWS Bedrock LLM Sensitive Content Refusals](../queries/aws_bedrock_sensitive_content_refusal_detection.toml)
 ## Query
 
 ```sql
@@ -28,14 +28,15 @@ from logs-aws_bedrock.invocation-*
 - Examine flagged interactions for patterns or anomalies in user requests that may indicate malicious intent or probing of model boundaries.
 - Regularly review and update the phrases that trigger refusals to adapt to new ethical guidelines and compliance requirements.
 - Ensure that data logs contain enough detail to provide context around the refusal, which will aid in subsequent investigations by security teams.
+
 ## MITRE ATT&CK Techniques
 
 - [AML.T0051](https://atlas.mitre.org/techniques/AML.T0051)
+
 ## References
 
 - https://www.elastic.co/security-labs/elastic-advances-llm-security
 - https://owasp.org/www-project-top-10-for-large-language-model-applications/
-- [AWS Bedrock LLM Sensitive Content Refusals](../queries/aws_bedrock_sensitive_content_refusal_detection.toml)
 
 ## License
 

--- a/hunting/macos/docs/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.md
+++ b/hunting/macos/docs/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.md
@@ -21,7 +21,7 @@ from logs-endpoint.events.file-*
   (Persistence.runatload == true or Persistence.keepalive == true) and process.executable is not null
 | eval args = MV_CONCAT(Persistence.args, ",")
  /* normalizing users home profile */
-| eval args = replace(args, """/Users/[a-zA-Z0-9]\.\-\_\$~ ]+/""", "/Users/user/")
+| eval args = replace(args, """/Users/[a-zA-Z0-9ñ\.\-\_\$~ ]+/""", "/Users/user/")
 | stats agents = count_distinct(host.id), total = count(*) by process.name, Persistence.name, args
 | where starts_with(args, "/") and agents == 1 and total == 1
 ```

--- a/hunting/macos/docs/suspicious_network_connections_by_unsigned_macho.md
+++ b/hunting/macos/docs/suspicious_network_connections_by_unsigned_macho.md
@@ -10,7 +10,7 @@
 - **UUID:** `dc04d70a-80aa-4c3f-ad02-2b18d54af6d4`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Suspicious Network Connections by Unsigned Mach-O](../queries/suspicious_network_connections_by_unsigned_macho.toml)
 ## Query
 
 ```sql
@@ -33,6 +33,7 @@ from logs-endpoint.events.network-*
 
 - This hunt returns a list of processes by entity_id and name that have a high number of connections per hour over a period of time greater than a defined threshold.
 - Pivoting by `process.entity_id` will allow further investigation (parent process, hash, child processes, other network events etc.).
+
 ## MITRE ATT&CK Techniques
 
 - [T1071](https://attack.mitre.org/techniques/T1071)

--- a/hunting/macos/docs/suspicious_network_connections_by_unsigned_macho.md
+++ b/hunting/macos/docs/suspicious_network_connections_by_unsigned_macho.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Suspicious Network Connections by Unsigned Mach-O](../queries/suspicious_network_connections_by_unsigned_macho.toml)
+
 ## Query
 
 ```sql

--- a/hunting/macos/queries/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.toml
+++ b/hunting/macos/queries/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.toml
@@ -20,7 +20,7 @@ from logs-endpoint.events.file-*
   (Persistence.runatload == true or Persistence.keepalive == true) and process.executable is not null
 | eval args = MV_CONCAT(Persistence.args, ",")
  /* normalizing users home profile */
-| eval args = replace(args, """/Users/[a-zA-Z0-9]\.\-\_\$~ ]+/""", "/Users/user/")
+| eval args = replace(args, """/Users/[a-zA-Z0-9ñ\.\-\_\$~ ]+/""", "/Users/user/")
 | stats agents = count_distinct(host.id), total = count(*) by process.name, Persistence.name, args
 | where starts_with(args, "/") and agents == 1 and total == 1
 '''

--- a/hunting/windows/docs/createremotethread_by_source_process_with_low_occurrence.md
+++ b/hunting/windows/docs/createremotethread_by_source_process_with_low_occurrence.md
@@ -10,13 +10,14 @@
 - **Integration:** [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Occurrence Rate of CreateRemoteThread by Source Process](../queries/createremotethread_by_source_process_with_low_occurrence.toml)
+
 ## Query
 
 ```sql
 from logs-windows.sysmon_operational-*
 | where @timestamp > now() - 7 day
 | where host.os.family == "windows" and event.category == "process" and event.action == "CreateRemoteThread"
-| eval source_process = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval source_process = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by source_process
  /* unique source and target processes combined and observed in 1 host */
 | where hosts == 1 and cc == 1

--- a/hunting/windows/docs/createremotethread_by_source_process_with_low_occurrence.md
+++ b/hunting/windows/docs/createremotethread_by_source_process_with_low_occurrence.md
@@ -17,7 +17,7 @@
 from logs-windows.sysmon_operational-*
 | where @timestamp > now() - 7 day
 | where host.os.family == "windows" and event.category == "process" and event.action == "CreateRemoteThread"
-| eval source_process = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval source_process = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by source_process
  /* unique source and target processes combined and observed in 1 host */
 | where hosts == 1 and cc == 1

--- a/hunting/windows/docs/createremotethread_by_source_process_with_low_occurrence.md
+++ b/hunting/windows/docs/createremotethread_by_source_process_with_low_occurrence.md
@@ -9,7 +9,7 @@
 - **UUID:** `4f878255-53b8-4914-9a7d-4b668bd2ea6a`
 - **Integration:** [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Occurrence Rate of CreateRemoteThread by Source Process](../queries/createremotethread_by_source_process_with_low_occurrence.toml)
 ## Query
 
 ```sql
@@ -25,6 +25,7 @@ from logs-windows.sysmon_operational-*
 ## Notes
 
 - Adding `winlog.event_data.TargetImage` to the aggregation clause can be beneficial but may introduce more false-positives.
+
 ## MITRE ATT&CK Techniques
 
 - [T1055](https://attack.mitre.org/techniques/T1055)

--- a/hunting/windows/docs/detect_dll_hijack_via_masquerading_as_microsoft_native_libraries.md
+++ b/hunting/windows/docs/detect_dll_hijack_via_masquerading_as_microsoft_native_libraries.md
@@ -9,7 +9,7 @@
 - **UUID:** `d06bc067-6174-412f-b1c9-bf8f15149519`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [DLL Hijack via Masquerading as Microsoft Native Libraries](../queries/detect_dll_hijack_via_masquerading_as_microsoft_native_libraries.toml)
 ## Query
 
 ```sql
@@ -52,6 +52,7 @@ from logs-windows.sysmon_operational-*
 - This hunt requires the creation of an [enrichment policy](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-enrich-data.html) to use with the ES|QL (ENRICH command).
 - The `dll.hash.sha256` field can be used to pivot and further investigate the DLL origin and purpose.
 - Paths like `C:\Users\Public and C:\ProgramData\` are often observed in malware employing DLL side-loading.
+
 ## MITRE ATT&CK Techniques
 
 - [T1574](https://attack.mitre.org/techniques/T1574)

--- a/hunting/windows/docs/detect_dll_hijack_via_masquerading_as_microsoft_native_libraries.md
+++ b/hunting/windows/docs/detect_dll_hijack_via_masquerading_as_microsoft_native_libraries.md
@@ -10,6 +10,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [DLL Hijack via Masquerading as Microsoft Native Libraries](../queries/detect_dll_hijack_via_masquerading_as_microsoft_native_libraries.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/detect_masquerading_attempts_as_native_windows_binaries.md
+++ b/hunting/windows/docs/detect_masquerading_attempts_as_native_windows_binaries.md
@@ -9,7 +9,7 @@
 - **UUID:** `a2006c66-d6ab-43ee-871e-d650e38f7972`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Masquerading Attempts as Native Windows Binaries](../queries/detect_masquerading_attempts_as_native_windows_binaries.toml)
 ## Query
 
 ```sql
@@ -31,6 +31,7 @@ from logs-endpoint.events.process-*
 - Output of the query is the `process.name` and `host.id` where you can pivot by `host.id` and `process.name` (non Microsoft signed) to find the specific suspicious instances.
 - Potential false-positives include processes with missing code signature details due to enrichment bugs.
 - The queried index must capture process start events with code signature information (e.g. Windows event 4688 is not supported).
+
 ## MITRE ATT&CK Techniques
 
 - [T1036](https://attack.mitre.org/techniques/T1036)

--- a/hunting/windows/docs/detect_masquerading_attempts_as_native_windows_binaries.md
+++ b/hunting/windows/docs/detect_masquerading_attempts_as_native_windows_binaries.md
@@ -10,6 +10,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Masquerading Attempts as Native Windows Binaries](../queries/detect_masquerading_attempts_as_native_windows_binaries.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/detect_rare_dll_sideload_by_occurrence.md
+++ b/hunting/windows/docs/detect_rare_dll_sideload_by_occurrence.md
@@ -10,6 +10,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Rare DLL Side-Loading by Occurrence](../queries/detect_rare_dll_sideload_by_occurrence.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/detect_rare_dll_sideload_by_occurrence.md
+++ b/hunting/windows/docs/detect_rare_dll_sideload_by_occurrence.md
@@ -9,7 +9,7 @@
 - **UUID:** `34a7aadb-fb0f-45ea-9260-830f39c3343b`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Rare DLL Side-Loading by Occurrence](../queries/detect_rare_dll_sideload_by_occurrence.toml)
 ## Query
 
 ```sql
@@ -48,6 +48,7 @@ from logs-windows.sysmon_operational-*
 - Based on the returned results you can further investigate suspicious DLLs by sha256 and library path.
 - Paths like `C:\\Users\\Public` and `C:\\ProgramData\\` are often observed in malware employing DLL side-loading.
 - Elastic Defned DLL Events include `dll.Ext.relative_file_creation_time` which help us limit the hunt to recently dropped DLLs.
+
 ## MITRE ATT&CK Techniques
 
 - [T1574](https://attack.mitre.org/techniques/T1574)

--- a/hunting/windows/docs/detect_rare_lsass_process_access_attempts.md
+++ b/hunting/windows/docs/detect_rare_lsass_process_access_attempts.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Rare LSASS Process Access Attempts](../queries/detect_rare_lsass_process_access_attempts.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/detect_rare_lsass_process_access_attempts.md
+++ b/hunting/windows/docs/detect_rare_lsass_process_access_attempts.md
@@ -10,7 +10,7 @@
 - **UUID:** `d0aed6f5-f84c-4da8-bb2a-b5ca0fbb55e0`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Rare LSASS Process Access Attempts](../queries/detect_rare_lsass_process_access_attempts.toml)
 ## Query
 
 ```sql
@@ -42,6 +42,7 @@ from logs-windows.sysmon_operational-*
 
 - Based on the process.executable and process.name you can pivot and investigate further for the matching instances.
 - Potential false-positives include rare legitimate conditions that may trigger this behavior due to third-party software or LSASS crashing.
+
 ## MITRE ATT&CK Techniques
 
 - [T1003](https://attack.mitre.org/techniques/T1003)

--- a/hunting/windows/docs/domain_names_queried_via_lolbins_and_with_low_occurence_frequency.md
+++ b/hunting/windows/docs/domain_names_queried_via_lolbins_and_with_low_occurence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [DNS Queries via LOLBins with Low Occurence Frequency](../queries/domain_names_queried_via_lolbins_and_with_low_occurence_frequency.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/domain_names_queried_via_lolbins_and_with_low_occurence_frequency.md
+++ b/hunting/windows/docs/domain_names_queried_via_lolbins_and_with_low_occurence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `1c7be6db-12eb-4281-878d-b6abe0454f36`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [DNS Queries via LOLBins with Low Occurence Frequency](../queries/domain_names_queried_via_lolbins_and_with_low_occurence_frequency.toml)
 ## Query
 
 ```sql
@@ -27,6 +27,7 @@ from logs-endpoint.events.network-*, logs-windows.sysmon_operational-*
 
 - Utilities like curl and SSL verification for web services are noisy, while others are rare such as scripting utilities and are worth further investigation.
 - Connection to legit domains like Github, Discord, Telegram and many other legit web services by LOLBins is still suspicious and require further investigation.
+
 ## MITRE ATT&CK Techniques
 
 - [T1071](https://attack.mitre.org/techniques/T1071)

--- a/hunting/windows/docs/drivers_load_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/drivers_load_with_low_occurrence_frequency.md
@@ -37,7 +37,7 @@ from logs-system.system-*
   winlog.event_data.ServiceType == "kernel mode driver"
 | eval ServiceFileName = replace(winlog.event_data.ImagePath, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 ```

--- a/hunting/windows/docs/drivers_load_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/drivers_load_with_low_occurrence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `cebfbb4d-5b2a-44d8-b763-5512b654fb26`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Occurrence of Drivers Loaded on Unique Hosts](../queries/drivers_load_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -48,6 +48,7 @@ from logs-system.system-*
 - `dll.Ext.relative_file_creation_time` is used in the first query to limit the result to recently dropped drivers (populated in Elastic Defend).
 - Aggregation can also be done by `dll.hash.sha256` / `file.hash.sha256` but will return more results.
 - Bring Your Own Vulnerable Driver (BYOVD) are all signed and not malicious, further investigation should be done to check the surrounding events (service creation, process that dropped the driver etc.).
+
 ## MITRE ATT&CK Techniques
 
 - [T1068](https://attack.mitre.org/techniques/T1068)

--- a/hunting/windows/docs/drivers_load_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/drivers_load_with_low_occurrence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Occurrence of Drivers Loaded on Unique Hosts](../queries/drivers_load_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql
@@ -36,7 +37,7 @@ from logs-system.system-*
   winlog.event_data.ServiceType == "kernel mode driver"
 | eval ServiceFileName = replace(winlog.event_data.ImagePath, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 ```

--- a/hunting/windows/docs/excessive_rdp_network_activity_by_source_host_and_user.md
+++ b/hunting/windows/docs/excessive_rdp_network_activity_by_source_host_and_user.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Excessive RDP Network Activity by Host and User](../queries/excessive_rdp_network_activity_by_source_host_and_user.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/excessive_rdp_network_activity_by_source_host_and_user.md
+++ b/hunting/windows/docs/excessive_rdp_network_activity_by_source_host_and_user.md
@@ -10,7 +10,7 @@
 - **UUID:** `f7d2054f-b571-4cd0-b39e-a779576e9398`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Excessive RDP Network Activity by Host and User](../queries/excessive_rdp_network_activity_by_source_host_and_user.toml)
 ## Query
 
 ```sql
@@ -38,6 +38,7 @@ from logs-endpoint.events.network-*, logs-windows.sysmon_operational-*
 - Further investigation can done pivoting by `host.id` and `user.name`.
 - Depending on normal SysAdmin RDP activity, the threshold of 10 can be adjusted to reduce normal noisy activity.
 - The second query uses Windows Security log event ID 4624 to summarize numbers of RDP connections by `source.ip` and `user.name` and duration.
+
 ## MITRE ATT&CK Techniques
 
 - [T1021](https://attack.mitre.org/techniques/T1021)

--- a/hunting/windows/docs/excessive_smb_network_activity_by_process_id.md
+++ b/hunting/windows/docs/excessive_smb_network_activity_by_process_id.md
@@ -10,7 +10,7 @@
 - **UUID:** `8a95f552-f149-4c71-888e-f2690f5add15`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Excessive SMB Network Activity by Process ID](../queries/excessive_smb_network_activity_by_process_id.toml)
 ## Query
 
 ```sql
@@ -28,6 +28,7 @@ from logs-endpoint.events.network-*, logs-windows.sysmon_operational-*
 
 - Further investigation can done pivoting by `process.entity_id` and `host.id.`
 - Maximum number of unique `destination.ip` by process can be adjusted to your environment to reduce normal noisy hosts by process ID.
+
 ## MITRE ATT&CK Techniques
 
 - [T1021](https://attack.mitre.org/techniques/T1021)

--- a/hunting/windows/docs/excessive_smb_network_activity_by_process_id.md
+++ b/hunting/windows/docs/excessive_smb_network_activity_by_process_id.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Excessive SMB Network Activity by Process ID](../queries/excessive_smb_network_activity_by_process_id.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/executable_file_creation_by_an_unusual_microsoft_binary.md
+++ b/hunting/windows/docs/executable_file_creation_by_an_unusual_microsoft_binary.md
@@ -11,7 +11,7 @@ code injection or some other form of exploitation for defense evasion.
 - **UUID:** `b786bcd7-b119-4ff7-b839-3927c2ff7f1f`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Executable File Creation by an Unusual Microsoft Binary](../queries/executable_file_creation_by_an_unusual_microsoft_binary.toml)
 ## Query
 
 ```sql
@@ -41,6 +41,7 @@ from logs-windows.sysmon_operational-*
 - Sysmon file events don't populate file header and process code signature information thus we use `file.extension`.
 - Some exploits may result in the creation of an executable file by the exploited process.
 - Further investigation can be done by pivoting on `process.executable` and filtering for executable file creation.
+
 ## MITRE ATT&CK Techniques
 
 - [T1211](https://attack.mitre.org/techniques/T1211)

--- a/hunting/windows/docs/executable_file_creation_by_an_unusual_microsoft_binary.md
+++ b/hunting/windows/docs/executable_file_creation_by_an_unusual_microsoft_binary.md
@@ -12,6 +12,7 @@ code injection or some other form of exploitation for defense evasion.
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Executable File Creation by an Unusual Microsoft Binary](../queries/executable_file_creation_by_an_unusual_microsoft_binary.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/execution_via_network_logon_by_occurrence_frequency_by_top_source_ip.md
+++ b/hunting/windows/docs/execution_via_network_logon_by_occurrence_frequency_by_top_source_ip.md
@@ -10,7 +10,7 @@
 - **UUID:** `24108755-4d1f-4d7a-ad5f-04c2ca55e9a3`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Frequency of Process Execution via Network Logon by Source Address](../queries/execution_via_network_logon_by_occurrence_frequency_by_top_source_ip.toml)
 ## Query
 
 ```sql
@@ -41,6 +41,7 @@ from logs-endpoint.events.process-*
 - `process.Ext.session_info.*` is populated for Elastic Defend versions 8.6.0+ and above.
 - Execution via legitimate Microsoft processes for PowerShell and cmd need to be further investigated via aggregation by `process.command_line`.
 - Aggregation can be also done by `process.executable`, normalizing process path by removing random patterns using the ES|QL REPLACE function.
+
 ## MITRE ATT&CK Techniques
 
 - [T1021](https://attack.mitre.org/techniques/T1021)

--- a/hunting/windows/docs/execution_via_network_logon_by_occurrence_frequency_by_top_source_ip.md
+++ b/hunting/windows/docs/execution_via_network_logon_by_occurrence_frequency_by_top_source_ip.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Frequency of Process Execution via Network Logon by Source Address](../queries/execution_via_network_logon_by_occurrence_frequency_by_top_source_ip.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/execution_via_remote_services_by_client_address.md
+++ b/hunting/windows/docs/execution_via_remote_services_by_client_address.md
@@ -10,7 +10,7 @@
 - **UUID:** `5fd5da54-0515-4d6b-b8d7-30fd05f5be33`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Execution via Remote Services by Client Address](../queries/execution_via_remote_services_by_client_address.toml)
 ## Query
 
 ```sql
@@ -28,6 +28,7 @@ from logs-endpoint.events.process-*
 ## Notes
 
 - `process.Ext.session_info.*` is populated for Elastic Defend versions 8.6.0+.
+
 ## MITRE ATT&CK Techniques
 
 - [T1021](https://attack.mitre.org/techniques/T1021)

--- a/hunting/windows/docs/execution_via_remote_services_by_client_address.md
+++ b/hunting/windows/docs/execution_via_remote_services_by_client_address.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Execution via Remote Services by Client Address](../queries/execution_via_remote_services_by_client_address.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/execution_via_startup_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/execution_via_startup_with_low_occurrence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `52a958e8-0368-4e74-bd4b-a64faf397bf4`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Startup Execution with Low Occurrence Frequency by Unique Host](../queries/execution_via_startup_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -32,6 +32,7 @@ from logs-endpoint.events.process-*
 
 - Items set to persist via Startup such as Run keys and Startup folder will be executed by `Explorer.exe` shortly after user logon (`process.Ext.session_info.relative_logon_time` helps us to capture that time difference).
 - Special attention to unknown hashes, suspicious paths and LOLBins should be given.
+
 ## MITRE ATT&CK Techniques
 
 - [T1547](https://attack.mitre.org/techniques/T1547)

--- a/hunting/windows/docs/execution_via_startup_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/execution_via_startup_with_low_occurrence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Startup Execution with Low Occurrence Frequency by Unique Host](../queries/execution_via_startup_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/execution_via_windows_management_instrumentation_by_occurrence_frequency_by_unique_agent.md
+++ b/hunting/windows/docs/execution_via_windows_management_instrumentation_by_occurrence_frequency_by_unique_agent.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Frequency of Process Execution via WMI by Unique Agent](../queries/execution_via_windows_management_instrumentation_by_occurrence_frequency_by_unique_agent.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/execution_via_windows_management_instrumentation_by_occurrence_frequency_by_unique_agent.md
+++ b/hunting/windows/docs/execution_via_windows_management_instrumentation_by_occurrence_frequency_by_unique_agent.md
@@ -10,7 +10,7 @@
 - **UUID:** `a95e69af-22ad-4ab7-919e-794501f10c95`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Frequency of Process Execution via WMI by Unique Agent](../queries/execution_via_windows_management_instrumentation_by_occurrence_frequency_by_unique_agent.toml)
 ## Query
 
 ```sql
@@ -49,6 +49,7 @@ from logs-endpoint.events.process-*, logs-windows.sysmon_operational-*
 ## Notes
 
 - This hunt contains three queries for Elastic Defend, Sysmon, and Windows Security event 4688.
+
 ## MITRE ATT&CK Techniques
 
 - [T1047](https://attack.mitre.org/techniques/T1047)

--- a/hunting/windows/docs/execution_via_windows_scheduled_task_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/execution_via_windows_scheduled_task_with_low_occurrence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `0d960760-8a40-49c1-bbdd-4deb32c7fd67`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Frequency of Process Execution via Windows Scheduled Task by Unique Agent](../queries/execution_via_windows_scheduled_task_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -29,6 +29,7 @@ from logs-endpoint.events.process-*, logs-windows.sysmon_operational-*
 
 - Windows security event 4688 lacks `process.parent.command_line` needed for this hunt to identify the Schedule `svchost` instance.
 - Unique `process.hash.sha256` and agent is not necessarily malicious, however this helps surface signals worth further investigation.
+
 ## MITRE ATT&CK Techniques
 
 - [T1053](https://attack.mitre.org/techniques/T1053)

--- a/hunting/windows/docs/execution_via_windows_scheduled_task_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/execution_via_windows_scheduled_task_with_low_occurrence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Frequency of Process Execution via Windows Scheduled Task by Unique Agent](../queries/execution_via_windows_scheduled_task_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/execution_via_windows_services_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/execution_via_windows_services_with_low_occurrence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `a0a84a86-115f-42f9-90a5-4cb7ceeef981`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Occurence of Process Execution via Windows Services with Unique Agent](../queries/execution_via_windows_services_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -41,6 +41,7 @@ from logs-system.security-*
 - Windows security event 4688 lacks code signature and hash information, hence the use of `process.executable` for aggregation.
 - Unique `process.hash.sha256` and agent is not necessarily malicious, this help surface ones worth further investigation.
 - Suspicious `process.executable` paths and LOLBins should be reviewed further.
+
 ## MITRE ATT&CK Techniques
 
 - [T1543](https://attack.mitre.org/techniques/T1543)

--- a/hunting/windows/docs/execution_via_windows_services_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/execution_via_windows_services_with_low_occurrence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Occurence of Process Execution via Windows Services with Unique Agent](../queries/execution_via_windows_services_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/high_count_of_network_connection_over_extended_period_by_process.md
+++ b/hunting/windows/docs/high_count_of_network_connection_over_extended_period_by_process.md
@@ -10,7 +10,7 @@
 - **UUID:** `5e5aa9c2-96a8-4d5b-bbca-ff2ec8fefa5b`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [High Count of Network Connection Over Extended Period by Process](../queries/high_count_of_network_connection_over_extended_period_by_process.toml)
 ## Query
 
 ```sql
@@ -68,6 +68,7 @@ not (process.name == "svchost.exe" and user.id == "S-1-5-18") and
 ## Notes
 
 - This hunt includes three queries for Elastic Defend and Sysmon data sources.
+
 ## MITRE ATT&CK Techniques
 
 - [T1071](https://attack.mitre.org/techniques/T1071)

--- a/hunting/windows/docs/high_count_of_network_connection_over_extended_period_by_process.md
+++ b/hunting/windows/docs/high_count_of_network_connection_over_extended_period_by_process.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [High Count of Network Connection Over Extended Period by Process](../queries/high_count_of_network_connection_over_extended_period_by_process.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/libraries_loaded_by_svchost_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/libraries_loaded_by_svchost_with_low_occurrence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `c00f1afe-4f25-4542-8cc9-277b23581121`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Libraries Loaded by svchost with Low Occurrence Frequency](../queries/libraries_loaded_by_svchost_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -50,6 +50,7 @@ from logs-windows.sysmon_operational-*
 - The hunt uses Elastic Defend library events for an extra optional condition `dll.Ext.relative_file_creation_time` to scope if for recently dropped DLLs.
 - The `count_dlls_per_folder` variable filter is used to avoid cases where multiple DLLs with different names are loaded from same directory (often observed in FPs loaded multiple dependencies from same dir).
 - Pay close attention unknown hashes and suspicious paths, usually ServiceDLLs are located in trusted directories like `%programfiles%` and `system32/syswow64`.
+
 ## MITRE ATT&CK Techniques
 
 - [T1543](https://attack.mitre.org/techniques/T1543)

--- a/hunting/windows/docs/libraries_loaded_by_svchost_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/libraries_loaded_by_svchost_with_low_occurrence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Libraries Loaded by svchost with Low Occurrence Frequency](../queries/libraries_loaded_by_svchost_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/microsoft_office_child_processes_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/microsoft_office_child_processes_with_low_occurrence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `f1b8519a-4dae-475f-965a-f53559233eab`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Microsoft Office Child Processes with Low Occurrence Frequency by Unique Agent](../queries/microsoft_office_child_processes_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -28,6 +28,7 @@ from logs-endpoint.events.process-*, logs-windows.sysmon_operational-*, logs-sys
 
 - Certain processes like `WerFault.exe`, `dw20.exe` and `dwwin.exe` are often related to application crash.
 - Closer attention should be attributed to lolbins and unsigned executables (Windows 4688 is not capturing process code signature information).
+
 ## MITRE ATT&CK Techniques
 
 - [T1566](https://attack.mitre.org/techniques/T1566)

--- a/hunting/windows/docs/microsoft_office_child_processes_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/microsoft_office_child_processes_with_low_occurrence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Microsoft Office Child Processes with Low Occurrence Frequency by Unique Agent](../queries/microsoft_office_child_processes_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/network_discovery_via_sensitive_ports_by_unusual_process.md
+++ b/hunting/windows/docs/network_discovery_via_sensitive_ports_by_unusual_process.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Network Discovery via Sensitive Ports by Unusual Process](../queries/network_discovery_via_sensitive_ports_by_unusual_process.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/network_discovery_via_sensitive_ports_by_unusual_process.md
+++ b/hunting/windows/docs/network_discovery_via_sensitive_ports_by_unusual_process.md
@@ -10,7 +10,7 @@
 - **UUID:** `386f9cec-bb44-4dd2-8368-45e6fa0a425b`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Network Discovery via Sensitive Ports by Unusual Process](../queries/network_discovery_via_sensitive_ports_by_unusual_process.toml)
 ## Query
 
 ```sql
@@ -32,6 +32,7 @@ from logs-endpoint.events.network-*, logs-windows.sysmon_operational-*
 - The query thresholds for SMB or RDP need to be adjusted to your environment.
 - You can add more sensitive ports to the list like FTP, SSH and others.
 - Elastic Network events include process code signature information, this can be added to filter out signed third party false positives.
+
 ## MITRE ATT&CK Techniques
 
 - [T1021](https://attack.mitre.org/techniques/T1021)

--- a/hunting/windows/docs/pe_file_transfer_via_smb_admin_shares_by_agent.md
+++ b/hunting/windows/docs/pe_file_transfer_via_smb_admin_shares_by_agent.md
@@ -10,7 +10,7 @@
 - **UUID:** `814894a4-c951-4f33-ab0b-09354e1cb957`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [PE File Transfer via SMB_Admin Shares by Agent or User](../queries/pe_file_transfer_via_smb_admin_shares_by_agent.toml)
 ## Query
 
 ```sql
@@ -35,6 +35,7 @@ from logs-endpoint.events.file-*
 ## Notes
 
 - Further investigation can done pivoting by `host.id` and `user.name`.
+
 ## MITRE ATT&CK Techniques
 
 - [T1021](https://attack.mitre.org/techniques/T1021)

--- a/hunting/windows/docs/pe_file_transfer_via_smb_admin_shares_by_agent.md
+++ b/hunting/windows/docs/pe_file_transfer_via_smb_admin_shares_by_agent.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [PE File Transfer via SMB_Admin Shares by Agent or User](../queries/pe_file_transfer_via_smb_admin_shares_by_agent.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/persistence_via_run_key_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/persistence_via_run_key_with_low_occurrence_frequency.md
@@ -24,7 +24,7 @@ from logs-endpoint.events.registry-*
 | keep registry.key, registry.data.strings, process.name, host.id
  /* Paths normalization in registry.data.strings to ease aggregation */
 | eval registry_data = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
-| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by process.name, registry_data
 | where hosts == 1 and cc == 1
 ```
@@ -38,7 +38,7 @@ from logs-windows.sysmon_operational-*
 | keep registry.key, registry.data.strings, process.name, host.id
  /* Paths normalization in registry.data.strings to ease aggregation */
 | eval registry_data = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
-| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by process.name, registry_data
 | where hosts == 1 and cc == 1
 ```

--- a/hunting/windows/docs/persistence_via_run_key_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/persistence_via_run_key_with_low_occurrence_frequency.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Persistence via Run Key with Low Occurrence Frequency](../queries/persistence_via_run_key_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql
@@ -23,7 +24,7 @@ from logs-endpoint.events.registry-*
 | keep registry.key, registry.data.strings, process.name, host.id
  /* Paths normalization in registry.data.strings to ease aggregation */
 | eval registry_data = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
-| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by process.name, registry_data
 | where hosts == 1 and cc == 1
 ```
@@ -37,7 +38,7 @@ from logs-windows.sysmon_operational-*
 | keep registry.key, registry.data.strings, process.name, host.id
  /* Paths normalization in registry.data.strings to ease aggregation */
 | eval registry_data = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
-| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by process.name, registry_data
 | where hosts == 1 and cc == 1
 ```

--- a/hunting/windows/docs/persistence_via_run_key_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/persistence_via_run_key_with_low_occurrence_frequency.md
@@ -10,7 +10,7 @@
 - **UUID:** `df4ee961-254d-4ad1-af15-c65c3b65abcd`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Persistence via Run Key with Low Occurrence Frequency](../queries/persistence_via_run_key_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -47,6 +47,7 @@ from logs-windows.sysmon_operational-*
 - This hunt includes two queries to cover both Sysmon and Elastic Defend data sources.
 - Sysmon registry events do not populate process code signature information (hence the separation of the queries).
 - Suspicious paths and LOLBins in the `registry.data.strings` value should be reviewed further.
+
 ## MITRE ATT&CK Techniques
 
 - [T1547](https://attack.mitre.org/techniques/T1547)

--- a/hunting/windows/docs/persistence_via_startup_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/persistence_via_startup_with_low_occurrence_frequency.md
@@ -9,7 +9,7 @@
 - **UUID:** `ea950361-33e4-4045-96a5-d36ca28fbc91`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Persistence via Startup with Low Occurrence Frequency by Unique Host](../queries/persistence_via_startup_with_low_occurrence_frequency.toml)
 ## Query
 
 ```sql
@@ -30,6 +30,7 @@ from logs-endpoint.events.file-*, logs-windows.sysmon_operational-default-*
 - Elastic Defend file event captures the `process.code_signature` information, this can be added to the hunt to limit to unsigned and Microsoft signed programs.
 - Unique `file.name` and limited to one agent is not necessarily malicious, however helps surface ones worth further investigation.
 - Suspicious `process.executable` paths and LOLBins should be reviewed further.
+
 ## MITRE ATT&CK Techniques
 
 - [T1547](https://attack.mitre.org/techniques/T1547)

--- a/hunting/windows/docs/persistence_via_startup_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/persistence_via_startup_with_low_occurrence_frequency.md
@@ -10,6 +10,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Persistence via Startup with Low Occurrence Frequency by Unique Host](../queries/persistence_via_startup_with_low_occurrence_frequency.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.md
+++ b/hunting/windows/docs/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Low Occurrence of Suspicious Launch Agent or Launch Daemon](../queries/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.toml)
+
 ## Query
 
 ```sql
@@ -20,7 +21,7 @@ from logs-endpoint.events.file-*
   (Persistence.runatload == true or Persistence.keepalive == true) and process.executable is not null
 | eval args = MV_CONCAT(Persistence.args, ",")
  /* normalizing users home profile */
-| eval args = replace(args, """/Users/[a-zA-Z0-9ñ\.\-\_\$~ ]+/""", "/Users/user/")
+| eval args = replace(args, """/Users/[a-zA-Z0-9]\.\-\_\$~ ]+/""", "/Users/user/")
 | stats agents = count_distinct(host.id), total = count(*) by process.name, Persistence.name, args
 | where starts_with(args, "/") and agents == 1 and total == 1
 ```

--- a/hunting/windows/docs/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.md
+++ b/hunting/windows/docs/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.md
@@ -10,7 +10,7 @@
 - **UUID:** `69fc4f40-8fb1-4652-99b7-52755cd370fe`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Low Occurrence of Suspicious Launch Agent or Launch Daemon](../queries/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.toml)
 ## Query
 
 ```sql
@@ -28,6 +28,7 @@ from logs-endpoint.events.file-*
 ## Notes
 
 - Further investigation can done pivoting by `Persistence.name` and `args`.
+
 ## MITRE ATT&CK Techniques
 
 - [T1547](https://attack.mitre.org/techniques/T1547)

--- a/hunting/windows/docs/potential_exfiltration_by_process_total_egress_bytes.md
+++ b/hunting/windows/docs/potential_exfiltration_by_process_total_egress_bytes.md
@@ -10,7 +10,7 @@
 - **UUID:** `24925575-defd-4581-bfda-a8753dcfb46e`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Egress Network Connections with Total Bytes Greater than Threshold](../queries/potential_exfiltration_by_process_total_egress_bytes.toml)
 ## Query
 
 ```sql
@@ -31,6 +31,7 @@ from logs-endpoint.events.network-*
 - The use of `host.os.family` is to optimise the query and avoid timeout. You can duplicate the same query for other platforms (linux, macos etc.)
 - Based on limited testing it's recommended to set the query time window to 8 hours.
 - Pivoting by `process.entity_id` will allow further investigation (parent process, hash, child processes, other network events etc.).
+
 ## MITRE ATT&CK Techniques
 
 - [T1071](https://attack.mitre.org/techniques/T1071)

--- a/hunting/windows/docs/potential_exfiltration_by_process_total_egress_bytes.md
+++ b/hunting/windows/docs/potential_exfiltration_by_process_total_egress_bytes.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Egress Network Connections with Total Bytes Greater than Threshold](../queries/potential_exfiltration_by_process_total_egress_bytes.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/rundll32_execution_aggregated_by_cmdline.md
+++ b/hunting/windows/docs/rundll32_execution_aggregated_by_cmdline.md
@@ -10,7 +10,7 @@
 - **UUID:** `44e6adc6-e183-4bfa-b06d-db41669641fa`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Rundll32 Execution Aggregated by Command Line](../queries/rundll32_execution_aggregated_by_cmdline.toml)
 ## Query
 
 ```sql
@@ -30,6 +30,7 @@ from logs-endpoint.events.process-*, logs-windows.sysmon_operational-*, logs-sys
 
 - Execution of DLLs from suspicious paths or with suspicious export function names or from suspicious parent should be further reviewed.
 - Parents such as svchost, `explorer.exe`, `wmiprvse.exe`, `winword.exe` and others should be carefully reviewed.
+
 ## MITRE ATT&CK Techniques
 
 - [T1127](https://attack.mitre.org/techniques/T1127)

--- a/hunting/windows/docs/rundll32_execution_aggregated_by_cmdline.md
+++ b/hunting/windows/docs/rundll32_execution_aggregated_by_cmdline.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Rundll32 Execution Aggregated by Command Line](../queries/rundll32_execution_aggregated_by_cmdline.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/scheduled_task_creation_by_action_via_registry.md
+++ b/hunting/windows/docs/scheduled_task_creation_by_action_via_registry.md
@@ -10,7 +10,7 @@
 - **UUID:** `df50f65e-e820-47f4-a039-671611582f51`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Scheduled tasks Creation by Action via Registry](../queries/scheduled_task_creation_by_action_via_registry.toml)
 ## Query
 
 ```sql
@@ -31,6 +31,7 @@ from logs-endpoint.events.registry-*
 ## Notes
 
 - Malware often abuse LOLBins to proxy execution or run executables from unusual paths, you can add more patterns to the query.
+
 ## MITRE ATT&CK Techniques
 
 - [T1053](https://attack.mitre.org/techniques/T1053)

--- a/hunting/windows/docs/scheduled_task_creation_by_action_via_registry.md
+++ b/hunting/windows/docs/scheduled_task_creation_by_action_via_registry.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint)
 - **Language:** `[ES|QL]`
 - **Source File:** [Scheduled tasks Creation by Action via Registry](../queries/scheduled_task_creation_by_action_via_registry.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/scheduled_tasks_creation_for_unique_hosts_by_task_command.md
+++ b/hunting/windows/docs/scheduled_tasks_creation_for_unique_hosts_by_task_command.md
@@ -10,7 +10,7 @@
 - **UUID:** `44223fd6-8241-4c21-9d54-21201fa15b12`
 - **Integration:** [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Scheduled Tasks Creation for Unique Hosts by Task Command](../queries/scheduled_tasks_creation_for_unique_hosts_by_task_command.toml)
 ## Query
 
 ```sql
@@ -35,6 +35,7 @@ from logs-system.security-default-*
 
 - This hunt returns the aggregation of created tasks by task name, command to execute and number of hosts where this task is present.
 - Close attention should be paid to suspicious paths like `C:\Users\Public and C:\ProgramData\` as well as LOLBins.
+
 ## MITRE ATT&CK Techniques
 
 - [T1053](https://attack.mitre.org/techniques/T1053)

--- a/hunting/windows/docs/scheduled_tasks_creation_for_unique_hosts_by_task_command.md
+++ b/hunting/windows/docs/scheduled_tasks_creation_for_unique_hosts_by_task_command.md
@@ -11,6 +11,7 @@
 - **Integration:** [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Scheduled Tasks Creation for Unique Hosts by Task Command](../queries/scheduled_tasks_creation_for_unique_hosts_by_task_command.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/suspicious_base64_encoded_powershell_commands.md
+++ b/hunting/windows/docs/suspicious_base64_encoded_powershell_commands.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Suspicious Base64 Encoded Powershell Command](../queries/suspicious_base64_encoded_powershell_commands.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/suspicious_base64_encoded_powershell_commands.md
+++ b/hunting/windows/docs/suspicious_base64_encoded_powershell_commands.md
@@ -10,7 +10,7 @@
 - **UUID:** `2e583d3c-7ad6-4544-a0db-c685b2066493`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Suspicious Base64 Encoded Powershell Command](../queries/suspicious_base64_encoded_powershell_commands.toml)
 ## Query
 
 ```sql
@@ -31,6 +31,7 @@ from logs-endpoint.events.process-*, logs-windows.sysmon_operational-*, logs-sys
 
 - This hunt can be expanded to include more evasion techniques and downloaders.
 - Pivoting by `agent.id` can provide more context on the affected hosts.
+
 ## MITRE ATT&CK Techniques
 
 - [T1059](https://attack.mitre.org/techniques/T1059)

--- a/hunting/windows/docs/suspicious_dns_txt_record_lookups_by_process.md
+++ b/hunting/windows/docs/suspicious_dns_txt_record_lookups_by_process.md
@@ -11,7 +11,7 @@ Adversaries may leverage DNS TXT queries to stage malicious content or exfiltrat
 - **UUID:** `7a2c8397-d219-47ad-a8e2-93562e568d08`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Suspicious DNS TXT Record Lookups by Process](../queries/suspicious_dns_txt_record_lookups_by_process.toml)
 ## Query
 
 ```sql
@@ -1592,6 +1592,7 @@ s```
 
 - This hunt returns a list of processes unique pids and executable paths that performs a high number of DNS TXT lookups.
 - Pivoting by `process.entity_id` will allow further investigation (parent process, hash, child processes, other network events etc.).
+
 ## MITRE ATT&CK Techniques
 
 - [T1071](https://attack.mitre.org/techniques/T1071)

--- a/hunting/windows/docs/suspicious_dns_txt_record_lookups_by_process.md
+++ b/hunting/windows/docs/suspicious_dns_txt_record_lookups_by_process.md
@@ -12,6 +12,7 @@ Adversaries may leverage DNS TXT queries to stage malicious content or exfiltrat
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows)
 - **Language:** `[ES|QL]`
 - **Source File:** [Suspicious DNS TXT Record Lookups by Process](../queries/suspicious_dns_txt_record_lookups_by_process.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/unique_windows_services_creation_by_servicefilename.md
+++ b/hunting/windows/docs/unique_windows_services_creation_by_servicefilename.md
@@ -10,7 +10,7 @@
 - **UUID:** `48b75e53-3c73-40bd-873d-569dd8d7d925`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Unique Windows Services Creation by Service File Name](../queries/unique_windows_services_creation_by_servicefilename.toml)
 ## Query
 
 ```sql
@@ -67,6 +67,7 @@ from logs-system.system-*
 
 - This hunt also identifies services registry modification by unusual process based on number of hosts and occurrences history.
 - Windows event IDs 4697 and 7045 are used to identify service creation and modification.
+
 ## MITRE ATT&CK Techniques
 
 - [T1543](https://attack.mitre.org/techniques/T1543)

--- a/hunting/windows/docs/unique_windows_services_creation_by_servicefilename.md
+++ b/hunting/windows/docs/unique_windows_services_creation_by_servicefilename.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Unique Windows Services Creation by Service File Name](../queries/unique_windows_services_creation_by_servicefilename.toml)
+
 ## Query
 
 ```sql
@@ -19,7 +20,7 @@ from logs-endpoint.events.registry-*, logs-windows.sysmon_operational-*
 | where host.os.family == "windows" and event.category == "registry" and event.action in ("modification",  "RegistryEvent (Value Set)") and
   registry.value in ("ServiceDLL", "ImagePath") and starts_with(registry.path, "HKLM\\SYSTEM\\") and
   process.executable != "C:\\Windows\\System32\\services.exe"
-| eval process_path = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval process_path = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats hosts = count_distinct(host.id), occurrences = count(*) by process_path
 /* unique process.executable found in one agent */
 | where hosts == 1 and occurrences == 1
@@ -33,7 +34,7 @@ from logs-endpoint.events.registry-*, logs-windows.sysmon_operational-*
   not registry.data.strings rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
  /* unique ServiceFileName observed in 1 host*/
 | where hosts == 1 and cc == 1
@@ -46,7 +47,7 @@ from logs-system.security-*
   not winlog.event_data.ServiceFileName rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(winlog.event_data.ServiceFileName, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9].\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 ```
@@ -58,7 +59,7 @@ from logs-system.system-*
   not winlog.event_data.ImagePath rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(winlog.event_data.ImagePath, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 ```

--- a/hunting/windows/docs/unique_windows_services_creation_by_servicefilename.md
+++ b/hunting/windows/docs/unique_windows_services_creation_by_servicefilename.md
@@ -20,7 +20,7 @@ from logs-endpoint.events.registry-*, logs-windows.sysmon_operational-*
 | where host.os.family == "windows" and event.category == "registry" and event.action in ("modification",  "RegistryEvent (Value Set)") and
   registry.value in ("ServiceDLL", "ImagePath") and starts_with(registry.path, "HKLM\\SYSTEM\\") and
   process.executable != "C:\\Windows\\System32\\services.exe"
-| eval process_path = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval process_path = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats hosts = count_distinct(host.id), occurrences = count(*) by process_path
 /* unique process.executable found in one agent */
 | where hosts == 1 and occurrences == 1
@@ -34,7 +34,7 @@ from logs-endpoint.events.registry-*, logs-windows.sysmon_operational-*
   not registry.data.strings rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
  /* unique ServiceFileName observed in 1 host*/
 | where hosts == 1 and cc == 1
@@ -47,7 +47,7 @@ from logs-system.security-*
   not winlog.event_data.ServiceFileName rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(winlog.event_data.ServiceFileName, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9].\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 ```
@@ -59,7 +59,7 @@ from logs-system.system-*
   not winlog.event_data.ImagePath rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(winlog.event_data.ImagePath, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 ```

--- a/hunting/windows/docs/windows_command_and_scripting_interpreter_from_unusual_parent.md
+++ b/hunting/windows/docs/windows_command_and_scripting_interpreter_from_unusual_parent.md
@@ -11,6 +11,7 @@
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Windows Command and Scripting Interpreter from Unusual Parent Process](../queries/windows_command_and_scripting_interpreter_from_unusual_parent.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/windows_command_and_scripting_interpreter_from_unusual_parent.md
+++ b/hunting/windows/docs/windows_command_and_scripting_interpreter_from_unusual_parent.md
@@ -10,7 +10,7 @@
 - **UUID:** `aca4877f-d284-4bdb-8e18-b1414d3a7c20`
 - **Integration:** [endpoint](https://docs.elastic.co/integrations/endpoint), [windows](https://docs.elastic.co/integrations/windows), [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Windows Command and Scripting Interpreter from Unusual Parent Process](../queries/windows_command_and_scripting_interpreter_from_unusual_parent.toml)
 ## Query
 
 ```sql
@@ -28,6 +28,7 @@ from logs-endpoint.events.process-*, logs-windows.sysmon_operational-*, logs-sys
 
 - Further pivoting can be done via `process.parent.name`.
 - Certain Microsoft binaries like LSASS, winlogon, spoolsv and others should never spawn `cmd.exe`, `powershell.exe` or `conhost.exe`, if so it's highly likely malicious.
+
 ## MITRE ATT&CK Techniques
 
 - [T1059](https://attack.mitre.org/techniques/T1059)

--- a/hunting/windows/docs/windows_logon_activity_by_source_ip.md
+++ b/hunting/windows/docs/windows_logon_activity_by_source_ip.md
@@ -11,6 +11,7 @@
 - **Integration:** [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
 - **Source File:** [Windows Logon Activity by Source IP](../queries/windows_logon_activity_by_source_ip.toml)
+
 ## Query
 
 ```sql

--- a/hunting/windows/docs/windows_logon_activity_by_source_ip.md
+++ b/hunting/windows/docs/windows_logon_activity_by_source_ip.md
@@ -10,7 +10,7 @@
 - **UUID:** `441fba85-47a9-4f1f-aab4-569bbfdc548b`
 - **Integration:** [system](https://docs.elastic.co/integrations/system)
 - **Language:** `[ES|QL]`
-
+- **Source File:** [Windows Logon Activity by Source IP](../queries/windows_logon_activity_by_source_ip.toml)
 ## Query
 
 ```sql
@@ -30,6 +30,7 @@ from logs-system.security-*
 ## Notes
 
 - Pay close attention to IP address sources with a high number of failed connections associated with low success attempts and high number of user accounts.
+
 ## MITRE ATT&CK Techniques
 
 - [T1110](https://attack.mitre.org/techniques/T1110)

--- a/hunting/windows/queries/createremotethread_by_source_process_with_low_occurrence.toml
+++ b/hunting/windows/queries/createremotethread_by_source_process_with_low_occurrence.toml
@@ -15,7 +15,7 @@ query = [
 from logs-windows.sysmon_operational-*
 | where @timestamp > now() - 7 day
 | where host.os.family == "windows" and event.category == "process" and event.action == "CreateRemoteThread"
-| eval source_process = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval source_process = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by source_process
  /* unique source and target processes combined and observed in 1 host */
 | where hosts == 1 and cc == 1

--- a/hunting/windows/queries/createremotethread_by_source_process_with_low_occurrence.toml
+++ b/hunting/windows/queries/createremotethread_by_source_process_with_low_occurrence.toml
@@ -15,7 +15,7 @@ query = [
 from logs-windows.sysmon_operational-*
 | where @timestamp > now() - 7 day
 | where host.os.family == "windows" and event.category == "process" and event.action == "CreateRemoteThread"
-| eval source_process = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval source_process = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by source_process
  /* unique source and target processes combined and observed in 1 host */
 | where hosts == 1 and cc == 1

--- a/hunting/windows/queries/drivers_load_with_low_occurrence_frequency.toml
+++ b/hunting/windows/queries/drivers_load_with_low_occurrence_frequency.toml
@@ -38,7 +38,7 @@ from logs-system.system-*
   winlog.event_data.ServiceType == "kernel mode driver"
 | eval ServiceFileName = replace(winlog.event_data.ImagePath, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 '''

--- a/hunting/windows/queries/drivers_load_with_low_occurrence_frequency.toml
+++ b/hunting/windows/queries/drivers_load_with_low_occurrence_frequency.toml
@@ -38,7 +38,7 @@ from logs-system.system-*
   winlog.event_data.ServiceType == "kernel mode driver"
 | eval ServiceFileName = replace(winlog.event_data.ImagePath, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 '''

--- a/hunting/windows/queries/persistence_via_run_key_with_low_occurrence_frequency.toml
+++ b/hunting/windows/queries/persistence_via_run_key_with_low_occurrence_frequency.toml
@@ -25,7 +25,7 @@ from logs-endpoint.events.registry-*
 | keep registry.key, registry.data.strings, process.name, host.id
  /* Paths normalization in registry.data.strings to ease aggregation */
 | eval registry_data = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
-| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by process.name, registry_data
 | where hosts == 1 and cc == 1
 ''',
@@ -38,7 +38,7 @@ from logs-windows.sysmon_operational-*
 | keep registry.key, registry.data.strings, process.name, host.id
  /* Paths normalization in registry.data.strings to ease aggregation */
 | eval registry_data = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
-| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by process.name, registry_data
 | where hosts == 1 and cc == 1
 '''

--- a/hunting/windows/queries/persistence_via_run_key_with_low_occurrence_frequency.toml
+++ b/hunting/windows/queries/persistence_via_run_key_with_low_occurrence_frequency.toml
@@ -25,7 +25,7 @@ from logs-endpoint.events.registry-*
 | keep registry.key, registry.data.strings, process.name, host.id
  /* Paths normalization in registry.data.strings to ease aggregation */
 | eval registry_data = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
-| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by process.name, registry_data
 | where hosts == 1 and cc == 1
 ''',
@@ -38,7 +38,7 @@ from logs-windows.sysmon_operational-*
 | keep registry.key, registry.data.strings, process.name, host.id
  /* Paths normalization in registry.data.strings to ease aggregation */
 | eval registry_data = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
-| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval registry_data = replace(registry_data, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by process.name, registry_data
 | where hosts == 1 and cc == 1
 '''

--- a/hunting/windows/queries/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.toml
+++ b/hunting/windows/queries/persistence_via_suspicious_launch_agent_or_launch_daemon_with_low_occurrence.toml
@@ -20,7 +20,7 @@ from logs-endpoint.events.file-*
   (Persistence.runatload == true or Persistence.keepalive == true) and process.executable is not null
 | eval args = MV_CONCAT(Persistence.args, ",")
  /* normalizing users home profile */
-| eval args = replace(args, """/Users/[a-zA-Z0-9ñ\.\-\_\$~ ]+/""", "/Users/user/")
+| eval args = replace(args, """/Users/[a-zA-Z0-9]\.\-\_\$~ ]+/""", "/Users/user/")
 | stats agents = count_distinct(host.id), total = count(*) by process.name, Persistence.name, args
 | where starts_with(args, "/") and agents == 1 and total == 1
 '''

--- a/hunting/windows/queries/unique_windows_services_creation_by_servicefilename.toml
+++ b/hunting/windows/queries/unique_windows_services_creation_by_servicefilename.toml
@@ -21,7 +21,7 @@ from logs-endpoint.events.registry-*, logs-windows.sysmon_operational-*
 | where host.os.family == "windows" and event.category == "registry" and event.action in ("modification",  "RegistryEvent (Value Set)") and
   registry.value in ("ServiceDLL", "ImagePath") and starts_with(registry.path, "HKLM\\SYSTEM\\") and
   process.executable != "C:\\Windows\\System32\\services.exe"
-| eval process_path = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval process_path = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats hosts = count_distinct(host.id), occurrences = count(*) by process_path
 /* unique process.executable found in one agent */
 | where hosts == 1 and occurrences == 1
@@ -34,7 +34,7 @@ from logs-endpoint.events.registry-*, logs-windows.sysmon_operational-*
   not registry.data.strings rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
  /* unique ServiceFileName observed in 1 host*/
 | where hosts == 1 and cc == 1
@@ -46,7 +46,7 @@ from logs-system.security-*
   not winlog.event_data.ServiceFileName rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(winlog.event_data.ServiceFileName, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9].\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 ''',
@@ -57,7 +57,7 @@ from logs-system.system-*
   not winlog.event_data.ImagePath rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(winlog.event_data.ImagePath, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 '''

--- a/hunting/windows/queries/unique_windows_services_creation_by_servicefilename.toml
+++ b/hunting/windows/queries/unique_windows_services_creation_by_servicefilename.toml
@@ -21,7 +21,7 @@ from logs-endpoint.events.registry-*, logs-windows.sysmon_operational-*
 | where host.os.family == "windows" and event.category == "registry" and event.action in ("modification",  "RegistryEvent (Value Set)") and
   registry.value in ("ServiceDLL", "ImagePath") and starts_with(registry.path, "HKLM\\SYSTEM\\") and
   process.executable != "C:\\Windows\\System32\\services.exe"
-| eval process_path = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval process_path = replace(process.executable, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats hosts = count_distinct(host.id), occurrences = count(*) by process_path
 /* unique process.executable found in one agent */
 | where hosts == 1 and occurrences == 1
@@ -34,7 +34,7 @@ from logs-endpoint.events.registry-*, logs-windows.sysmon_operational-*
   not registry.data.strings rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(registry.data.strings, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
  /* unique ServiceFileName observed in 1 host*/
 | where hosts == 1 and cc == 1
@@ -46,7 +46,7 @@ from logs-system.security-*
   not winlog.event_data.ServiceFileName rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(winlog.event_data.ServiceFileName, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9].\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 ''',
@@ -57,7 +57,7 @@ from logs-system.system-*
   not winlog.event_data.ImagePath rlike """(.{1,2}[c-fC-F]:\\Program Files.+)|([c-fC-F]:\\Program Files.+)|(.*\\System32\\DriverStore\\FileRepository\\.+)"""
 | eval ServiceFileName = replace(winlog.event_data.ImagePath, """([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|ns[a-z][A-Z0-9]{3,4}\.tmp|DX[A-Z0-9]{3,4}\.tmp|7z[A-Z0-9]{3,5}\.tmp|[0-9\.\-\_]{3,})""", "")
 | eval ServiceFileName = replace(ServiceFileName, """.inf_amd[a-z0-9]{5,}\\""", "_replaced_")
-| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9]\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
+| eval ServiceFileName = replace(ServiceFileName, """[cC]:\\[uU][sS][eE][rR][sS]\\[a-zA-Z0-9ñ\.\-\_\$~ ]+\\""", "C:\\\\users\\\\user\\\\")
 | stats cc = count(*), hosts = count_distinct(host.id) by ServiceFileName
 | where hosts == 1 and cc == 1
 '''


### PR DESCRIPTION
## Related Issues
* https://github.com/elastic/ia-trade-team/issues/280

## Summary
This pull request fixes a bug in the hunting folder where reference links in the `index.md` file were generating according to the platform `generate_markdown.py` was executed on.

courtesy of @Aegrah 
![image (3)](https://github.com/elastic/detection-rules/assets/99630311/ddd63d2c-c4f4-4ce7-b688-0c161a1f41c4)

## Additional Information
- Added `Source File` to metadata. Originally these were only generated in the LLM docs because they had references. Rather, we should do it globally across rules so visitors can easily from from MD to TOML since URL links are rendered. The original bug existed here as well since it was a generated link. Had to regenerate all docs as a result.


## Testing
1. Checkout branch
2. Run `python hunting/generate_markdown.py` on a Windows platform
