### PR TITLE
Update credential_access_suspicious_web_browser_sensitive_file_access…

### DIFF
--- a/rules/macos/credential_access_suspicious_web_browser_sensitive_file_access.toml
+++ b/rules/macos/credential_access_suspicious_web_browser_sensitive_file_access.toml
@@ -4,7 +4,7 @@ integration = ["endpoint"]
 maturity = "production"
 min_stack_comments = "New fields added: file_access_events, process.Ext.effective_parent"
 min_stack_version = "8.11.0"
-updated_date = "2024/05/17"
+updated_date = "2024/08/28"
 
 [rule]
 author = ["Elastic"]
@@ -60,7 +60,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
               "Login Data") and 
  ((process.code_signature.trusted == false or process.code_signature.exists == false) or process.name : "osascript") and 
  not process.code_signature.signing_id : "org.mozilla.firefox" and
- not process.Ext.effective_parent.executable : "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
+ not Effective_process.executable : "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
 '''
 
 


### PR DESCRIPTION
related discussion https://github.com/elastic/integrations/issues/10901#issue-2490392777 

the rule contains the correct index but the incorrect exclusion `process.Ext.effective_parent.executable` (replaced by `Effective_process.executable`).