### PR TITLE
[DaC] [FR] Autogenerate Custom Schema

### DIFF
--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -186,6 +186,7 @@ class RulesConfig:
     version_lock: Dict[str, dict]
 
     action_dir: Optional[Path] = None
+    auto_gen_schema_file: Optional[Path] = None
     bbr_rules_dirs: Optional[List[Path]] = field(default_factory=list)
     bypass_version_lock: bool = False
     exception_dir: Optional[Path] = None
@@ -283,6 +284,9 @@ def parse_rules_config(path: Optional[Path] = None) -> RulesConfig:
 
     # kql keyword normalization
     contents['normalize_kql_keywords'] = loaded.get('normalize_kql_keywords', True)
+
+    if loaded.get('auto_gen_schema_file'):
+        contents['auto_gen_schema_file'] = base_dir.joinpath(loaded['auto_gen_schema_file'])
 
     try:
         rules_config = RulesConfig(test_config=test_config, **contents)

--- a/detection_rules/custom_schemas.py
+++ b/detection_rules/custom_schemas.py
@@ -4,13 +4,15 @@
 # 2.0.
 
 """Custom Schemas management."""
+import uuid
 from pathlib import Path
 
 import eql
 import eql.types
+from eql import load_dump, save_dump
 
 from .config import parse_rules_config
-from .utils import cached
+from .utils import cached, clear_caches
 
 RULES_CONFIG = parse_rules_config()
 RESERVED_SCHEMA_NAMES = ["beats", "ecs", "endgame"]
@@ -37,3 +39,77 @@ def get_custom_schemas(stack_version: str = None) -> dict:
                     raise ValueError(f"Custom schema must be a file: {schema_path}")
 
     return custom_schema_dump
+
+
+def resolve_schema_path(path: str) -> Path:
+    """Helper function to resolve the schema path."""
+    path_obj = Path(path)
+    return path_obj if path_obj.is_absolute() else RULES_CONFIG.stack_schema_map_file.parent.joinpath(path)
+
+
+def update_data(index: str, field: str, data: dict) -> dict:
+    """Update the schema entry with the appropriate index and field."""
+    if index not in data:
+        data[index] = {}
+    data[index][field] = "keyword"
+    return data
+
+
+def update_stack_schema_map(stack_schema_map: dict, auto_gen_schema_file: str) -> dict:
+    """Update the stack-schema-map.yaml file with the appropriate auto_gen_schema_file location."""
+    random_uuid = str(uuid.uuid4())
+    auto_generated_id = None
+    for version in stack_schema_map:
+        key_found = False
+        for key, value in stack_schema_map[version].items():
+            value_path = resolve_schema_path(value)
+            if value_path == Path(auto_gen_schema_file).resolve() and key not in RESERVED_SCHEMA_NAMES:
+                auto_generated_id = key
+                key_found = True
+                break
+        if key_found is False:
+            if auto_generated_id is None:
+                auto_generated_id = random_uuid
+            stack_schema_map[version][auto_generated_id] = str(auto_gen_schema_file)
+    return stack_schema_map, auto_generated_id, random_uuid
+
+
+def clean_stack_schema_map(stack_schema_map: dict, auto_generated_id: str, random_uuid: str) -> dict:
+    """Clean up the stack-schema-map.yaml file replacing the random UUID with a known key if possible."""
+    for version in stack_schema_map:
+        if random_uuid in stack_schema_map[version]:
+            stack_schema_map[version][auto_generated_id] = stack_schema_map[version].pop(random_uuid)
+    return stack_schema_map
+
+
+def update_auto_generated_schema(index: str, field: str):
+    """Load custom schemas if present."""
+    auto_gen_schema_file = str(RULES_CONFIG.auto_gen_schema_file)
+    stack_schema_map_file = str(RULES_CONFIG.stack_schema_map_file)
+
+    # Read the existing data
+    data = load_dump(auto_gen_schema_file)
+
+    # Update the data
+    data = update_data(index, field, data)
+
+    # Write the updated data back to the file
+    save_dump(data, auto_gen_schema_file)
+
+    # Update the stack-schema-map.yaml file
+    stack_schema_map = load_dump(stack_schema_map_file)
+
+    # Check if auto_gen_schema_file is already in stack_schema_map
+    stack_schema_map, auto_generated_id, random_uuid = update_stack_schema_map(stack_schema_map, auto_gen_schema_file)
+
+    save_dump(stack_schema_map, stack_schema_map_file)
+
+    # Clean up the stack-schema-map.yaml file replacing the random UUID with the auto_generated_id
+    stack_schema_map = load_dump(stack_schema_map_file)
+    stack_schema_map = clean_stack_schema_map(stack_schema_map, auto_generated_id, random_uuid)
+
+    save_dump(stack_schema_map, stack_schema_map_file)
+
+    RULES_CONFIG.stack_schema_map = stack_schema_map
+    # IMPORTANT must clear cache in order to reload schema
+    clear_caches()

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -4,6 +4,7 @@
 # 2.0.
 
 """Validation logic for rules containing queries."""
+import re
 from enum import Enum
 from functools import cached_property, wraps
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -19,6 +20,7 @@ import kql
 
 from . import ecs, endgame
 from .config import CUSTOM_RULES_DIR, load_current_package_version, parse_rules_config
+from .custom_schemas import update_auto_generated_schema
 from .integrations import (get_integration_schema_data,
                            load_integrations_manifests)
 from .rule import (EQLRuleData, QueryRuleData, QueryValidator, RuleMeta,
@@ -114,11 +116,19 @@ class KQLValidator(QueryValidator):
     def unique_fields(self) -> List[str]:
         return list(set(str(f) for f in self.ast if isinstance(f, kql.ast.Field)))
 
+    def auto_add_field(self, validation_checks_error: kql.errors.KqlParseError, index_or_dataview: str) -> None:
+        """Auto add a missing field to the schema."""
+        field_name = extract_error_field(self.query, validation_checks_error)
+        update_auto_generated_schema(index_or_dataview, field_name)
+
     def to_eql(self) -> eql.ast.Expression:
         return kql.to_eql(self.query)
 
-    def validate(self, data: QueryRuleData, meta: RuleMeta) -> None:
+    def validate(self, data: QueryRuleData, meta: RuleMeta, depth: int = 0, max_depth: int = 50) -> None:
         """Validate the query, called from the parent which contains [metadata] information."""
+        if depth > max_depth:
+            raise ValueError("Maximum recursion depth exceeded")
+
         if meta.query_schema_validation is False or meta.maturity == "deprecated":
             # syntax only, which is done via self.ast
             return
@@ -136,10 +146,22 @@ class KQLValidator(QueryValidator):
                 validation_checks["integrations"] = self.validate_integration(data, meta, package_integrations)
 
             if (validation_checks["stack"] and not package_integrations):
-                raise validation_checks["stack"]
+                # if auto add, try auto adding and then call stack_combo validation again
+                if validation_checks["stack"].error_msg == "Unknown field" and RULES_CONFIG.auto_gen_schema_file:
+                    # auto add the field and re-validate
+                    self.auto_add_field(validation_checks["stack"], data.index_or_dataview[0])
+                    self.validate(data, meta, depth + 1)
+                else:
+                    raise validation_checks["stack"]
 
             if (validation_checks["stack"] and validation_checks["integrations"]):
-                raise ValueError(f"Error in both stack and integrations checks: {validation_checks}")
+                # if auto add, try auto adding and then call stack_combo validation again
+                if validation_checks["stack"].error_msg == "Unknown field" and RULES_CONFIG.auto_gen_schema_file:
+                    # auto add the field and re-validate
+                    self.auto_add_field(validation_checks["stack"], data.index_or_dataview[0])
+                    self.validate(data, meta, depth + 1)
+                else:
+                    raise ValueError(f"Error in both stack and integrations checks: {validation_checks}")
 
     def validate_stack_combos(self, data: QueryRuleData, meta: RuleMeta) -> Union[KQL_ERROR_TYPES, None, TypeError]:
         """Validate the query against ECS and beats schemas across stack combinations."""
@@ -302,8 +324,16 @@ class EQLValidator(QueryValidator):
     def unique_fields(self) -> List[str]:
         return list(set(str(f) for f in self.ast if isinstance(f, eql.ast.Field)))
 
-    def validate(self, data: 'QueryRuleData', meta: RuleMeta) -> None:
+    def auto_add_field(self, validation_checks_error: eql.errors.EqlParseError, index_or_dataview: str) -> None:
+        """Auto add a missing field to the schema."""
+        field_name = extract_error_field(self.query, validation_checks_error)
+        update_auto_generated_schema(index_or_dataview, field_name)
+
+    def validate(self, data: 'QueryRuleData', meta: RuleMeta, depth: int = 0, max_depth: int = 10) -> None:
         """Validate an EQL query while checking TOMLRule."""
+        if depth > max_depth:
+            raise ValueError("Maximum recursion depth exceeded")
+
         if meta.query_schema_validation is False or meta.maturity == "deprecated":
             # syntax only, which is done via self.ast
             return
@@ -321,16 +351,28 @@ class EQLValidator(QueryValidator):
                 validation_checks["integrations"] = self.validate_integration(data, meta, package_integrations)
 
             if validation_checks["stack"] and not package_integrations:
-                raise validation_checks["stack"]
+                # if auto add, try auto adding and then call stack_combo validation again
+                if "Field not recognized" in validation_checks["stack"].error_msg and RULES_CONFIG.auto_gen_schema_file:
+                    # auto add the field and re-validate
+                    self.auto_add_field(validation_checks["stack"], data.index_or_dataview[0])
+                    self.validate(data, meta, depth + 1)
+                else:
+                    raise validation_checks["stack"]
 
             if validation_checks["stack"] and validation_checks["integrations"]:
-                raise ValueError(f"Error in both stack and integrations checks: {validation_checks}")
+                # if auto add, try auto adding and then call stack_combo validation again
+                if validation_checks["stack"].error_msg == "Unknown field" and RULES_CONFIG.auto_gen_schema_file:
+                    # auto add the field and re-validate
+                    self.auto_add_field(validation_checks["stack"], data.index_or_dataview[0])
+                    self.validate(data, meta, depth + 1)
+                else:
+                    raise ValueError(f"Error in both stack and integrations checks: {validation_checks}")
 
             rule_type_config_fields, rule_type_config_validation_failed = \
                 self.validate_rule_type_configurations(data, meta)
             if rule_type_config_validation_failed:
                 raise ValueError(f"""Rule type config values are not ECS compliant, check these values:
-                                 {rule_type_config_fields}""")
+                                {rule_type_config_fields}""")
 
     def validate_stack_combos(self, data: QueryRuleData, meta: RuleMeta) -> Union[EQL_ERROR_TYPES, None, ValueError]:
         """Validate the query against ECS and beats schemas across stack combinations."""
@@ -550,4 +592,4 @@ def extract_error_field(source: str, exc: Union[eql.EqlParseError, kql.KqlParseE
     line = lines[exc.line + mod]
     start = exc.column
     stop = start + len(exc.caret.strip())
-    return line[start:stop]
+    return re.sub(r'^\W+|\W+$', '', line[start:stop])

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -7,9 +7,22 @@
 
 from typing import List, Literal, Final
 
-from marshmallow import validate
+from marshmallow import fields, validate
 from marshmallow_dataclass import NewType
 from semver import Version
+
+from detection_rules.config import CUSTOM_RULES_DIR
+
+
+def elastic_rule_name_regexp(pattern):
+    """Custom validator for rule names."""
+    def validator(value):
+        if not CUSTOM_RULES_DIR:
+            validate.Regexp(pattern)(value)
+        else:
+            fields.String().deserialize(value)
+    return validator
+
 
 ASSET_TYPE = "security_rule"
 SAVED_OBJECT_TYPE = "security-rule"
@@ -166,7 +179,7 @@ Operator = Literal['equals']
 OSType = Literal['windows', 'linux', 'macos']
 PositiveInteger = NewType('PositiveInteger', int, validate=validate.Range(min=1))
 RiskScore = NewType("MaxSignals", int, validate=validate.Range(min=1, max=100))
-RuleName = NewType('RuleName', str, validate=validate.Regexp(NAME_PATTERN))
+RuleName = NewType('RuleName', str, validate=elastic_rule_name_regexp(NAME_PATTERN))
 RuleType = Literal['query', 'saved_query', 'machine_learning', 'eql', 'esql', 'threshold', 'threat_match', 'new_terms']
 SemVer = NewType('SemVer', str, validate=validate.Regexp(VERSION_PATTERN))
 SemVerMinorOnly = NewType('SemVerFullStrict', str, validate=validate.Regexp(MINOR_SEMVER))


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

## Summary - What I changed

This PR adds the ability to specify a config variable to auto generate a custom schema file for any missing non-ecs fields. To trigger this behavior add the following line to your `_config.yaml`
```
auto_gen_schema_file: <path_to_schema_json_file>
```  


## How To Test

To test this, first add the appropriate config variable. Next, run view-rule on a rule that has fields that are not currently present in a schema. The rule should validate successfully and your schema file should be updated. 

Example: `python -m detection_rules view-rule custom_rules/rules/dac_demo_dev_rule_1.toml`

<details><summary>Details</summary>
<p>

```toml
[metadata]
creation_date = "2024/07/29"
maturity = "production"
updated_date = "2024/07/29"

[rule]
actions = []
author = ["DAC User"]
description = "Test Rule"
enabled = true
exceptions_list = []
false_positives = []
from = "now-6m"
index = ["the-best-integration-ever*"]
interval = "5m"
language = "eql"
max_signals = 100
name = "DAC Demo Dev Rule 1"
references = []
risk_score = 47
risk_score_mapping = []
rule_id = "794d2fc0-ecd0-4963-99da-fd587666b80d"
setup = "Test Setup"
severity = "medium"
severity_mapping = []
tags = []
threat = []
to = "now"
type = "eql"

query = '''
process where host.os.type.fakeData == "linux" and process.name.okta.thread == "updated"
'''
[[rule.related_integrations]]
package = "endpoint"
version = "^8.2.0"

[[rule.required_fields]]
ecs = true
name = "host.os.type"
type = "keyword"

[[rule.required_fields]]
ecs = true
name = "process.name"
type = "keyword"


```

</p>
</details> 


![auto_gen_schema](https://github.com/user-attachments/assets/f8869e0f-ff64-43df-9dbc-5b7e99a54860)

This will occur in any command where rule contents are validated against a schema, including `import-rules-to-repo`, `kibana export-rules` and others. 

Additionally added, is the `--skip-errors` flag to `import-rules-to-repo` to follow similar functionality from this same flag for the `kibana export-rules` command.

Also, rule names will no longer be validated against our naming conversions for custom rules. Any valid string name will now validate. 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
