### PR TITLE
[FR] Add Alert Suppression for Addtional Rule Types

### DIFF
--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -132,6 +132,9 @@ def rule_prompt(path=None, rule_type=None, required_only=True, save=True, verbos
 
     for name, options in props.items():
 
+        if name == 'index' and kwargs["type"] == "esql":
+            continue
+
         if name == 'type':
             contents[name] = rule_type
             continue

--- a/detection_rules/etc/test_cli.bash
+++ b/detection_rules/etc/test_cli.bash
@@ -19,7 +19,7 @@ mkdir tmp-export 2>/dev/null
 python -m detection_rules export-rules-from-repo --rule-id 0a97b20f-4144-49ea-be32-b540ecc445de -o tmp-export/test_rule.ndjson
 
 echo "Importing rule by ID: 0a97b20f-4144-49ea-be32-b540ecc445de"
-python -m detection_rules import-rules-to-repo tmp-export/test_rule.ndjson --required-only
+python -m detection_rules import-rules-to-repo tmp-export/test_rule.ndjson --required-only -s tmp-export
 rm -rf tmp-export
 
 echo "Updating rule data schemas"

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -758,13 +758,6 @@ class QueryRuleData(BaseRuleData):
         if data.get('index') and data.get('data_view_id'):
             raise ValidationError("Only one of index or data_view_id should be set.")
 
-    @validates_schema
-    def validates_query_data(self, data, **kwargs):
-        """Custom validation for query rule type and subclasses."""
-        # alert suppression is only valid for query rule type and not any of its subclasses
-        if data.get('alert_suppression') and data['type'] not in ('query', 'threshold'):
-            raise ValidationError("Alert suppression is only valid for query and threshold rule types.")
-
 
 @dataclass(frozen=True)
 class MachineLearningRuleData(BaseRuleData):
@@ -772,6 +765,7 @@ class MachineLearningRuleData(BaseRuleData):
 
     anomaly_threshold: int
     machine_learning_job_id: Union[str, List[str]]
+    alert_suppression: Optional[AlertSuppressionMapping] = field(metadata=dict(metadata=dict(min_compat="8.15")))
 
 
 @dataclass(frozen=True)
@@ -811,6 +805,7 @@ class NewTermsRuleData(QueryRuleData):
 
     type: Literal["new_terms"]
     new_terms: NewTermsMapping
+    alert_suppression: Optional[AlertSuppressionMapping] = field(metadata=dict(metadata=dict(min_compat="8.14")))
 
     @pre_load
     def preload_data(self, data: dict, **kwargs) -> dict:
@@ -849,6 +844,11 @@ class EQLRuleData(QueryRuleData):
     timestamp_field: Optional[str] = field(metadata=dict(metadata=dict(min_compat="8.0")))
     event_category_override: Optional[str] = field(metadata=dict(metadata=dict(min_compat="8.0")))
     tiebreaker_field: Optional[str] = field(metadata=dict(metadata=dict(min_compat="8.0")))
+    alert_suppression: Optional[AlertSuppressionMapping] = field(metadata=dict(metadata=dict(min_compat="8.14")))
+
+    def __post_init__(self):
+        # Eagerly compute cached properties
+        object.__getattribute__(self, 'is_sequence')
 
     def convert_relative_delta(self, lookback: str) -> int:
         now = len("now")
@@ -905,6 +905,7 @@ class ESQLRuleData(QueryRuleData):
     type: Literal["esql"]
     language: Literal["esql"]
     query: str
+    alert_suppression: Optional[AlertSuppressionMapping] = field(metadata=dict(metadata=dict(min_compat="8.15")))
 
     @validates_schema
     def validates_esql_data(self, data, **kwargs):
@@ -939,6 +940,7 @@ class ThreatMatchRuleData(QueryRuleData):
     threat_language: Optional[definitions.FilterLanguages]
     threat_index: List[str]
     threat_indicator_path: Optional[str]
+    alert_suppression: Optional[AlertSuppressionMapping] = field(metadata=dict(metadata=dict(min_compat="8.13")))
 
     def validate_query(self, meta: RuleMeta) -> None:
         super(ThreatMatchRuleData, self).validate_query(meta)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -846,10 +846,6 @@ class EQLRuleData(QueryRuleData):
     tiebreaker_field: Optional[str] = field(metadata=dict(metadata=dict(min_compat="8.0")))
     alert_suppression: Optional[AlertSuppressionMapping] = field(metadata=dict(metadata=dict(min_compat="8.14")))
 
-    def __post_init__(self):
-        # Eagerly compute cached properties
-        object.__getattribute__(self, 'is_sequence')
-
     def convert_relative_delta(self, lookback: str) -> int:
         now = len("now")
         min_length = now + len('+5m')

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1352,8 +1352,7 @@ class TestAlertSuppression(BaseRuleTest):
     def test_group_field_in_schemas(self):
         """Test to ensure the fields are defined is in ECS/Beats/Integrations schema."""
         for rule in self.all_rules:
-            rule_type = rule.contents.data.get('type')
-            if rule_type in ('query', 'threshold') and rule.contents.data.get('alert_suppression'):
+            if rule.contents.data.get('alert_suppression'):
                 if isinstance(rule.contents.data.alert_suppression, AlertSuppressionMapping):
                     group_by_fields = rule.contents.data.alert_suppression.group_by
                 elif isinstance(rule.contents.data.alert_suppression, ThresholdAlertSuppression):
@@ -1381,3 +1380,12 @@ class TestAlertSuppression(BaseRuleTest):
                     if fld not in schema.keys():
                         self.fail(f"{self.rule_str(rule)} alert suppression field {fld} not \
                             found in ECS, Beats, or non-ecs schemas")
+
+    @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.14.0"),
+                     "Test only applicable to 8.14+ stacks for eql non-sequence rule alert suppression feature.")
+    def test_eql_non_sequence_support_only(self):
+        for rule in self.all_rules:
+            if rule.contents.data.get('alert_suppression') and rule.contents.data.is_sequence:
+                # is_sequence method not yet available during schema validation
+                # so we have to check in a unit test
+                self.fail(f'{self.rule_str(rule)} Sequence rules cannot have alert suppression')

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -24,7 +24,7 @@ from detection_rules.integrations import (find_latest_compatible_version,
                                           load_integrations_manifests,
                                           load_integrations_schemas)
 from detection_rules.packaging import current_stack_version
-from detection_rules.rule import (AlertSuppressionMapping, QueryRuleData, QueryValidator,
+from detection_rules.rule import (AlertSuppressionMapping, EQLRuleData, QueryRuleData, QueryValidator,
                                   ThresholdAlertSuppression, TOMLRuleContents)
 from detection_rules.rule_loader import FILE_PATTERN, RULES_CONFIG
 from detection_rules.rule_validators import EQLValidator, KQLValidator
@@ -1385,7 +1385,8 @@ class TestAlertSuppression(BaseRuleTest):
                      "Test only applicable to 8.14+ stacks for eql non-sequence rule alert suppression feature.")
     def test_eql_non_sequence_support_only(self):
         for rule in self.all_rules:
-            if rule.contents.data.get('alert_suppression') and rule.contents.data.is_sequence:
+            if isinstance(rule.contents.data, EQLRuleData) and rule.contents.data.get('alert_suppression') and \
+                rule.contents.data.is_sequence:
                 # is_sequence method not yet available during schema validation
                 # so we have to check in a unit test
                 self.fail(f'{self.rule_str(rule)} Sequence rules cannot have alert suppression')

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1385,8 +1385,12 @@ class TestAlertSuppression(BaseRuleTest):
                      "Test only applicable to 8.14+ stacks for eql non-sequence rule alert suppression feature.")
     def test_eql_non_sequence_support_only(self):
         for rule in self.all_rules:
-            if isinstance(rule.contents.data, EQLRuleData) and rule.contents.data.get('alert_suppression') and \
-                rule.contents.data.is_sequence:
+            if (
+                isinstance(rule.contents.data, EQLRuleData) and rule.contents.data.get("alert_suppression")
+                and rule.contents.data.is_sequence  # noqa: W503
+            ):
                 # is_sequence method not yet available during schema validation
                 # so we have to check in a unit test
-                self.fail(f'{self.rule_str(rule)} Sequence rules cannot have alert suppression')
+                self.fail(
+                    f"{self.rule_str(rule)} Sequence rules cannot have alert suppression"
+                )


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/3640

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

Adds Alert Suppression support to our schemas for different rule types based on the [Kibana Schemas](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/common/api/detection_engine/model/rule_schema/rule_schemas.schema.yaml). 

- EQL Non Sequence : [Kibana PR](https://github.com/elastic/kibana/pull/176422) - `8.14.0`
- ML : [Kibana PR](https://github.com/elastic/kibana/pull/181926) - `8.15.0`
- ESQL : [Kibana PR](https://github.com/elastic/kibana/pull/180927) - `8.15.0`
- New Terms : [Kibana PR](https://github.com/elastic/kibana/pull/178294) - `8.14.0`
- Indicator Match : [Kibana PR](https://github.com/elastic/kibana/pull/174241) - `8.13.0`

### PR Checklist
- [x] Link to the relevant Kibana PR or issue provided
- [x] Exported detection rule(s) from Kibana to showcase the feature(s)
- [x] Converted the exported ndjson file(s) to toml in the detection-rules repo
- [x] Re-exported the toml rule(s) to ndjson and re-imported into Kibana
- [x] Updated necessary unit tests to accommodate the feature
- [x] Applied min_compat restrictions to limit the feature to a specified minimum stack version
- [ ] Executed all unit tests locally with a test toml rule to confirm passing
- [x] Included Kibana PR implementer as an optional reviewer for insights on the feature
- [ ] ~~Implemented requisite downgrade functionality~~
- [x] Cross-referenced the feature with product documentation for consistency
- [ ] ~~Incorporated a comprehensive test rule in unit tests for full schema coverage~~ (no new base schemas were introduced)
- [x] Conducted system testing, including fleet, import, and create APIs

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

<details><summary>Make Tests</summary>
<p>

- [test_cli_results.txt](https://github.com/user-attachments/files/16628077/test_cli_results.txt)
- [test_cli_remote_results.txt](https://github.com/user-attachments/files/16628109/test_cli_remote_results.txt)


</p>
</details> 

<details><summary>Importing / Exporting Test Files</summary>
<p>

1. Delete `.txt` extension:

[rules_export_supression.ndjson.txt](https://github.com/user-attachments/files/16617709/rules_export_supression.ndjson.txt)

2. Try to import it into our repo:

```bash
(detection-rules-build) ➜  detection-rules git:(3640-fr-new-terms-suppression-schema-updates) ✗ python -m detection_rules import-rules-to-repo ~/Downloads/rules_export_supression.ndjson --required-only
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/test_new_terms_suppress_rule.toml
[+] Building rule for /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/test_esql_suppress_rule.toml
[+] Building rule for /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/test_eql_suppress_rule.toml
[+] Building rule for /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/test_ml_suppress_rule_per_execution.toml
[+] Building rule for /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/test_threat_indicator_match_suppress_rule.toml
[+] Building rule for /Users/stryker/workspace/ElasticGitHub/detection-rules/rules/test_ml_suppress_rule.toml
6 results exported
6 rules converted
0 exceptions exported
0 actions connectors exported
(detection-rules-build) ➜  detectio
```

```bash
(detection-rules-build) ➜  detection-rules git:(3640-fr-new-terms-suppression-schema-updates) ✗ python -m detection_rules kibana --space "main" export-rules -s -d custom_rules   
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

- skipping Test ESQL Suppress Rule - ValidationError
- skipping Test New Terms Suppress Rule - ValidationError
- skipping Test Threat Indicator Match Suppress Rule - ValidationError
- skipping Test EQL Suppress Rule - ValidationError
- skipping Test ML Suppress Rule Per Execution - ValidationError
- skipping Test ML Suppress Rule - ValidationError
6 results exported
0 rules converted
0 exceptions exported
0 action connectors exported
0 rules saved to custom_rules
0 exception lists saved to None
0 action connectors saved to None
6 errors saved to custom_rules/_errors.txt
(detection-rules-build) ➜  detection-rules git:(3640-fr-new-terms-suppression-schema-updates) ✗ 
```

```bash
(detection-rules-build) ➜  detection-rules git:(3640-fr-new-terms-suppression-schema-updates) ✗ python -m detection_rules kibana --space "main" import-rules -d custom_r
ules -o
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

5 rule(s) successfully imported
 - 3ea1fa0a-0a25-4043-b23e-450e1e9c5730
 - 749ac911-16fd-406c-b1d1-d16b69322cbb
 - 804d56c3-18bd-4e92-81f4-0c4f08af6e24
 - c5904049-0d3a-4416-ad23-e1cceaf9f9f2
 - fbdbcb5f-1e75-4931-92b2-aedc830c9b8e
 ```


```bash
(detection-rules-build) ➜  detection-rules git:(3640-fr-new-terms-suppression-schema-updates) ✗ python -m detection_rules export-rules-from-repo -d custom_rules
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Exported 5 rules into /Users/stryker/workspace/ElasticGitHub/detection-rules/exports/20240815T084001L.ndjson
```

</p>
</details> 

<details><summary>Unit Tests</summary>
<p>

Have to test locally since we dont have rules with this feature in our repo yet.

```bash
(detection-rules-build) ➜  detection-rules git:(3640-fr-new-terms-suppression-schema-updates) ✗ python -m detection_rules test
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

========================================================================= test session starts ==========================================================================
platform darwin -- Python 3.12.2, pytest-8.2.0, pluggy-1.5.0 -- /Users/stryker/workspace/ElasticGitHub/detection-rules/env/detection-rules-build/bin/python
cachedir: .pytest_cache
rootdir: /Users/stryker/workspace/ElasticGitHub/detection-rules
configfile: pyproject.toml
plugins: typeguard-3.0.2
collected 150 items                                                                                                                                                    

tests/kuery/test_dsl.py::TestKQLtoDSL::test_and_query PASSED                                                                                                     [  0%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_exists PASSED                                                                                                  [  1%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_inequality PASSED                                                                                              [  2%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_field_match PASSED                                                                                                   [  2%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_not_query PASSED                                                                                                     [  3%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_optimizations PASSED                                                                                                 [  4%]
tests/kuery/test_dsl.py::TestKQLtoDSL::test_or_query PASSED                                                                                                      [  4%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_and_query PASSED                                                                                                  [  5%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_boolean_precedence PASSED                                                                                         [  6%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_field_equals PASSED                                                                                               [  6%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_field_inequality PASSED                                                                                           [  7%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_ip_checks PASSED                                                                                                  [  8%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_list_of_values PASSED                                                                                             [  8%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_not_query PASSED                                                                                                  [  9%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_or_query PASSED                                                                                                   [ 10%]
tests/kuery/test_eql2kql.py::TestEql2Kql::test_wildcard_field PASSED                                                                                             [ 10%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_and_expr PASSED                                                                                              [ 11%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_and_values PASSED                                                                                            [ 12%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_cidr_match PASSED                                                                                            [ 12%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_field_exists PASSED                                                                                          [ 13%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_flattening PASSED                                                                                            [ 14%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_list_value PASSED                                                                                            [ 14%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_not_value PASSED                                                                                             [ 15%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_or_expr PASSED                                                                                               [ 16%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_or_values PASSED                                                                                             [ 16%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_quoted_wildcard PASSED                                                                                       [ 17%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_range PASSED                                                                                                 [ 18%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_single_value PASSED                                                                                          [ 18%]
tests/kuery/test_evaluator.py::EvaluatorTests::test_wildcard PASSED                                                                                              [ 19%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_and_query PASSED                                                                                                  [ 20%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_boolean_precedence PASSED                                                                                         [ 20%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_field_equals PASSED                                                                                               [ 21%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_field_inequality PASSED                                                                                           [ 22%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_list_of_values PASSED                                                                                             [ 22%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_lone_value PASSED                                                                                                 [ 23%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_nested_query PASSED                                                                                               [ 24%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_not_query PASSED                                                                                                  [ 24%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_or_query PASSED                                                                                                   [ 25%]
tests/kuery/test_kql2eql.py::TestKql2Eql::test_schema PASSED                                                                                                     [ 26%]
tests/kuery/test_lint.py::LintTests::test_and_not PASSED                                                                                                         [ 26%]
tests/kuery/test_lint.py::LintTests::test_compound PASSED                                                                                                        [ 27%]
tests/kuery/test_lint.py::LintTests::test_double_negate PASSED                                                                                                   [ 28%]
tests/kuery/test_lint.py::LintTests::test_extract_not PASSED                                                                                                     [ 28%]
tests/kuery/test_lint.py::LintTests::test_ip PASSED                                                                                                              [ 29%]
tests/kuery/test_lint.py::LintTests::test_lint_field PASSED                                                                                                      [ 30%]
tests/kuery/test_lint.py::LintTests::test_lint_precedence PASSED                                                                                                 [ 30%]
tests/kuery/test_lint.py::LintTests::test_merge_fields PASSED                                                                                                    [ 31%]
tests/kuery/test_lint.py::LintTests::test_mixed_demorgans PASSED                                                                                                 [ 32%]
tests/kuery/test_lint.py::LintTests::test_not_demorgans PASSED                                                                                                   [ 32%]
tests/kuery/test_lint.py::LintTests::test_not_or PASSED                                                                                                          [ 33%]
tests/kuery/test_lint.py::LintTests::test_upper_tokens PASSED                                                                                                    [ 34%]
tests/kuery/test_parser.py::ParserTests::test_conversion PASSED                                                                                                  [ 34%]
tests/kuery/test_parser.py::ParserTests::test_date PASSED                                                                                                        [ 35%]
tests/kuery/test_parser.py::ParserTests::test_keyword PASSED                                                                                                     [ 36%]
tests/kuery/test_parser.py::ParserTests::test_list_equals PASSED                                                                                                 [ 36%]
tests/kuery/test_parser.py::ParserTests::test_multiple_types_fail PASSED                                                                                         [ 37%]
tests/kuery/test_parser.py::ParserTests::test_multiple_types_success PASSED                                                                                      [ 38%]
tests/kuery/test_parser.py::ParserTests::test_number_exists PASSED                                                                                               [ 38%]
tests/kuery/test_parser.py::ParserTests::test_number_wildcard_fail PASSED                                                                                        [ 39%]
tests/kuery/test_parser.py::ParserTests::test_type_family_fail PASSED                                                                                            [ 40%]
tests/kuery/test_parser.py::ParserTests::test_type_family_success PASSED                                                                                         [ 40%]
tests/test_all_rules.py::TestAlertSuppression::test_eql_non_sequence_support_only PASSED                                                                         [ 41%]
tests/test_all_rules.py::TestAlertSuppression::test_group_field_in_schemas PASSED                                                                                [ 42%]
tests/test_all_rules.py::TestBuildTimeFields::test_build_fields_min_stack PASSED                                                                                 [ 42%]
tests/test_all_rules.py::TestIncompatibleFields::test_rule_backports_for_restricted_fields PASSED                                                                [ 43%]
tests/test_all_rules.py::TestIntegrationRules::test_all_min_stack_rules_have_comment PASSED                                                                      [ 44%]
tests/test_all_rules.py::TestIntegrationRules::test_integration_guide SKIPPED (8.3+ Stacks Have Related Integrations Feature)                                    [ 44%]
tests/test_all_rules.py::TestIntegrationRules::test_ml_integration_jobs_exist PASSED                                                                             [ 45%]
tests/test_all_rules.py::TestIntegrationRules::test_rule_demotions PASSED                                                                                        [ 46%]
tests/test_all_rules.py::TestLicense::test_elastic_license_only_v2 PASSED                                                                                        [ 46%]
tests/test_all_rules.py::TestNoteMarkdownPlugins::test_if_plugins_explicitly_defined PASSED                                                                      [ 47%]
tests/test_all_rules.py::TestNoteMarkdownPlugins::test_note_has_osquery_warning PASSED                                                                           [ 48%]
tests/test_all_rules.py::TestNoteMarkdownPlugins::test_plugin_placeholders_match_entries PASSED                                                                  [ 48%]
tests/test_all_rules.py::TestRiskScoreMismatch::test_rule_risk_score_severity_mismatch PASSED                                                                    [ 49%]
tests/test_all_rules.py::TestRuleFiles::test_bbr_in_correct_dir PASSED                                                                                           [ 50%]
tests/test_all_rules.py::TestRuleFiles::test_non_bbr_in_correct_dir PASSED                                                                                       [ 50%]
tests/test_all_rules.py::TestRuleFiles::test_rule_file_name_tactic PASSED                                                                                        [ 51%]
tests/test_all_rules.py::TestRuleMetadata::test_deprecated_rules PASSED                                                                                          [ 52%]
tests/test_all_rules.py::TestRuleMetadata::test_deprecated_rules_modified PASSED                                                                                 [ 52%]
tests/test_all_rules.py::TestRuleMetadata::test_event_dataset PASSED                                                                                             [ 53%]
tests/test_all_rules.py::TestRuleMetadata::test_integration_tag PASSED                                                                                           [ 54%]
tests/test_all_rules.py::TestRuleMetadata::test_invalid_queries PASSED                                                                                           [ 54%]
tests/test_all_rules.py::TestRuleMetadata::test_rule_change_has_updated_date PASSED                                                                              [ 55%]
tests/test_all_rules.py::TestRuleMetadata::test_updated_date_newer_than_creation PASSED                                                                          [ 56%]
tests/test_all_rules.py::TestRuleTags::test_casing_and_spacing PASSED                                                                                            [ 56%]
tests/test_all_rules.py::TestRuleTags::test_investigation_guide_tag SKIPPED (Skipping until all Investigation Guides follow the proper format.)                  [ 57%]
tests/test_all_rules.py::TestRuleTags::test_ml_rule_type_tags PASSED                                                                                             [ 58%]
tests/test_all_rules.py::TestRuleTags::test_no_duplicate_tags PASSED                                                                                             [ 58%]
tests/test_all_rules.py::TestRuleTags::test_os_tags PASSED                                                                                                       [ 59%]
tests/test_all_rules.py::TestRuleTags::test_primary_tactic_as_tag PASSED                                                                                         [ 60%]
tests/test_all_rules.py::TestRuleTags::test_required_tags PASSED                                                                                                 [ 60%]
tests/test_all_rules.py::TestRuleTags::test_tag_prefix PASSED                                                                                                    [ 61%]
tests/test_all_rules.py::TestRuleTimelines::test_timeline_has_title PASSED                                                                                       [ 62%]
tests/test_all_rules.py::TestRuleTiming::test_eql_interval_to_maxspan PASSED                                                                                     [ 62%]
tests/test_all_rules.py::TestRuleTiming::test_eql_lookback PASSED                                                                                                [ 63%]
tests/test_all_rules.py::TestRuleTiming::test_event_override PASSED                                                                                              [ 64%]
tests/test_all_rules.py::TestRuleTiming::test_required_lookback PASSED                                                                                           [ 64%]
tests/test_all_rules.py::TestThreatMappings::test_duplicated_tactics PASSED                                                                                      [ 65%]
tests/test_all_rules.py::TestThreatMappings::test_tactic_to_technique_correlations PASSED                                                                        [ 66%]
tests/test_all_rules.py::TestThreatMappings::test_technique_deprecations PASSED                                                                                  [ 66%]
tests/test_all_rules.py::TestValidRules::test_all_rule_queries_optimized PASSED                                                                                  [ 67%]
tests/test_all_rules.py::TestValidRules::test_bbr_validation PASSED                                                                                              [ 68%]
tests/test_all_rules.py::TestValidRules::test_duplicate_file_names PASSED                                                                                        [ 68%]
tests/test_all_rules.py::TestValidRules::test_file_names PASSED                                                                                                  [ 69%]
tests/test_all_rules.py::TestValidRules::test_from_filed_value PASSED                                                                                            [ 70%]
tests/test_all_rules.py::TestValidRules::test_index_or_data_view_id_present PASSED                                                                               [ 70%]
tests/test_all_rules.py::TestValidRules::test_max_signals_note PASSED                                                                                            [ 71%]
tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta PASSED                                                                                   [ 72%]
tests/test_all_rules.py::TestValidRules::test_rule_type_changes PASSED                                                                                           [ 72%]
tests/test_all_rules.py::TestValidRules::test_schema_and_dupes PASSED                                                                                            [ 73%]
tests/test_gh_workflows.py::TestWorkflows::test_matrix_to_lock_version_defaults PASSED                                                                           [ 74%]
tests/test_hunt_data.py::TestHunt::test_load_toml_files PASSED                                                                                                   [ 74%]
tests/test_hunt_data.py::TestHunt::test_markdown_existence PASSED                                                                                                [ 75%]
tests/test_hunt_data.py::TestHunt::test_toml_loading PASSED                                                                                                      [ 76%]
tests/test_mappings.py::TestMappings::test_false_positives PASSED                                                                                                [ 76%]
tests/test_mappings.py::TestMappings::test_true_positives PASSED                                                                                                 [ 77%]
tests/test_mappings.py::TestRTAs::test_rtas_with_triggered_rules_have_uuid PASSED                                                                                [ 78%]
tests/test_packages.py::TestPackages::test_package_loader_default_configs PASSED                                                                                 [ 78%]
tests/test_packages.py::TestPackages::test_package_loader_production_config PASSED                                                                               [ 79%]
tests/test_packages.py::TestPackages::test_package_summary PASSED                                                                                                [ 80%]
tests/test_packages.py::TestPackages::test_rule_versioning PASSED                                                                                                [ 80%]
tests/test_packages.py::TestRegistryPackage::test_registry_package_config PASSED                                                                                 [ 81%]
tests/test_python_library.py::TestEQLInSet::test_eql_in_set PASSED                                                                                               [ 82%]
tests/test_schemas.py::TestSchemas::test_eql_validation PASSED                                                                                                   [ 82%]
tests/test_schemas.py::TestSchemas::test_query_downgrade_7_x PASSED                                                                                              [ 83%]
tests/test_schemas.py::TestSchemas::test_query_downgrade_8_x PASSED                                                                                              [ 84%]
tests/test_schemas.py::TestSchemas::test_threshold_downgrade_7_x PASSED                                                                                          [ 84%]
tests/test_schemas.py::TestSchemas::test_threshold_downgrade_8_x PASSED                                                                                          [ 85%]
tests/test_schemas.py::TestSchemas::test_versioned_downgrade_7_x PASSED                                                                                          [ 86%]
tests/test_schemas.py::TestSchemas::test_versioned_downgrade_8_x PASSED                                                                                          [ 86%]
tests/test_schemas.py::TestVersionLockSchema::test_version_lock_has_nested_previous PASSED                                                                       [ 87%]
tests/test_schemas.py::TestVersionLockSchema::test_version_lock_no_previous PASSED                                                                               [ 88%]
tests/test_schemas.py::TestVersions::test_stack_schema_map PASSED                                                                                                [ 88%]
tests/test_specific_rules.py::TestESQLRules::test_esql_queries PASSED                                                                                            [ 89%]
tests/test_specific_rules.py::TestEndpointQuery::test_os_and_platform_in_query PASSED                                                                            [ 90%]
tests/test_specific_rules.py::TestNewTerms::test_history_window_start PASSED                                                                                     [ 90%]
tests/test_specific_rules.py::TestNewTerms::test_new_terms_field_exists PASSED                                                                                   [ 91%]
tests/test_specific_rules.py::TestNewTerms::test_new_terms_fields PASSED                                                                                         [ 92%]
tests/test_specific_rules.py::TestNewTerms::test_new_terms_fields_unique PASSED                                                                                  [ 92%]
tests/test_specific_rules.py::TestNewTerms::test_new_terms_max_limit PASSED                                                                                      [ 93%]
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_formatter_deep PASSED                                                                                  [ 94%]
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_formatter_rule PASSED                                                                                  [ 94%]
tests/test_toml_formatter.py::TestRuleTomlFormatter::test_normalization PASSED                                                                                   [ 95%]
tests/test_transform_fields.py::TestGuideMarkdownPlugins::test_plugin_conversion PASSED                                                                          [ 96%]
tests/test_transform_fields.py::TestGuideMarkdownPlugins::test_transform_guide_markdown_plugins PASSED                                                           [ 96%]
tests/test_utils.py::TestTimeUtils::test_caching PASSED                                                                                                          [ 97%]
tests/test_utils.py::TestTimeUtils::test_event_class_normalization PASSED                                                                                        [ 98%]
tests/test_utils.py::TestTimeUtils::test_schema_multifields PASSED                                                                                               [ 98%]
tests/test_utils.py::TestTimeUtils::test_time_normalize PASSED                                                                                                   [ 99%]
tests/test_version_locking.py::TestVersionLock::test_previous_entries_gte_current_min_stack PASSED                                                               [100%]

=========================================================================== warnings summary ===========================================================================
env/detection-rules-build/lib/python3.12/site-packages/_pytest/config/__init__.py:1285
  /Users/stryker/workspace/ElasticGitHub/detection-rules/env/detection-rules-build/lib/python3.12/site-packages/_pytest/config/__init__.py:1285: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: typeguard
    self._mark_plugins_for_rewrite(hook)

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/uac_sysprep.py:31: SyntaxWarning: invalid escape sequence '\s'
    "C:\\Windows\\system32\sysprep\\CRYPTBASE.DLL",

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/uac_sysprep.py:33: SyntaxWarning: invalid escape sequence '\s'
    common.execute(["C:\\Windows\\system32\sysprep\\sysprep.exe"], timeout=5, kill=True)

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/uac_sysprep.py:34: SyntaxWarning: invalid escape sequence '\s'
    common.remove_file("C:\\Windows\\system32\sysprep\\CRYPTBASE.DLL")

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/credaccess_sam_from_vss.py:22: SyntaxWarning: invalid escape sequence '\c'
    wmi = wcd.ConnectServer(".","root\cimv2")

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/shellcode_load_ws2_32_unbacked.py:11: SyntaxWarning: invalid escape sequence '\9'
    SHELLCODE = b"\x33\xC9\x64\x8B\x41\x30\x8B\x40\x0C\x8B\x70\x14\xAD\x96\xAD\x8B\x58\x10\x8B\x53\x3C\x03\xD3\x8B\x52\x78\x03\xD3\x8B\x72\x20\x03\xF3\x33\xC9\x41\xAD\x03\xC3\x81\x38\x47\x65\x74\x50\x75\xF4\x81\x78\x04\x72\x6F\x63\x41\x75\xEB\x81\x78\x08\x64\x64\x72\x65\x75\xE2\x8B\x72\x24\x03\xF3\x66\x8B\x0C\x4E\x49\x8B\x72\x1C\x03\xF3\x8B\x14\x8E\x03\xD3\x33\xC9\x53\x52\x51\x68\x61\x72\x79\x41\x68\x4C\x69\x62\x72\x68\x4C\x6F\x61\x64\x54\x53\xFF\xD2\x83\xC4\x0C\x59\x50\x51\x66\xB9\x6C\x6C\x51\x68\x33\x32\x2E\x64\x68\x77\x73\x32\x5F\x54\xFF\xD0\x83\xC4\x10\x8B\x54\x24\x04\x33\xC9\x51\xB9\x74\x6F\x6E\x61\x51\x83\x6C\x24\x03\x61\x68\x65\x42\x75\x74\x68\x4D\x6F\x75\x73\x68\x53\x77\x61\x70\x54\x50\xFF\xD2\x83\xC4\x14\x33\xC9\x41\x51\xFF\xD0\x83\xC4\x04\x5A\x5B\xB9\x65\x73\x73\x61\x51\x83\x6C\x24\x03\x61\x68\x50\x72\x6F\x63\x68\x45\x78\x69\x74\x54\x53\xFF\xD2\x33\xC9\x51\xFF\xD0\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90\90"

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/exec_persistence_from_iso.py:33: SyntaxWarning: invalid escape sequence '\S'
    for arg in ["'/c reg.exe add hkcu\SOFTWARE\Microsoft\Windows\CurrentVersion\Run /v FromISO /d test.exe /f'", "'/c SCHTASKS.exe /Create /TN FromISO /TR test.exe /sc hourly /F'"] :

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/exec_persistence_from_iso.py:39: SyntaxWarning: invalid escape sequence '\S'
    rem_cmd = "reg.exe delete 'HKCU\Software\Microsoft\Windows\CurrentVersion\Run' /v FromISO"

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/at_command.py:67: SyntaxWarning: invalid escape sequence '\d'
    job_id = re.search("ID = (\d+)", output).group(1)

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/obfuscated_cmd_commands.py:28: SyntaxWarning: invalid escape sequence '\#'
    commands = """

tests/test_all_rules.py::TestValidRules::test_production_rules_have_rta
  /Users/stryker/workspace/ElasticGitHub/detection-rules/rta/rundll32_javascript_callback.py:34: SyntaxWarning: invalid escape sequence '\.'
    js = """

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 148 passed, 2 skipped, 11 warnings in 113.74s (0:01:53) ========================================================
(detection-rules-build) ➜  detection-rules git:(3640-fr-new-terms-suppression-schema-updates) ✗ 

```


</p>
</details> 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] ~~Added the `meta:rapid-merge` label if planning to merge within 24 hours~~
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

