### PR TITLE
[Rule Tuning] Potential Disabling of AppArmor

### DIFF
--- a/rules/linux/defense_evasion_disable_apparmor_attempt.toml
+++ b/rules/linux/defense_evasion_disable_apparmor_attempt.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/28"
 integration = ["endpoint", "auditd_manager"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/08"
 
 [rule]
 author = ["Elastic"]
@@ -55,31 +55,30 @@ tags = [
 ]
 timestamp_override = "event.ingested"
 type = "eql"
-
 query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
  and (
-  (process.name == "systemctl" and process.args == "disable" and process.args == "apparmor") or
+  (process.name == "systemctl" and process.args in ("stop", "disable", "kill") and process.args == ("apparmor", "apparmor.service") or
+  (process.name == "service" and process.args == "apparmor" and process.args == "stop") or 
+  (process.name == "chkconfig" and process.args == "apparmor" and process.args == "off") or
   (process.name == "ln" and process.args : "/etc/apparmor.d/*" and process.args == "/etc/apparmor.d/disable/")
 )
 '''
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
 
-
-
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-

--- a/rules/linux/defense_evasion_disable_apparmor_attempt.toml
+++ b/rules/linux/defense_evasion_disable_apparmor_attempt.toml
@@ -58,7 +58,7 @@ type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
  and (
-  (process.name == "systemctl" and process.args in ("stop", "disable", "kill") and process.args == ("apparmor", "apparmor.service") or
+  (process.name == "systemctl" and process.args in ("stop", "disable", "kill") and process.args in ("apparmor", "apparmor.service")) or
   (process.name == "service" and process.args == "apparmor" and process.args == "stop") or 
   (process.name == "chkconfig" and process.args == "apparmor" and process.args == "off") or
   (process.name == "ln" and process.args : "/etc/apparmor.d/*" and process.args == "/etc/apparmor.d/disable/")


### PR DESCRIPTION
## Summary
The current rule does not have all ways of disabling app armor integrated. While detonating malware samples, I noticed we were lacking coverage. This tuning PR adds this coverage. 

Hits in detonate:
<img width="1582" alt="{729F7025-6A3F-4FF9-BAA3-892538AD3373}" src="https://github.com/user-attachments/assets/e50bc468-da45-47ca-85dd-1132085cc81a">
