### PR TITLE
[New Rule] AWS S3 Bucket Replicated to Another Account

### DIFF
--- a/rules/integrations/aws/exfiltration_s3_bucket_replicated_to_external_account.toml
+++ b/rules/integrations/aws/exfiltration_s3_bucket_replicated_to_external_account.toml
@@ -1,0 +1,93 @@
+[metadata]
+creation_date = "2024/07/12"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2024/07/12"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when the `PutBucketReplication` operation is used to replicate S3 objects to a bucket in another AWS account. Adversaries may use bucket replication to exfiltrate sensitive data to an environment they control.
+"""
+false_positives = [
+    """
+    Bucket replication accross accounts is a legitimate practice in some AWS environments. Ensure that the sharing is authorized before taking action.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "AWS S3 Bucket Replicated to Another Account"
+note = """
+## Triage and Analysis
+
+### Investigating AWS S3 Bucket Replicated to Another Account
+
+This rule identifies when an S3 bucket is replicated to another AWS account. While sharing bucket replication is a common practice, adversaries may exploit this feature to exfiltrate data by replicating objects to external accounts under their control.
+
+#### Possible Investigation Steps
+
+- **Identify the Actor**: Review the `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.access_key_id` fields to identify who made the change. Verify if this actor typically performs such actions and if they have the necessary permissions.
+- **Review the Sharing Event**: Identify the S3 bucket involved and review the event details. Look for `PutBucketReplication` actions where an `Account` key-value pair is included signifying replication to an external account.
+    - **Request and Response Parameters**: Check the `aws.cloudtrail.request_parameters` and `aws.cloudtrail.response_elements` fields in the CloudTrail event to identify the role used and account ID where the bucket was replicated.
+- **Verify the Shared Bucket**: Check the S3 bucket that was replicated and its contents to determine the sensitivity of the data stored within it.
+- **Validate External Account**: Examine the AWS account to which the bucket was replicated. Determine whether this account is known and previously authorized to access such resources.
+- **Contextualize with Recent Changes**: Compare this sharing event against recent changes in S3 configurations. Look for any other recent permissions changes or unusual administrative actions.
+- **Correlate with Other Activities**: Search for related CloudTrail events before and after this change to see if the same actor or IP address engaged in other potentially suspicious activities.
+- **Interview Relevant Personnel**: If the share was initiated by a user, verify the intent and authorization for this action with the person or team responsible for managing DB backups and snapshots.
+
+### False Positive Analysis
+
+- **Legitimate Backup Actions**: Confirm if the S3 bucket replication aligns with scheduled backups or legitimate automation tasks.
+- **Consistency Check**: Compare the action against historical data of similar actions performed by the user or within the organization. If the action is consistent with past legitimate activities, it might indicate a false alarm.
+
+### Response and Remediation
+
+- **Immediate Review and Reversal**: If the change was unauthorized, update the S3 configurations to remove any unauthorized replication rules.
+- **Enhance Monitoring and Alerts**: Adjust monitoring systems to alert on similar actions, especially those involving sensitive data or permissions.
+- **Policy Update**: Review and possibly update your organization’s policies on S3 bucket/object sharing to tighten control and prevent unauthorized access.
+- **Incident Response**: If malicious intent is confirmed, consider it a data breach incident and initiate the incident response protocol. This includes further investigation, containment, and recovery.
+
+### Additional Information:
+
+For further guidance on managing and securing S3 buckets in AWS environments, refer to the [AWS S3 documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/security.html/) and AWS best practices for security.
+"""
+references = [
+    "https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-walkthrough-2.html/",
+    "https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html/",
+]
+risk_score = 47
+rule_id = "d488f026-7907-4f56-ad51-742feb3db01c"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS S3",
+    "Resources: Investigation Guide",
+    "Use Case: Threat Detection",
+    "Tactic: Exfiltration",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+any where event.dataset == "aws.cloudtrail" 
+   and event.action == "PutBucketReplication"
+   and event.outcome == "success" 
+   and stringContains(aws.cloudtrail.request_parameters, "Account")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1537"
+name = "Transfer Data to Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1537/"
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"
+


### PR DESCRIPTION
*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/346

## Summary - What I changed

Identifies when the `PutBucketReplication` operation is used to replicate S3 objects to a bucket in another AWS account. Adversaries may use bucket replication to exfiltrate sensitive data to an environment they control.

--

I used EQL to look in the `request_parameters` for inclusion of an `Account` key-value pair which is only included when an S3 bucket is replicated to an external account. I've included screenshots of replication to a bucket in the same account and replication to a bucket in a separate account showing this difference. 

## How To Test
Bucket Replicated in the Same Account
<img width="1709" alt="Screenshot 2024-07-13 at 12 32 35 AM" src="https://github.com/user-attachments/assets/b5ab9f5d-f794-447d-b4ec-9bc31c4d375d">

Bucket Replicated to a Seperate Account
<img width="1709" alt="Screenshot 2024-07-13 at 12 37 02 AM" src="https://github.com/user-attachments/assets/33f41730-9b62-437f-8fec-05b7bd07f9c0">
