### PR TITLE
[Rule Tuning] Suspicious DLL Loaded for Persistence or Privilege Escalation

### DIFF
--- a/rules/windows/privilege_escalation_persistence_phantom_dll.toml
+++ b/rules/windows/privilege_escalation_persistence_phantom_dll.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/07"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/11"
 
 [rule]
 author = ["Elastic"]
@@ -92,27 +92,52 @@ type = "eql"
 
 query = '''
 any where host.os.type == "windows" and
- (event.category : ("driver", "library") or (event.category == "process" and event.action : "Image loaded*")) and
- (
+(event.category : ("driver", "library") or (event.category == "process" and event.action : "Image loaded*")) and
+(
   /* compatible with Elastic Endpoint Library Events */
-  (?dll.name : ("wlbsctrl.dll", "wbemcomn.dll", "WptsExtensions.dll", "Tsmsisrv.dll", "TSVIPSrv.dll", "Msfte.dll",
-               "wow64log.dll", "WindowsCoreDeviceInfo.dll", "Ualapi.dll", "wlanhlp.dll", "phoneinfo.dll", "EdgeGdi.dll",
-               "cdpsgshims.dll", "windowsperformancerecordercontrol.dll", "diagtrack_win.dll", "oci.dll", "TPPCOIPW32.dll", 
-               "tpgenlic.dll", "thinmon.dll", "fxsst.dll", "msTracer.dll")
-   and (?dll.code_signature.trusted != true or ?dll.code_signature.exists != true)) or
+  (
+    ?dll.name : (
+        "wlbsctrl.dll", "wbemcomn.dll", "WptsExtensions.dll", "Tsmsisrv.dll", "TSVIPSrv.dll", "Msfte.dll",
+        "wow64log.dll", "WindowsCoreDeviceInfo.dll", "Ualapi.dll", "wlanhlp.dll", "phoneinfo.dll", "EdgeGdi.dll",
+        "cdpsgshims.dll", "windowsperformancerecordercontrol.dll", "diagtrack_win.dll", "oci.dll", "TPPCOIPW32.dll", 
+        "tpgenlic.dll", "thinmon.dll", "fxsst.dll", "msTracer.dll"
+    )
+    and (
+      ?dll.code_signature.trusted != true or
+      ?dll.code_signature.exists != true or
+      (
+        dll.code_signature.trusted == true and
+          not dll.code_signature.subject_name : ("Microsoft Windows", "Microsoft Corporation", "Microsoft Windows Publisher")
+      )
+  ) or
 
   /* compatible with Sysmon EventID 7 - Image Load */
   (file.name : ("wlbsctrl.dll", "wbemcomn.dll", "WptsExtensions.dll", "Tsmsisrv.dll", "TSVIPSrv.dll", "Msfte.dll",
                "wow64log.dll", "WindowsCoreDeviceInfo.dll", "Ualapi.dll", "wlanhlp.dll", "phoneinfo.dll", "EdgeGdi.dll",
                "cdpsgshims.dll", "windowsperformancerecordercontrol.dll", "diagtrack_win.dll", "oci.dll", "TPPCOIPW32.dll", 
                "tpgenlic.dll", "thinmon.dll", "fxsst.dll", "msTracer.dll") and 
-   not file.path : ("?:\\Windows\\System32\\wbemcomn.dll", "?:\\Windows\\SysWOW64\\wbemcomn.dll") and 
    not file.hash.sha256 : 
             ("6e837794fc282446906c36d681958f2f6212043fc117c716936920be166a700f", 
              "b14e4954e8cca060ffeb57f2458b6a3a39c7d2f27e94391cbcea5387652f21a4", 
              "c258d90acd006fa109dc6b748008edbb196d6168bc75ace0de0de54a4db46662") and 
    not file.code_signature.status == "Valid")
+  ) and
+  not
+  (
+    ?dll.path : (
+      "?:\\Windows\\System32\\wbemcomn.dll",
+      "?:\\Windows\\SysWOW64\\wbemcomn.dll",
+      "?:\\Windows\\System32\\windowsperformancerecordercontrol.dll",
+      "?:\\Windows\\System32\\wlanhlp.dll"
+    ) or
+    file.path : (
+      "?:\\Windows\\System32\\wbemcomn.dll",
+      "?:\\Windows\\SysWOW64\\wbemcomn.dll",
+      "?:\\Windows\\System32\\windowsperformancerecordercontrol.dll",
+      "?:\\Windows\\System32\\wlanhlp.dll"
+    )
   )
+)
 '''
 
 


### PR DESCRIPTION
## Summary

Tunes a few noisy patterns and adds a condition to alert non-MS signatures.

![image](https://github.com/elastic/detection-rules/assets/26856693/416c6258-22ea-487a-8c87-8814b742f1db)

