### PR TITLE
Remove unused @click.pass_context

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -204,7 +204,6 @@ def build_integration_docs(ctx: click.Context, registry_version: str, pre: str, 
 @click.option("--new-package", type=click.Choice(['true', 'false']), help="indicates new package")
 @click.option("--maturity", type=click.Choice(['beta', 'ga'], case_sensitive=False),
               required=True, help="beta or production versions")
-@click.pass_context
 def bump_versions(major_release: bool, minor_release: bool, patch_release: bool, new_package: str, maturity: str):
     """Bump the versions"""
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: Release Fleet Workflow failures https://github.com/elastic/detection-rules/actions/runs/10475629333/job/29012708561

![image](https://github.com/user-attachments/assets/ae1d67ef-8099-4cfb-bfef-ab18b56e57cc)

## Summary - What I changed

- @click.pass_context was added to bump_versions as part of DAC [commit](https://github.com/elastic/detection-rules/pull/3889/commits/303a64e388bdd7684ee654a4a48ebd19a9934e3a#diff-e451accac6e3d163c27239dce087f27f707daf31a84a45b12ebd0f0c26dc8c83)
- This is not being used in the function and is causing type errors for variables
- We have removed this context for the function

## How To Test

- Locally Built a patch release on main and worked as expected 
```
❯ python -m detection_rules dev bump-pkg-versions --patch-release  --new-package true   --maturity beta

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

loaded security_detection_engine manifests from the following package versions: ['8.15.2', '8.15.2-beta.1', '8.15.1', '8.15.1-beta.1', '8.14.8', '8.14.8-beta.1', '8.14.7', '8.14.7-beta.1', '8.14.6', '8.14.6-beta.1', '8.14.5', '8.14.5-beta.1', '8.14.4', '8.14.4-beta.1', '8.14.3', '8.14.3-beta.1', '8.14.2', '8.14.2-beta.1', '8.14.1', '8.14.1-beta.1', '8.13.14', '8.13.14-beta.1', '8.13.13', '8.13.13-beta.1', '8.13.12', '8.13.12-beta.1', '8.13.11', '8.13.11-beta.1', '8.13.10', '8.13.10-beta.1', '8.13.9', '8.13.9-beta.1', '8.13.8', '8.13.8-beta.1', '8.13.7', '8.13.7-beta.1', '8.13.6', '8.13.6-beta.1', '8.13.5', '8.13.5-beta.1', '8.13.4', '8.13.4-beta.1', '8.13.3', '8.13.3-beta.1', '8.13.2', '8.13.2-beta.1', '8.13.1', '8.13.1-beta.1', '8.12.19', '8.12.19-beta.1', '8.12.18', '8.12.18-beta.1', '8.12.17', '8.12.17-beta.1', '8.12.16', '8.12.16-beta.1', '8.12.15', '8.12.15-beta.1', '8.12.14', '8.12.14-beta.1', '8.12.13', '8.12.13-beta.1', '8.12.12', '8.12.12-beta.1', '8.12.11', '8.12.11-beta.1', '8.12.10', '8.12.10-beta.1', '8.12.9', '8.12.9-beta.1', '8.12.8', '8.12.8-beta.1', '8.12.7', '8.12.7-beta.1', '8.12.6', '8.12.6-beta.1', '8.12.5', '8.12.5-beta.1', '8.12.4', '8.12.4-beta.1', '8.12.3', '8.12.3-beta.1', '8.12.2', '8.12.2-beta.1', '8.12.1', '8.12.1-beta.1', '8.11.21', '8.11.21-beta.1', '8.11.20', '8.11.20-beta.1', '8.11.19', '8.11.19-beta.1', '8.11.18', '8.11.18-beta.1', '8.11.17', '8.11.17-beta.1', '8.11.16', '8.11.16-beta.1', '8.11.15', '8.11.15-beta.1', '8.11.14', '8.11.14-beta.1', '8.11.13', '8.11.13-beta.1', '8.11.12', '8.11.12-beta.1', '8.11.11', '8.11.11-beta.1', '8.11.10', '8.11.10-beta.1', '8.11.9', '8.11.9-beta.1', '8.11.8', '8.11.8-beta.1', '8.11.7', '8.11.7-beta.1', '8.11.6', '8.11.6-beta.1', '8.11.5', '8.11.5-beta.1', '8.11.4', '8.11.4-beta.1', '8.11.3', '8.11.3-beta.1', '8.11.2', '8.11.2-beta.1', '8.11.1', '8.11.1-beta.1', '8.10.18', '8.10.18-beta.1', '8.10.17', '8.10.17-beta.1', '8.10.16', '8.10.16-beta.1', '8.10.15', '8.10.15-beta.1', '8.10.14', '8.10.14-beta.1', '8.10.13', '8.10.13-beta.1', '8.10.12', '8.10.12-beta.1', '8.10.11', '8.10.11-beta.1', '8.10.10', '8.10.10-beta.1', '8.10.9', '8.10.9-beta.1', '8.10.8', '8.10.8-beta.1', '8.10.7', '8.10.7-beta.1', '8.10.6', '8.10.6-beta.1', '8.10.5', '8.10.5-beta.1', '8.10.4', '8.10.4-beta.2', '8.10.4-beta.1', '8.10.3', '8.10.3-beta.1', '8.10.2', '8.10.2-beta.1', '8.10.1', '8.10.1-beta.1', '8.9.15', '8.9.15-beta.1', '8.9.14', '8.9.14-beta.1', '8.9.13', '8.9.13-beta.1', '8.9.12', '8.9.12-beta.1', '8.9.11', '8.9.11-beta.1', '8.9.10', '8.9.10-beta.1', '8.9.9', '8.9.9-beta.1', '8.9.8', '8.9.8-beta.1', '8.9.7', '8.9.7-beta.2', '8.9.7-beta.1', '8.9.6', '8.9.6-beta.1', '8.9.5', '8.9.5-beta.1', '8.9.4', '8.9.4-beta.1', '8.9.3', '8.9.3-beta.1', '8.9.2', '8.9.1', '8.8.15', '8.8.15-beta.1', '8.8.14', '8.8.14-beta.1', '8.8.13', '8.8.13-beta.1', '8.8.12', '8.8.12-beta.2', '8.8.12-beta.1', '8.8.11', '8.8.11-beta.1', '8.8.10', '8.8.10-beta.1', '8.8.9', '8.8.9-beta.1', '8.8.8', '8.8.8-beta.1', '8.8.7', '8.8.6', '8.8.5', '8.8.5-beta.1', '8.8.4', '8.8.4-beta.1', '8.8.3', '8.8.3-beta.1', '8.8.2', '8.8.2-beta.1', '8.8.1', '8.8.1-beta.1', '8.7.14-beta.1', '8.7.13', '8.7.13-beta.1', '8.7.12', '8.7.12-beta.1', '8.7.11', '8.7.11-beta.1', '8.7.10', '8.7.10-beta.1', '8.7.9', '8.7.9-beta.1', '8.7.8', '8.7.7', '8.7.7-beta.1', '8.7.6', '8.7.6-beta.1', '8.7.5', '8.7.5-beta.1', '8.7.4', '8.7.4-beta.1', '8.7.3', '8.7.3-beta.1', '8.7.3-beta.0', '8.7.2', '8.7.2-beta.1', '8.7.1', '8.7.1-beta.1', '8.6.10', '8.6.10-beta.1', '8.6.9', '8.6.8', '8.6.7', '8.6.7-beta.1', '8.6.6', '8.6.6-beta.1', '8.6.5', '8.6.5-beta.1', '8.6.4', '8.6.4-beta.1', '8.6.3', '8.6.3-beta.1', '8.6.2', '8.6.2-beta.1', '8.6.1', '8.6.1-beta.1', '8.5.8', '8.5.7', '8.5.7-beta.1', '8.5.6', '8.5.6-beta.1', '8.5.5', '8.5.5-beta.1', '8.5.4', '8.5.4-beta.1', '8.5.3', '8.5.3-beta.1', '8.5.2', '8.5.2-beta.1', '8.5.1', '8.5.1-beta.1', '8.4.5', '8.4.5-beta.1', '8.4.4', '8.4.4-beta.1', '8.4.3', '8.4.3-beta.1', '8.4.2', '8.4.2-beta.1', '8.4.1', '8.3.4', '8.3.4-beta.1', '8.3.3', '8.3.2', '8.3.1', '8.2.1', '8.1.1', '1.0.2', '1.0.1']
Kibana version: 8.16
Package Kibana version: ^8.16.0
Package version: 8.16.1-beta.1
```

Without the Fix

```
 python -m detection_rules dev bump-pkg-versions --patch-release  --new-package true   --maturity beta

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/shashankks/elastic_workspace/detection-rules/detection_rules/__main__.py", line 35, in <module>
    main()
  File "/Users/shashankks/elastic_workspace/detection-rules/detection_rules/__main__.py", line 32, in main
    root(prog_name="detection_rules")
  File "/Users/shashankks/elastic_workspace/detection-rules/.venv/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shashankks/elastic_workspace/detection-rules/.venv/lib/python3.12/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/shashankks/elastic_workspace/detection-rules/.venv/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shashankks/elastic_workspace/detection-rules/.venv/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shashankks/elastic_workspace/detection-rules/.venv/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shashankks/elastic_workspace/detection-rules/.venv/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/shashankks/elastic_workspace/detection-rules/.venv/lib/python3.12/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: bump_versions() got multiple values for argument 'major_release'
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
