### PR TITLE
[Bug] Add historical Rules as Default when Build Package

### DIFF
--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -425,7 +425,7 @@ class SecurityDetectionEngine:
 
         # Separate rule ID and version, and group by base rule ID
         for key in assets:
-            base_id, version = key.rsplit('_', 1)
+            base_id, version = assets[key]["attributes"]["rule_id"], assets[key]["attributes"]["version"]
             version = int(version)  # Convert version to an integer for sorting
             rule_versions[base_id].append((version, key))
 

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -26,7 +26,7 @@ from .utils import cached, get_etc_path, read_gzip, unzip
 from .schemas import definitions
 
 MANIFEST_FILE_PATH = get_etc_path('integration-manifests.json.gz')
-NUM_LATEST_RULE_VERSIONS = 1
+NUM_LATEST_RULE_VERSIONS = 2
 SCHEMA_FILE_PATH = get_etc_path('integration-schemas.json.gz')
 _notified_integrations = set()
 

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -26,7 +26,7 @@ from .utils import cached, get_etc_path, read_gzip, unzip
 from .schemas import definitions
 
 MANIFEST_FILE_PATH = get_etc_path('integration-manifests.json.gz')
-NUM_LATEST_RULE_VERSIONS = 2
+NUM_LATEST_RULE_VERSIONS = 1
 SCHEMA_FILE_PATH = get_etc_path('integration-schemas.json.gz')
 _notified_integrations = set()
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -412,14 +412,12 @@ class Package(object):
 
         for rule in self.rules:
             asset = rule.get_asset()
-            if self.historical:
-                # if this package includes historical rules the IDs need to be changed
-                # asset['id] and the file name needs to resemble RULEID_VERSION instead of RULEID
-                asset_id = f"{asset['attributes']['rule_id']}_{asset['attributes']['version']}"
-                asset["id"] = asset_id
-                asset_path = rules_dir / f'{asset_id}.json'
-            else:
-                asset_path = rules_dir / f'{asset["id"]}.json'
+            # if this package includes historical rules the IDs need to be changed
+            # asset['id] and the file name needs to resemble RULEID_VERSION instead of RULEID
+            asset_id = f"{asset['attributes']['rule_id']}_{asset['attributes']['version']}"
+            asset["id"] = asset_id
+            asset_path = rules_dir / f'{asset_id}.json'
+
             asset_path.write_text(json.dumps(asset, indent=4, sort_keys=True), encoding="utf-8")
 
         notice_contents = NOTICE_FILE.read_text()

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -500,7 +500,7 @@ class Package(object):
         rules_dir = CURRENT_RELEASE_PATH / 'fleet' / manifest_version / 'kibana' / 'security_rule'
 
         # iterates over historical rules from previous package and writes them to disk
-        for historical_rule_id, historical_rule_contents in historical_rules.items():
+        for _, historical_rule_contents in historical_rules.items():
             rule_id = historical_rule_contents["attributes"]["rule_id"]
             historical_rule_version = historical_rule_contents['attributes']['version']
 
@@ -517,7 +517,7 @@ class Package(object):
             # if the historical rule version and current rules version differ, write
             # the historical rule to disk
             if historical_rule_version != current_rule_version:
-                historical_rule_path = rules_dir / f"{historical_rule_id}.json"
+                historical_rule_path = rules_dir / f"{rule_id}_{historical_rule_version}.json"
                 with historical_rule_path.open("w", encoding="UTF-8") as file:
                     json.dump(historical_rule_contents, file)
 

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -228,7 +228,7 @@ class Package(object):
 
     @classmethod
     def from_config(cls, rule_collection: Optional[RuleCollection] = None, config: Optional[dict] = None,
-                    verbose: Optional[bool] = False) -> 'Package':
+                    verbose: Optional[bool] = False, historical: Optional[bool] = True) -> 'Package':
         """Load a rules package given a config."""
         all_rules = rule_collection or RuleCollection.default()
         config = config or {}
@@ -245,7 +245,7 @@ class Package(object):
         if verbose:
             click.echo(f' - {len(all_rules) - len(rules)} rules excluded from package')
 
-        package = cls(rules, verbose=verbose, **config)
+        package = cls(rules, verbose=verbose, historical=historical, **config)
 
         return package
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: N/A First observed [here](https://github.com/elastic/detection-rules/pull/4000) 

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

In this original [commit](https://github.com/elastic/detection-rules/pull/3407/files#diff-f52ba8aa6684236d546d35ef2525ef97bcd8c2443a763574c458bb727cec9039), the historical rule functionality was removed, and broke the file naming schema which appends rule version to the end of the rule_id (`e.g. <rule_id>_<version>.json`).   This PR  re-adds historical rules by default and ensures only the latest historical rules and the latest version are generated for the release package, but ensures they have versions appended. The versions are necessary for kibana's historical rules feature.

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

1. Run the build without fail.

```bash
python -m detection_rules dev build-release --update-version-lock
Loaded config file: /Users/stryker/workspace/ElasticGitHub/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building package 8.16
 - 5 rules excluded from package
Package saved to: /Users/stryker/workspace/ElasticGitHub/detection-rules/releases/8.16
loaded security_detection_engine manifests from the following package versions: ['8.15.3', '8.15.2', '8.15.1', '8.14.9', '8.14.8', '8.14.7', '8.14.6', '8.14.5', '8.14.4', '8.14.3', '8.14.2', '8.14.1', '8.13.15', '8.13.14', '8.13.13', '8.13.12', '8.13.11', '8.13.10', '8.13.9', '8.13.8', '8.13.7', '8.13.6', '8.13.5', '8.13.4', '8.13.3', '8.13.2', '8.13.1', '8.12.20', '8.12.19', '8.12.18', '8.12.17', '8.12.16', '8.12.15', '8.12.14', '8.12.13', '8.12.12', '8.12.11', '8.12.10', '8.12.9', '8.12.8', '8.12.7', '8.12.6', '8.12.5', '8.12.4', '8.12.3', '8.12.2', '8.12.1', '8.11.21', '8.11.20', '8.11.19', '8.11.18', '8.11.17', '8.11.16', '8.11.15', '8.11.14', '8.11.13', '8.11.12', '8.11.11', '8.11.10', '8.11.9', '8.11.8', '8.11.7', '8.11.6', '8.11.5', '8.11.4', '8.11.3', '8.11.2', '8.11.1', '8.10.18', '8.10.17', '8.10.16', '8.10.15', '8.10.14', '8.10.13', '8.10.12', '8.10.11', '8.10.10', '8.10.9', '8.10.8', '8.10.7', '8.10.6', '8.10.5', '8.10.4', '8.10.3', '8.10.2', '8.10.1', '8.9.15', '8.9.14', '8.9.13', '8.9.12', '8.9.11', '8.9.10', '8.9.9', '8.9.8', '8.9.7', '8.9.6', '8.9.5', '8.9.4', '8.9.3', '8.9.2', '8.9.1', '8.8.15', '8.8.14', '8.8.13', '8.8.12', '8.8.11', '8.8.10', '8.8.9', '8.8.8', '8.8.7', '8.8.6', '8.8.5', '8.8.4', '8.8.3', '8.8.2', '8.8.1', '8.7.13', '8.7.12', '8.7.11', '8.7.10', '8.7.9', '8.7.8', '8.7.7', '8.7.6', '8.7.5', '8.7.4', '8.7.3', '8.7.2', '8.7.1', '8.6.10', '8.6.9', '8.6.8', '8.6.7', '8.6.6', '8.6.5', '8.6.4', '8.6.3', '8.6.2', '8.6.1', '8.5.8', '8.5.7', '8.5.6', '8.5.5', '8.5.4', '8.5.3', '8.5.2', '8.5.1', '8.4.5', '8.4.4', '8.4.3', '8.4.2', '8.4.1', '8.3.4', '8.3.3', '8.3.2', '8.3.1', '8.2.1', '8.1.1', '1.0.2', '1.0.1']
[+] Adding historical rules from 8.15.3 package
- sha256: f487ba5e502a8ee82317c65bc9a419f3aa294bba82200115ce5873ee65834aca
- 1193 rules included
```

2. Check the `/releases/8.16/fleet/8.16.0-beta.1/kibana/security_rule` folder and ensure all haves have an `<rule_id>_<version>` 

```
ls -ltr |grep -v "_"
````

3. Make sure rules have <= 2 rules only per build 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Additional Context

Now that the DAC Beta branch has been merged, this is the first DR release that runs on this code. Even though the original commit reflects a while ago, it was only recently merged into main. Furthermore, the issue only appeared since the rule files changed as a side effect of the inadvertent code additions. With the latest rules staged on [epr](https://epr.elastic.co/package/security_detection_engine/8.15.3/), the issue appears since rule file names do not include versions.