### PR TITLE
[FR] Support new_terms schema import/export w/custom format

### DIFF
--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -165,18 +165,6 @@ def rule_prompt(path=None, rule_type=None, required_only=True, save=True, verbos
             contents[name] = schema_prompt(name, value=kwargs.pop(name))
             continue
 
-        if name == "new_terms":
-            # patch to allow new_term imports
-            result = {"field": "new_terms_fields"}
-            result["value"] = schema_prompt("new_terms_fields", value=kwargs.pop("new_terms_fields"))
-            history_window_start_value = kwargs.pop("history_window_start", None)
-            result["history_window_start"] = [
-                {
-                    "field": "history_window_start",
-                    "value": schema_prompt("history_window_start", value=history_window_start_value),
-                }
-            ]
-
         else:
             result = schema_prompt(name, is_required=name in required_fields, **options.copy())
 

--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -165,6 +165,18 @@ def rule_prompt(path=None, rule_type=None, required_only=True, save=True, verbos
             contents[name] = schema_prompt(name, value=kwargs.pop(name))
             continue
 
+        if name == "new_terms":
+            # patch to allow new_term imports
+            result = {"field": "new_terms_fields"}
+            result["value"] = schema_prompt("new_terms_fields", value=kwargs.pop("new_terms_fields"))
+            history_window_start_value = kwargs.pop("history_window_start", None)
+            result["history_window_start"] = [
+                {
+                    "field": "history_window_start",
+                    "value": schema_prompt("history_window_start", value=history_window_start_value),
+                }
+            ]
+
         else:
             result = schema_prompt(name, is_required=name in required_fields, **options.copy())
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -111,8 +111,7 @@ def import_rules_into_repo(input_file, required_only, directory):
         base_path = contents.get('name') or contents.get('rule', {}).get('name')
         base_path = rulename_to_filename(base_path) if base_path else base_path
         rule_path = os.path.join(RULES_DIR, base_path) if base_path else None
-        data_view_id = contents.get("data_view_id") or contents.get("rule", {}).get("data_view_id")
-        additional = ["index"] if not data_view_id else ["data_view_id"]
+        additional = ['index'] if not contents.get('data_view_id') else ['data_view_id']
         rule_prompt(rule_path, required_only=required_only, save=True, verbose=True,
                     additional_required=additional, **contents)
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -111,7 +111,10 @@ def import_rules_into_repo(input_file, required_only, directory):
         base_path = contents.get('name') or contents.get('rule', {}).get('name')
         base_path = rulename_to_filename(base_path) if base_path else base_path
         rule_path = os.path.join(RULES_DIR, base_path) if base_path else None
-        additional = ['index'] if not contents.get('data_view_id') else ['data_view_id']
+
+        # handle both rule json formats loaded from kibana and toml
+        data_view_id = contents.get("data_view_id") or contents.get("rule", {}).get("data_view_id")
+        additional = ["index"] if not data_view_id else ["data_view_id"]
         rule_prompt(rule_path, required_only=required_only, save=True, verbose=True,
                     additional_required=additional, **contents)
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -111,7 +111,8 @@ def import_rules_into_repo(input_file, required_only, directory):
         base_path = contents.get('name') or contents.get('rule', {}).get('name')
         base_path = rulename_to_filename(base_path) if base_path else base_path
         rule_path = os.path.join(RULES_DIR, base_path) if base_path else None
-        additional = ['index'] if not contents.get('data_view_id') else ['data_view_id']
+        data_view_id = contents.get("data_view_id") or contents.get("rule", {}).get("data_view_id")
+        additional = ["index"] if not data_view_id else ["data_view_id"]
         rule_prompt(rule_path, required_only=required_only, save=True, verbose=True,
                     additional_required=additional, **contents)
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -21,7 +21,7 @@ import marshmallow
 from semver import Version
 from marko.block import Document as MarkoDocument
 from marko.ext.gfm import gfm
-from marshmallow import ValidationError, validates_schema
+from marshmallow import ValidationError, validates_schema, pre_load
 
 import kql
 
@@ -767,6 +767,23 @@ class NewTermsRuleData(QueryRuleData):
 
     type: Literal["new_terms"]
     new_terms: NewTermsMapping
+
+    @pre_load
+    def preload_data(self, data: dict, **kwargs) -> dict:
+        """Preloads and formats the data to match the required schema."""
+        if "new_terms_fields" in data and "history_window_start" in data:
+            new_terms_mapping = {
+                "field": "new_terms_fields",
+                "value": data.pop("new_terms_fields"),
+                "history_window_start": [
+                    {
+                        "field": "history_window_start",
+                        "value": data.pop("history_window_start")
+                    }
+                ]
+            }
+            data["new_terms"] = new_terms_mapping
+        return data
 
     def transform(self, obj: dict) -> dict:
         """Transforms new terms data to API format for Kibana."""

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -774,15 +774,19 @@ class NewTermsRuleData(QueryRuleData):
         if "new_terms_fields" in data and "history_window_start" in data:
             new_terms_mapping = {
                 "field": "new_terms_fields",
-                "value": data.pop("new_terms_fields"),
+                "value": data["new_terms_fields"],
                 "history_window_start": [
                     {
                         "field": "history_window_start",
-                        "value": data.pop("history_window_start")
+                        "value": data["history_window_start"]
                     }
                 ]
             }
             data["new_terms"] = new_terms_mapping
+
+            # cleanup original fields after building into our toml format
+            data.pop("new_terms_fields")
+            data.pop("history_window_start")
         return data
 
     def transform(self, obj: dict) -> dict:

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -216,6 +216,11 @@ def toml_write(rule_contents, outfile=None):
                 preserved_fields = ["params.message"]
                 v = [preserve_formatting_for_fields(action, preserved_fields) for action in v]
 
+            if k == 'filters':
+                # explicitly preserve formatting for value field in filters
+                preserved_fields = ["meta.value"]
+                v = [preserve_formatting_for_fields(meta, preserved_fields) for meta in v]
+
             if k == 'note' and isinstance(v, str):
                 # Transform instances of \ to \\ as calling write will convert \\ to \.
                 # This will ensure that the output file has the correct number of backslashes.


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/detection-rules/issues/3542

This PR supports import/export of the `new_terms` rule type w/custom toml formatting. 

In https://github.com/elastic/detection-rules/pull/2360 We added the inital support to new_terms schemas, however this introduced something new to our ruleset where we added custom formating in our toml files that does not 1-1 match the schema exported from Kibana. The custom formatting within the toml rule IMO is more organized in this way. The original intent also was to manually develop rules for prebuilt content and push externally (one-way support).

The problem is that it introduced an issue where it prevented us from importing the rules from ndjson since the schemas do not much (two-way support of import/export).

 In https://github.com/elastic/detection-rules/pull/3569 we introduced a stop-gap to the cli_utils that allowed us to also import new_term rules in our schema using the rule prompt. The intent was to wait until we could refactor the new_terms rules and update the schemas to match 1-1 with kibana exports.

This PR on the other hand maintains the current format and instead adds an `pre_load` to parse the ndjson and format into toml rules.

The benefit is that we should be able to keep the same toml format, which means we also shouldnt have to update rules at all. 

Note: If after thorough testing, this still doesn't meet our needs, we can still update the schemas so that the perfectly match 1-1 at a later time & close (not merge).

## Testing

- Try to import rules from kibana (on main using the kibana).
- I tested this on the DAC-feature with custom rules.
- Import / export should work on the core detection-rules and kibana cli commands.


## Additional Info

Cleaning up a couple bugs while testing different features with import/export rules:

- 2ef6fe864d589b99d36cbb5f28e8e03a6c6a50ef
- b5e16308b026e0612da375983159d34b9a037af4