### PR TITLE
[DaC] [FR] Ndjson support for action connectors

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -296,7 +296,7 @@ Options:
   -id, --rule-id TEXT
   -o, --outfile PATH              Name of file for exported rules
   -r, --replace-id                Replace rule IDs with new IDs before export
-  --stack-version [7.10|7.11|7.12|7.13|7.14|7.15|7.16|7.8|7.9|8.0|8.1|8.10|8.11|8.12|8.13|8.14|8.2|8.3|8.4|8.5|8.6|8.7|8.8|8.9]
+  --stack-version [7.8|7.9|7.10|7.11|7.12|7.13|7.14|7.15|7.16|8.0|8.1|8.2|8.3|8.4|8.5|8.6|8.7|8.8|8.9|8.10|8.11|8.12|8.13|8.14]
                                   Downgrade a rule version to be compatible
                                   with older instances of Kibana
   -s, --skip-unsupported          If `--stack-version` is passed, skip rule

--- a/CLI.md
+++ b/CLI.md
@@ -85,12 +85,18 @@ Usage: detection_rules import-rules-to-repo [OPTIONS] [INPUT_FILE]...
   Import rules from json, toml, yaml, or Kibana exported rule file(s).
 
 Options:
+  -ac, --action-connector-import  Include action connectors in export
   -e, --exceptions-import         Include exceptions in export
   --required-only                 Only prompt for required fields
   -d, --directory DIRECTORY       Load files from a directory
   -s, --save-directory DIRECTORY  Save imported rules to a directory
   -se, --exceptions-directory DIRECTORY
                                   Save imported exceptions to a directory
+  -sa, --action-connectors-directory DIRECTORY
+                                  Save imported actions to a directory
+  -ske, --skip-errors             Skip rule import errors
+  -da, --default-author TEXT      Default author for rules missing one
+  -snv, --strip-none-values       Strip None values from the rule
   -h, --help                      Show this message and exit.
 ```
 
@@ -290,13 +296,15 @@ Options:
   -id, --rule-id TEXT
   -o, --outfile PATH              Name of file for exported rules
   -r, --replace-id                Replace rule IDs with new IDs before export
-  --stack-version [7.10|7.11|7.12|7.13|7.14|7.15|7.16|7.8|7.9|8.0|8.1|8.2|8.3|8.4|8.5|8.6|8.7|8.8|8.9|8.10|8.11|8.12|8.13|8.14|8.15]
+  --stack-version [7.10|7.11|7.12|7.13|7.14|7.15|7.16|7.8|7.9|8.0|8.1|8.10|8.11|8.12|8.13|8.14|8.2|8.3|8.4|8.5|8.6|8.7|8.8|8.9]
                                   Downgrade a rule version to be compatible
                                   with older instances of Kibana
   -s, --skip-unsupported          If `--stack-version` is passed, skip rule
                                   types which are unsupported (an error will
                                   be raised otherwise)
   --include-metadata              Add metadata to the exported rules
+  -ac, --include-action-connectors
+                                  Include Action Connectors in export
   -e, --include-exceptions        Include Exceptions Lists in export
   -h, --help                      Show this message and exit.
 ```
@@ -332,6 +340,7 @@ Options:
   --kibana-url TEXT
   -kp, --kibana-password TEXT
   -kc, --kibana-cookie TEXT    Cookie from an authed session
+  --api-key TEXT
   --cloud-id TEXT              ID of the cloud instance.
 
 Usage: detection_rules kibana import-rules [OPTIONS]
@@ -344,7 +353,7 @@ Options:
   -id, --rule-id TEXT
   -o, --overwrite                 Overwrite existing rules
   -e, --overwrite-exceptions      Overwrite exceptions in existing rules
-  -a, --overwrite-action-connectors
+  -ac, --overwrite-action-connectors
                                   Overwrite action connectors in existing
                                   rules
   -h, --help                      Show this message and exit.
@@ -512,6 +521,7 @@ Options:
   --kibana-url TEXT
   -kp, --kibana-password TEXT
   -kc, --kibana-cookie TEXT    Cookie from an authed session
+  --api-key TEXT
   --cloud-id TEXT              ID of the cloud instance.
 
 Usage: detection_rules kibana export-rules [OPTIONS]
@@ -520,14 +530,17 @@ Usage: detection_rules kibana export-rules [OPTIONS]
 
 Options:
   -d, --directory PATH            Directory to export rules to  [required]
+  -acd, --action-connectors-directory PATH
+                                  Directory to export action connectors to
   -ed, --exceptions-directory PATH
                                   Directory to export exceptions to
   -r, --rule-id TEXT              Optional Rule IDs to restrict export to
+  -ac, --export-action-connectors
+                                  Include action connectors in export
   -e, --export-exceptions         Include exceptions in export
   -s, --skip-errors               Skip errors when exporting rules
   -sv, --strip-version            Strip the version fields from all rules
   -h, --help                      Show this message and exit.
-
 
 ```
 

--- a/detection_rules/action.py
+++ b/detection_rules/action.py
@@ -5,28 +5,19 @@
 
 """Dataclasses for Action."""
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-import pytoml
-from marshmallow import EXCLUDE
-
 from .mixins import MarshmallowDataclassMixin
 from .schemas import definitions
-from .config import parse_rules_config
-
-RULES_CONFIG = parse_rules_config()
 
 
 @dataclass(frozen=True)
 class ActionMeta(MarshmallowDataclassMixin):
     """Data stored in an exception's [metadata] section of TOML."""
-
     creation_date: definitions.Date
-    action_container_name: str
-    rule_ids: List[definitions.UUIDString]
-    rule_names: List[str]
+    rule_id: List[definitions.UUIDString]
+    rule_name: str
     updated_date: definitions.Date
 
     # Optional fields
@@ -37,95 +28,37 @@ class ActionMeta(MarshmallowDataclassMixin):
 
 @dataclass
 class Action(MarshmallowDataclassMixin):
-    """Data object for rule Action Connector."""
+    """Data object for rule Action."""
+    @dataclass
+    class ActionParams:
+        """Data object for rule Action params."""
+        body: str
 
-    group: Optional[str]
-    id: str
-    attributes: dict
+    action_type_id: definitions.ActionTypeId
+    group: str
+    params: ActionParams
+    id: Optional[str]
     frequency: Optional[dict]
     alerts_filter: Optional[dict]
-    managed: Optional[bool]
-    type: Optional[str]
-    references: Optional[List]
 
 
 @dataclass(frozen=True)
 class TOMLActionContents(MarshmallowDataclassMixin):
-    """Object for action connector from TOML file."""
-
+    """Object for action from TOML file."""
     metadata: ActionMeta
     actions: List[Action]
-
-    @classmethod
-    def from_actions_dict(
-        cls,
-        actions_dict: dict,
-        rule_list: dict,
-    ) -> "TOMLActionContents":
-        """Create a TOMLActionContents from a kibana rule resource."""
-        rule_ids = []
-        rule_names = []
-
-        for rule in rule_list:
-            rule_ids.append(rule["id"])
-            rule_names.append(rule["name"])
-
-        # Format date to match schema
-        creation_date = datetime.strptime(actions_dict["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y/%m/%d")
-        updated_date = datetime.strptime(actions_dict["updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y/%m/%d")
-        metadata = {
-            "creation_date": creation_date,
-            "rule_ids": rule_ids,
-            "rule_names": rule_names,
-            "updated_date": updated_date,
-            "action_container_name": f"Action Container {actions_dict.get('id')}",
-        }
-
-        return cls.from_dict({"metadata": metadata, "actions": [actions_dict]}, unknown=EXCLUDE)
-
-    def to_api_format(self) -> List[dict]:
-        """Convert the TOML Action Connector to the API format."""
-        converted = []
-
-        for action in self.actions:
-            converted.append(action.to_dict())
-        return converted
 
 
 @dataclass(frozen=True)
 class TOMLAction:
-    """Object for action connector from TOML file."""
-
+    """Object for action from TOML file."""
     contents: TOMLActionContents
     path: Path
 
     @property
     def name(self):
-        return self.contents.metadata.action_container_name
+        return self.contents.metadata.rule_name
 
-    def save_toml(self):
-        """Save the action to a TOML file."""
-        assert self.path is not None, f"Can't save action for {self.name} without a path"
-        # Check if self.path has a .toml extension
-        path = self.path
-        if path.suffix != ".toml":
-            # If it doesn't, add one
-            path = path.with_suffix(".toml")
-        with path.open("w") as f:
-            contents_dict = self.contents.to_dict()
-            # Sort the dictionary so that 'metadata' is at the top
-            sorted_dict = dict(sorted(contents_dict.items(), key=lambda item: item[0] != "metadata"))
-            pytoml.dump(sorted_dict, f)
-
-
-def parse_actions_results_from_api(results: List[dict]) -> tuple[List[dict], List[dict]]:
-    """Parse the results from the API to split into action results and non-actions."""
-    action_results = []
-    non_action_results = []
-    for result in results:
-        if result.get("type") != "action":
-            non_action_results.append(result)
-        else:
-            action_results.append(result)
-
-    return action_results, non_action_results
+    @property
+    def id(self):
+        return self.contents.metadata.rule_id

--- a/detection_rules/action.py
+++ b/detection_rules/action.py
@@ -119,7 +119,7 @@ class TOMLAction:
 
 
 def parse_actions_results_from_api(results: List[dict]) -> tuple[List[dict], List[dict]]:
-    """Parse the results from the API into TOMLAction objects."""
+    """Parse the results from the API to split into action results and non-actions."""
     action_results = []
     non_action_results = []
     for result in results:

--- a/detection_rules/action.py
+++ b/detection_rules/action.py
@@ -5,19 +5,28 @@
 
 """Dataclasses for Action."""
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
+import pytoml
+from marshmallow import EXCLUDE
+
 from .mixins import MarshmallowDataclassMixin
 from .schemas import definitions
+from .config import parse_rules_config
+
+RULES_CONFIG = parse_rules_config()
 
 
 @dataclass(frozen=True)
 class ActionMeta(MarshmallowDataclassMixin):
     """Data stored in an exception's [metadata] section of TOML."""
+
     creation_date: definitions.Date
-    rule_id: List[definitions.UUIDString]
-    rule_name: str
+    action_container_name: str
+    rule_ids: List[definitions.UUIDString]
+    rule_names: List[str]
     updated_date: definitions.Date
 
     # Optional fields
@@ -28,37 +37,95 @@ class ActionMeta(MarshmallowDataclassMixin):
 
 @dataclass
 class Action(MarshmallowDataclassMixin):
-    """Data object for rule Action."""
-    @dataclass
-    class ActionParams:
-        """Data object for rule Action params."""
-        body: str
+    """Data object for rule Action Connector."""
 
-    action_type_id: definitions.ActionTypeId
-    group: str
-    params: ActionParams
-    id: Optional[str]
+    group: Optional[str]
+    id: str
+    attributes: dict
     frequency: Optional[dict]
     alerts_filter: Optional[dict]
+    managed: Optional[bool]
+    type: Optional[str]
+    references: Optional[List]
 
 
 @dataclass(frozen=True)
 class TOMLActionContents(MarshmallowDataclassMixin):
-    """Object for action from TOML file."""
+    """Object for action connector from TOML file."""
+
     metadata: ActionMeta
     actions: List[Action]
+
+    @classmethod
+    def from_actions_dict(
+        cls,
+        actions_dict: dict,
+        rule_list: dict,
+    ) -> "TOMLActionContents":
+        """Create a TOMLActionContents from a kibana rule resource."""
+        rule_ids = []
+        rule_names = []
+
+        for rule in rule_list:
+            rule_ids.append(rule["id"])
+            rule_names.append(rule["name"])
+
+        # Format date to match schema
+        creation_date = datetime.strptime(actions_dict["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y/%m/%d")
+        updated_date = datetime.strptime(actions_dict["updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y/%m/%d")
+        metadata = {
+            "creation_date": creation_date,
+            "rule_ids": rule_ids,
+            "rule_names": rule_names,
+            "updated_date": updated_date,
+            "action_container_name": f"Action Container {actions_dict.get('id')}",
+        }
+
+        return cls.from_dict({"metadata": metadata, "actions": [actions_dict]}, unknown=EXCLUDE)
+
+    def to_api_format(self) -> List[dict]:
+        """Convert the TOML Action Connector to the API format."""
+        converted = []
+
+        for action in self.actions:
+            converted.append(action.to_dict())
+        return converted
 
 
 @dataclass(frozen=True)
 class TOMLAction:
-    """Object for action from TOML file."""
+    """Object for action connector from TOML file."""
+
     contents: TOMLActionContents
     path: Path
 
     @property
     def name(self):
-        return self.contents.metadata.rule_name
+        return self.contents.metadata.action_container_name
 
-    @property
-    def id(self):
-        return self.contents.metadata.rule_id
+    def save_toml(self):
+        """Save the action to a TOML file."""
+        assert self.path is not None, f"Can't save action for {self.name} without a path"
+        # Check if self.path has a .toml extension
+        path = self.path
+        if path.suffix != ".toml":
+            # If it doesn't, add one
+            path = path.with_suffix(".toml")
+        with path.open("w") as f:
+            contents_dict = self.contents.to_dict()
+            # Sort the dictionary so that 'metadata' is at the top
+            sorted_dict = dict(sorted(contents_dict.items(), key=lambda item: item[0] != "metadata"))
+            pytoml.dump(sorted_dict, f)
+
+
+def parse_actions_results_from_api(results: List[dict]) -> tuple[List[dict], List[dict]]:
+    """Parse the results from the API into TOMLAction objects."""
+    action_results = []
+    non_action_results = []
+    for result in results:
+        if result.get("type") != "action":
+            non_action_results.append(result)
+        else:
+            action_results.append(result)
+
+    return action_results, non_action_results

--- a/detection_rules/action_connector.py
+++ b/detection_rules/action_connector.py
@@ -1,0 +1,129 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+"""Dataclasses for Action."""
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import pytoml
+from marshmallow import EXCLUDE
+
+from .mixins import MarshmallowDataclassMixin
+from .schemas import definitions
+from .config import parse_rules_config
+
+RULES_CONFIG = parse_rules_config()
+
+
+@dataclass(frozen=True)
+class ActionConnectorMeta(MarshmallowDataclassMixin):
+    """Data stored in an Action Connector's [metadata] section of TOML."""
+
+    creation_date: definitions.Date
+    action_connector_name: str
+    rule_ids: List[definitions.UUIDString]
+    rule_names: List[str]
+    updated_date: definitions.Date
+
+    # Optional fields
+    deprecation_date: Optional[definitions.Date]
+    comments: Optional[str]
+    maturity: Optional[definitions.Maturity]
+
+
+@dataclass
+class ActionConnector(MarshmallowDataclassMixin):
+    """Data object for rule Action Connector."""
+
+    id: str
+    attributes: dict
+    frequency: Optional[dict]
+    managed: Optional[bool]
+    type: Optional[str]
+    references: Optional[List]
+
+
+@dataclass(frozen=True)
+class TOMLActionConnectorContents(MarshmallowDataclassMixin):
+    """Object for action connector from TOML file."""
+
+    metadata: ActionConnectorMeta
+    action_connectors: List[ActionConnector]
+
+    @classmethod
+    def from_actions_dict(
+        cls,
+        actions_dict: dict,
+        rule_list: dict,
+    ) -> "TOMLActionConnectorContents":
+        """Create a TOMLActionContents from a kibana rule resource."""
+        rule_ids = []
+        rule_names = []
+
+        for rule in rule_list:
+            rule_ids.append(rule["id"])
+            rule_names.append(rule["name"])
+
+        # Format date to match schema
+        creation_date = datetime.strptime(actions_dict["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y/%m/%d")
+        updated_date = datetime.strptime(actions_dict["updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").strftime("%Y/%m/%d")
+        metadata = {
+            "creation_date": creation_date,
+            "rule_ids": rule_ids,
+            "rule_names": rule_names,
+            "updated_date": updated_date,
+            "action_connector_name": f"Action Connector {actions_dict.get('id')}",
+        }
+
+        return cls.from_dict({"metadata": metadata, "action_connectors": [actions_dict]}, unknown=EXCLUDE)
+
+    def to_api_format(self) -> List[dict]:
+        """Convert the TOML Action Connector to the API format."""
+        converted = []
+
+        for action in self.action_connectors:
+            converted.append(action.to_dict())
+        return converted
+
+
+@dataclass(frozen=True)
+class TOMLActionConnector:
+    """Object for action connector from TOML file."""
+
+    contents: TOMLActionConnectorContents
+    path: Path
+
+    @property
+    def name(self):
+        return self.contents.metadata.action_connector_name
+
+    def save_toml(self):
+        """Save the action to a TOML file."""
+        assert self.path is not None, f"Can't save action for {self.name} without a path"
+        # Check if self.path has a .toml extension
+        path = self.path
+        if path.suffix != ".toml":
+            # If it doesn't, add one
+            path = path.with_suffix(".toml")
+        with path.open("w") as f:
+            contents_dict = self.contents.to_dict()
+            # Sort the dictionary so that 'metadata' is at the top
+            sorted_dict = dict(sorted(contents_dict.items(), key=lambda item: item[0] != "metadata"))
+            pytoml.dump(sorted_dict, f)
+
+
+def parse_action_connector_results_from_api(results: List[dict]) -> tuple[List[dict], List[dict]]:
+    """Parse the results from the API to split into action connector results and non-actions."""
+    action_results = []
+    non_action_results = []
+    for result in results:
+        if result.get("type") != "action":
+            non_action_results.append(result)
+        else:
+            action_results.append(result)
+
+    return action_results, non_action_results

--- a/detection_rules/action_connector.py
+++ b/detection_rules/action_connector.py
@@ -55,7 +55,7 @@ class TOMLActionConnectorContents(MarshmallowDataclassMixin):
     action_connectors: List[ActionConnector]
 
     @classmethod
-    def from_actions_dict(
+    def from_action_connector_dict(
         cls,
         actions_dict: dict,
         rule_list: dict,

--- a/detection_rules/action_connector.py
+++ b/detection_rules/action_connector.py
@@ -117,7 +117,7 @@ class TOMLActionConnector:
 
 
 def parse_action_connector_results_from_api(results: List[dict]) -> tuple[List[dict], List[dict]]:
-    """Parse the results from the API to split into action connector results and non-actions."""
+    """Filter Kibana export rule results for action connector dictionaries."""
     action_results = []
     non_action_results = []
     for result in results:

--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -186,6 +186,7 @@ class RulesConfig:
     version_lock: Dict[str, dict]
 
     action_dir: Optional[Path] = None
+    action_connector_dir: Optional[Path] = None
     auto_gen_schema_file: Optional[Path] = None
     bbr_rules_dirs: Optional[List[Path]] = field(default_factory=list)
     bypass_version_lock: bool = False
@@ -273,6 +274,8 @@ def parse_rules_config(path: Optional[Path] = None) -> RulesConfig:
             contents['exception_dir'] = base_dir.joinpath(directories.get('exception_dir')).resolve()
         if directories.get('action_dir'):
             contents['action_dir'] = base_dir.joinpath(directories.get('action_dir')).resolve()
+        if directories.get('action_connector_dir'):
+            contents['action_connector_dir'] = base_dir.joinpath(directories.get('action_connector_dir')).resolve()
 
     # version strategy
     contents['bypass_version_lock'] = loaded.get('bypass_version_lock', False)

--- a/detection_rules/custom_rules.py
+++ b/detection_rules/custom_rules.py
@@ -29,6 +29,11 @@ def create_config_content() -> str:
     config_content = {
         'rule_dirs': ['rules'],
         'bbr_rules_dirs': ['rules_building_block'],
+        'directories': {
+            'action_dir': 'actions',
+            'action_connector_dir': 'action_connectors',
+            'exception_dir': 'exceptions',
+        },
         'files': {
             'deprecated_rules': 'etc/deprecated_rules.json',
             'packages': 'etc/packages.yaml',
@@ -98,6 +103,7 @@ def setup_config(directory: Path, kibana_version: str, overwrite: bool, enable_p
     ]
     directories = [
         directory / 'actions',
+        directory / 'action_connectors',
         directory / 'exceptions',
         directory / 'rules',
         directory / 'rules_building_block',

--- a/detection_rules/etc/_config.yaml
+++ b/detection_rules/etc/_config.yaml
@@ -19,6 +19,7 @@ normalize_kql_keywords: False
 # directories:
   # action_dir: actions
   # exception_dir: exceptions
+  # action_connector_dir: action_connectors
 
 # to set up a custom rules directory, copy this file to the root of the custom rules directory, which is set
 #   using the environment variable CUSTOM_RULES_DIR

--- a/detection_rules/generic_loader.py
+++ b/detection_rules/generic_loader.py
@@ -101,9 +101,9 @@ class GenericCollection:
         file_map = self.file_map
         name_map = self.name_map
 
-        assert not self.frozen, f"Unable to add item {item.name} {item.id} to a frozen collection"
+        assert not self.frozen, f"Unable to add item {item.name} to a frozen collection"
         assert item.name not in name_map, \
-            f"Rule Name {item.name} for {item.id} collides with rule ID {name_map.get(item.name).id}"
+            f"Rule Name {item.name} collides with {name_map[item.name].name}"
 
         if item.path is not None:
             item_path = item.path.resolve()

--- a/detection_rules/generic_loader.py
+++ b/detection_rules/generic_loader.py
@@ -120,7 +120,7 @@ class GenericCollection:
         """Load a dictionary into the collection."""
         is_exception = True if 'exceptions' in obj else False
         contents = TOMLExceptionContents.from_dict(obj) if is_exception else TOMLActionContents.from_dict(obj)
-        item = TOMLException(path=path, contents=contents)
+        item = TOMLException(path=path, contents=contents) if is_exception else TOMLAction(path=path, contents=contents)
         self.add_item(item)
         return item
 

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -15,8 +15,8 @@ from kibana import Signal, RuleResource
 
 from .config import parse_rules_config
 from .cli_utils import multi_collection
-from .action import (TOMLAction, TOMLActionContents,
-                     parse_actions_results_from_api)
+from .action_connector import (TOMLActionConnector, TOMLActionConnectorContents,
+                               parse_action_connector_results_from_api)
 from .exception import (TOMLException, TOMLExceptionContents,
                         parse_exceptions_results_from_api)
 from .generic_loader import GenericCollection
@@ -86,7 +86,7 @@ def upload_rule(ctx, rules: RuleCollection, replace_id):
 @multi_collection
 @click.option('--overwrite', '-o', is_flag=True, help='Overwrite existing rules')
 @click.option('--overwrite-exceptions', '-e', is_flag=True, help='Overwrite exceptions in existing rules')
-@click.option('--overwrite-action-connectors', '-a', is_flag=True,
+@click.option('--overwrite-action-connectors', '-ac', is_flag=True,
               help='Overwrite action connectors in existing rules')
 @click.pass_context
 def kibana_import_rules(ctx: click.Context, rules: RuleCollection, overwrite: Optional[bool] = False,
@@ -100,11 +100,13 @@ def kibana_import_rules(ctx: click.Context, rules: RuleCollection, overwrite: Op
         exception_dicts = [
             d.contents.to_api_format() for d in cl.items if isinstance(d.contents, TOMLExceptionContents)
         ]
-        actions_dicts = [d.contents.to_api_format() for d in cl.items if isinstance(d.contents, TOMLActionContents)]
+        action_connectors_dicts = [
+            d.contents.to_api_format() for d in cl.items if isinstance(d.contents, TOMLActionConnectorContents)
+        ]
         response, successful_rule_ids, results = RuleResource.import_rules(
             rule_dicts,
             exception_dicts,
-            actions_dicts,
+            action_connectors_dicts,
             overwrite=overwrite,
             overwrite_exceptions=overwrite_exceptions,
             overwrite_action_connectors=overwrite_action_connectors
@@ -124,10 +126,12 @@ def kibana_import_rules(ctx: click.Context, rules: RuleCollection, overwrite: Op
 
 @kibana_group.command("export-rules")
 @click.option("--directory", "-d", required=True, type=Path, help="Directory to export rules to")
-@click.option("--actions-directory", "-ad", required=False, type=Path, help="Directory to export action connectors to")
+@click.option(
+    "--action-connectors-directory", "-acd", required=False, type=Path, help="Directory to export action connectors to"
+)
 @click.option("--exceptions-directory", "-ed", required=False, type=Path, help="Directory to export exceptions to")
 @click.option("--rule-id", "-r", multiple=True, help="Optional Rule IDs to restrict export to")
-@click.option("--export-actions", "-a", is_flag=True, help="Include action connectors in export")
+@click.option("--export-action-connectors", "-ac", is_flag=True, help="Include action connectors in export")
 @click.option("--export-exceptions", "-e", is_flag=True, help="Include exceptions in export")
 @click.option("--skip-errors", "-s", is_flag=True, help="Skip errors when exporting rules")
 @click.option("--strip-version", "-sv", is_flag=True, help="Strip the version fields from all rules")
@@ -135,10 +139,10 @@ def kibana_import_rules(ctx: click.Context, rules: RuleCollection, overwrite: Op
 def kibana_export_rules(
     ctx: click.Context,
     directory: Path,
-    actions_directory: Optional[Path],
+    action_connectors_directory: Optional[Path],
     exceptions_directory: Optional[Path],
     rule_id: Optional[Iterable[str]] = None,
-    export_actions: bool = False,
+    export_action_connectors: bool = False,
     export_exceptions: bool = False,
     skip_errors: bool = False,
     strip_version: bool = False,
@@ -156,10 +160,10 @@ def kibana_export_rules(
         click.echo("Warning: Exceptions export requested, but no exceptions directory found")
 
     # Handle Actions Connector Directory Location
-    if results and actions_directory:
-        actions_directory.mkdir(parents=True, exist_ok=True)
-    actions_directory = actions_directory or RULES_CONFIG.action_dir
-    if not actions_directory and export_actions:
+    if results and action_connectors_directory:
+        action_connectors_directory.mkdir(parents=True, exist_ok=True)
+    action_connectors_directory = action_connectors_directory or RULES_CONFIG.action_connector_dir
+    if not action_connectors_directory and export_action_connectors:
         click.echo("Warning: Exceptions export requested, but no exceptions directory found")
 
     if results:
@@ -263,8 +267,8 @@ def kibana_export_rules(
 
     # Parse action connector results from API return
     action_connectors = []
-    if export_actions:
-        action_results, _ = parse_actions_results_from_api(action_corrector_results)
+    if export_action_connectors:
+        action_results, _ = parse_action_connector_results_from_api(action_corrector_results)
 
         # Build TOMLException Objects
         for connector in action_results:
@@ -275,12 +279,12 @@ def kibana_export_rules(
                     click.echo(f"Warning action connector {connector_id} has no associated rules. Loading skipped.")
                     continue
                 else:
-                    contents = TOMLActionContents.from_actions_dict(
+                    contents = TOMLActionConnectorContents.from_actions_dict(
                         connector,
                         rule_list
                     )
-                    action_connector = TOMLAction(
-                        contents=contents, path=actions_directory / f"{connector_id}_actions.toml"
+                    action_connector = TOMLActionConnector(
+                        contents=contents, path=action_connectors_directory / f"{connector_id}_actions.toml"
                     )
             except Exception as e:
                 if skip_errors:
@@ -339,7 +343,7 @@ def kibana_export_rules(
     click.echo(f"{len(action_connectors)} action connectors exported")
     click.echo(f"{len(saved)} rules saved to {directory}")
     click.echo(f"{len(saved_exceptions)} exception lists saved to {exceptions_directory}")
-    click.echo(f"{len(saved_action_connectors)} action connectors saved to {actions_directory}")
+    click.echo(f"{len(saved_action_connectors)} action connectors saved to {action_connectors_directory}")
     if errors:
         err_file = directory / "_errors.txt"
         err_file.write_text("\n".join(errors))

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -184,7 +184,7 @@ def kibana_export_rules(
         rules_results = results[:rules_count]
         exception_results = results[rules_count:rules_count + exception_list_count + exception_list_item_count]
         rules_and_exceptions_count = rules_count + exception_list_count + exception_list_item_count
-        action_corrector_results = results[
+        action_connector_results = results[
             rules_and_exceptions_count: rules_and_exceptions_count + action_connector_count
         ]
 
@@ -268,19 +268,19 @@ def kibana_export_rules(
     # Parse action connector results from API return
     action_connectors = []
     if export_action_connectors:
-        action_results, _ = parse_action_connector_results_from_api(action_corrector_results)
+        action_connector_results, _ = parse_action_connector_results_from_api(action_connector_results)
 
-        # Build TOMLException Objects
-        for connector in action_results:
+        # Build TOMLAction Objects
+        for action_connector_dict in action_connector_results:
             try:
-                connector_id = connector.get("id")
+                connector_id = action_connector_dict.get("id")
                 rule_list = action_connector_rule_table.get(connector_id)
                 if not rule_list:
                     click.echo(f"Warning action connector {connector_id} has no associated rules. Loading skipped.")
                     continue
                 else:
-                    contents = TOMLActionConnectorContents.from_actions_dict(
-                        connector,
+                    contents = TOMLActionConnectorContents.from_action_connector_dict(
+                        action_connector_dict,
                         rule_list
                     )
                     action_connector = TOMLActionConnector(

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -164,7 +164,7 @@ def kibana_export_rules(
         action_connectors_directory.mkdir(parents=True, exist_ok=True)
     action_connectors_directory = action_connectors_directory or RULES_CONFIG.action_connector_dir
     if not action_connectors_directory and export_action_connectors:
-        click.echo("Warning: Exceptions export requested, but no exceptions directory found")
+        click.echo("Warning: Action Connector export requested, but no Action Connector directory found")
 
     if results:
         directory.mkdir(parents=True, exist_ok=True)

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -445,17 +445,13 @@ def _export_rules(
         # Get exceptions in API format
         if include_exceptions:
             exceptions = [d.contents.to_api_format() for d in cl.items if isinstance(d.contents, TOMLExceptionContents)]
-            # Flatten list of lists
             exceptions = [e for sublist in exceptions for e in sublist]
-            # Append to Rules List
             output_lines.extend(json.dumps(e, sort_keys=True) for e in exceptions)
         if include_action_connectors:
             action_connectors = [
                 d.contents.to_api_format() for d in cl.items if isinstance(d.contents, TOMLActionConnectorContents)
             ]
-            # Flatten list of lists
             actions = [a for sublist in action_connectors for a in sublist]
-            # Append to Rules List
             output_lines.extend(json.dumps(a, sort_keys=True) for a in actions)
 
     outfile.write_text('\n'.join(output_lines) + '\n')

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -261,7 +261,7 @@ def import_rules_into_repo(
                     filename = f"{connector_id}_actions.toml"
                     if RULES_CONFIG.action_connector_dir is None and not action_connectors_directory:
                         raise FileNotFoundError(
-                            "No Exceptions directory is specified. Please specify either in the config or CLI."
+                            "No Action Connector directory is specified. Please specify either in the config or CLI."
                         )
                     actions_path = (
                         Path(action_connectors_directory) / filename

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -19,6 +19,8 @@ from typing import Dict, Iterable, List, Optional, get_args
 from uuid import uuid4
 import click
 
+from .action import (TOMLAction, TOMLActionContents,
+                     parse_actions_results_from_api)
 from .attack import build_threat_map_entry
 from .cli_utils import rule_prompt, multi_collection
 from .config import load_current_package_version, parse_rules_config
@@ -99,6 +101,7 @@ def generate_rules_index(ctx: click.Context, query, overwrite, save_files=True):
 
 @root.command("import-rules-to-repo")
 @click.argument("input-file", type=click.Path(dir_okay=False, exists=True), nargs=-1, required=False)
+@click.option("--actions-import", "-a", is_flag=True, help="Include actions in export")
 @click.option("--exceptions-import", "-e", is_flag=True, help="Include exceptions in export")
 @click.option("--required-only", is_flag=True, help="Only prompt for required fields")
 @click.option("--directory", "-d", type=click.Path(file_okay=False, exists=True), help="Load files from a directory")
@@ -111,15 +114,23 @@ def generate_rules_index(ctx: click.Context, query, overwrite, save_files=True):
     type=click.Path(file_okay=False, exists=True),
     help="Save imported exceptions to a directory",
 )
+@click.option(
+    "--actions-directory",
+    "-sa",
+    type=click.Path(file_okay=False, exists=True),
+    help="Save imported actions to a directory",
+)
 @click.option("--skip-errors", "-ske", is_flag=True, help="Skip rule import errors")
 @click.option("--default-author", "-da", type=str, required=False, help="Default author for rules missing one")
 @click.option("--strip-none-values", "-snv", is_flag=True, help="Strip None values from the rule")
 def import_rules_into_repo(
     input_file: click.Path,
     required_only: bool,
+    actions_import: bool,
     exceptions_import: bool,
     directory: click.Path,
     save_directory: click.Path,
+    actions_directory: click.Path,
     exceptions_directory: click.Path,
     skip_errors: bool,
     default_author: str,
@@ -144,9 +155,12 @@ def import_rules_into_repo(
         file_contents, skip_errors=True
     )
 
+    action_connectors, unparsed_results = parse_actions_results_from_api(unparsed_results)
+
     file_contents = unparsed_results
 
     exception_list_rule_table = {}
+    action_connector_rule_table = {}
     for contents in file_contents:
         # Don't load exceptions as rules
         if contents["type"] not in get_args(definitions.RuleType):
@@ -191,6 +205,14 @@ def import_rules_into_repo(
                     exception_list_rule_table[exception_id] = []
                 exception_list_rule_table[exception_id].append({"id": contents["id"], "name": contents["name"]})
 
+        if contents.get("actions"):
+            # use connector ids as rule source
+            for action in contents["actions"]:
+                action_id = action["id"]
+                if action_id not in action_connector_rule_table:
+                    action_connector_rule_table[action_id] = []
+                action_connector_rule_table[action_id].append({"id": contents["id"], "name": contents["name"]})
+
     # Build TOMLException Objects
     if exceptions_import:
         for container in exceptions_containers.values():
@@ -219,6 +241,38 @@ def import_rules_into_repo(
                     contents=contents,
                     path=exceptions_path,
                 ).save_toml()
+            except Exception:
+                raise
+
+    # Build TOMLAction Objects
+    if actions_import:
+        for connector in action_connectors:
+            try:
+                connector_id = connector.get("id")
+                rule_list = action_connector_rule_table.get(connector_id)
+                if not rule_list:
+                    click.echo(f"Warning action connector {connector_id} has no associated rules. Loading skipped.")
+                    continue
+                else:
+                    contents = TOMLActionContents.from_actions_dict(
+                        connector,
+                        rule_list
+                    )
+                    filename = f"{connector_id}_actions.toml"
+                    if RULES_CONFIG.action_dir is None and not actions_directory:
+                        raise FileNotFoundError(
+                            "No Exceptions directory is specified. Please specify either in the config or CLI."
+                        )
+                    actions_path = (
+                        Path(actions_directory) / filename
+                        if actions_directory
+                        else RULES_CONFIG.action_dir / filename
+                    )
+                    click.echo(f"[+] Building exception(s) for {actions_path}")
+                    TOMLAction(
+                        contents=contents,
+                        path=actions_path,
+                    ).save_toml()
             except Exception:
                 raise
 
@@ -354,6 +408,7 @@ def _export_rules(
     verbose=True,
     skip_unsupported=False,
     include_metadata: bool = False,
+    include_actions: bool = False,
     include_exceptions: bool = False,
 ):
     """Export rules and exceptions into a consolidated ndjson file."""
@@ -384,14 +439,21 @@ def _export_rules(
                                    sort_keys=True) for r in rules]
 
     # Add exceptions to api format here and add to output_lines
-    if include_exceptions:
+    if include_exceptions or include_actions:
         cl = GenericCollection.default()
         # Get exceptions in API format
-        exceptions = [d.contents.to_api_format() for d in cl.items]
-        # Flatten list of lists
-        exceptions = [e for sublist in exceptions for e in sublist]
-        # Append to Rules List
-        output_lines.extend(json.dumps(e, sort_keys=True) for e in exceptions)
+        if include_exceptions:
+            exceptions = [d.contents.to_api_format() for d in cl.items if isinstance(d.contents, TOMLExceptionContents)]
+            # Flatten list of lists
+            exceptions = [e for sublist in exceptions for e in sublist]
+            # Append to Rules List
+            output_lines.extend(json.dumps(e, sort_keys=True) for e in exceptions)
+        if include_actions:
+            actions = [d.contents.to_api_format() for d in cl.items if isinstance(d.contents, TOMLActionContents)]
+            # Flatten list of lists
+            actions = [a for sublist in actions for a in sublist]
+            # Append to Rules List
+            output_lines.extend(json.dumps(a, sort_keys=True) for a in actions)
 
     outfile.write_text('\n'.join(output_lines) + '\n')
 
@@ -426,10 +488,20 @@ def _export_rules(
 )
 @click.option("--include-metadata", type=bool, is_flag=True, default=False, help="Add metadata to the exported rules")
 @click.option(
+    "--include-actions", "-a", type=bool, is_flag=True, default=False, help="Include Action Connectors in export"
+)
+@click.option(
     "--include-exceptions", "-e", type=bool, is_flag=True, default=False, help="Include Exceptions Lists in export"
 )
 def export_rules_from_repo(
-    rules, outfile: Path, replace_id, stack_version, skip_unsupported, include_metadata: bool, include_exceptions: bool
+    rules,
+    outfile: Path,
+    replace_id,
+    stack_version,
+    skip_unsupported,
+    include_metadata: bool,
+    include_actions: bool,
+    include_exceptions: bool,
 ) -> RuleCollection:
     """Export rule(s) and exception(s) into an importable ndjson file."""
     assert len(rules) > 0, "No rules found"
@@ -452,6 +524,7 @@ def export_rules_from_repo(
         downgrade_version=stack_version,
         skip_unsupported=skip_unsupported,
         include_metadata=include_metadata,
+        include_actions=include_actions,
         include_exceptions=include_exceptions,
     )
 

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -280,6 +280,7 @@ def import_rules_into_repo(
     click.echo(f"{len(file_contents) + exceptions_count} results exported")
     click.echo(f"{len(file_contents)} rules converted")
     click.echo(f"{exceptions_count} exceptions exported")
+    click.echo(f"{len(action_connectors)} actions connectors exported")
     if errors:
         err_file = save_directory if save_directory is not None else RULES_DIRS[0] / "_errors.txt"
         err_file.write_text("\n".join(errors))

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -246,16 +246,16 @@ def import_rules_into_repo(
 
     # Build TOMLAction Objects
     if action_connector_import:
-        for connector in action_connectors:
+        for actions_connector_dict in action_connectors:
             try:
-                connector_id = connector.get("id")
+                connector_id = actions_connector_dict.get("id")
                 rule_list = action_connector_rule_table.get(connector_id)
                 if not rule_list:
                     click.echo(f"Warning action connector {connector_id} has no associated rules. Loading skipped.")
                     continue
                 else:
-                    contents = TOMLActionConnectorContents.from_actions_dict(
-                        connector,
+                    contents = TOMLActionConnectorContents.from_action_connector_dict(
+                        actions_connector_dict,
                         rule_list
                     )
                     filename = f"{connector_id}_actions.toml"

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -612,7 +612,7 @@ class DataValidator:
                                   f"field, use the environment variable `DR_BYPASS_NOTE_VALIDATION_AND_PARSE`")
 
         # raise if setup header is in note and in setup
-        if self.setup_in_note and self.setup:
+        if self.setup_in_note and (self.setup and self.setup != "None"):
             raise ValidationError("Setup header found in both note and setup fields.")
 
 

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -231,6 +231,11 @@ def toml_write(rule_contents, outfile=None):
                 # This will ensure that the output file has the correct number of backslashes.
                 v = v.replace("\\", "\\\\")
 
+            if k == 'setup' and isinstance(v, str):
+                # Transform instances of \ to \\ as calling write will convert \\ to \.
+                # This will ensure that the output file has the correct number of backslashes.
+                v = v.replace("\\", "\\\\")
+
             if k == 'description' and isinstance(v, str):
                 # Transform instances of \ to \\ as calling write will convert \\ to \.
                 # This will ensure that the output file has the correct number of backslashes.

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -36,7 +36,7 @@ migrations = {}
 
 def all_versions() -> List[str]:
     """Get all known stack versions."""
-    return [str(v) for v in sorted(migrations)]
+    return [str(v) for v in sorted(migrations, key=lambda x: Version.parse(x, optional_minor_and_patch=True))]
 
 
 def migrate(version: str):

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -29,9 +29,12 @@ custom-rules
 └── actions
     ├── action_1.toml
     ├── action_2.toml
+└── action_connectors
+    ├── action_connector_1.toml
+    └── action_connectors_2.toml    
 └── exceptions
     ├── exception_1.toml
-    └──  exception_2.toml
+    └── exception_2.toml
 ```
 
 This structure represents a portable set of custom rules. This is just an example, and the exact locations of the files
@@ -58,6 +61,7 @@ files:
   version_lock: version.lock.json
 directories:
   action_dir: actions
+  action_connector_dir: action_connectors
   exception_dir: exceptions
 ```
 
@@ -69,7 +73,9 @@ Some notes:
 * To bypass using the version lock versioning strategy (version lock file) you can set the optional `bypass_version_lock` value to be `True`
 * To normalize the capitalization KQL keywords in KQL rule queries one can use the optional `normalize_kql_keywords` value set to `True` or `False` as desired.
 * To manage exceptions tied to rules one can set an exceptions directory using the optional `exception_dir` value (included above) set to be the desired path. If an exceptions directory is explicitly specified in a CLI command, the config value will be ignored.
+* To manage action-connectors tied to rules one can set an action-connectors directory using the optional `action_connector_dir` value (included above) set to be the desired path. If an actions_connector directory is explicitly specified in a CLI command, the config value will be ignored.
 * To turn on automatic schema generation for non-ecs fields a custom schemas add `auto_gen_schema_file: <path_to_your_json_file>`. This will generate a schema file in the specified location that will be used to add entries for each field and index combination that is not already in a known schema. This will also automatically add it to your stack-schema-map.yaml file when using a custom rules directory and config.
+* For Kibana action items, currently these are included in the rule toml files themselves. At a later date, we may allow for bulk editing of rule action items through separate action toml files. The action_dir config key is left available for this later implementation. For now to bulk update, use the bulk actions add rule actions UI in Kibana.
 
 
 When using the repo, set the environment variable `CUSTOM_RULES_DIR=<directory-with-_config.yaml>`
@@ -185,6 +191,8 @@ Example:
 ```
 
 Note: the `custom` key can be any alpha numeric value except `beats`, `ecs`, or `endgame` as these are reserved terms. 
+
+Note: Remember if you want to turn on automatic schema generation for non-ecs fields a custom schemas add `auto_gen_schema_file: <path_to_your_json_file>`. 
 
 Example schema json:
 

--- a/lib/kibana/kibana/resources.py
+++ b/lib/kibana/kibana/resources.py
@@ -234,7 +234,7 @@ class RuleResource(BaseResource):
         cls,
         rules: List[dict],
         exceptions: List[List[dict]] = [],
-        actions: List[List[dict]] = [],
+        action_connectors: List[List[dict]] = [],
         overwrite: bool = False,
         overwrite_exceptions: bool = False,
         overwrite_action_connectors: bool = False,
@@ -248,7 +248,7 @@ class RuleResource(BaseResource):
         )
         rule_ids = [r['rule_id'] for r in rules]
         flattened_exceptions = [e for sublist in exceptions for e in sublist]
-        flattened_actions_connectors = [a for sublist in actions for a in sublist]
+        flattened_actions_connectors = [a for sublist in action_connectors for a in sublist]
         headers, raw_data = Kibana.ndjson_file_data_prep(
             rules + flattened_exceptions + flattened_actions_connectors, "import.ndjson"
         )

--- a/lib/kibana/kibana/resources.py
+++ b/lib/kibana/kibana/resources.py
@@ -248,8 +248,10 @@ class RuleResource(BaseResource):
         )
         rule_ids = [r['rule_id'] for r in rules]
         flattened_exceptions = [e for sublist in exceptions for e in sublist]
-        flattened_actions = [a for sublist in actions for a in sublist]
-        headers, raw_data = Kibana.ndjson_file_data_prep(rules + flattened_exceptions + flattened_actions, "import.ndjson")
+        flattened_actions_connectors = [a for sublist in actions for a in sublist]
+        headers, raw_data = Kibana.ndjson_file_data_prep(
+            rules + flattened_exceptions + flattened_actions_connectors, "import.ndjson"
+        )
         response = Kibana.current().post(url, headers=headers, params=params, raw_data=raw_data)
         errors = response.get("errors", [])
         error_rule_ids = [e['rule_id'] for e in errors]

--- a/lib/kibana/kibana/resources.py
+++ b/lib/kibana/kibana/resources.py
@@ -234,6 +234,7 @@ class RuleResource(BaseResource):
         cls,
         rules: List[dict],
         exceptions: List[List[dict]] = [],
+        actions: List[List[dict]] = [],
         overwrite: bool = False,
         overwrite_exceptions: bool = False,
         overwrite_action_connectors: bool = False,
@@ -247,7 +248,8 @@ class RuleResource(BaseResource):
         )
         rule_ids = [r['rule_id'] for r in rules]
         flattened_exceptions = [e for sublist in exceptions for e in sublist]
-        headers, raw_data = Kibana.ndjson_file_data_prep(rules + flattened_exceptions, "import.ndjson")
+        flattened_actions = [a for sublist in actions for a in sublist]
+        headers, raw_data = Kibana.ndjson_file_data_prep(rules + flattened_exceptions + flattened_actions, "import.ndjson")
         response = Kibana.current().post(url, headers=headers, params=params, raw_data=raw_data)
         errors = response.get("errors", [])
         error_rule_ids = [e['rule_id'] for e in errors]

--- a/lib/kibana/pyproject.toml
+++ b/lib/kibana/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection-rules-kibana"
-version = "0.4.0"
+version = "0.5.0"
 description = "Kibana API utilities for Elastic Detection Rules"
 license = {text = "Elastic License v2"}
 keywords = ["Elastic", "Kibana", "Detection Rules", "Security", "Elasticsearch"]

--- a/rules/integrations/aws/credential_access_iam_compromisedkeyquarantine_policy_attached_to_user.toml
+++ b/rules/integrations/aws/credential_access_iam_compromisedkeyquarantine_policy_attached_to_user.toml
@@ -1,0 +1,91 @@
+[metadata]
+creation_date = "2024/07/20"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2024/07/20"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule looks for use of the IAM `AttachUserPolicy` API operation to attach the `CompromisedKeyQuarantine` or `CompromisedKeyQuarantineV2` AWS managed policies to an existing IAM user.
+This policy denies access to certain actions and is applied by the AWS team in the event that an IAM user's credentials have been compromised or exposed publicly.
+"""
+false_positives = [
+    """
+    This is an intentional action taken by AWS in the event of compromised credentials. Follow the instructions specified in the support case created for you regarding this event.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "AWS IAM CompromisedKeyQuarantine Policy Attached to User"
+note = """
+## Triage and Analysis
+
+### Investigating AWS IAM CompromisedKeyQuarantine Policy Attached to User
+
+The AWS IAM `CompromisedKeyQuarantine` and `CompromisedKeyQuarantineV2` managed policies deny certain action and is applied by the AWS team to a user with exposed credentials. 
+This action is accompanied by a support case which specifies instructions to follow before detaching the policy. 
+
+#### Possible Investigation Steps
+
+- **Identify Potentially Compromised Identity**: Review the `userName` parameter of the `aws.cloudtrail.request_parameters` to determine the quarantined IAM entity.
+- **Contextualize with AWS Support Case**: Review any information from AWS comtaining additional information about the quarantined account and the reasoning for quarantine.
+- **Follow Support Case Instructions**: Do not revert the quarantine policy attachment or delete the compromised keys. Instead folow the instructions given in your support case.
+- **Correlate with Other Activities**: Search for related CloudTrail events before and after this change to see if the same actor or IP address engaged in potentially suspicious activities.
+- **Interview Relevant Personnel**: If the compromised key belongs to a user, verify the intent and authorization for these correlated actions with the person or team responsible for managing the compromised key.
+
+### False Positive Analysis
+
+- There shouldn't be many false positives related to this action as it is inititated by AWS in response to compromised or publicly exposed credentials.
+
+### Response and Remediation
+
+- **Immediate Review and Reversal**: Update the user IAM permissions to remove the quarantine policy and disable the compromised credentials.
+- **Policy Update**: Review and possibly update your organization’s policies on credential storage to tighten control and prevent public exposure.
+- **Incident Response**: If malicious intent is confirmed, consider it a data breach incident and initiate the incident response protocol. This includes further investigation, containment, and recovery.
+
+### Additional Information:
+
+For further guidance on managing and securing credentials in AWS environments, refer to the [AWS IAM User Guide](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html) regarding security best practices and guidance on [Remediating Potentially Compromised AWS Credentials](https://docs.aws.amazon.com/guardduty/latest/ug/compromised-creds.html).
+"""
+references = [
+    "https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSCompromisedKeyQuarantine.html/",
+    "https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSCompromisedKeyQuarantineV2.html/",
+]
+risk_score = 73
+rule_id = "0b79f5c0-2c31-4fea-86cd-e62644278205"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS IAM",
+    "Resources: Investigation Guide",
+    "Use Case: Identity and Access Audit",
+    "Tactic: Credential Access",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+any where event.dataset == "aws.cloudtrail" 
+   and event.action == "AttachUserPolicy"
+   and event.outcome == "success" 
+   and stringContains(aws.cloudtrail.request_parameters, "AWSCompromisedKeyQuarantine")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/integrations/aws/impact_s3_object_versioning_disabled.toml
+++ b/rules/integrations/aws/impact_s3_object_versioning_disabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/12"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2024/07/12"
+updated_date = "2024/08/02"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ false_positives = [
     """,
 ]
 from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "AWS S3 Object Versioning Suspended"

--- a/rules/linux/defense_evasion_binary_copied_to_suspicious_directory.toml
+++ b/rules/linux/defense_evasion_binary_copied_to_suspicious_directory.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/29"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/07/18"
+updated_date = "2024/07/31"
 
 [rule]
 author = ["Elastic"]
@@ -73,7 +73,7 @@ file.Ext.original.path : (
     "/bin/node", "/usr/bin/node", "/sbin/apk", "/usr/sbin/apk", "/usr/local/sbin/apk", "/usr/bin/pip", "/bin/pip",
     "/usr/local/bin/pip", "/usr/libexec/platform-python", "/usr/bin/platform-python", "/bin/platform-python",
     "/usr/lib/systemd/systemd", "/usr/sbin/sshd", "/sbin/sshd", "/usr/local/sbin/sshd", "/usr/sbin/crond", "/sbin/crond",
-    "/usr/local/sbin/crond", "/usr/sbin/gdm", 
+    "/usr/local/sbin/crond", "/usr/sbin/gdm"
   ) or
   file.Ext.original.path : (
     "/bin/*.tmp", "/usr/bin/*.tmp", "/usr/local/bin/*.tmp", "/sbin/*.tmp", "/usr/sbin/*.tmp", "/usr/local/sbin/*.tmp"

--- a/rules/linux/persistence_potential_persistence_script_executable_bit_set.toml
+++ b/rules/linux/persistence_potential_persistence_script_executable_bit_set.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/03"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/06/21"
+updated_date = "2024/07/30"
 
 [rule]
 author = ["Elastic"]
@@ -64,8 +64,8 @@ query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
 process.args : (
   // Misc.
-  "/etc/rc.local", "/etc/rc.common", "/etc/init.d/*", "/etc/update-motd.d/*", "/etc/apt/apt.conf.d/*", "/etc/cron*",
-  "/etc/init/*",
+  "/etc/rc.local", "/etc/rc.common", "/etc/rc.d/rc.local", "/etc/init.d/*", "/etc/update-motd.d/*",
+  "/etc/apt/apt.conf.d/*", "/etc/cron*", "/etc/init/*",
 
   // XDG
   "/etc/xdg/autostart/*", "/home/*/.config/autostart/*", "/root/.config/autostart/*",

--- a/rules/network/command_and_control_accepted_default_telnet_port_connection.toml
+++ b/rules/network/command_and_control_accepted_default_telnet_port_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["network_traffic"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/02"
 
 [rule]
 author = ["Elastic"]
@@ -44,7 +44,7 @@ type = "query"
 query = '''
 (event.dataset:network_traffic.flow or event.category:(network or network_traffic))
     and event.type:connection and not event.action:(
-        flow_dropped or denied or deny or
+        flow_dropped or flow_denied or denied or deny or
         flow_terminated or timeout or Reject or network_flow)
     and destination.port:23
 '''

--- a/rules/windows/command_and_control_outlook_home_page.toml
+++ b/rules/windows/command_and_control_outlook_home_page.toml
@@ -1,0 +1,73 @@
+[metadata]
+creation_date = "2024/08/01"
+integration = ["endpoint", "windows"]
+maturity = "production"
+updated_date = "2024/08/01"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies modifications in registry keys associated with abuse of the Outlook Home Page functionality for command and
+control or persistence.
+"""
+from = "now-9m"
+index = ["winlogbeat-*", "logs-endpoint.events.registry-*", "logs-windows.sysmon_operational-*", "endgame-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Outlook Home Page Registry Modification"
+references = [
+    "https://cloud.google.com/blog/topics/threat-intelligence/breaking-the-rules-tough-outlook-for-home-page-attacks/",
+    "https://github.com/trustedsec/specula"
+]
+risk_score = 47
+rule_id = "ac5a2759-5c34-440a-b0c4-51fe674611d6"
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Windows",
+    "Use Case: Threat Detection",
+    "Tactic: Command and Control",
+    "Tactic: Persistence",
+    "Data Source: Elastic Endgame",
+    "Data Source: Elastic Defend",
+    "Data Source: Sysmon"
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
+    registry.path : (
+        "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Office\\*\\Outlook\\Webview\\Inbox\\URL",
+        "HKU\\*\\SOFTWARE\\Microsoft\\Office\\*\\Outlook\\Webview\\Inbox\\URL",
+        "\\REGISTRY\\USER\\*\\SOFTWARE\\Microsoft\\Office\\*\\Outlook\\Webview\\Inbox\\URL"
+    ) and registry.data.strings : "*http*"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1137"
+name = "Office Application Startup"
+reference = "https://attack.mitre.org/techniques/T1137/"
+[[rule.threat.technique.subtechnique]]
+id = "T1137.004"
+name = "Outlook Home Page"
+reference = "https://attack.mitre.org/techniques/T1137/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+

--- a/rules/windows/credential_access_dollar_account_relay.toml
+++ b/rules/windows/credential_access_dollar_account_relay.toml
@@ -1,0 +1,73 @@
+[metadata]
+creation_date = "2024/07/24"
+integration = ["system", "windows"]
+maturity = "production"
+updated_date = "2024/07/24"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies potential relay attacks against a domain controller (DC) by identifying authentication events using the
+domain controller computer account coming from other hosts to the DC that owns the account. Attackers may relay the DC
+hash after capturing it using forced authentication.
+"""
+from = "now-9m"
+index = ["logs-system.security-*", "logs-windows.forwarded*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Relay Attack against a Domain Controller"
+references = [
+    "https://github.com/p0dalirius/windows-coerced-authentication-methods",
+    "https://www.thehacker.recipes/a-d/movement/mitm-and-coerced-authentications",
+    "https://attack.mitre.org/techniques/T1187/",
+]
+risk_score = 21
+rule_id = "263481c8-1e9b-492e-912d-d1760707f810"
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Windows",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Data Source: Elastic Defend",
+    "Data Source: Active Directory",
+    "Use Case: Active Directory Monitoring",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+authentication where host.os.type == "windows" and event.code in ("4624", "4625") and endswith~(user.name, "$") and
+    winlog.event_data.AuthenticationPackageName : "NTLM" and winlog.logon.type : "network" and
+
+    /* Filter for a machine account that matches the hostname */
+    startswith~(host.name, substring(user.name, 0, -1)) and
+    
+    /* Verify if the Source IP belongs to the host */
+    not endswith(string(source.ip), string(host.ip)) and
+    source.ip != null and source.ip != "::1" and source.ip != "127.0.0.1"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1187"
+name = "Forced Authentication"
+reference = "https://attack.mitre.org/techniques/T1187/"
+
+[[rule.threat.technique]]
+id = "T1557"
+name = "Adversary-in-the-Middle"
+reference = "https://attack.mitre.org/techniques/T1557/"
+[[rule.threat.technique.subtechnique]]
+id = "T1557.001"
+name = "LLMNR/NBT-NS Poisoning and SMB Relay"
+reference = "https://attack.mitre.org/techniques/T1557/001/"
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/windows/credential_access_regback_sam_security_hives.toml
+++ b/rules/windows/credential_access_regback_sam_security_hives.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/01"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/07/01"
+updated_date = "2024/08/01"
 
 [rule]
 author = ["Elastic"]
@@ -70,7 +70,10 @@ file where host.os.type == "windows" and
       ("?:\\Windows\\System32\\config\\RegBack\\SAM",
        "?:\\Windows\\System32\\config\\RegBack\\SECURITY",
        "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and 
- not (user.id == "S-1-5-18" and process.executable : "?:\\Windows\\system32\\taskhostw.exe")
+ not (
+    user.id == "S-1-5-18" and process.executable : (
+        "?:\\Windows\\system32\\taskhostw.exe", "?:\\Windows\\system32\\taskhost.exe"
+    ))
 '''
 
 

--- a/rules_building_block/credential_access_iis_apppoolsa_pwd_appcmd.toml
+++ b/rules_building_block/credential_access_iis_apppoolsa_pwd_appcmd.toml
@@ -1,11 +1,13 @@
 [metadata]
+bypass_bbr_timing = true
 creation_date = "2020/08/18"
 integration = ["endpoint", "windows", "system"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/07/31"
 
 [rule]
 author = ["Elastic"]
+building_block_type = "default"
 description = """
 Identifies the Internet Information Services (IIS) command-line tool, AppCmd, being used to list passwords. An attacker
 with IIS web server access via a web shell can decrypt and dump the IIS AppPool service account password using AppCmd.
@@ -20,20 +22,11 @@ index = [
 ]
 language = "eql"
 license = "Elastic License v2"
-max_signals = 33
 name = "Microsoft IIS Service Account Password Dumped"
 references = ["https://blog.netspi.com/decrypting-iis-passwords-to-break-out-of-the-dmz-part-1/"]
-risk_score = 73
+risk_score = 21
 rule_id = "0564fb9d-90b9-4234-a411-82a546dc1343"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
-severity = "high"
+severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: Windows",
@@ -41,6 +34,7 @@ tags = [
     "Tactic: Credential Access",
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
+    "Rule Type: BBR",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -48,7 +42,7 @@ type = "eql"
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
    (process.name : "appcmd.exe" or ?process.pe.original_file_name == "appcmd.exe") and
-   process.args : "/list" and process.args : "/text*password"
+   process.args : "list" and process.args : "/text*"
 '''
 
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:


## Summary - What I changed

This PR adds support for action connectors in separate toml files. This connector information was previously ignored by our import and export processes and would cause the import/export of rules with action connectors to fail as the connector could 
not be found.  

It is worth noting that actions and action connectors are different. The support we are looking to provide with `actions.py` is the ability to store action information separate from the rule toml. Actions are currently attached to the rule file and are supported that way for editing on an individual level. However, action connectors are a shared resource among actions that some action types use (e.g. webhook) to save information that can broadly applicable to individual actions. For instance in the example below the connector is a webhook connector and contains information for Kibana on the configuration of the webhook in general as opposed to the rule specific action it is supposed to take with that webhook (which is store in the rule). Certain actions such as email actions, do not require a connector and are stored directly in the rule also like in our example.

This effects the following commands:
- `import-rules-to-repo`
- `export-rules-from-repo`
- `kibana import-rules`
- `kibana export-rules`

## How To Test

You will need to test each command with the new `-ac` option to include action connectors. Also, you may want to update your config yaml to include a directory to put them.

```
directories:
  action_dir: actions
  action_connector_dir: action_connectors
  exception_dir: exceptions
```

Here are 2 example rules and an example action connector toml you can use for testing. 

<details><summary>Rule Example 1</summary>
<p>

```toml
[metadata]
creation_date = "2024/08/04"
maturity = "production"
updated_date = "2024/08/04"

[rule]
author = []
description = "here is a test file"
enabled = false
exceptions_list = []
false_positives = []
filters = []
from = "now-360s"
index = ["logs-*"]
interval = "5m"
language = "eql"
license = ""
max_signals = 100
name = "test mail rule"
references = []
related_integrations = []
required_fields = []
revision = 0
risk_score = 21
risk_score_mapping = []
rule_id = "a1a32864-24de-4314-94cd-39f859b56619"
setup = ""
severity = "low"
severity_mapping = []
tags = []
threat = []
to = "now"
type = "eql"
version = 1

query = '''
process where true
'''


[[rule.actions]]
action_type_id = ".email"
group = "default"
id = "elastic-cloud-email"
uuid = "cf7fc283-0463-4a21-a800-fab3550a7048"

[rule.actions.frequency]
notifyWhen = "onActiveAlert"
summary = true
[rule.actions.params]
message = """Rule {{context.rule.name}} generated {{state.signals_count}} alerts.  
my double space newline here

### My header newline

More stuff here."""
subject = "test subject"
to = ["test@all.org"]

[rule.meta]
from = "1m"
kibana_siem_app_url = "https://stryker8-12.kb.europe-west1.gcp.cloud.es.io:9243/app/security"



```

</p>
</details> 

<details><summary>Rule Example 2</summary>
<p>


```toml
[metadata]
creation_date = "2024/08/04"
maturity = "production"
updated_date = "2024/08/04"

[rule]
author = ["INFOSEC_TEST"]
description = "Test"
enabled = true
exceptions_list = []
false_positives = []
filters = []
from = "now-360s"
index = [
    "apm-*-transaction*",
    "auditbeat-*",
    "endgame-*",
    "filebeat-*",
    "logs-*",
    "packetbeat-*",
    "traces-apm*",
    "winlogbeat-*",
    "-*elastic-cloud-logs-*",
]
interval = "5m"
language = "kuery"
max_signals = 100
name = "TestActionRule"
note = "None"
references = []
related_integrations = []
required_fields = []
revision = 6
risk_score = 21
risk_score_mapping = []
rule_id = "e818bf1b-dcc8-4746-80fa-a155a94a7f6b"
setup = ""
severity = "low"
severity_mapping = []
tags = []
threat = []
to = "now"
type = "query"
version = 1

query = '''
process.command_line : "FakeRoot"
'''


[[rule.actions]]
action_type_id = ".email"
group = "default"
id = "elastic-cloud-email"
uuid = "c405d3e6-f47d-4ee2-bfc2-9fa786051c66"

[rule.actions.frequency]
notifyWhen = "onActiveAlert"
summary = true
[rule.actions.params]
message = "Rule {{context.rule.name}} generated {{state.signals_count}} alerts"
subject = "TestEmail"
to = ["eric.forte@elastic.co"]
[[rule.actions]]
action_type_id = ".webhook"
group = "default"
id = "478b2165-83fb-480d-8a4a-bb47cfcafd4c"
uuid = "fd2c83b6-414b-4e31-939a-27f399c06203"

[rule.actions.frequency]
notifyWhen = "onActiveAlert"
summary = true
[rule.actions.params]
body = "{}"

[rule.meta]
from = "1m"
kibana_siem_app_url = "https://dev-deployment-2c684a.kb.us-central1.gcp.cloud.es.io:9243/s/infosec/app/security"



```


</p>
</details> 

<details><summary>Action Connector</summary>
<p>

filename: `custom_rules/action_connectors/478b2165-83fb-480d-8a4a-bb47cfcafd4c_actions.toml`

```toml

[metadata]
creation_date = "2024/08/04"
action_connector_name = "Action Connector 478b2165-83fb-480d-8a4a-bb47cfcafd4c"
rule_ids = ["2e299dad-3a09-4c08-89cb-f08c4f85a18e"]
rule_names = ["TestActionRule"]
updated_date = "2024/08/04"

[[action_connectors]]
id = "478b2165-83fb-480d-8a4a-bb47cfcafd4c"
managed = false
type = "action"
references = []

[action_connectors.attributes]
actionTypeId = ".webhook"
isMissingSecrets = false
name = "test"

[action_connectors.attributes.config]
hasAuth = false
method = "post"
url = "https://dev-deployment-2c684a.kb.us-central1.gcp.cloud.es.io"

[action_connectors.attributes.secrets]


```

</p>
</details> 

Example rules and connector as ndjson: 
[action_connector_testting.ndjson.txt](https://github.com/user-attachments/files/16489197/action_connector_testting.ndjson.txt)


Example commands:
`python -m detection_rules export-rules-from-repo -ac -e`
`python -m detection_rules import-rules-to-repo action_connector_testting.ndjson --required-only -e -ske -ac`
`python -m detection_rules kibana export-rules -d custom_rules/rules/ -ac -e --skip-errors`
`python -m detection_rules kibana import-rules -o -ac -e`


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
