### PR TITLE
[New Rule] SSL Certificate Deletion

### DIFF
--- a/rules/linux/defense_evasion_ssl_certificate_deletion.toml
+++ b/rules/linux/defense_evasion_ssl_certificate_deletion.toml
@@ -11,7 +11,7 @@ This rule detects the deletion of SSL certificates on a Linux system. Adversarie
 trust controls and negatively impact the system.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.file*"]
 language = "eql"
 license = "Elastic License v2"
 name = "SSL Certificate Deletion"

--- a/rules/linux/defense_evasion_ssl_certificate_deletion.toml
+++ b/rules/linux/defense_evasion_ssl_certificate_deletion.toml
@@ -54,8 +54,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where event.type == "deletion" and file.path : "/etc/ssl/certs/*" and file.extension in ("pem", "crt") and
-not process.name in ("dockerd", "pacman")
+file where host.os.type == "linux" and event.type == "deletion" and file.path : "/etc/ssl/certs/*" and
+file.extension in ("pem", "crt") and not process.name in ("dockerd", "pacman")
 '''
 
 [[rule.threat]]

--- a/rules/linux/defense_evasion_ssl_certificate_deletion.toml
+++ b/rules/linux/defense_evasion_ssl_certificate_deletion.toml
@@ -1,0 +1,95 @@
+[metadata]
+creation_date = "2024/08/28"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/08/28"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the deletion of SSL certificates on a Linux system. Adversaries may delete SSL certificates to subvert
+trust controls and negatively impact the system.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "SSL Certificate Deletion"
+risk_score = 21
+rule_id = "7957f3b9-f590-4062-b9f9-003c32bfc7d6"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Tactic: Impact",
+    "Data Source: Elastic Defend",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+file where event.type == "deletion" and file.path : "/etc/ssl/certs/*" and file.extension in ("pem", "crt") and
+not process.name in ("dockerd", "pacman")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1070"
+name = "Indicator Removal"
+reference = "https://attack.mitre.org/techniques/T1070/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1070.004"
+name = "File Deletion"
+reference = "https://attack.mitre.org/techniques/T1070/004/"
+
+[[rule.threat.technique]]
+id = "T1553"
+name = "Subvert Trust Controls"
+reference = "https://attack.mitre.org/techniques/T1553/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1485"
+name = "Data Destruction"
+reference = "https://attack.mitre.org/techniques/T1485/"
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"


### PR DESCRIPTION
## Summary
This rule detects the deletion of SSL certificates on a Linux system. Adversaries may delete SSL certificates to subvert trust controls and negatively impact the system.

## Telemetry
This behavior is not inherently malicious, so telemetry shows 70 hits last 90d. I bumped it to low, rather than BBR, because it is a note worthy event.

One TP in detonate stack:

<img width="1680" alt="{1DC55ADF-E31A-4B9E-A62D-57490A698948}" src="https://github.com/user-attachments/assets/77b76f4d-2882-43f0-9345-d22c18d403d4">
