### PR TITLE
Add Unit Test test_index_or_data_view_id_present

### DIFF
--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -190,13 +190,13 @@ class TestValidRules(BaseRuleTest):
     def test_index_or_data_view_id_present(self):
         """Ensure that either 'index' or 'data_view_id' is present for prebuilt rules."""
         failures = []
+        machine_learning_packages = [val.lower() for val in definitions.MACHINE_LEARNING_PACKAGES]
         for rule in self.all_rules:
             rule_type = rule.contents.data.get('language')
             rule_integrations = rule.contents.metadata.get('integration') or []
             if rule_type == 'esql':
                 continue  # the index is part of the query and would be validated in the query
-            elif rule.contents.data.type == 'machine_learning' or rule_integrations == \
-                    any(ri in [*map(str.lower, definitions.MACHINE_LEARNING_PACKAGES)] for ri in rule_integrations):
+            elif rule.contents.data.type == 'machine_learning' or rule_integrations in machine_learning_packages:
                 continue  # Skip all rules of machine learning type or rules that are part of machine learning packages
             elif rule.contents.data.type == 'threat_match':
                 continue  # Skip all rules of threat_match type

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -190,16 +190,16 @@ class TestValidRules(BaseRuleTest):
     def test_index_or_data_view_id_present(self):
         """Ensure that either 'index' or 'data_view_id' is present for prebuilt rules."""
         failures = []
-        for rule in self.all_rules: 
+        for rule in self.all_rules:
             rule_type = rule.contents.data.get('language')
             rule_integrations = rule.contents.metadata.get('integration') or []
             if rule_type == 'esql':
-                continue # the index is part of the query and would be validated in the query
+                continue  # the index is part of the query and would be validated in the query
             elif rule.contents.data.type == 'machine_learning' or rule_integrations == \
-                any(ri in [*map(str.lower, definitions.MACHINE_LEARNING_PACKAGES)] for ri in rule_integrations):
-                continue # Skip all rules of machine learning type or rules that are part of machine learning packages
+                    any(ri in [*map(str.lower, definitions.MACHINE_LEARNING_PACKAGES)] for ri in rule_integrations):
+                continue  # Skip all rules of machine learning type or rules that are part of machine learning packages
             elif rule.contents.data.type == 'threat_match':
-                continue # Skip all rules of threat_match type
+                continue  # Skip all rules of threat_match type
             else:
                 index = rule.contents.data.get('index')
                 data_view_id = rule.contents.data.get('data_view_id')

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -187,6 +187,31 @@ class TestValidRules(BaseRuleTest):
             """
             self.fail(fail_msg + '\n'.join(failures))
 
+    def test_index_or_data_view_id_present(self):
+        """Ensure that either 'index' or 'data_view_id' is present for prebuilt rules."""
+        failures = []
+        for rule in self.all_rules: 
+            rule_type = rule.contents.data.get('language')
+            rule_integrations = rule.contents.metadata.get('integration') or []
+            if rule_type == 'esql':
+                continue # the index is part of the query and would be validated in the query
+            elif rule.contents.data.type == 'machine_learning' or rule_integrations == \
+                any(ri in [*map(str.lower, definitions.MACHINE_LEARNING_PACKAGES)] for ri in rule_integrations):
+                continue # Skip all rules of machine learning type or rules that are part of machine learning packages
+            elif rule.contents.data.type == 'threat_match':
+                continue # Skip all rules of threat_match type
+            else:
+                index = rule.contents.data.get('index')
+                data_view_id = rule.contents.data.get('data_view_id')
+                if index is None and data_view_id is None:
+                    err_msg = f'{self.rule_str(rule)} does not have either index or data_view_id'
+                    failures.append(err_msg)
+        if failures:
+            fail_msg = """
+            The following prebuilt rules do not have either 'index' or 'data_view_id' \n
+            """
+            self.fail(fail_msg + '\n'.join(failures))
+
 
 class TestThreatMappings(BaseRuleTest):
     """Test threat mapping data for rules."""


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/3965

## Summary - What I changed

- Of the two possible solutions proposed in https://github.com/elastic/detection-rules/issues/3965, the PR is raised for unit test creation.
- Primarily because skipping Unit tests in DAC is simpler and documented [here](https://dac-reference.readthedocs.io/en/latest/internals_of_the_detection_rules_repo.html#unit-testing)
    - With this for developers working on prebuilt rule set, having an index or a data_view_id is enforced.
    - For customers working on their custom rule set, this enforcement can easily be skipped.

## How To Test

- All Unit Tests should Pass
- Local Testing 

> - All rules have the required index
> ```
> Received JSON data in run script
> Running pytest with args: ['-p', 'vscode_pytest', '--rootdir=/Users/shashankks/elastic_workspace/detection-rules', '/Users/shashankks/elastic_workspace/detection-rules/tests/test_all_rules.py::TestValidRules::test_index_or_data_view_id_present']
> ============================= test session starts ==============================
> platform darwin -- Python 3.12.3, pytest-8.1.1, pluggy-1.4.0
> rootdir: /Users/shashankks/elastic_workspace/detection-rules
> configfile: pyproject.toml
> plugins: typeguard-3.0.2
> collected 1 item
> 
> tests/test_all_rules.py .                                                [100%]
> 
> ============================== 1 passed in 49.43s ==============================
> Finished running tests!
> ```

> - Identifying missing indexes like an example case [here](https://github.com/elastic/detection-rules/pull/3953/files) 
> ```
> Received JSON data in run script
> Running pytest with args: ['-p', 'vscode_pytest', '--rootdir=/Users/shashankks/elastic_workspace/detection-rules', '/Users/shashankks/elastic_workspace/detection-rules/tests/test_all_rules.py::TestValidRules::test_index_or_data_view_id_present']
> ============================= test session starts ==============================
> platform darwin -- Python 3.12.3, pytest-8.1.1, pluggy-1.4.0
> rootdir: /Users/shashankks/elastic_workspace/detection-rules
> configfile: pyproject.toml
> plugins: typeguard-3.0.2
> collected 1 item
> 
> tests/test_all_rules.py F                                                [100%]
> 
> =================================== FAILURES ===================================
> ______________ TestValidRules.test_index_or_data_view_id_present _______________
> 
> >           self.fail(fail_msg + '\n'.join(failures))
> E           AssertionError: 
> E                       The following prebuilt rules do not have either 'index' or 'data_view_id' 
> E           
> E                       30b5bb96-c7db-492c-80e9-1eab00db580b - AWS S3 Object Versioning Suspended -> does not have either index or data_view_id
> 
> tests/test_all_rules.py:213: AssertionError
> =========================== short test summary info ============================
> FAILED tests/test_all_rules.py::TestValidRules::test_index_or_data_view_id_present
> ============================== 1 failed in 48.31s ==============================
> Finished running tests!
> ```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
