### PR TITLE
[New Rules] CVE-2024-x.x.x.x.x (CUPS/Foomatic-RIP RCE)

### DIFF
--- a/rules/linux/command_and_control_cupsd_foomatic_rip_netcon.toml
+++ b/rules/linux/command_and_control_cupsd_foomatic_rip_netcon.toml
@@ -112,8 +112,10 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=10s
   [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-   process.parent.name == "foomatic-rip" andprocess.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")] by process.entity_id
-  [network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted"] by process.parent.entity_id
+   process.parent.name == "foomatic-rip" and
+   process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")] by process.entity_id
+  [network where host.os.type == "linux" and event.type == "start" and
+   event.action == "connection_attempted"] by process.parent.entity_id
 '''
 
 [[rule.threat]]

--- a/rules/linux/command_and_control_cupsd_foomatic_rip_netcon.toml
+++ b/rules/linux/command_and_control_cupsd_foomatic_rip_netcon.toml
@@ -1,0 +1,154 @@
+[metadata]
+creation_date = "2024/09/27"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/09/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+This detection rule addresses multiple vulnerabilities in the CUPS printing system, including CVE-2024-47176,
+CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177. Specifically, this rule detects network connections initiated by a
+child processes of foomatic-rip. These flaws impact components like cups-browsed, libcupsfilters, libppd, and
+foomatic-rip, allowing remote unauthenticated attackers to manipulate IPP URLs or inject malicious data through crafted
+UDP packets or network spoofing. This can result in arbitrary command execution when a print job is initiated.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Network Connection by Cups or Foomatic-rip Child"
+note = """## Triage and analysis
+
+### Investigating Network Connection by Cups or Foomatic-rip Child
+
+This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the incoming IPP requests or UDP packets targeting port 631.
+- Examine the printer configurations on the system to determine if any unauthorized printers or URLs have been added.
+- Investigate the process tree to check if any unexpected processes were triggered as a result of IPP activity. Review the executable files for legitimacy.
+- Check for additional alerts related to the compromised system or user within the last 48 hours.
+- Investigate network traffic logs for suspicious outbound connections to unrecognized domains or IP addresses.
+- Check if any of the contacted domains or addresses are newly registered or have a suspicious reputation.
+- Retrieve any scripts or executables dropped by the attack for further analysis in a private sandbox environment:
+- Analyze potential malicious activity, including:
+  - Attempts to communicate with external servers.
+  - File access or creation of unauthorized executables.
+  - Cron jobs, services, or other persistence mechanisms.
+
+### Related Rules
+- Cupsd or Foomatic-rip Shell Execution - 476267ff-e44f-476e-99c1-04c78cb3769d
+- Printer User (lp) Shell Execution - f86cd31c-5c7e-4481-99d7-6875a3e31309
+- Suspicious Execution from Foomatic-rip or Cupsd Parent - 986361cd-3dac-47fe-afa1-5c5dd89f2fb4
+- File Creation by Cups or Foomatic-rip Child - b9b14be7-b7f4-4367-9934-81f07d2f63c4
+
+### False Positive Analysis
+
+- This activity is rarely legitimate. However, verify the context to rule out non-malicious printer configuration changes or legitimate IPP requests.
+
+### Response and Remediation
+
+- Initiate the incident response process based on the triage outcome.
+- Isolate the compromised host to prevent further exploitation.
+- If the investigation confirms malicious activity, search the environment for additional compromised hosts.
+- Implement network segmentation or restrictions to contain the attack.
+- Stop suspicious processes or services tied to CUPS exploitation.
+- Block identified Indicators of Compromise (IoCs), including IP addresses, domains, or hashes of involved files.
+- Review compromised systems for backdoors, such as reverse shells or persistence mechanisms like cron jobs.
+- Investigate potential credential exposure on compromised systems and reset passwords for any affected accounts.
+- Restore the original printer configurations or uninstall unauthorized printer entries.
+- Perform a thorough antimalware scan to identify any lingering threats or artifacts from the attack.
+- Investigate how the attacker gained initial access and address any weaknesses to prevent future exploitation.
+- Use insights from the incident to improve detection and response times in future incidents (MTTD and MTTR).
+"""
+references = [
+    "https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/",
+    "https://gist.github.com/stong/c8847ef27910ae344a7b5408d9840ee1",
+    "https://github.com/RickdeJager/cupshax/blob/main/cupshax.py",
+]
+risk_score = 73
+rule_id = "e80ee207-9505-49ab-8ca8-bc57d80e2cab"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Use Case: Vulnerability",
+    "Tactic: Command and Control",
+    "Data Source: Elastic Defend",
+]
+type = "eql"
+query = '''
+sequence by host.id with maxspan=10s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+   process.parent.name == "foomatic-rip" andprocess.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")] by process.entity_id
+  [network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted"] by process.parent.entity_id
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1203"
+name = "Exploitation for Client Execution"
+reference = "https://attack.mitre.org/techniques/T1203/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"

--- a/rules/linux/command_and_control_cupsd_foomatic_rip_netcon.toml
+++ b/rules/linux/command_and_control_cupsd_foomatic_rip_netcon.toml
@@ -24,10 +24,6 @@ note = """## Triage and analysis
 
 This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
 
-> **Note**:
-> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
-
 #### Possible Investigation Steps
 
 - Investigate the incoming IPP requests or UDP packets targeting port 631.

--- a/rules/linux/execution_cupsd_foomatic_rip_file_creation.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_file_creation.toml
@@ -1,0 +1,132 @@
+[metadata]
+creation_date = "2024/09/27"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/09/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+This detection rule addresses multiple vulnerabilities in the CUPS printing system, including CVE-2024-47176,
+CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177. Specifically, this rule detects suspicious file creation events
+executed by child processes of foomatic-rip. These flaws impact components like cups-browsed, libcupsfilters, libppd,
+and foomatic-rip, allowing remote unauthenticated attackers to manipulate IPP URLs or inject malicious data through
+crafted UDP packets or network spoofing. This can result in arbitrary command execution when a print job is initiated.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "File Creation by Cups or Foomatic-rip Child"
+note = """## Triage and analysis
+
+### Investigating File Creation by Cups or Foomatic-rip Child
+
+This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the incoming IPP requests or UDP packets targeting port 631.
+- Examine the printer configurations on the system to determine if any unauthorized printers or URLs have been added.
+- Investigate the process tree to check if any unexpected processes were triggered as a result of IPP activity. Review the executable files for legitimacy.
+- Check for additional alerts related to the compromised system or user within the last 48 hours.
+- Investigate network traffic logs for suspicious outbound connections to unrecognized domains or IP addresses.
+- Check if any of the contacted domains or addresses are newly registered or have a suspicious reputation.
+- Retrieve any scripts or executables dropped by the attack for further analysis in a private sandbox environment:
+- Analyze potential malicious activity, including:
+  - Attempts to communicate with external servers.
+  - File access or creation of unauthorized executables.
+  - Cron jobs, services, or other persistence mechanisms.
+
+### Related Rules
+- Cupsd or Foomatic-rip Shell Execution - 476267ff-e44f-476e-99c1-04c78cb3769d
+- Printer User (lp) Shell Execution - f86cd31c-5c7e-4481-99d7-6875a3e31309
+- Network Connection by Cups or Foomatic-rip Child - e80ee207-9505-49ab-8ca8-bc57d80e2cab
+- Suspicious Execution from Foomatic-rip or Cupsd Parent - 986361cd-3dac-47fe-afa1-5c5dd89f2fb4
+
+### False Positive Analysis
+
+- This activity is rarely legitimate. However, verify the context to rule out non-malicious printer configuration changes or legitimate IPP requests.
+
+### Response and Remediation
+
+- Initiate the incident response process based on the triage outcome.
+- Isolate the compromised host to prevent further exploitation.
+- If the investigation confirms malicious activity, search the environment for additional compromised hosts.
+- Implement network segmentation or restrictions to contain the attack.
+- Stop suspicious processes or services tied to CUPS exploitation.
+- Block identified Indicators of Compromise (IoCs), including IP addresses, domains, or hashes of involved files.
+- Review compromised systems for backdoors, such as reverse shells or persistence mechanisms like cron jobs.
+- Investigate potential credential exposure on compromised systems and reset passwords for any affected accounts.
+- Restore the original printer configurations or uninstall unauthorized printer entries.
+- Perform a thorough antimalware scan to identify any lingering threats or artifacts from the attack.
+- Investigate how the attacker gained initial access and address any weaknesses to prevent future exploitation.
+- Use insights from the incident to improve detection and response times in future incidents (MTTD and MTTR).
+"""
+references = [
+    "https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/",
+    "https://gist.github.com/stong/c8847ef27910ae344a7b5408d9840ee1",
+    "https://github.com/RickdeJager/cupshax/blob/main/cupshax.py",
+]
+risk_score = 73
+rule_id = "b9b14be7-b7f4-4367-9934-81f07d2f63c4"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Use Case: Vulnerability",
+    "Tactic: Execution",
+    "Data Source: Elastic Defend",
+]
+type = "eql"
+query = '''
+sequence by host.id with maxspan=10s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+   process.parent.name == "foomatic-rip" and
+   process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")] by process.entity_id
+  [file where host.os.type == "linux" and event.type != "deletion" and
+   not (process.name == "gs" and file.path like "/tmp/gs_*")] by process.parent.entity_id
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1203"
+name = "Exploitation for Client Execution"
+reference = "https://attack.mitre.org/techniques/T1203/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"

--- a/rules/linux/execution_cupsd_foomatic_rip_file_creation.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_file_creation.toml
@@ -24,10 +24,6 @@ note = """## Triage and analysis
 
 This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
 
-> **Note**:
-> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
-
 #### Possible Investigation Steps
 
 - Investigate the incoming IPP requests or UDP packets targeting port 631.

--- a/rules/linux/execution_cupsd_foomatic_rip_lp_user_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_lp_user_execution.toml
@@ -9,9 +9,10 @@ author = ["Elastic"]
 description = """
 This detection rule addresses multiple vulnerabilities in the CUPS printing system, including CVE-2024-47176,
 CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177. Specifically, this rule detects shell executions from the foomatic-rip
-parent process. These flaws impact components like cups-browsed, libcupsfilters, libppd, and foomatic-rip, allowing
-remote unauthenticated attackers to manipulate IPP URLs or inject malicious data through crafted UDP packets or network
-spoofing. This can result in arbitrary command execution when a print job is initiated.
+parent process through the default printer user (lp). These flaws impact components like cups-browsed, libcupsfilters,
+libppd, and foomatic-rip, allowing remote unauthenticated attackers to manipulate IPP URLs or inject malicious data
+through crafted UDP packets or network spoofing. This can result in arbitrary command execution when a print job is
+initiated.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*"]

--- a/rules/linux/execution_cupsd_foomatic_rip_lp_user_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_lp_user_execution.toml
@@ -1,0 +1,131 @@
+[metadata]
+creation_date = "2024/09/27"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/09/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+This detection rule addresses multiple vulnerabilities in the CUPS printing system, including CVE-2024-47176,
+CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177. Specifically, this rule detects shell executions from the foomatic-rip
+parent process. These flaws impact components like cups-browsed, libcupsfilters, libppd, and foomatic-rip, allowing
+remote unauthenticated attackers to manipulate IPP URLs or inject malicious data through crafted UDP packets or network
+spoofing. This can result in arbitrary command execution when a print job is initiated.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Printer User (lp) Shell Execution"
+note = """## Triage and analysis
+
+### Investigating Printer User (lp) Shell Execution
+
+This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the incoming IPP requests or UDP packets targeting port 631.
+- Examine the printer configurations on the system to determine if any unauthorized printers or URLs have been added.
+- Investigate the process tree to check if any unexpected processes were triggered as a result of IPP activity. Review the executable files for legitimacy.
+- Check for additional alerts related to the compromised system or user within the last 48 hours.
+- Investigate network traffic logs for suspicious outbound connections to unrecognized domains or IP addresses.
+- Check if any of the contacted domains or addresses are newly registered or have a suspicious reputation.
+- Retrieve any scripts or executables dropped by the attack for further analysis in a private sandbox environment:
+- Analyze potential malicious activity, including:
+  - Attempts to communicate with external servers.
+  - File access or creation of unauthorized executables.
+  - Cron jobs, services, or other persistence mechanisms.
+
+### Related Rules
+- Cupsd or Foomatic-rip Shell Execution - 476267ff-e44f-476e-99c1-04c78cb3769d
+- Network Connection by Cups or Foomatic-rip Child - e80ee207-9505-49ab-8ca8-bc57d80e2cab
+- File Creation by Cups or Foomatic-rip Child - b9b14be7-b7f4-4367-9934-81f07d2f63c4
+- Suspicious Execution from Foomatic-rip or Cupsd Parent - 986361cd-3dac-47fe-afa1-5c5dd89f2fb4
+
+### False Positive Analysis
+
+- This activity is rarely legitimate. However, verify the context to rule out non-malicious printer configuration changes or legitimate IPP requests.
+
+### Response and Remediation
+
+- Initiate the incident response process based on the triage outcome.
+- Isolate the compromised host to prevent further exploitation.
+- If the investigation confirms malicious activity, search the environment for additional compromised hosts.
+- Implement network segmentation or restrictions to contain the attack.
+- Stop suspicious processes or services tied to CUPS exploitation.
+- Block identified Indicators of Compromise (IoCs), including IP addresses, domains, or hashes of involved files.
+- Review compromised systems for backdoors, such as reverse shells or persistence mechanisms like cron jobs.
+- Investigate potential credential exposure on compromised systems and reset passwords for any affected accounts.
+- Restore the original printer configurations or uninstall unauthorized printer entries.
+- Perform a thorough antimalware scan to identify any lingering threats or artifacts from the attack.
+- Investigate how the attacker gained initial access and address any weaknesses to prevent future exploitation.
+- Use insights from the incident to improve detection and response times in future incidents (MTTD and MTTR).
+"""
+references = [
+    "https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/",
+    "https://gist.github.com/stong/c8847ef27910ae344a7b5408d9840ee1",
+    "https://github.com/RickdeJager/cupshax/blob/main/cupshax.py",
+]
+risk_score = 73
+rule_id = "f86cd31c-5c7e-4481-99d7-6875a3e31309"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Use Case: Vulnerability",
+    "Tactic: Execution",
+    "Data Source: Elastic Defend",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and user.name == "lp" and
+process.parent.name in ("cupsd", "foomatic-rip", "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+not process.command_line like ("*/tmp/foomatic-*", "*-sDEVICE=ps2write*")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1203"
+name = "Exploitation for Client Execution"
+reference = "https://attack.mitre.org/techniques/T1203/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"

--- a/rules/linux/execution_cupsd_foomatic_rip_lp_user_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_lp_user_execution.toml
@@ -25,10 +25,6 @@ note = """## Triage and analysis
 
 This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
 
-> **Note**:
-> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
-
 #### Possible Investigation Steps
 
 - Investigate the incoming IPP requests or UDP packets targeting port 631.

--- a/rules/linux/execution_cupsd_foomatic_rip_shell_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_shell_execution.toml
@@ -1,0 +1,131 @@
+[metadata]
+creation_date = "2024/09/27"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/09/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+This detection rule addresses multiple vulnerabilities in the CUPS printing system, including CVE-2024-47176,
+CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177. Specifically, this rule detects shell executions from the foomatic-rip
+parent process. These flaws impact components like cups-browsed, libcupsfilters, libppd, and foomatic-rip, allowing
+remote unauthenticated attackers to manipulate IPP URLs or inject malicious data through crafted UDP packets or network
+spoofing. This can result in arbitrary command execution when a print job is initiated.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Cupsd or Foomatic-rip Shell Execution"
+note = """## Triage and analysis
+
+### Investigating Cupsd or Foomatic-rip Shell Execution
+
+This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the incoming IPP requests or UDP packets targeting port 631.
+- Examine the printer configurations on the system to determine if any unauthorized printers or URLs have been added.
+- Investigate the process tree to check if any unexpected processes were triggered as a result of IPP activity. Review the executable files for legitimacy.
+- Check for additional alerts related to the compromised system or user within the last 48 hours.
+- Investigate network traffic logs for suspicious outbound connections to unrecognized domains or IP addresses.
+- Check if any of the contacted domains or addresses are newly registered or have a suspicious reputation.
+- Retrieve any scripts or executables dropped by the attack for further analysis in a private sandbox environment:
+- Analyze potential malicious activity, including:
+  - Attempts to communicate with external servers.
+  - File access or creation of unauthorized executables.
+  - Cron jobs, services, or other persistence mechanisms.
+
+### Related Rules
+- Printer User (lp) Shell Execution - f86cd31c-5c7e-4481-99d7-6875a3e31309
+- Network Connection by Cups or Foomatic-rip Child - e80ee207-9505-49ab-8ca8-bc57d80e2cab
+- File Creation by Cups or Foomatic-rip Child - b9b14be7-b7f4-4367-9934-81f07d2f63c4
+- Suspicious Execution from Foomatic-rip or Cupsd Parent - 986361cd-3dac-47fe-afa1-5c5dd89f2fb4
+
+### False Positive Analysis
+
+- This activity is rarely legitimate. However, verify the context to rule out non-malicious printer configuration changes or legitimate IPP requests.
+
+### Response and Remediation
+
+- Initiate the incident response process based on the triage outcome.
+- Isolate the compromised host to prevent further exploitation.
+- If the investigation confirms malicious activity, search the environment for additional compromised hosts.
+- Implement network segmentation or restrictions to contain the attack.
+- Stop suspicious processes or services tied to CUPS exploitation.
+- Block identified Indicators of Compromise (IoCs), including IP addresses, domains, or hashes of involved files.
+- Review compromised systems for backdoors, such as reverse shells or persistence mechanisms like cron jobs.
+- Investigate potential credential exposure on compromised systems and reset passwords for any affected accounts.
+- Restore the original printer configurations or uninstall unauthorized printer entries.
+- Perform a thorough antimalware scan to identify any lingering threats or artifacts from the attack.
+- Investigate how the attacker gained initial access and address any weaknesses to prevent future exploitation.
+- Use insights from the incident to improve detection and response times in future incidents (MTTD and MTTR).
+"""
+references = [
+    "https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/",
+    "https://gist.github.com/stong/c8847ef27910ae344a7b5408d9840ee1",
+    "https://github.com/RickdeJager/cupshax/blob/main/cupshax.py",
+]
+risk_score = 73
+rule_id = "476267ff-e44f-476e-99c1-04c78cb3769d"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Use Case: Vulnerability",
+    "Tactic: Execution",
+    "Data Source: Elastic Defend",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process.parent.name == "foomatic-rip" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+not process.command_line like ("*/tmp/foomatic-*", "*-sDEVICE=ps2write*")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1203"
+name = "Exploitation for Client Execution"
+reference = "https://attack.mitre.org/techniques/T1203/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"

--- a/rules/linux/execution_cupsd_foomatic_rip_shell_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_shell_execution.toml
@@ -24,10 +24,6 @@ note = """## Triage and analysis
 
 This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
 
-> **Note**:
-> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
-
 #### Possible Investigation Steps
 
 - Investigate the incoming IPP requests or UDP packets targeting port 631.

--- a/rules/linux/execution_cupsd_foomatic_rip_suspicious_child_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_suspicious_child_execution.toml
@@ -25,10 +25,6 @@ note = """## Triage and analysis
 
 This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
 
-> **Note**:
-> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
-> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
-
 #### Possible Investigation Steps
 
 - Investigate the incoming IPP requests or UDP packets targeting port 631.

--- a/rules/linux/execution_cupsd_foomatic_rip_suspicious_child_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_suspicious_child_execution.toml
@@ -1,0 +1,152 @@
+[metadata]
+creation_date = "2024/09/27"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2024/09/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+This detection rule addresses multiple vulnerabilities in the CUPS printing system, including CVE-2024-47176,
+CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177. Specifically, this rule detects suspicious process command lines
+executed by child processes of foomatic-rip and cupsd. These flaws impact components like cups-browsed, libcupsfilters,
+libppd, and foomatic-rip, allowing remote unauthenticated attackers to manipulate IPP URLs or inject malicious data
+through crafted UDP packets or network spoofing. This can result in arbitrary command execution when a print job is
+initiated.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Suspicious Execution from Foomatic-rip or Cupsd Parent"
+note = """## Triage and analysis
+
+### Investigating Suspicious Execution from Foomatic-rip or Cupsd Parent
+
+This rule identifies potential exploitation attempts of several vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, CVE-2024-47177). These vulnerabilities allow attackers to send crafted IPP requests or manipulate UDP packets to execute arbitrary commands or modify printer configurations. Attackers can exploit these flaws to inject malicious data, leading to Remote Code Execution (RCE) on affected systems.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/master/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+> This investigation guide uses [placeholder fields](https://www.elastic.co/guide/en/security/current/osquery-placeholder-fields.html) to dynamically pass alert data into Osquery queries. Placeholder fields were introduced in Elastic Stack version 8.7.0. If you're using Elastic Stack version 8.6.0 or earlier, you'll need to manually adjust this investigation guide's queries to ensure they properly run.
+
+#### Possible Investigation Steps
+
+- Investigate the incoming IPP requests or UDP packets targeting port 631.
+- Examine the printer configurations on the system to determine if any unauthorized printers or URLs have been added.
+- Investigate the process tree to check if any unexpected processes were triggered as a result of IPP activity. Review the executable files for legitimacy.
+- Check for additional alerts related to the compromised system or user within the last 48 hours.
+- Investigate network traffic logs for suspicious outbound connections to unrecognized domains or IP addresses.
+- Check if any of the contacted domains or addresses are newly registered or have a suspicious reputation.
+- Retrieve any scripts or executables dropped by the attack for further analysis in a private sandbox environment:
+- Analyze potential malicious activity, including:
+  - Attempts to communicate with external servers.
+  - File access or creation of unauthorized executables.
+  - Cron jobs, services, or other persistence mechanisms.
+
+### Related Rules
+- Cupsd or Foomatic-rip Shell Execution - 476267ff-e44f-476e-99c1-04c78cb3769d
+- Printer User (lp) Shell Execution - f86cd31c-5c7e-4481-99d7-6875a3e31309
+- Network Connection by Cups or Foomatic-rip Child - e80ee207-9505-49ab-8ca8-bc57d80e2cab
+- File Creation by Cups or Foomatic-rip Child - b9b14be7-b7f4-4367-9934-81f07d2f63c4
+
+### False Positive Analysis
+
+- This activity is rarely legitimate. However, verify the context to rule out non-malicious printer configuration changes or legitimate IPP requests.
+
+### Response and Remediation
+
+- Initiate the incident response process based on the triage outcome.
+- Isolate the compromised host to prevent further exploitation.
+- If the investigation confirms malicious activity, search the environment for additional compromised hosts.
+- Implement network segmentation or restrictions to contain the attack.
+- Stop suspicious processes or services tied to CUPS exploitation.
+- Block identified Indicators of Compromise (IoCs), including IP addresses, domains, or hashes of involved files.
+- Review compromised systems for backdoors, such as reverse shells or persistence mechanisms like cron jobs.
+- Investigate potential credential exposure on compromised systems and reset passwords for any affected accounts.
+- Restore the original printer configurations or uninstall unauthorized printer entries.
+- Perform a thorough antimalware scan to identify any lingering threats or artifacts from the attack.
+- Investigate how the attacker gained initial access and address any weaknesses to prevent future exploitation.
+- Use insights from the incident to improve detection and response times in future incidents (MTTD and MTTR).
+"""
+references = [
+    "https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/",
+    "https://gist.github.com/stong/c8847ef27910ae344a7b5408d9840ee1",
+    "https://github.com/RickdeJager/cupshax/blob/main/cupshax.py",
+]
+risk_score = 73
+rule_id = "986361cd-3dac-47fe-afa1-5c5dd89f2fb4"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Use Case: Vulnerability",
+    "Tactic: Execution",
+    "Data Source: Elastic Defend",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
+  // persistence
+  "*cron*", "*/etc/rc.local*", "*/dev/tcp/*", "*/etc/init.d*", "*/etc/update-motd.d*", "*/etc/sudoers*",
+  "*/etc/profile*", "*autostart*", "*/etc/ssh*", "*/home/*/.ssh/*", "*/root/.ssh*", "*~/.ssh/*", "*udev*",
+  "*/etc/shadow*", "*/etc/passwd*",
+
+  // Downloads
+  "*curl*", "*wget*",
+
+  // encoding and decoding
+  "*base64 *", "*base32 *", "*xxd *", "*openssl*",
+
+  // reverse connections
+  "*GS_ARGS=*", "*/dev/tcp*", "*/dev/udp/*", "*import*pty*spawn*", "*import*subprocess*call*", "*TCPSocket.new*",
+  "*TCPSocket.open*", "*io.popen*", "*os.execute*", "*fsockopen*", "*disown*", "*nohup*",
+
+  // SO loads
+  "*openssl*-engine*.so*", "*cdll.LoadLibrary*.so*", "*ruby*-e**Fiddle.dlopen*.so*", "*Fiddle.dlopen*.so*",
+  "*cdll.LoadLibrary*.so*",
+
+  // misc. suspicious command lines
+   "*/etc/ld.so*", "*/dev/shm/*", "*/var/tmp*", "*echo*", "*>>*", "*|*"
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1203"
+name = "Exploitation for Client Execution"
+reference = "https://attack.mitre.org/techniques/T1203/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"


### PR DESCRIPTION
## Summary
A set of vulnerabilities in the CUPS printing system (CVE-2024-47176, CVE-2024-47076, CVE-2024-47175, and CVE-2024-47177) allows remote unauthenticated attackers to achieve remote code execution (RCE) by sending UDP packets to port 631 or through local network-based attacks, such as spoofing mDNS or DNS-SD advertisements. These flaws affect components like cups-browsed, libcupsfilters, libppd, and foomatic-rip, enabling attackers to replace or install malicious printer configurations, which could lead to arbitrary command execution when a print job is started. The detection rules aim to identify suspicious IPP requests and command execution attempts to mitigate the risk of exploitation from these vulnerabilities.

## Detections
This PR adds 5 new detection rules, all focusing on different behaviors that are part of the attack chain:

- Cupsd or Foomatic-rip Shell Execution - 476267ff-e44f-476e-99c1-04c78cb3769d
- Printer User (lp) Shell Execution - f86cd31c-5c7e-4481-99d7-6875a3e31309
- Network Connection by Cups Foomatic-rip Child - e80ee207-9505-49ab-8ca8-bc57d80e2cab
- File Creation by Cups Foomatic-rip Child - b9b14be7-b7f4-4367-9934-81f07d2f63c4
- Suspicious Execution from Foomatic-rip or Cupsd Parent - 986361cd-3dac-47fe-afa1-5c5dd89f2fb4

### Cupsd or Foomatic-rip Shell Execution
This rule detects shell executions from the foomatic-rip parent process. This detection rule detects all 33 attempts that we ran with the POC.

```
process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
process.parent.name == "foomatic-rip" and
process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
not process.command_line like ("*/tmp/foomatic-*", "*-sDEVICE=ps2write*")
```

<img width="1900" alt="{64EF366A-597A-4AC6-8002-70D33D53AE9C}" src="https://github.com/user-attachments/assets/ac7624f7-bf72-40f7-88e8-cce84363a259">

### Printer User (lp) Shell Execution
This rule detects shell executions from the foomatic-rip parent process through the default printer user (lp). This query is broader, but will only work when your Cups/foomatic-rip processes run as the lp-user. You can alter this query to a different user.name if this is different in your environment.

```
process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and user.name == "lp" and
process.parent.name in ("cupsd", "foomatic-rip", "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
not process.command_line like ("*/tmp/foomatic-*", "*-sDEVICE=ps2write*")
```

<img width="1900" alt="{C236EF52-08CA-4FB6-91CD-4F1B65DC280B}" src="https://github.com/user-attachments/assets/20c12675-e6e1-4d09-a741-81bc580c29d6">

### Network Connection by Cups Foomatic-rip Child
This rule detects network connections initiated by a child processes of foomatic-rip. This should be suspicious. If these services do communicate in your environment, make sure to whitelist destination IP's.

```
sequence by host.id with maxspan=10s
  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
   process.parent.name == "foomatic-rip" and
   process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")] by process.entity_id
  [network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted"] by process.parent.entity_id
```

<img width="1901" alt="{0F71CAAF-2233-4382-86A6-823A6512C3A2}" src="https://github.com/user-attachments/assets/e0eb5f62-f188-43ec-a28f-49bbbcc18739">

### File Creation by Cups Foomatic-rip Child
This rule detects suspicious file creation events executed by child processes of foomatic-rip. The default PoCs test by writing a file to /tmp/, which would be detected through this rule. Additionally, if the attacker were to download a stage and execute it manually afterwards, this rule would detect the file creation event.

This rule excludes `/tmp/gs_*`, because this is the default pattern. If you want to be more secure, remove the white listing. It will become noisier though. 

```
sequence by host.id with maxspan=10s
  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
   process.parent.name == "foomatic-rip" and
   process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")] by process.entity_id
  [file where host.os.type == "linux" and event.type != "deletion" and
   not (process.name == "gs" and file.path like "/tmp/gs_*")] by process.parent.entity_id
```

<img width="1894" alt="{388B1BD0-16CF-4286-8FE9-B12BDDD4D864}" src="https://github.com/user-attachments/assets/b9573295-bec8-4035-b9d0-fd9bd3479d0e">

### Suspicious Execution from Foomatic-rip or Cupsd Parent
This rule detects suspicious process command lines executed by child processes of foomatic-rip and cupsd. The command lines focus on persistence, file downloading, encoding/decoding activity, reverse shells, shared-object loading through GTFOBins and more. 

```
process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
  // persistence
  "*cron*", "*/etc/rc.local*", "*/dev/tcp/*", "*/etc/init.d*", "*/etc/update-motd.d*", "*/etc/sudoers*",
  "*/etc/profile*", "*autostart*", "*/etc/ssh*", "*/home/*/.ssh/*", "*/root/.ssh*", "*~/.ssh/*", "*udev*",
  "*/etc/shadow*", "*/etc/passwd*",

  // Downloads
  "*curl*", "*wget*",

  // encoding and decoding
  "*base64 *", "*base32 *", "*xxd *", "*openssl*",

  // reverse connections
  "*GS_ARGS=*", "*/dev/tcp*", "*/dev/udp/*", "*import*pty*spawn*", "*import*subprocess*call*", "*TCPSocket.new*",
  "*TCPSocket.open*", "*io.popen*", "*os.execute*", "*fsockopen*", "*disown*", "*nohup*",

  // SO loads
  "*openssl*-engine*.so*", "*cdll.LoadLibrary*.so*", "*ruby*-e**Fiddle.dlopen*.so*", "*Fiddle.dlopen*.so*",
  "*cdll.LoadLibrary*.so*",

  // misc. suspicious command lines
   "*/etc/ld.so*", "*/dev/shm/*", "*/var/tmp*", "*echo*", "*>>*", "*|*"
)
```

<img width="1906" alt="{950CDCA6-3B7D-4FF7-9A1F-B1645A62EE36}" src="https://github.com/user-attachments/assets/bd4ef5e1-ba7c-4456-883a-8b37514780a7">

## References
- https://www.evilsocket.net/2024/09/26/Attacking-UNIX-systems-via-CUPS-Part-I/
- https://gist.github.com/stong/c8847ef27910ae344a7b5408d9840ee1
- https://github.com/RickdeJager/cupshax/blob/main/cupshax.py