### PR TITLE
[Rule Tuning] System Binary Moved or Copied

### DIFF
--- a/rules/linux/defense_evasion_binary_copied_to_suspicious_directory.toml
+++ b/rules/linux/defense_evasion_binary_copied_to_suspicious_directory.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/29"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/07/18"
+updated_date = "2024/07/31"
 
 [rule]
 author = ["Elastic"]
@@ -73,7 +73,7 @@ file.Ext.original.path : (
     "/bin/node", "/usr/bin/node", "/sbin/apk", "/usr/sbin/apk", "/usr/local/sbin/apk", "/usr/bin/pip", "/bin/pip",
     "/usr/local/bin/pip", "/usr/libexec/platform-python", "/usr/bin/platform-python", "/bin/platform-python",
     "/usr/lib/systemd/systemd", "/usr/sbin/sshd", "/sbin/sshd", "/usr/local/sbin/sshd", "/usr/sbin/crond", "/sbin/crond",
-    "/usr/local/sbin/crond", "/usr/sbin/gdm", 
+    "/usr/local/sbin/crond", "/usr/sbin/gdm"
   ) or
   file.Ext.original.path : (
     "/bin/*.tmp", "/usr/bin/*.tmp", "/usr/local/bin/*.tmp", "/sbin/*.tmp", "/usr/sbin/*.tmp", "/usr/local/sbin/*.tmp"


### PR DESCRIPTION
## Summary
While checking malware events, I noticed this rule did not trigger when it should have triggered. Putting it into timelines showed a syntax error. 

How did this pass unit testing?

Removing the `,` to fix the query.