### PR TITLE
[New Rule] Root Certificate Installation

### DIFF
--- a/rules/linux/defense_evasion_root_certificate_installation.toml
+++ b/rules/linux/defense_evasion_root_certificate_installation.toml
@@ -13,7 +13,7 @@ in public key cryptography to identify a root certificate authority (CA). When a
 system or application will trust certificates in the root's chain of trust that have been signed by the root certificate.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.process*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Root Certificate Installation"

--- a/rules/linux/defense_evasion_root_certificate_installation.toml
+++ b/rules/linux/defense_evasion_root_certificate_installation.toml
@@ -1,0 +1,85 @@
+[metadata]
+creation_date = "2024/08/28"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/08/28"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the installation of root certificates on a Linux system. Adversaries may install a root certificate on
+a compromised system to avoid warnings when connecting to their command and control servers. Root certificates are used
+in public key cryptography to identify a root certificate authority (CA). When a root certificate is installed, the
+system or application will trust certificates in the root's chain of trust that have been signed by the root certificate.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Root Certificate Installation"
+references = ["https://github.com/redcanaryco/atomic-red-team/blob/f339e7da7d05f6057fdfcdd3742bfcf365fee2a9/atomics/T1553.004/T1553.004.md"]
+risk_score = 47
+rule_id = "6ded0996-7d4b-40f2-bf4a-6913e7591795"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Data Source: Elastic Defend",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where event.type == "start" and event.action == "exec" and
+process.name in ("update-ca-trust", "update-ca-certificates") and not (
+  process.parent.name : (
+    "ca-certificates.postinst", "ca-certificates-*.trigger", "pacman", "pamac-daemon", "autofirma.postinst"
+  ) or
+  process.parent.args : "/var/tmp/rpm*" or
+  (process.parent.name in ("sh", "bash", "zsh") and process.args == "-e")
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1553"
+name = "Subvert Trust Controls"
+reference = "https://attack.mitre.org/techniques/T1553/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1553.004"
+name = "Install Root Certificate"
+reference = "https://attack.mitre.org/techniques/T1553/004/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/linux/defense_evasion_root_certificate_installation.toml
+++ b/rules/linux/defense_evasion_root_certificate_installation.toml
@@ -56,7 +56,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where event.type == "start" and event.action == "exec" and
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.name in ("update-ca-trust", "update-ca-certificates") and not (
   process.parent.name : (
     "ca-certificates.postinst", "ca-certificates-*.trigger", "pacman", "pamac-daemon", "autofirma.postinst"


### PR DESCRIPTION
## Summary
This rule detects the installation of root certificates on a Linux system. Adversaries may install a root certificate on a compromised system to avoid warnings when connecting to their command and control servers. Root certificates are used in public key cryptography to identify a root certificate authority (CA). When a root certificate is installed, the system or application will trust certificates in the root's chain of trust that have been signed by the root certificate.

## Telemetry
3 hits in telemetry, only TPs in testing stack from e.g. a CVE installing a root certificate.

<img width="1499" alt="{B9305A13-8B00-4708-9A9E-7CC65B495108}" src="https://github.com/user-attachments/assets/e333480c-cc27-4249-945b-93a9edc3dc5d">

