### PR TITLE
Fix Attribute Issue in RTA common.py

### DIFF
--- a/rta/common.py
+++ b/rta/common.py
@@ -208,7 +208,7 @@ def dependencies(*paths: str):
         @functools.wraps(f)
         def decorated(*args, **kwargs):
             if len(missing):
-                log("Missing dependencies for %s:%s()" % ((f.__code__.co_filename, f.__code__.co_name), "!")
+                log("Missing dependencies for %s:%s()" % (f.__code__.co_filename, f.__code__.co_name), "!")
                 for dep in missing:
                     # NOTE os.path.relpath supports Path objects and does not exist in pathlib
                     print("    - %s" % os.path.relpath(dep, BASE_DIR))

--- a/rta/common.py
+++ b/rta/common.py
@@ -208,7 +208,7 @@ def dependencies(*paths: str):
         @functools.wraps(f)
         def decorated(*args, **kwargs):
             if len(missing):
-                log("Missing dependencies for %s:%s()" % (f.func_code.co_filename, f.func_code.co_name), "!")
+                log("Missing dependencies for %s:%s()" % ((f.__code__.co_filename, f.__code__.co_name), "!")
                 for dep in missing:
                     # NOTE os.path.relpath supports Path objects and does not exist in pathlib
                     print("    - %s" % os.path.relpath(dep, BASE_DIR))


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: Issue reported in community slack

<img width="713" alt="image" src="https://github.com/user-attachments/assets/04c68eae-e4df-4ab4-adb1-31f215b75027">


## Summary - What I changed

- Fix attribute isse with func.__code__object per 3.11 [Refer](https://discuss.python.org/t/some-attribute-issue-with-python-3-11-func-code-object/33784/2)

## How To Test

- RTA should execute with no attribute errors

```console
(venv) PS C:\Users\shashank_suryanaraya\detection-rules> python -m rta -n winrar_encrypted
[!] Missing dependencies for C:\Users\shashank_suryanaraya\detection-rules\rta\winrar_encrypted.py:main()
    - bin\Rar.exe
(venv) PS C:\Users\shashank_suryanaraya\detection-rules>
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
