### PR TITLE
[Rule Tuning] Fix event.action conditions - AD Rules

### DIFF
--- a/rules/windows/credential_access_adidns_wildcard.toml
+++ b/rules/windows/credential_access_adidns_wildcard.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/03/26"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -60,7 +60,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where host.os.type == "windows" and event.action == "Directory Service Changes" and
+any where host.os.type == "windows" and event.action in ("Directory Service Changes", "directory-service-object-modified") and
     event.code == "5137" and startsWith(winlog.event_data.ObjectDN, "DC=*,")
 '''
 

--- a/rules/windows/credential_access_adidns_wpad_record.toml
+++ b/rules/windows/credential_access_adidns_wpad_record.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/03"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/06/03"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -57,7 +57,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where host.os.type == "windows" and event.action == "Directory Service Changes" and
+any where host.os.type == "windows" and event.action in ("Directory Service Changes", "directory-service-object-modified") and
     event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
 '''
 

--- a/rules/windows/credential_access_dnsnode_creation.toml
+++ b/rules/windows/credential_access_dnsnode_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/03/26"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -60,7 +60,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where host.os.type == "windows" and event.action == "Directory Service Changes" and
+any where host.os.type == "windows" and event.action in ("Directory Service Changes", "directory-service-object-modified") and
     event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
     not winlog.event_data.SubjectUserName : "*$"
 '''

--- a/rules/windows/credential_access_ldap_attributes.toml
+++ b/rules/windows/credential_access_ldap_attributes.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/11/09"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,7 @@ name = "Access to a Sensitive LDAP Attribute"
 references = [
     "https://www.mandiant.com/resources/blog/apt29-windows-credential-roaming",
     "https://social.technet.microsoft.com/wiki/contents/articles/11483.windows-credential-roaming.aspx",
-    "https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-5136",
+    "https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4662",
 ]
 risk_score = 47
 rule_id = "764c9fcd-4c4c-41e6-a0c7-d6c46c2eff66"
@@ -52,7 +52,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where event.action == "Directory Service Access" and event.code == "4662" and
+any where event.action in ("Directory Service Access", "object-operation-performed") and event.code == "4662" and
 
   not winlog.event_data.SubjectUserSid : "S-1-5-18" and
 

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/01/26"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -98,7 +98,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.action:"Directory Service Changes" and event.code:"5136" and
+event.action:("Directory Service Changes" or "directory-service-object-modified") and event.code:"5136" and
  winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and winlog.event_data.AttributeValue :B\:828* and
  not winlog.event_data.SubjectUserName: MSOL_*
 '''

--- a/rules/windows/credential_access_spn_attribute_modified.toml
+++ b/rules/windows/credential_access_spn_attribute_modified.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/22"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -97,7 +97,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.action:"Directory Service Changes" and event.code:5136 and
+event.action:("Directory Service Changes" or "directory-service-object-modified") and event.code:5136 and
   winlog.event_data.OperationType:"%%14674" and
   winlog.event_data.ObjectClass:"user" and
   winlog.event_data.AttributeLDAPDisplayName:"servicePrincipalName"

--- a/rules/windows/discovery_high_number_ad_properties.toml
+++ b/rules/windows/discovery_high_number_ad_properties.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/29"
 integration = ["windows", "system"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -43,7 +43,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where event.action == "Directory Service Access" and
+any where event.action in ("Directory Service Access", "object-operation-performed") and
  event.code == "4662" and not winlog.event_data.SubjectUserSid : "S-1-5-18" and
  winlog.event_data.AccessMaskDescription == "Read Property" and length(winlog.event_data.Properties) >= 2000
 '''

--- a/rules/windows/persistence_ad_adminsdholder.toml
+++ b/rules/windows/persistence_ad_adminsdholder.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/01/31"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -37,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.action:"Directory Service Changes" and event.code:5136 and
+event.action:("Directory Service Changes" or "directory-service-object-modified") and event.code:5136 and
   winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
 '''
 

--- a/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
+++ b/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/24"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -98,7 +98,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where event.action == "Directory Service Changes" and
+any where event.action in ("Directory Service Changes", "directory-service-object-modified") and
   event.code == "5136" and
   winlog.event_data.AttributeLDAPDisplayName : "dSHeuristics" and
   length(winlog.event_data.AttributeValue) > 15 and

--- a/rules/windows/privilege_escalation_credroaming_ldap.toml
+++ b/rules/windows/privilege_escalation_credroaming_ldap.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/11/09"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/08"
 
 [rule]
 author = ["Elastic"]
@@ -53,7 +53,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.action:"Directory Service Changes" and event.code:"5136" and
+event.action:("Directory Service Changes" or "directory-service-object-modified") and event.code:"5136" and
   winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and winlog.event_data.OperationType:"%%14674" and
   not winlog.event_data.SubjectUserSid : "S-1-5-18"
 '''


### PR DESCRIPTION
## Summary

Fix the `event.action` conditions.

This [PR](https://github.com/elastic/integrations/pull/8289) introduced hard coded values to the `event.action` fields for 5136 and 4662 events, which break the conditions we have on our rules.