### PR TITLE
Remove Rule:Promotion labels and add other relavent labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,7 @@ from your submission, but they are here to help bring them to your attention.
 
 <!-- Delete any items that are not applicable to this PR. -->
 
-- [ ] Added a label for the type of pr: `bug`, `enhancement`, `Rule: New`, `Rule: Deprecation`, `Rule: Promote`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
+- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
 - [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
 - [ ] Secret and sensitive material has been managed correctly
 - [ ] Automated testing was updated or added to match the most common scenarios

--- a/.github/workflows/add-guidelines.yml
+++ b/.github/workflows/add-guidelines.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "CONTINUE_JOB=true" >> $GITHUB_ENV
           if [[ "${{ github.event.action }}" == "labeled" || "${{ github.event.action }}" == "opened" ]]; then
-            RELEVANT_LABELS=("bug" "enhancement" "Rule: New" "Rule: Tuning" "Rule: Promotion" "Rule: Deprecation")
+            RELEVANT_LABELS=("bug" "enhancement" "schema" "Rule: New" "Rule: Tuning" "Rule: Deprecation" "Hunt: New" "Hunt: Tuning")
             TRIGGERED_LABEL="${{ github.event.label.name }}"
             if [[ ! " ${RELEVANT_LABELS[@]} " =~ " ${TRIGGERED_LABEL} " ]]; then
               echo "CONTINUE_JOB=false" >> $GITHUB_ENV


### PR DESCRIPTION
# Pull Request

*Issue*: Remove Rule: Promotion in https://github.com/elastic/detection-rules/blob/main/.github/workflows/add-guidelines.yml#L19 since promotions don't exist in detection rules

## Summary - What I changed

- Remove Rule:Promotion
- Add schema and hunting lables

## How To Test

- Add relavant labels to test

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `Rule: New`, `Rule: Deprecation`, `Rule: Promote`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation
