### PR TITLE
[New Rule] Access Control List Modification via setfacl

### DIFF
--- a/rules_building_block/defense_evasion_acl_modification_via_setfacl.toml
+++ b/rules_building_block/defense_evasion_acl_modification_via_setfacl.toml
@@ -49,7 +49,7 @@ reference = "https://attack.mitre.org/techniques/T1222/"
 [[rule.threat.technique.subtechnique]]
 id = "T1222.002"
 name = "Linux and Mac File and Directory Permissions Modification"
-reference = "https://attack.mitre.org/techniques/T1222/001/"
+reference = "https://attack.mitre.org/techniques/T1222/002/"
 
 [rule.threat.tactic]
 id = "TA0005"

--- a/rules_building_block/defense_evasion_acl_modification_via_setfacl.toml
+++ b/rules_building_block/defense_evasion_acl_modification_via_setfacl.toml
@@ -16,6 +16,7 @@ index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_mana
 language = "eql"
 license = "Elastic License v2"
 name = "Access Control List Modification via setfacl"
+references = ["https://www.uptycs.com/blog/threat-research-report-team/evasive-techniques-used-by-malicious-linux-shell-scripts"]
 risk_score = 21
 rule_id = "999565a2-fc52-4d72-91e4-ba6712c0377e"
 severity = "low"

--- a/rules_building_block/defense_evasion_acl_modification_via_setfacl.toml
+++ b/rules_building_block/defense_evasion_acl_modification_via_setfacl.toml
@@ -1,0 +1,56 @@
+[metadata]
+bypass_bbr_timing = true
+creation_date = "2024/08/23"
+integration = ["endpoint", "auditd_manager"]
+maturity = "production"
+updated_date = "2024/08/23"
+
+[rule]
+author = ["Elastic"]
+building_block_type = "default"
+description = """
+This building block rule (BBR) detects Linux Access Control List (ACL) modification via the setfacl command.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Access Control List Modification via setfacl"
+risk_score = 21
+rule_id = "999565a2-fc52-4d72-91e4-ba6712c0377e"
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Rule Type: BBR",
+    "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
+    "Data Source: Auditd Manager",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started") and
+process.name == "setfacl"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1222"
+name = "File and Directory Permissions Modification"
+reference = "https://attack.mitre.org/techniques/T1222/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1222.002"
+name = "Linux and Mac File and Directory Permissions Modification"
+reference = "https://attack.mitre.org/techniques/T1222/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"


### PR DESCRIPTION
## Summary
This BBR increases coverage for ACL modifications. This is not a malicious action but is used by malicious scripts (see [ref](https://www.uptycs.com/blog/threat-research-report-team/evasive-techniques-used-by-malicious-linux-shell-scripts)) to modify file attributes. 

This BBR is useful to just get an extra signal for instances where it might be used to evade detection. 