### PR TITLE
[Rule Tuning] AWS S3 Object Versioning Suspended

### DIFF
--- a/rules/integrations/aws/impact_s3_object_versioning_disabled.toml
+++ b/rules/integrations/aws/impact_s3_object_versioning_disabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/12"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2024/07/12"
+updated_date = "2024/08/02"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ false_positives = [
     """,
 ]
 from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "AWS S3 Object Versioning Suspended"


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/detection-rules/issues/3950

## Summary

Adds missing index field.