### PR TITLE
[Bug] Fix typo in dataview variable

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -714,8 +714,8 @@ class QueryRuleData(BaseRuleData):
         """Return the index or dataview depending on which is set. If neither returns empty list."""
         if self.index is not None:
             return self.index
-        elif self.dataview is not None:
-            return [self.dataview]
+        elif self.data_view_id is not None:
+            return [self.data_view_id]
         else:
             return []
 


### PR DESCRIPTION
## Summary

We inadvertently [intoduced](https://github.com/elastic/detection-rules/pull/3857/files#diff-4bfef80203b44ad6eb23895355be52bd3437a54c62666495093527c7c9832749R708) a small bug with a typo. This PR fixes the typo.

## Testing

Running an export originally triggered this error `python -m detection_rules kibana export-rules -d test_rules/ -sv`. See below:

<details><summary>Prior CLI Snippet</summary>



```bash

  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule.py", line 734, in validate_query
    return validator.validate(self, meta)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule_validators.py", line 132, in validate
    validation_checks["stack"] = self.validate_stack_combos(data, meta)
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule_validators.py", line 151, in validate_stack_combos
    beat_types, beat_schema, schema = self.get_beats_schema(data.index_or_dataview,
                                                            ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.2_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/functools.py", line 995, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/stryker/workspace/ElasticGitHub/detection-rules/detection_rules/rule.py", line 717, in index_or_dataview
    elif self.dataview is not None:
         ^^^^^^^^^^^^^
AttributeError: 'QueryRuleData' object has no attribute 'dataview'
```

</details> 
