### PR TITLE
Fix Double Bump For Rule Microsoft Management Console File from Unusu…

### DIFF
--- a/rules/windows/execution_via_mmc_console_file_unusual_path.toml
+++ b/rules/windows/execution_via_mmc_console_file_unusual_path.toml
@@ -2,9 +2,9 @@
 creation_date = "2024/06/19"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
-min_stack_comments = "New fields added: required_fields, related_integrations, setup"
-min_stack_version = "8.3.0"
-updated_date = "2024/06/19"
+min_stack_comments = "Breaking change at 8.8.0 for Sentinel One Cloud Funnel Integration"
+min_stack_version = "8.12.0"
+updated_date = "2024/07/09"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Issues

- Fix Double Bump in PR - https://github.com/elastic/detection-rules/pull/3876

## Summary

- For Rule `Microsoft Management Console File from Unusual Path` there is a breaking change for integration `sentinel_one_cloud_funnel` at version `8.12`.
- For versions 8.13 --> main the related integrations are 
```
"related_integrations": [
    {
      "package": "endpoint",
      "version": "^8.2.0"
    },
    {
      "package": "windows",
      "version": "^1.5.0"
    },
    {
      "package": "sentinel_one_cloud_funnel",
      "version": "^1.0.0"
    },
    {
      "package": "m365_defender",
      "version": "^2.0.0"
    }
  ],
  ```
- For versions 8.12  --> 8.9  the related integrations are 
```
"related_integrations": [
    {
      "package": "endpoint",
      "version": "^8.2.0"
    },
    {
      "package": "windows",
      "version": "^1.5.0"
    },
    {
      "package": "sentinel_one_cloud_funnel",
      "version": "^0.1.0"
    },
    {
      "package": "m365_defender",
      "version": "^2.0.0"
    }
  ],
  ```
- Hence min stacking the rule to `8.12` 

