### PR TITLE
[Rule Tuning] System Log File Deletion

### DIFF
--- a/rules/linux/defense_evasion_log_files_deleted.toml
+++ b/rules/linux/defense_evasion_log_files_deleted.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/03"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/08"
 
 [rule]
 author = ["Elastic"]
@@ -86,27 +86,26 @@ file where host.os.type == "linux" and event.type == "deletion" and
     "/var/log/secure",
     "/var/log/auth.log",
     "/var/log/boot.log",
-    "/var/log/kern.log"
+    "/var/log/kern.log",
+    "/var/log/dmesg"
     ) and
     not process.name in ("gzip", "executor", "dockerd")
 '''
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1070"
 name = "Indicator Removal"
 reference = "https://attack.mitre.org/techniques/T1070/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1070.002"
 name = "Clear Linux or Mac System Logs"
 reference = "https://attack.mitre.org/techniques/T1070/002/"
 
-
-
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-


### PR DESCRIPTION
## Summary
Rootkits are seen to remove `/var/log/dmesg`, and this was missing in the current rule. This tuning adds it. 