### PR TITLE
[Rule Tuning] 3rd Party EDR Compatibility - 6

### DIFF
--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/01/19"
-integration = ["endpoint", "windows", "m365_defender"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/06/25"
+updated_date = "2024/11/07"
 
 [rule]
 author = ["Elastic"]
@@ -12,20 +12,12 @@ when the name or location of a file is manipulated as a means of tricking a user
 benign file type but is actually executable code.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.file-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-m365_defender.event-*"]
+index = ["winlogbeat-*", "logs-endpoint.events.file-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-m365_defender.event-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Executable File Creation with Multiple Extensions"
 risk_score = 47
 rule_id = "8b2b3a62-a598-4293-bc14-3d5fa22bb98f"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "medium"
 tags = [
     "Domain: Endpoint",
@@ -35,7 +27,8 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
-    "Data Source: Microsoft Defender for Endpoint"
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_from_unusual_directory.toml
+++ b/rules/windows/defense_evasion_from_unusual_directory.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/10/30"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/08/07"
+updated_date = "2024/11/07"
 
 [transform]
 [[transform.osquery]]
@@ -40,9 +40,12 @@ from = "now-9m"
 index = [
     "winlogbeat-*",
     "logs-endpoint.events.process-*",
-    "logs-windows.*",
+    "logs-windows.forwarded*",
+    "logs-windows.sysmon_operational-*",
     "endgame-*",
     "logs-system.security*",
+    "logs-m365_defender.event-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -104,14 +107,6 @@ This rule identifies processes that are executed from suspicious default Windows
 """
 risk_score = 47
 rule_id = "ebfe1448-7fac-4d59-acea-181bd89b1f7f"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "medium"
 tags = [
     "Domain: Endpoint",
@@ -121,6 +116,9 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: System",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -168,8 +166,6 @@ process where host.os.type == "windows" and event.type == "start" and
              "?:\\Users\\Public\\IBM\\ClientSolutions\\*.exe",
              "?:\\Users\\Public\\Documents\\syspin.exe",
              "?:\\Users\\Public\\res\\FileWatcher.exe")
- /* uncomment once in winlogbeat */
- /* and not (process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true) */
 '''
 
 

--- a/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
+++ b/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
@@ -1,10 +1,10 @@
 [metadata]
 creation_date = "2020/11/25"
-integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
 min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
 min_stack_version = "8.13.0"
-updated_date = "2024/08/07"
+updated_date = "2024/11/07"
 
 [rule]
 author = ["Elastic"]
@@ -13,14 +13,14 @@ Identifies registry write modifications to hide an encoded portable executable. 
 defense evasion by avoiding the storing of malicious content directly on disk.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.registry-*", "endgame-*", "logs-windows.sysmon_operational-*", "logs-sentinel_one_cloud_funnel.*", "winlogbeat-*"]
+index = ["logs-endpoint.events.registry-*", "endgame-*", "logs-windows.sysmon_operational-*", "logs-sentinel_one_cloud_funnel.*", "winlogbeat-*", "logs-m365_defender.event-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Encoded Executable Stored in the Registry"
 risk_score = 47
 rule_id = "93c1ce76-494c-4f01-8167-35edfb52f7b1"
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Defense Evasion", "Data Source: Elastic Endgame", "Data Source: Elastic Defend", "Data Source: Sysmon", "Data Source: SentinelOne"]
+tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Defense Evasion", "Data Source: Elastic Endgame", "Data Source: Elastic Defend", "Data Source: Sysmon", "Data Source: SentinelOne", "Data Source: Microsoft Defender for Endpoint"]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/defense_evasion_iis_httplogging_disabled.toml
+++ b/rules/windows/defense_evasion_iis_httplogging_disabled.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/04/14"
-integration = ["endpoint", "windows", "system"]
+integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/08/07"
+updated_date = "2024/11/07"
 
 [rule]
 author = ["Elastic"]
@@ -14,9 +14,12 @@ from = "now-9m"
 index = [
     "winlogbeat-*",
     "logs-endpoint.events.process-*",
-    "logs-windows.*",
+    "logs-windows.forwarded*",
+    "logs-windows.sysmon_operational-*",
     "endgame-*",
     "logs-system.security*",
+    "logs-m365_defender.event-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -58,14 +61,6 @@ This rule monitors commands that disable IIS logging.
 """
 risk_score = 73
 rule_id = "ebf1adea-ccf2-4943-8b96-7ab11ca173a5"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "high"
 tags = [
     "Domain: Endpoint",
@@ -76,6 +71,9 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: System",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
+++ b/rules/windows/defense_evasion_masquerading_as_elastic_endpoint_process.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/08/24"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/08/07"
+updated_date = "2024/11/07"
 
 [rule]
 author = ["Elastic"]
@@ -14,23 +14,18 @@ from = "now-9m"
 index = [
     "winlogbeat-*",
     "logs-endpoint.events.process-*",
-    "logs-windows.*",
+    "logs-windows.forwarded*",
+    "logs-windows.sysmon_operational-*",
     "endgame-*",
     "logs-system.security*",
+    "logs-m365_defender.event-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Endpoint Security Parent Process"
 risk_score = 47
 rule_id = "b41a13c6-ba45-4bab-a534-df53d0cfed6a"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "medium"
 tags = [
     "Domain: Endpoint",
@@ -40,6 +35,9 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: System",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
+++ b/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/09/01"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "m365_defender"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/11/07"
 
 [transform]
 [[transform.osquery]]
@@ -37,7 +37,7 @@ Identifies a suspicious AutoIt process execution. Malware written as an AutoIt s
 executable to avoid detection.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*"]
+index = ["winlogbeat-*", "logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-m365_defender.event-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Renamed AutoIt Scripts Interpreter"
@@ -93,14 +93,6 @@ This rule checks for renamed instances of AutoIt, which can indicate an attempt 
 """
 risk_score = 47
 rule_id = "2e1e835d-01e5-48ca-b9fc-7a61f7f11902"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "medium"
 tags = [
     "Domain: Endpoint",
@@ -111,6 +103,7 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: Microsoft Defender for Endpoint",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
+++ b/rules/windows/defense_evasion_masquerading_suspicious_werfault_childproc.toml
@@ -1,10 +1,10 @@
 [metadata]
 creation_date = "2020/08/24"
-integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
 min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
 min_stack_version = "8.13.0"
-updated_date = "2024/06/11"
+updated_date = "2024/11/07"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,14 @@ registry key manipulation. Verify process details such as command line, network 
 """
 false_positives = ["Custom Windows error reporting debugger or applications restarted by WerFault after a crash."]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.process-*", "logs-windows.*", "endgame-*", "logs-sentinel_one_cloud_funnel.*"]
+index = [
+    "winlogbeat-*",
+    "logs-endpoint.events.process-*",
+    "logs-windows.sysmon_operational-*",
+    "endgame-*",
+    "logs-sentinel_one_cloud_funnel.*",
+    "logs-m365_defender.event-*"
+  ]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious WerFault Child Process"
@@ -26,16 +33,20 @@ references = [
 ]
 risk_score = 47
 rule_id = "ac5012b8-8da8-440b-aaaf-aedafdea2dff"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "medium"
-tags = ["Domain: Endpoint", "OS: Windows", "Use Case: Threat Detection", "Tactic: Defense Evasion", "Tactic: Persistence", "Tactic: Privilege Escalation", "Data Source: Elastic Endgame", "Data Source: Elastic Defend", "Data Source: SentinelOne"]
+tags = [
+    "Domain: Endpoint",
+    "OS: Windows",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+    "Data Source: Elastic Endgame",
+    "Data Source: Elastic Defend",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Sysmon",
+    "Data Source: SentinelOne",
+]
 timestamp_override = "event.ingested"
 type = "eql"
 

--- a/rules/windows/defense_evasion_masquerading_trusted_directory.toml
+++ b/rules/windows/defense_evasion_masquerading_trusted_directory.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/18"
-integration = ["endpoint", "windows", "m365_defender"]
+integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/08/07"
+updated_date = "2024/11/07"
 
 [rule]
 author = ["Elastic"]
@@ -15,24 +15,18 @@ from = "now-9m"
 index = [
     "winlogbeat-*",
     "logs-endpoint.events.process-*",
-    "logs-windows.*",
+    "logs-windows.forwarded*",
+    "logs-windows.sysmon_operational-*",
     "endgame-*",
     "logs-system.security*",
-    "logs-m365_defender.event-*"
+    "logs-m365_defender.event-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
 name = "Program Files Directory Masquerading"
 risk_score = 47
 rule_id = "32c5cf9c-2ef8-4e87-819e-5ccb7cd18b14"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "medium"
 tags = [
     "Domain: Endpoint",
@@ -41,8 +35,10 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
-    "Data Source: Microsoft Defender for Endpoint",
     "Data Source: System",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_microsoft_defender_tampering.toml
+++ b/rules/windows/defense_evasion_microsoft_defender_tampering.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/10/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/08/05"
+updated_date = "2024/11/07"
 
 [rule]
 author = ["Austin Songer"]
@@ -12,7 +12,14 @@ Microsoft Defender features to evade detection and conceal malicious behavior.
 """
 false_positives = ["Legitimate Windows Defender configuration changes"]
 from = "now-9m"
-index = ["winlogbeat-*", "logs-endpoint.events.registry-*", "logs-windows.sysmon_operational-*"]
+index = [
+    "winlogbeat-*",
+    "logs-endpoint.events.registry-*",
+    "logs-windows.sysmon_operational-*",
+    "logs-m365_defender.event-*",
+    "logs-sentinel_one_cloud_funnel.*",
+    "endgame-*"
+]
 language = "eql"
 license = "Elastic License v2"
 name = "Microsoft Windows Defender Tampering"
@@ -65,14 +72,6 @@ references = [
 ]
 risk_score = 47
 rule_id = "fe794edd-487f-4a90-b285-3ee54f2af2d3"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "medium"
 tags = [
     "Domain: Endpoint",
@@ -82,6 +81,9 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -90,25 +92,15 @@ query = '''
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
   (
     (
-      registry.path : (
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\PUAProtection",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender Security Center\\App and Browser protection\\DisallowExploitProtectionOverride",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Features\\TamperProtection",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\Controlled Folder Access\\EnableControlledFolderAccess",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SpynetReporting",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SubmitSamplesConsent"
+      registry.value : (
+        "PUAProtection", "DisallowExploitProtectionOverride", "TamperProtection", "EnableControlledFolderAccess",
+        "SpynetReporting", "SubmitSamplesConsent"
       ) and registry.data.strings : ("0", "0x00000000")
     ) or
     (
       registry.path : (
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\DisableAntiSpyware",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableRealtimeMonitoring",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIntrusionPreventionSystem",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableScriptScanning",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIOAVProtection",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Reporting\\DisableEnhancedNotifications",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\DisableBlockAtFirstSeen",
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableBehaviorMonitoring"
+        "DisableAntiSpyware", "DisableRealtimeMonitoring", "DisableIntrusionPreventionSystem", "DisableScriptScanning",
+        "DisableIOAVProtection", "DisableEnhancedNotifications", "DisableBlockAtFirstSeen", "DisableBehaviorMonitoring"
       ) and registry.data.strings : ("1", "0x00000001")
     )
   ) and
@@ -118,6 +110,24 @@ registry where host.os.type == "windows" and event.type == "change" and process.
     "?:\\Windows\\System32\\DeviceEnroller.exe", 
     "?:\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe"
   )
+
+/*
+    Full registry key paths omitted due to data source variations:
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\DisableAntiSpyware"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableRealtimeMonitoring"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIntrusionPreventionSystem"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableScriptScanning"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableIOAVProtection"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Reporting\\DisableEnhancedNotifications"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\DisableBlockAtFirstSeen"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Real-Time Protection\\DisableBehaviorMonitoring"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\PUAProtection"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender Security Center\\App and Browser protection\\DisallowExploitProtectionOverride"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Features\\TamperProtection"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\Windows Defender Exploit Guard\\Controlled Folder Access\\EnableControlledFolderAccess"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SpynetReporting"
+    "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows Defender\\SpyNet\\SubmitSamplesConsent"
+*/
 '''
 
 

--- a/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
+++ b/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2022/01/12"
-integration = ["windows"]
+integration = ["windows", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/08/05"
+updated_date = "2024/11/07"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Macros. Adversaries may abuse these security settings to modify the default beha
 future macros and/or disable security warnings, which could increase their chances of establishing persistence.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.sysmon_operational-*", "endgame-*"]
+index = ["winlogbeat-*", "logs-windows.sysmon_operational-*", "endgame-*", "logs-m365_defender.event-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "MS Office Macro Security Registry Modifications"
@@ -65,14 +65,6 @@ This rule looks for registry changes affecting the conditions above.
 """
 risk_score = 47
 rule_id = "feeed87c-5e95-4339-aef1-47fd79bcfbe3"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "medium"
 tags = [
     "Domain: Endpoint",
@@ -82,6 +74,8 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Endgame",
     "Data Source: Sysmon",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -89,14 +83,26 @@ type = "eql"
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("AccessVBOM", "VbaWarnings") and
     registry.path : (
+        /* Sysmon */
         "HKU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
         "HKU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
         "HKU\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
         "HKU\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
+        /* MDE */
+        "HKCU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
+        "HKCU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
+        "HKCU\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
+        "HKCU\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
+        /* Endgame */
         "\\REGISTRY\\USER\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
         "\\REGISTRY\\USER\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
         "\\REGISTRY\\USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "\\REGISTRY\\USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings"
+        "\\REGISTRY\\USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
+        /* SentinelOne */
+        "USER\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
+        "USER\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
+        "USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
+        "USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings"
         ) and
     registry.data.strings : ("0x00000001", "1")
 '''


### PR DESCRIPTION
## Issues

* https://github.com/elastic/ia-trade-team/issues/406
* https://github.com/elastic/ia-trade-team/issues/407

## Summary

Adjusts to rules to introduce or improve compatibility and documentation with 3rd party data such as Sysmon, MDE, and S1.

EDR field compatibility matrix: https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing

## Blocker

To use SentinelOne cloud funnel data right now, we would need to min_stack the rules to 8.13, so we are going to hold off on merging these until 8.16 is released and support for 8.12 is dropped. The updated_date is set to the 8.16 public release date.