### PR TITLE
[Rule Tuning] Potential privilege escalation via CVE-2022-38028

### DIFF
--- a/rules/windows/privilege_escalation_exploit_cve_202238028.toml
+++ b/rules/windows/privilege_escalation_exploit_cve_202238028.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/23"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2024/08/07"
+updated_date = "2024/08/22"
 
 [rule]
 author = ["Elastic"]
@@ -32,9 +32,12 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where host.os.type == "windows" and
-           file.path : ("?:\\*\\Windows\\system32\\DriVerStoRe\\FiLeRePoSiToRy\\*\\MPDW-constraints.js",
-                        "?:\\*\\Windows\\WinSxS\\amd64_microsoft-windows-printing-printtopdf_*\\MPDW-constraints.js")
+file where host.os.type == "windows" and event.type != "deletion" and
+    file.name : "MPDW-constraints.js" and
+    file.path : (
+        "?:\\*\\Windows\\system32\\DriVerStoRe\\FiLeRePoSiToRy\\*\\MPDW-constraints.js",
+        "?:\\*\\Windows\\WinSxS\\amd64_microsoft-windows-printing-printtopdf_*\\MPDW-constraints.js"
+    )
 '''
 
 


### PR DESCRIPTION
## Summary - What I changed

Adds some filters for `event.type` and `file.name` before the wildcards to improve performance.