### PR TITLE
[Bug] [DAC] Fix Kibana action connector export to export details with action connectors 

### DIFF
--- a/detection_rules/config.py
+++ b/detection_rules/config.py
@@ -294,7 +294,8 @@ def parse_rules_config(path: Optional[Path] = None) -> RulesConfig:
 
         # Check if the file exists
         if not contents['auto_gen_schema_file'].exists():
-            # If the file doesn't exist, create an empty JSON file
+            # If the file doesn't exist, create the necessary directories and file
+            contents['auto_gen_schema_file'].parent.mkdir(parents=True, exist_ok=True)
             contents['auto_gen_schema_file'].write_text('{}')
 
     # bypass_optional_elastic_validation

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -174,8 +174,9 @@ def kibana_export_rules(ctx: click.Context, directory: Path, action_connectors_d
                         ) -> List[TOMLRule]:
     """Export custom rules from Kibana."""
     kibana = ctx.obj["kibana"]
+    kibana_include_details = export_exceptions or export_action_connectors
     with kibana:
-        results = RuleResource.export_rules(list(rule_id), exclude_export_details=not export_exceptions)
+        results = RuleResource.export_rules(list(rule_id), exclude_export_details=not kibana_include_details)
 
     # Handle Exceptions Directory Location
     if results and exceptions_directory:
@@ -198,7 +199,7 @@ def kibana_export_rules(ctx: click.Context, directory: Path, action_connectors_d
         return []
 
     rules_results = results
-    if export_exceptions:
+    if kibana_include_details:
         # Assign counts to variables
         rules_count = results[-1]["exported_rules_count"]
         exception_list_count = results[-1]["exported_exception_list_count"]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

This PR addresses a bug when exporting action connectors, the required export details from the Kibana API were not provided. Now the flag appropriately informs the Kibana API call to include the necessary details to parse the action connectors separately from the rules. 

## How To Test

To test this, run the `kibana export-rules` command with the `-ac` flag without the `-e` flag. In prior tests, the Kibana export details were not provided and the parsing of the connectors would fail. Note you do not need rules with action connectors to test this as the parsing issue occurs with the Kibana response message details which will be provided regardless of whether or not you have exceptions or action connectors, but based on whether or not either of those flags are passed to the `RuleResource.export_rules` call. 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
