### PR TITLE
[Tuning] Executable Bit Set for Potential Persistence Script

### DIFF
--- a/rules/linux/persistence_potential_persistence_script_executable_bit_set.toml
+++ b/rules/linux/persistence_potential_persistence_script_executable_bit_set.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/03"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/06/21"
+updated_date = "2024/07/30"
 
 [rule]
 author = ["Elastic"]
@@ -64,8 +64,8 @@ query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
 process.args : (
   // Misc.
-  "/etc/rc.local", "/etc/rc.common", "/etc/init.d/*", "/etc/update-motd.d/*", "/etc/apt/apt.conf.d/*", "/etc/cron*",
-  "/etc/init/*",
+  "/etc/rc.local", "/etc/rc.common", "/etc/rc.d/rc.local", "/etc/init.d/*", "/etc/update-motd.d/*",
+  "/etc/apt/apt.conf.d/*", "/etc/cron*", "/etc/init/*",
 
   // XDG
   "/etc/xdg/autostart/*", "/home/*/.config/autostart/*", "/root/.config/autostart/*",


### PR DESCRIPTION
## Summary
RHEL derivatives require execution permissions to be set for `/etc/rc.d/rc.local` when attempting to manually enable and execute `/etc/rc.local`. Added this to the rule, to ensure coverage.