### PR TITLE
Revert "[Bug] Handle formatting empty list"

### DIFF
--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -161,7 +161,7 @@ class RuleTomlEncoder(toml.TomlEncoder):
                     dump.append(' ' * 4 + self.dump_value(item))
             return '[\n{},\n]'.format(',\n'.join(dump))
 
-        if v and all(isinstance(i, dict) for i in v):
+        if all(isinstance(i, dict) for i in v):
             # Compact inline format for lists of dictionaries with proper indentation
             retval = "\n" + ' ' * 2 + "[\n"
             retval += ",\n".join([' ' * 4 + self.dump_inline_table(u).strip() for u in v])


### PR DESCRIPTION
Reverts elastic/detection-rules#4086

This technically introduced a bug and will create opaque issues - most specifically when dumping a rule with empty lists then reparsing them (if required by the schema)

details:

https://github.com/elastic/detection-rules/pull/4086#issuecomment-2356772048