### PR TITLE
[Rule Tuning] Windows Registry Rules Tuning - 1

### DIFF
--- a/rules/windows/credential_access_mod_wdigest_security_provider.toml
+++ b/rules/windows/credential_access_mod_wdigest_security_provider.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/19"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -91,7 +91,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type : ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "creation" and
     registry.path : (
         "HKLM\\SYSTEM\\*ControlSet*\\Control\\SecurityProviders\\WDigest\\UseLogonCredential",
         "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Control\\SecurityProviders\\WDigest\\UseLogonCredential"

--- a/rules/windows/credential_access_persistence_network_logon_provider_modification.toml
+++ b/rules/windows/credential_access_persistence_network_logon_provider_modification.toml
@@ -119,7 +119,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.data.strings : "?*" and registry.value : "ProviderPath" and
+registry where host.os.type == "windows" and event.type == "change" and
+  registry.data.strings : "?*" and registry.value : "ProviderPath" and
   registry.path : (
     "HKLM\\SYSTEM\\*ControlSet*\\Services\\*\\NetworkProvider\\ProviderPath",
     "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Services\\*\\NetworkProvider\\ProviderPath"

--- a/rules/windows/credential_access_persistence_network_logon_provider_modification.toml
+++ b/rules/windows/credential_access_persistence_network_logon_provider_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/03/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [transform]
 [[transform.osquery]]
@@ -119,7 +119,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.data.strings : "?*" and
+registry where host.os.type == "windows" and registry.data.strings : "?*" and registry.value : "ProviderPath" and
   registry.path : (
     "HKLM\\SYSTEM\\*ControlSet*\\Services\\*\\NetworkProvider\\ProviderPath",
     "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Services\\*\\NetworkProvider\\ProviderPath"

--- a/rules/windows/defense_evasion_amsienable_key_mod.toml
+++ b/rules/windows/defense_evasion_amsienable_key_mod.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/06/01"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -94,7 +94,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and registry.value : "AmsiEnable" and
   registry.path : (
     "HKEY_USERS\\*\\Software\\Microsoft\\Windows Script\\Settings\\AmsiEnable",
     "HKU\\*\\Software\\Microsoft\\Windows Script\\Settings\\AmsiEnable",

--- a/rules/windows/defense_evasion_code_signing_policy_modification_registry.toml
+++ b/rules/windows/defense_evasion_code_signing_policy_modification_registry.toml
@@ -99,7 +99,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type : ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and
   registry.value: "BehaviorOnFailedVerify" and
   registry.path : (
     "HKEY_USERS\\*\\Software\\Policies\\Microsoft\\Windows NT\\Driver Signing\\BehaviorOnFailedVerify",

--- a/rules/windows/defense_evasion_code_signing_policy_modification_registry.toml
+++ b/rules/windows/defense_evasion_code_signing_policy_modification_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/31"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [transform]
 [[transform.osquery]]
@@ -100,15 +100,12 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type : ("creation", "change") and
-(
+  registry.value: "BehaviorOnFailedVerify" and
   registry.path : (
     "HKEY_USERS\\*\\Software\\Policies\\Microsoft\\Windows NT\\Driver Signing\\BehaviorOnFailedVerify",
     "HKU\\*\\Software\\Policies\\Microsoft\\Windows NT\\Driver Signing\\BehaviorOnFailedVerify",
     "\\REGISTRY\\USER\\*\\Software\\Policies\\Microsoft\\Windows NT\\Driver Signing\\BehaviorOnFailedVerify"
-  ) and
-  registry.value: "BehaviorOnFailedVerify" and
-  registry.data.strings : ("0", "0x00000000", "1", "0x00000001")
-)
+  ) and registry.data.strings : ("0", "0x00000000", "1", "0x00000001")
 '''
 
 

--- a/rules/windows/defense_evasion_create_mod_root_certificate.toml
+++ b/rules/windows/defense_evasion_create_mod_root_certificate.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/02/01"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -91,7 +91,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
   registry.path :
     (
       "HKLM\\Software\\Microsoft\\SystemCertificates\\Root\\Certificates\\*\\Blob",
@@ -106,8 +106,10 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
   not process.executable : (
           "?:\\ProgramData\\Lenovo\\Vantage\\Addins\\LenovoHardwareScanAddin\\*\\LdeApi.Server.exe",
           "?:\\ProgramData\\Logishrd\\LogiOptionsPlus\\Plugins\\64\\certmgr.exe",
+          "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MpDefenderCoreService.exe",
           "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
           "?:\\ProgramData\\Quest\\KACE\\modules\\clientidentifier\\clientidentifier.exe",
+          "?:\\ProgramData\\Sophos\\AutoUpdate\\Cache\\sophos_autoupdate1.dir\\SophosUpdate.exe",
           "?:\\Program Files (x86)\\*.exe",
           "?:\\Program Files\\*.exe",
           "?:\\Windows\\CCM\\CcmExec.exe",

--- a/rules/windows/defense_evasion_defender_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_defender_disabled_via_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -78,7 +78,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and
   (
     (
       registry.path: (

--- a/rules/windows/defense_evasion_dns_over_https_enabled.toml
+++ b/rules/windows/defense_evasion_dns_over_https_enabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/07/22"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Austin Songer"]
@@ -44,7 +44,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and
   (registry.path : "*\\SOFTWARE\\Policies\\Microsoft\\Edge\\BuiltInDnsClientEnabled" and
   registry.data.strings : "1") or
   (registry.path : "*\\SOFTWARE\\Google\\Chrome\\DnsOverHttpsMode" and

--- a/rules/windows/defense_evasion_microsoft_defender_tampering.toml
+++ b/rules/windows/defense_evasion_microsoft_defender_tampering.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/10/18"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/06/27"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Austin Songer"]
@@ -87,41 +87,37 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
- process.executable != null and 
-  not process.executable :
-              ("?:\\Windows\\system32\\svchost.exe", 
-               "?:\\Windows\\CCM\\CcmExec.exe", 
-               "?:\\Windows\\System32\\DeviceEnroller.exe", 
-               "?:\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe") and 
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\PUAProtection" and
-  registry.data.strings : ("0", "0x00000000")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender Security Center\\App and Browser protection\\DisallowExploitProtectionOverride" and
-  registry.data.strings : ("0", "0x00000000")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\DisableAntiSpyware" and
-  registry.data.strings : ("1", "0x00000001")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Features\\TamperProtection" and
-  registry.data.strings : ("0", "0x00000000")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableRealtimeMonitoring" and
-  registry.data.strings : ("1", "0x00000001")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIntrusionPreventionSystem" and
-  registry.data.strings : ("1", "0x00000001")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableScriptScanning" and
-  registry.data.strings : ("1", "0x00000001")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\Controlled Folder Access\\EnableControlledFolderAccess" and
-  registry.data.strings : ("0", "0x00000000")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIOAVProtection" and
-  registry.data.strings : ("1", "0x00000001")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Reporting\\DisableEnhancedNotifications" and
-  registry.data.strings : ("1", "0x00000001")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\DisableBlockAtFirstSeen" and
-  registry.data.strings : ("1", "0x00000001")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SpynetReporting" and
-  registry.data.strings : ("0", "0x00000000")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SubmitSamplesConsent" and
-  registry.data.strings : ("0", "0x00000000")) or
-  (registry.path : "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableBehaviorMonitoring" and
-  registry.data.strings : ("1", "0x00000001"))
+registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
+  (
+    (
+      registry.path : (
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\PUAProtection",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender Security Center\\App and Browser protection\\DisallowExploitProtectionOverride",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Features\\TamperProtection",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\Controlled Folder Access\\EnableControlledFolderAccess",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SpynetReporting",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SubmitSamplesConsent"
+      ) and registry.data.strings : ("0", "0x00000000")
+    ) or
+    (
+      registry.path : (
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\DisableAntiSpyware",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableRealtimeMonitoring",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIntrusionPreventionSystem",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableScriptScanning",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIOAVProtection",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Reporting\\DisableEnhancedNotifications",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\DisableBlockAtFirstSeen",
+        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableBehaviorMonitoring"
+      ) and registry.data.strings : ("1", "0x00000001")
+    )
+  ) and
+  not process.executable : (
+    "?:\\Windows\\system32\\svchost.exe", 
+    "?:\\Windows\\CCM\\CcmExec.exe", 
+    "?:\\Windows\\System32\\DeviceEnroller.exe", 
+    "?:\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe"
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
+++ b/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/01/12"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -87,7 +87,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type == "change" and registry.value : ("AccessVBOM", "VbaWarnings") and
     registry.path : (
         "HKU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
         "HKU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
@@ -98,8 +98,7 @@ registry where host.os.type == "windows" and event.type == "change" and
         "\\REGISTRY\\USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
         "\\REGISTRY\\USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings"
         ) and
-    registry.data.strings : ("0x00000001", "1") and
-    process.name : ("cscript.exe", "wscript.exe", "mshta.exe", "mshta.exe", "winword.exe", "excel.exe")
+    registry.data.strings : ("0x00000001", "1")
 '''
 
 

--- a/rules/windows/defense_evasion_persistence_account_tokenfilterpolicy.toml
+++ b/rules/windows/defense_evasion_persistence_account_tokenfilterpolicy.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defende
 maturity = "production"
 min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
 min_stack_version = "8.13.0"
-updated_date = "2024/06/25"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -42,11 +42,13 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.path : (
-  "HKLM\\*\\LocalAccountTokenFilterPolicy",
-  "\\REGISTRY\\MACHINE\\*\\LocalAccountTokenFilterPolicy",
-  "MACHINE\\*\\LocalAccountTokenFilterPolicy") and
-  registry.data.strings : ("1", "0x00000001")
+registry where host.os.type == "windows" and event.type == "change" and
+  registry.value : "LocalAccountTokenFilterPolicy" and
+  registry.path : (
+    "HKLM\\*\\LocalAccountTokenFilterPolicy",
+    "\\REGISTRY\\MACHINE\\*\\LocalAccountTokenFilterPolicy",
+    "MACHINE\\*\\LocalAccountTokenFilterPolicy"
+  ) and registry.data.strings : ("1", "0x00000001")
 '''
 
 

--- a/rules/windows/defense_evasion_reg_disable_enableglobalqueryblocklist.toml
+++ b/rules/windows/defense_evasion_reg_disable_enableglobalqueryblocklist.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/05/31"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/31"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -37,7 +37,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type : "change" and
+registry where host.os.type == "windows" and event.type == "change" and
 (
   (registry.value : "EnableGlobalQueryBlockList" and registry.data.strings : ("0", "0x00000000")) or
   (registry.value : "GlobalQueryBlockList" and not registry.data.strings : "wpad")

--- a/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
+++ b/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/23"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -42,7 +42,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
+registry where host.os.type == "windows" and event.type == "change" and
   registry.path : (
     "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt",
     "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt"

--- a/rules/windows/defense_evasion_sip_provider_mod.toml
+++ b/rules/windows/defense_evasion_sip_provider_mod.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -33,14 +33,16 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type:"change" and
+registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
   registry.path: (
     "*\\SOFTWARE\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptSIPDllPutSignedDataMsg\\{*}\\Dll",
     "*\\SOFTWARE\\WOW6432Node\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CryptSIPDllPutSignedDataMsg\\{*}\\Dll",
     "*\\SOFTWARE\\Microsoft\\Cryptography\\Providers\\Trust\\FinalPolicy\\{*}\\$Dll",
     "*\\SOFTWARE\\WOW6432Node\\Microsoft\\Cryptography\\Providers\\Trust\\FinalPolicy\\{*}\\$Dll"
     ) and
-  registry.data.strings:"*.dll"
+  registry.data.strings:"*.dll" and
+  not (process.name : "msiexec.exe" and registry.data.strings : "mso.dll") and
+  not (process.name : "regsvr32.exe" and registry.data.strings == "WINTRUST.DLL")
 '''
 
 

--- a/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
+++ b/rules/windows/defense_evasion_solarwinds_backdoor_service_disabled_via_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/14"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -43,7 +43,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.path : (
+registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
+  registry.path : (
     "HKLM\\SYSTEM\\*ControlSet*\\Services\\*\\Start",
     "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Services\\*\\Start"
   ) and

--- a/rules/windows/defense_evasion_wsl_registry_modification.toml
+++ b/rules/windows/defense_evasion_wsl_registry_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/12"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
+registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
  registry.path : 
        ("HK*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Lxss\\*\\PackageFamilyName",
         "\\REGISTRY\\*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Lxss\\*\\PackageFamilyName")

--- a/rules/windows/lateral_movement_defense_evasion_lanman_nullsessionpipe_modification.toml
+++ b/rules/windows/lateral_movement_defense_evasion_lanman_nullsessionpipe_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/03/22"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -36,11 +36,12 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and
 registry.path : (
     "HKLM\\SYSTEM\\*ControlSet*\\services\\LanmanServer\\Parameters\\NullSessionPipes",
     "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\services\\LanmanServer\\Parameters\\NullSessionPipes"
-) and length(registry.data.strings) > 0
+) and length(registry.data.strings) > 0 and
+not registry.data.strings : "(empty)"
 '''
 
 

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/25"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -77,8 +77,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and 
- event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and
   registry.path : "HKLM\\SYSTEM\\*ControlSet*\\Control\\Terminal Server\\fDenyTSConnections" and
   registry.data.strings : ("0", "0x00000000") and
   not process.executable : ("?:\\Windows\\System32\\SystemPropertiesRemote.exe", 

--- a/rules/windows/lateral_movement_rdp_sharprdp_target.toml
+++ b/rules/windows/lateral_movement_rdp_sharprdp_target.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -40,7 +40,7 @@ sequence by host.id with maxspan=1m
    source.ip != "127.0.0.1" and source.ip != "::1"
   ]
 
-  [registry where host.os.type == "windows" and process.name : "explorer.exe" and
+  [registry where host.os.type == "windows" and event.type == "change" and process.name : "explorer.exe" and
    registry.path : ("HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU\\*") and
    registry.data.strings : ("cmd.exe*", "powershell.exe*", "taskmgr*", "\\\\tsclient\\*.exe\\*")
   ]

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/20"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -67,7 +67,8 @@ sequence by host.id, process.entity_id with maxspan = 1m
    network.direction : ("incoming", "ingress") and source.port >= 49152 and destination.port >= 49152 and
    source.ip != "127.0.0.1" and source.ip != "::1"
    ]
-   [registry where host.os.type == "windows" and registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions"]
+   [registry where host.os.type == "windows" and event.type == "change" and registry.value : "Actions" and
+    registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions"]
 '''
 
 


### PR DESCRIPTION
## Summary

* Excludes some noisy patterns from rules that use registry events.
* Uses `registry.value` to filter registry keys before expensive wildcards.
* Adds `event.type` to rules that don't use it to avoid matches in other types like access.
* Removes `creation` from `event.type` as there are no events of that type either on my stack or telemetry.