### PR TITLE
[Rule Tuning] Sensitive Registry Hive Access via RegBack

### DIFF
--- a/rules/windows/credential_access_regback_sam_security_hives.toml
+++ b/rules/windows/credential_access_regback_sam_security_hives.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/01"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/07/01"
+updated_date = "2024/08/01"
 
 [rule]
 author = ["Elastic"]
@@ -70,7 +70,10 @@ file where host.os.type == "windows" and
       ("?:\\Windows\\System32\\config\\RegBack\\SAM",
        "?:\\Windows\\System32\\config\\RegBack\\SECURITY",
        "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and 
- not (user.id == "S-1-5-18" and process.executable : "?:\\Windows\\system32\\taskhostw.exe")
+ not (
+    user.id == "S-1-5-18" and process.executable : (
+        "?:\\Windows\\system32\\taskhostw.exe", "?:\\Windows\\system32\\taskhost.exe"
+    ))
 '''
 
 


### PR DESCRIPTION
## Summary - What I changed

Excludes `taskhost.exe` as it is used in windows server 2012 instead of `taskhostw.exe`