### PR TITLE
[Rule Tuning] Windows Registry Rules Tuning - 2

### DIFF
--- a/rules/windows/persistence_app_compat_shim.toml
+++ b/rules/windows/persistence_app_compat_shim.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -30,7 +30,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and
     registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Custom\\*.sdb" and 
     not process.executable : 
                        ("?:\\Program Files (x86)\\DesktopCentral_Agent\\swrepository\\1\\swuploads\\SAP-SLC\\SAPSetupSLC02_14-80001954\\Setup\\NwSapSetup.exe", 

--- a/rules/windows/persistence_appcertdlls_registry.toml
+++ b/rules/windows/persistence_appcertdlls_registry.toml
@@ -4,7 +4,7 @@ integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defende
 maturity = "production"
 min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
 min_stack_version = "8.13.0"
-updated_date = "2024/06/25"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -33,8 +33,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
-/* uncomment once stable length(bytes_written_string) > 0 and */
+registry where host.os.type == "windows" and event.type == "change" and
   registry.path : (
     "HKLM\\SYSTEM\\*ControlSet*\\Control\\Session Manager\\AppCertDLLs\\*",
     "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Control\\Session Manager\\AppCertDLLs\\*",

--- a/rules/windows/persistence_appinitdlls_registry.toml
+++ b/rules/windows/persistence_appinitdlls_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/18"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [transform]
 [[transform.osquery]]
@@ -121,7 +121,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
+registry where host.os.type == "windows" and event.type == "change" and
   registry.path : (
      "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
      "HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",

--- a/rules/windows/persistence_evasion_hidden_local_account_creation.toml
+++ b/rules/windows/persistence_evasion_hidden_local_account_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/18"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -72,7 +72,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.path : (
+registry where host.os.type == "windows" and event.type == "change" and
+  registry.path : (
     "HKLM\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
     "\\REGISTRY\\MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\"
 )

--- a/rules/windows/persistence_evasion_registry_ifeo_injection.toml
+++ b/rules/windows/persistence_evasion_registry_ifeo_injection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/17"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -35,7 +35,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and length(registry.data.strings) > 0 and
+registry where host.os.type == "windows" and event.type == "change" and
+  registry.value : ("Debugger", "MonitorProcess") and length(registry.data.strings) > 0 and
   registry.path : (
     "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*.exe\\Debugger",
     "HKLM\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Image File Execution Options\\*\\Debugger",

--- a/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
+++ b/rules/windows/persistence_evasion_registry_startup_shell_folder_modified.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/03/15"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [transform]
 [[transform.osquery]]
@@ -111,7 +111,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
+registry where host.os.type == "windows" and event.type == "change" and
+ registry.value : ("Common Startup", "Startup") and
  registry.path : (
      "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\User Shell Folders\\Common Startup",
      "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\Common Startup",

--- a/rules/windows/persistence_local_scheduled_task_scripting.toml
+++ b/rules/windows/persistence_local_scheduled_task_scripting.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/29"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -46,9 +46,11 @@ sequence by host.id with maxspan = 30s
     (event.category : ("library", "driver") or (event.category == "process" and event.action : "Image loaded*")) and
     (?dll.name : "taskschd.dll" or file.name : "taskschd.dll") and
     process.name : ("cscript.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe")]
-  [registry where host.os.type == "windows" and registry.path : (
-    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions",
-    "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions")]
+  [registry where host.os.type == "windows" and event.type == "change" and registry.value : "Actions" and
+    registry.path : (
+      "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions",
+      "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions"
+  )]
 '''
 
 

--- a/rules/windows/persistence_registry_uncommon.toml
+++ b/rules/windows/persistence_registry_uncommon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -33,7 +33,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and
  length(registry.data.strings) > 0 and
  registry.path : (
       "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\Install\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run\\*",
@@ -92,7 +92,20 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
                            "C:\\Windows\\SysWOW64\\msiexec.exe",
                            "C:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
                            "C:\\Program Files\\*.exe",
-                           "C:\\Program Files (x86)\\*.exe")
+                           "C:\\Program Files (x86)\\*.exe") and
+ not (process.name : ("TiWorker.exe", "poqexec.exe") and registry.value : "SetupExecute" and
+      registry.data.strings : (
+        "C:\\windows\\System32\\poqexec.exe /display_progress \\SystemRoot\\WinSxS\\pending.xml",
+        "C:\\Windows\\System32\\poqexec.exe /skip_critical_poq /display_progress \\SystemRoot\\WinSxS\\pending.xml"
+      )
+     ) and
+ not (process.name : "svchost.exe" and registry.value : "SCRNSAVE.EXE" and
+      registry.data.strings : (
+        "%windir%\\system32\\rundll32.exe user32.dll,LockWorkStation",
+        "scrnsave.scr",
+        "%windir%\\system32\\Ribbons.scr"
+      )
+     )
 '''
 
 

--- a/rules/windows/persistence_run_key_and_startup_broad.toml
+++ b/rules/windows/persistence_run_key_and_startup_broad.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [transform]
 [[transform.osquery]]
@@ -116,7 +116,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.data.strings != null and
+registry where host.os.type == "windows" and event.type == "change" and 
+ registry.data.strings != null and registry.hive : ("HKEY_USERS", "HKLM") and
  registry.path : (
      /* Machine Hive */
      "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\*",

--- a/rules/windows/persistence_services_registry.toml
+++ b/rules/windows/persistence_services_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -34,6 +34,7 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
+  registry.value : ("ServiceDLL", "ImagePath") and
   registry.path : (
       "HKLM\\SYSTEM\\ControlSet*\\Services\\*\\ServiceDLL",
       "HKLM\\SYSTEM\\ControlSet*\\Services\\*\\ImagePath",
@@ -43,6 +44,7 @@ registry where host.os.type == "windows" and event.type == "change" and
       "?:\\windows\\system32\\Drivers\\*.sys",
       "\\SystemRoot\\System32\\drivers\\*.sys",
       "\\??\\?:\\Windows\\system32\\Drivers\\*.SYS",
+      "\\??\\?:\\Windows\\syswow64\\*.sys",
       "system32\\DRIVERS\\USBSTOR") and
   not (process.name : "procexp??.exe" and registry.data.strings : "?:\\*\\procexp*.sys") and
   not process.executable : (
@@ -53,7 +55,9 @@ registry where host.os.type == "windows" and event.type == "change" and
       "?:\\Windows\\System32\\drvinst.exe",
       "?:\\Windows\\System32\\services.exe",
       "?:\\Windows\\System32\\msiexec.exe",
-      "?:\\Windows\\System32\\regsvr32.exe")
+      "?:\\Windows\\System32\\regsvr32.exe",
+      "?:\\Windows\\System32\\WaaSMedicAgent.exe"
+  )
 '''
 
 

--- a/rules/windows/persistence_suspicious_com_hijack_registry.toml
+++ b/rules/windows/persistence_suspicious_com_hijack_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -85,7 +85,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
+registry where host.os.type == "windows" and event.type == "change" and
   /* not necessary but good for filtering privileged installations */
   user.domain != "NT AUTHORITY" and process.executable != null and 
   (

--- a/rules/windows/persistence_suspicious_service_created_registry.toml
+++ b/rules/windows/persistence_suspicious_service_created_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -32,12 +32,14 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.path : (
+registry where host.os.type == "windows" and event.type == "change" and
+  registry.value : "ImagePath" and
+  registry.path : (
     "HKLM\\SYSTEM\\ControlSet*\\Services\\*\\ImagePath",
     "\\REGISTRY\\MACHINE\\SYSTEM\\ControlSet*\\Services\\*\\ImagePath"
     ) and
- /* add suspicious registry ImagePath values here */
-    registry.data.strings : ("%COMSPEC%*", "*\\.\\pipe\\*")
+  /* add suspicious registry ImagePath values here */
+  registry.data.strings : ("%COMSPEC%*", "*\\.\\pipe\\*")
 '''
 
 

--- a/rules/windows/persistence_time_provider_mod.toml
+++ b/rules/windows/persistence_time_provider_mod.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/19"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [transform]
 [[transform.osquery]]
@@ -111,7 +111,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type:"change" and
+registry where host.os.type == "windows" and event.type == "change" and
   registry.path: (
     "HKLM\\SYSTEM\\*ControlSet*\\Services\\W32Time\\TimeProviders\\*",
     "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Services\\W32Time\\TimeProviders\\*"
@@ -121,7 +121,8 @@ registry where host.os.type == "windows" and event.type:"change" and
   (
     process.executable : "?:\\Windows\\System32\\msiexec.exe" and
     registry.data.strings : "?:\\Program Files\\VMware\\VMware Tools\\vmwTimeProvider\\vmwTimeProvider.dll"
-  )
+  ) and
+  not registry.data.strings : "C:\\Windows\\SYSTEM32\\w32time.DLL"
 '''
 
 

--- a/rules/windows/persistence_via_hidden_run_key_valuename.toml
+++ b/rules/windows/persistence_via_hidden_run_key_valuename.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/15"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -46,7 +46,7 @@ type = "eql"
 
 query = '''
 /* Registry Path ends with backslash */
-registry where host.os.type == "windows" and /* length(registry.data.strings) > 0 and */
+registry where host.os.type == "windows" and event.type == "change" and length(registry.data.strings) > 0 and
  registry.path : ("HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
                   "HKU\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
                   "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",

--- a/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
+++ b/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/18"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -40,7 +40,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
+registry where host.os.type == "windows" and event.type == "change" and
    registry.path : (
       "HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\Security Packages*",
       "HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\OSConfig\\Security Packages*",

--- a/rules/windows/persistence_via_wmi_stdregprov_run_services.toml
+++ b/rules/windows/persistence_via_wmi_stdregprov_run_services.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/03/15"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [transform]
 [[transform.osquery]]
@@ -112,7 +112,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
+registry where host.os.type == "windows" and event.type == "change" and
  registry.data.strings != null and process.name : "WmiPrvSe.exe" and
  registry.path : (
                   "HKEY_USERS\\*\\SOFTWARE\\Microsoft\\Command Processor\\Autorun",

--- a/rules/windows/privilege_escalation_port_monitor_print_pocessor_abuse.toml
+++ b/rules/windows/privilege_escalation_port_monitor_print_pocessor_abuse.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -32,7 +32,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type in ("creation", "change") and
+registry where host.os.type == "windows" and event.type == "change" and
   registry.path : (
       "HKLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Monitors\\*",
       "HKLM\\SYSTEM\\*ControlSet*\\Control\\Print\\Environments\\Windows*\\Print Processors\\*",

--- a/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
+++ b/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/26"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -32,7 +32,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.path : (
+registry where host.os.type == "windows" and event.type == "change" and
+registry.value : ("windir", "systemroot") and
+registry.path : (
     "HKEY_USERS\\*\\Environment\\windir",
     "HKEY_USERS\\*\\Environment\\systemroot",
     "HKU\\*\\Environment\\windir",

--- a/rules_building_block/defense_evasion_msiexec_installsource_archive_file.toml
+++ b/rules_building_block/defense_evasion_msiexec_installsource_archive_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/26"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/05"
 
 [rule]
 author = ["Elastic"]
@@ -33,7 +33,7 @@ type = "eql"
 
 query = '''
 sequence with maxspan=1m
-  [registry where host.os.type == "windows" and process.name : "msiexec.exe" and
+  [registry where host.os.type == "windows" and event.type == "change" and process.name : "msiexec.exe" and
    (
     (registry.value : "InstallSource" and
      registry.data.strings : ("?:\\Users\\*\\Temp\\Temp?_*.zip\\*",


### PR DESCRIPTION
## Summary

* Excludes some noisy patterns from rules that use registry events.
* Uses `registry.value` to filter registry keys before expensive wildcards.
* Adds `event.type` to rules that don't use it to avoid matches in other types like access.
* Removes `creation` from `event.type` as there are no events of that type either on my stack or telemetry.