### PR TITLE
[Rule Tuning] Removed Endgame from Incompatible Rules

### DIFF
--- a/rules/linux/privilege_escalation_linux_suspicious_symbolic_link.toml
+++ b/rules/linux/privilege_escalation_linux_suspicious_symbolic_link.toml
@@ -57,7 +57,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.name == "ln" and process.args in ("-s", "-sf") and 
   (
     /* suspicious files */

--- a/rules/linux/privilege_escalation_linux_suspicious_symbolic_link.toml
+++ b/rules/linux/privilege_escalation_linux_suspicious_symbolic_link.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/07/27"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/30"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ privileged process into following the symbolic link to a sensitive file, giving 
 capabilities they would not normally have.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Symbolic Link Created"
@@ -52,12 +52,10 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Privilege Escalation",
     "Tactic: Credential Access",
-    "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
-
 query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
 process.name == "ln" and process.args in ("-s", "-sf") and 
@@ -80,34 +78,33 @@ process.name == "ln" and process.args in ("-s", "-sf") and
   not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 '''
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1548"
 name = "Abuse Elevation Control Mechanism"
 reference = "https://attack.mitre.org/techniques/T1548/"
 
-
 [rule.threat.tactic]
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1003"
 name = "OS Credential Dumping"
 reference = "https://attack.mitre.org/techniques/T1003/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1003.008"
 name = "/etc/passwd and /etc/shadow"
 reference = "https://attack.mitre.org/techniques/T1003/008/"
 
-
-
 [rule.threat.tactic]
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
-

--- a/rules/linux/privilege_escalation_sda_disk_mount_non_root.toml
+++ b/rules/linux/privilege_escalation_sda_disk_mount_non_root.toml
@@ -60,7 +60,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
 process.name == "debugfs" and process.args : "/dev/sd*" and not process.args == "-R" and 
 not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 '''

--- a/rules/linux/privilege_escalation_sda_disk_mount_non_root.toml
+++ b/rules/linux/privilege_escalation_sda_disk_mount_non_root.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/30"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,7 @@ root, such as the shadow file, root ssh private keys or other sensitive files th
 privileges.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Suspicious DebugFS Root Device Access"
@@ -54,7 +54,6 @@ tags = [
     "OS: Linux",
     "Use Case: Threat Detection",
     "Tactic: Privilege Escalation",
-    "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
 ]
 timestamp_override = "event.ingested"
@@ -66,22 +65,20 @@ process.name == "debugfs" and process.args : "/dev/sd*" and not process.args == 
 not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 '''
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1078"
 name = "Valid Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1078.003"
 name = "Local Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/003/"
 
-
-
 [rule.threat.tactic]
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
-


### PR DESCRIPTION
## Summary
Related to a community Slack discussion: https://elasticstack.slack.com/archives/C016E72DWDS/p1722357007143239?thread_ts=1722278293.016539&cid=C016E72DWDS. 

These two rules were created with Endgame compatibility but were made incompatible after tunings. The tunings did not remove the Endgame compatibility within the rule.

This PR fixes this.