### PR TITLE
[Rule Tuning] Fix missing Winlogbeat index

### DIFF
--- a/rules/cross-platform/command_and_control_google_drive_malicious_file_download.toml
+++ b/rules/cross-platform/command_and_control_google_drive_malicious_file_download.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/06/19"
 integration = ["endpoint", "system"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/08/08"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/command_and_control_google_drive_malicious_file_download.toml
+++ b/rules/cross-platform/command_and_control_google_drive_malicious_file_download.toml
@@ -15,7 +15,7 @@ false_positives = [
     "Legitimate publicly shared files from Google Drive.",
 ]
 from = "now-9m"
-index = ["auditbeat-*", "logs-endpoint*", "logs-system.security*"]
+index = ["auditbeat-*", "logs-endpoint*", "logs-system.security*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious File Downloaded from Google Drive"

--- a/rules/cross-platform/credential_access_forced_authentication_pipes.toml
+++ b/rules/cross-platform/credential_access_forced_authentication_pipes.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/23"
 integration = ["endpoint", "system"]
 maturity = "production"
-updated_date = "2024/07/23"
+updated_date = "2024/08/08"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/credential_access_forced_authentication_pipes.toml
+++ b/rules/cross-platform/credential_access_forced_authentication_pipes.toml
@@ -11,7 +11,7 @@ Identifies a potential forced authentication using related SMB named pipes. Atta
 authenticate to a host controlled by them to capture hashes or enable relay attacks.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.network-*", "logs-system.security-*"]
+index = ["logs-endpoint.events.network-*", "logs-system.security-*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Active Directory Forced Authentication from Linux Host - SMB Named Pipes"

--- a/rules/windows/credential_access_dollar_account_relay.toml
+++ b/rules/windows/credential_access_dollar_account_relay.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/24"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2024/07/24"
+updated_date = "2024/08/08"
 
 [rule]
 author = ["Elastic"]

--- a/rules/windows/credential_access_dollar_account_relay.toml
+++ b/rules/windows/credential_access_dollar_account_relay.toml
@@ -12,7 +12,7 @@ domain controller computer account coming from other hosts to the DC that owns t
 hash after capturing it using forced authentication.
 """
 from = "now-9m"
-index = ["logs-system.security-*", "logs-windows.forwarded*"]
+index = ["logs-system.security-*", "logs-windows.forwarded*", "winlogbeat-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Relay Attack against a Domain Controller"


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/detection-rules/issues/3939

## Summary

Adds winlogbeat index to some Windows rules.