### PR TITLE
[Bug] [DAC] Import rules into repo loads exceptions without argument

### DIFF
--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -145,7 +145,7 @@ def import_rules_into_repo(
         base_path = contents.get("name") or contents.get("rule", {}).get("name")
         base_path = rulename_to_filename(base_path) if base_path else base_path
         rule_path = os.path.join(save_directory if save_directory is not None else RULES_DIRS[0], base_path)
-        
+
         # handle both rule json formats loaded from kibana and toml
         data_view_id = contents.get("data_view_id") or contents.get("rule", {}).get("data_view_id")
         additional = ["index"] if not data_view_id else ["data_view_id"]
@@ -171,9 +171,13 @@ def import_rules_into_repo(
                 )
                 filename = f"{list_id}_exceptions.toml"
                 if RULES_CONFIG.exception_dir is None and not exceptions_directory:
-                    raise FileNotFoundError("No Exceptions directory is specified. Please specify either in the config or CLI.")
+                    raise FileNotFoundError(
+                        "No Exceptions directory is specified. Please specify either in the config or CLI."
+                    )
                 exceptions_path = (
-                    Path(exceptions_directory) / filename if exceptions_directory else RULES_CONFIG.exception_dir / filename
+                    Path(exceptions_directory) / filename
+                    if exceptions_directory
+                    else RULES_CONFIG.exception_dir / filename
                 )
                 click.echo(f"[+] Building exception(s) for {exceptions_path}")
                 TOMLException(


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:


## Summary - What I changed

This PR addresses a few issues in the `import_rules_into_repo` command on the DAC-Feature branch where the rule_prompt would attempt to import exceptions as rule if the `-e` flag was not used and there are exceptions in the .ndjson export. Also, this addresses a case where the exceptions would be parsed unnecessarily even if the `-e` flag was not used. Additionally I added some cleaner error handling for cases where exception parsing is desired but no directory is specified for writing the files.

## How To Test

To test run the following command without a rules config env variable set, and you should have a clean FileNotFound error message. 

<details><summary>Example</summary>
<p>

```shell
detection-rules on  import_rules_into_repo_bug [$!?] is  v0.1.0 via  v3.12.4 (detection-rules-build) on  eric.forte 
❯ python -m detection_rules import-rules-to-repo ~/Downloads/new_terms_testing.ndjson --required-only -d test_dir/ -e
Loaded config file: /home/forteea1/Code/clean_mains/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_exception_list.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/adding_hidden_file_attribute_via_attrib_duplicate.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/enumeration_of_privileged_local_groups_membership_duplicate.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/infosec_css_test_rule.toml
author (required)  (multi, comma separated): test
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_2_feedback.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_potential_protocol_tunneling_via_chisel_client.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1_also_updated.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1_updated.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suspicious_endpoint_security_parent_process_eql_8_11.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_13.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_not_enabled_threshold_fields_not_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_not_enabled_threshold_fields_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/h_defenseevasion_266_windows_defender_exclusions_added_no_new_value.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/h_defenseevasion_266_windows_defender_exclusions_added.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/new_terms_rule_test.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_threshold.toml
author (required)  (multi, comma separated): test
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_enabled_threshold_fields_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/adding_hidden_file_attribute_via_attrib_data_view.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_13.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_potential_protocol_tunneling_via_chisel_client.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1_also_updated.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1_updated.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_2_feedback.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/adding_hidden_file_attribute_via_attrib_duplicate.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/enumeration_of_privileged_local_groups_membership_duplicate.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/h_defenseevasion_266_windows_defender_exclusions_added.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/h_defenseevasion_266_windows_defender_exclusions_added_no_new_value.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/infosec_css_test_rule.toml
author (required)  (multi, comma separated): test
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/new_terms_rule_test.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_enabled_threshold_fields_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_not_enabled_threshold_fields_not_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_not_enabled_threshold_fields_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suspicious_endpoint_security_parent_process_eql_8_11.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_exception_list.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_threshold.toml
author (required)  (multi, comma separated): test
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/forteea1/Code/clean_mains/detection-rules/detection_rules/__main__.py", line 35, in <module>
    main()
  File "/home/forteea1/Code/clean_mains/detection-rules/detection_rules/__main__.py", line 32, in main
    root(prog_name="detection_rules")
  File "/home/forteea1/Code/clean_mains/detection-rules/env/detection-rules-build/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/forteea1/Code/clean_mains/detection-rules/env/detection-rules-build/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/forteea1/Code/clean_mains/detection-rules/env/detection-rules-build/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/forteea1/Code/clean_mains/detection-rules/env/detection-rules-build/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/forteea1/Code/clean_mains/detection-rules/env/detection-rules-build/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/forteea1/Code/clean_mains/detection-rules/detection_rules/main.py", line 172, in import_rules_into_repo
    raise FileNotFoundError("No Exceptions directory is specified. Please specify either in the config or CLI.")
FileNotFoundError: No Exceptions directory is specified. Please specify either in the config or CLI.
```

</p>
</details> 


Also try testing on the following ndjsin set of rules with and without using `-e`. These should succeed (note you will have to supply authors for some)
[data_view_rules_export_test.ndjson.txt](https://github.com/user-attachments/files/16199737/data_view_rules_export_test.ndjson.txt)

<details><summary>Example</summary>
<p>

```shell
detection-rules on  import_rules_into_repo_bug [$?] is  v0.1.0 via  v3.12.4 (detection-rules-build) on  eric.forte 
❯ python -m detection_rules import-rules-to-repo ~/Downloads/new_terms_testing.ndjson --required-only -d test_dir/
Loaded config file: /home/forteea1/Code/clean_mains/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_exception_list.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/adding_hidden_file_attribute_via_attrib_duplicate.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/enumeration_of_privileged_local_groups_membership_duplicate.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/infosec_css_test_rule.toml
author (required)  (multi, comma separated): test
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_2_feedback.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_potential_protocol_tunneling_via_chisel_client.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1_also_updated.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1_updated.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suspicious_endpoint_security_parent_process_eql_8_11.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_1.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/dac_demo_dev_rule_13.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_not_enabled_threshold_fields_not_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_not_enabled_threshold_fields_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/h_defenseevasion_266_windows_defender_exclusions_added_no_new_value.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/h_defenseevasion_266_windows_defender_exclusions_added.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/new_terms_rule_test.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/test_threshold.toml
author (required)  (multi, comma separated): test
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/suppression_is_enabled_threshold_fields_selected.toml
[+] Building rule for /home/forteea1/Code/clean_mains/detection-rules/rules/adding_hidden_file_attribute_via_attrib_data_view.toml

```


</p>
</details> 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `Rule: New`, `Rule: Deprecation`, `Rule: Promote`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

