### PR TITLE
[New Rule] Attempt to Disable Auditd Service

### DIFF
--- a/rules/linux/defense_evasion_attempt_to_disable_auditd_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_auditd_service.toml
@@ -1,0 +1,82 @@
+[metadata]
+creation_date = "2024/08/28"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/08/28"
+
+[rule]
+author = ["Elastic"]
+description = """
+Adversaries may attempt to disable the Auditd service in an attempt to evade detection. Auditd is a Linux service that
+provides system auditing and logging. Disabling the Auditd service can prevent the system from logging important
+security events, which can be used to detect malicious activity.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*", "endgame-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Attempt to Disable Auditd Service"
+risk_score = 21
+rule_id = "6a058ed6-4e9f-49f3-8f8e-f32165ae7ebf"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
+  (process.name == "service" and process.args == "stop") or
+  (process.name == "chkconfig" and process.args == "off") or
+  (process.name == "systemctl" and process.args in ("disable", "stop", "kill"))
+) and
+process.args in ("auditd", "auditd.service")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/linux/defense_evasion_attempt_to_disable_auditd_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_auditd_service.toml
@@ -12,7 +12,7 @@ provides system auditing and logging. Disabling the Auditd service can prevent t
 security events, which can be used to detect malicious activity.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.process*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Attempt to Disable Auditd Service"

--- a/rules/linux/defense_evasion_attempt_to_disable_auditd_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_auditd_service.toml
@@ -7,7 +7,7 @@ updated_date = "2024/08/28"
 [rule]
 author = ["Elastic"]
 description = """
-Adversaries may attempt to disable the Auditd service in an attempt to evade detection. Auditd is a Linux service that
+Adversaries may attempt to disable the Auditd service to evade detection. Auditd is a Linux service that
 provides system auditing and logging. Disabling the Auditd service can prevent the system from logging important
 security events, which can be used to detect malicious activity.
 """


### PR DESCRIPTION
## Summary
Adversaries may attempt to disable the Auditd service in an attempt to evade detection. Auditd is a Linux service that provides system auditing and logging. Disabling the Auditd service can prevent the system from logging important security events, which can be used to detect malicious activity.

## Telemetry
This rule is created as `low` severity, as it can be administrator activity as well. 

<img width="1508" alt="{43DB81AA-4238-4607-8A80-F6CCE54620E8}" src="https://github.com/user-attachments/assets/2b01f658-1647-4dd9-bd99-2cb6b81f348a">
