### PR TITLE
[Rule Tuning] AWS STS GetCallerIdentity API Called for the First Time

### DIFF
--- a/rules/integrations/aws/discovery_new_terms_sts_getcalleridentity.toml
+++ b/rules/integrations/aws/discovery_new_terms_sts_getcalleridentity.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/05/24"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2024/05/24"
+updated_date = "2024/09/30"
 
 [rule]
 author = ["Elastic"]
@@ -93,7 +93,8 @@ timestamp_override = "event.ingested"
 type = "new_terms"
 
 query = '''
-event.dataset:"aws.cloudtrail" and event.provider:"sts.amazonaws.com" and event.action:"GetCallerIdentity"
+event.dataset: "aws.cloudtrail" and event.provider: "sts.amazonaws.com" and event.action: "GetCallerIdentity"
+and not aws.cloudtrail.user_identity.type: "AssumedRole"
 '''
 
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: https://github.com/elastic/ia-trade-team/issues/458 

## Summary - What I changed

Tuning this rule to exclude identity type `AssumedRole` as this is too common a behavior, often automated, and used to verify current identity and role assumptions. Therefore it is not as indicative of suspicious behavior when used by assumed roles. This rule will still trigger for `IAMUser` and `FederatedUser` identity types. In telemetry this change reduces alerts from ~240,000 to 43 in the last 30 days.




<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->
<details><summary>Screenshot to show valid query</summary>
<p>

<img width="1545" alt="image" src="https://github.com/user-attachments/assets/ed119851-6ab2-4435-b4cf-eee20cd34351">


</p>
</details> 


