### PR TITLE
Support toml lint for investigate transforms

### DIFF
--- a/detection_rules/etc/test_cli.bash
+++ b/detection_rules/etc/test_cli.bash
@@ -28,6 +28,9 @@ python -m detection_rules dev schemas update-rule-data
 echo "Validating rule: execution_github_new_event_action_for_pat.toml"
 python -m detection_rules validate-rule rules_building_block/execution_github_new_event_action_for_pat.toml
 
+echo "Linting Rule: execution_github_new_event_action_for_pat.toml"
+python -m detection_rules toml-lint -f rules_building_block/execution_github_new_event_action_for_pat.toml
+
 echo "Checking licenses"
 python -m detection_rules dev license-check
 

--- a/detection_rules/etc/test_cli.bash
+++ b/detection_rules/etc/test_cli.bash
@@ -28,8 +28,8 @@ python -m detection_rules dev schemas update-rule-data
 echo "Validating rule: execution_github_new_event_action_for_pat.toml"
 python -m detection_rules validate-rule rules_building_block/execution_github_new_event_action_for_pat.toml
 
-echo "Linting Rule: execution_github_new_event_action_for_pat.toml"
-python -m detection_rules toml-lint -f rules_building_block/execution_github_new_event_action_for_pat.toml
+echo "Linting Rule: command_and_control_common_webservices.toml"
+python -m detection_rules toml-lint -f rules/windows/command_and_control_common_webservices.toml
 
 echo "Checking licenses"
 python -m detection_rules dev license-check

--- a/detection_rules/etc/test_toml.json
+++ b/detection_rules/etc/test_toml.json
@@ -115,5 +115,52 @@
         }
       }
     }
+  },
+  {
+    "metadata": {
+      "just": "some",
+      "flat": "fields",
+      "for": "testing"
+    },
+    "transform": {
+        "osquery": [
+            {
+                "label": "some label",
+                "query": "some query"
+            },
+            {
+              "label": "some label",
+              "query": "some query"
+            },
+            {
+              "label": "some label",
+              "query": "some query"
+            }
+        ],
+        "investigate": [
+            {
+                "label": "some label",
+                "relativeFrom": "now-48h/h",
+                "relativeTo": "now",
+                "providers": [
+                    [
+                        {"field": "event.kind", "excluded": false, "queryType": "phrase", "value": "signal", "valueType": "string"},
+                        {"field": "user.id", "excluded": false, "queryType": "phrase", "value": "{{user.id}}", "valueType": "string"}
+                    ]
+                ]
+            },
+            {
+                "label": "some label",
+                "relativeFrom": "now-48h/h",
+                "relativeTo": "now",
+                "providers": [
+                    [
+                        {"field": "event.kind", "excluded": false, "queryType": "phrase", "value": "signal", "valueType": "string"},
+                        {"field": "host.name", "excluded": false, "queryType": "phrase", "value": "{{host.name}}", "valueType": "string"}
+                    ]
+                ]
+            }
+        ]
+    }
   }
 ]

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -160,14 +160,14 @@ class RuleTomlEncoder(toml.TomlEncoder):
                 else:
                     dump.append(' ' * 4 + self.dump_value(item))
             return '[\n{},\n]'.format(',\n'.join(dump))
-        
+
         if all(isinstance(i, dict) for i in v):
             # Compact inline format for lists of dictionaries with proper indentation
             retval = "\n" + ' ' * 2 + "[\n"
-            retval += ",\n".join([' ' * 4 + self.dump_inline_table(u).strip() for u in v]) 
+            retval += ",\n".join([' ' * 4 + self.dump_inline_table(u).strip() for u in v])
             retval += "\n" + ' ' * 2 + "]\n"
             return retval
-        
+
         return self._dump_flat_list(v)
 
 

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -160,6 +160,14 @@ class RuleTomlEncoder(toml.TomlEncoder):
                 else:
                     dump.append(' ' * 4 + self.dump_value(item))
             return '[\n{},\n]'.format(',\n'.join(dump))
+        
+        if all(isinstance(i, dict) for i in v):
+            # Compact inline format for lists of dictionaries with proper indentation
+            retval = "\n" + ' ' * 2 + "[\n"
+            retval += ",\n".join([' ' * 4 + self.dump_inline_table(u).strip() for u in v]) 
+            retval += "\n" + ' ' * 2 + "]\n"
+            return retval
+        
         return self._dump_flat_list(v)
 
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/4033

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

- Added a code condition to handle  lists of dictionaries in toml linting.
- Also added toml-lint commands to `test_cli.bash` script
- Update the test_toml.json to include transform fields

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

- Try to run toml-lint on the rule with transform.investigate fields 
   `python -m detection_rules toml-lint -f rules/windows/command_and_control_common_webservices.toml`
<details><summary>No Errors Found</summary>
<p>

```console
❯ python -m detection_rules toml-lint -f rules/windows/command_and_control_remote_file_copy_powershell.toml       
Loaded config file: /Users/shashankks/elastic_workspace/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

TOML file linting complete
(.venv) 
detection-rules on  issue-4033 [$!?] is 📦 v0.1.0 via 🐍 v3.12.5 (.venv) on ☁️  shashank.suryanarayana@elastic.co 
❯ 
```

![image](https://github.com/user-attachments/assets/eb5cff41-9384-4fc2-959d-41d1afac13cb)

</p>
</details> 

- Try toml-lint on any existing rule without investigate transforms to check existing behaviour
<details><summary>Existing Functionality is not broken</summary>
<p>

```console
❯ python -m detection_rules toml-lint -f rules/linux/persistence_setuid_setgid_capability_set.toml         
Loaded config file: /Users/shashankks/elastic_workspace/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

TOML file linting complete
(.venv) 
detection-rules on  issue-4033 [$?] is 📦 v0.1.0 via 🐍 v3.12.5 (.venv) on ☁️  shashank.suryanarayana@elastic.co 
❯ 
```

No changes detected

![image](https://github.com/user-attachments/assets/fbfba86c-48b6-47a3-a3bb-de8c92792978)


</p>
</details>  
## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
