### PR TITLE
[Bug] Hunting - Add UTF-8 Encoding for all Read and Write Operations

### DIFF
--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -50,7 +50,7 @@ def load_all_toml(base_path: Path) -> List[tuple[Hunt, Path]]:
     """Load all TOML files from the directory and return a list of Hunt configurations and their paths."""
     hunts = []
     for toml_file in base_path.rglob("*.toml"):
-        hunt_config = load_toml(toml_file.read_text(encoding='utf-8'))
+        hunt_config = load_toml(toml_file.read_text(encoding="utf-8"))
         hunts.append((hunt_config, toml_file))
     return hunts
 

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -117,7 +117,7 @@ def process_toml_files(base_path: Path) -> None:
         markdown_content = convert_toml_to_markdown(hunt_config, toml_file)
         markdown_path = toml_file.parent.parent / "docs" / f"{toml_file.stem}.md"
         markdown_path.parent.mkdir(parents=True, exist_ok=True)
-        markdown_path.write_text(markdown_content, encoding='utf-8')
+        markdown_path.write_text(markdown_content, encoding="utf-8")
         print(f"Markdown generated: {markdown_path}")
         relative_path = markdown_path.relative_to(base_path)
         folder_name = toml_file.parent.parent.name
@@ -132,7 +132,7 @@ def process_toml_files(base_path: Path) -> None:
 
     # Write the index file at the base directory level
     index_path = base_path / "index.md"
-    index_path.write_text(index_content, encoding='utf-8')
+    index_path.write_text(index_content, encoding="utf-8")
     print(f"Index Markdown generated at: {index_path}")
 
 

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -50,7 +50,9 @@ def load_all_toml(base_path: Path) -> List[tuple[Hunt, Path]]:
     """Load all TOML files from the directory and return a list of Hunt configurations and their paths."""
     hunts = []
     for toml_file in base_path.rglob("*.toml"):
-        hunt_config = load_toml(toml_file.read_text())
+        with toml_file.open('r', encoding='utf-8') as file:
+            contents = file.read()
+        hunt_config = load_toml(contents)
         hunts.append((hunt_config, toml_file))
     return hunts
 
@@ -117,7 +119,8 @@ def process_toml_files(base_path: Path) -> None:
         markdown_content = convert_toml_to_markdown(hunt_config, toml_file)
         markdown_path = toml_file.parent.parent / "docs" / f"{toml_file.stem}.md"
         markdown_path.parent.mkdir(parents=True, exist_ok=True)
-        markdown_path.write_text(markdown_content, encoding="utf-8")
+        with markdown_path.open('w', encoding='utf-8') as file:
+            file.write(markdown_content)
         print(f"Markdown generated: {markdown_path}")
         relative_path = markdown_path.relative_to(base_path)
         folder_name = toml_file.parent.parent.name
@@ -132,7 +135,8 @@ def process_toml_files(base_path: Path) -> None:
 
     # Write the index file at the base directory level
     index_path = base_path / "index.md"
-    index_path.write_text(index_content, encoding="utf-8")
+    with index_path.open('w', encoding='utf-8') as file:
+        file.write(index_content)
     print(f"Index Markdown generated at: {index_path}")
 
 

--- a/hunting/generate_markdown.py
+++ b/hunting/generate_markdown.py
@@ -50,9 +50,7 @@ def load_all_toml(base_path: Path) -> List[tuple[Hunt, Path]]:
     """Load all TOML files from the directory and return a list of Hunt configurations and their paths."""
     hunts = []
     for toml_file in base_path.rglob("*.toml"):
-        with toml_file.open('r', encoding='utf-8') as file:
-            contents = file.read()
-        hunt_config = load_toml(contents)
+        hunt_config = load_toml(toml_file.read_text(encoding='utf-8'))
         hunts.append((hunt_config, toml_file))
     return hunts
 
@@ -119,8 +117,7 @@ def process_toml_files(base_path: Path) -> None:
         markdown_content = convert_toml_to_markdown(hunt_config, toml_file)
         markdown_path = toml_file.parent.parent / "docs" / f"{toml_file.stem}.md"
         markdown_path.parent.mkdir(parents=True, exist_ok=True)
-        with markdown_path.open('w', encoding='utf-8') as file:
-            file.write(markdown_content)
+        markdown_path.write_text(markdown_content, encoding='utf-8')
         print(f"Markdown generated: {markdown_path}")
         relative_path = markdown_path.relative_to(base_path)
         folder_name = toml_file.parent.parent.name
@@ -135,8 +132,7 @@ def process_toml_files(base_path: Path) -> None:
 
     # Write the index file at the base directory level
     index_path = base_path / "index.md"
-    with index_path.open('w', encoding='utf-8') as file:
-        file.write(index_content)
+    index_path.write_text(index_content, encoding='utf-8')
     print(f"Index Markdown generated at: {index_path}")
 
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/280

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

⚡ A list of hunting queries (see below) had `ñ` characters in the regex when normalizing paths in ES|QL queries. This was added intentionally to match on that character. However, when running `hunting/generate_markdown.py` script, we did not include UTF-8 encoding on the content when loading the TOML file, only when writing to Markdown. As a result @Aegrah [pointed out](https://github.com/elastic/detection-rules/pull/3872#pullrequestreview-2165516644) that the `ñ` changed when writing to the Markdown files from a Windows host.

This is likely because UTF-8 was used on the writing operations and not the loading.

List of hunts affected:
- Low Occurrence of Suspicious Launch Agent or Launch Daemon
- Low Occurrence Rate of CreateRemoteThread by Source Process
- Low Occurrence of Drivers Loaded on Unique Hosts
- Persistence via Run Key with Low Occurrence Frequency
- Unique Windows Services Creation by Service File Name

Note that the hunts listed, both TOML and MD files, are correct in main and do not require further adjustment.

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

1. From a Windows host, checkout the main
2. Run `python ~/detection-rules/hunting/generate_markdown.py`
3. Notice the diff on the queries listed above
4. Remove changes
5. Checkout `bug-hunting-encoding-content-from-files` branch
6. Run  `python ~/detection-rules/hunting/generate_markdown.py`
7. Notice no changes

![hunt-utf](https://github.com/elastic/detection-rules/assets/99630311/e2bbc2ca-9478-456d-85e7-5a0e26dbb912)

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `Rule: New`, `Rule: Deprecation`, `Rule: Promote`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
