### PR TITLE
Endpoint Security - Decrease max events to Kibana allowance of 1k

### DIFF
--- a/rules/integrations/endpoint/elastic_endpoint_security.toml
+++ b/rules/integrations/endpoint/elastic_endpoint_security.toml
@@ -3,7 +3,7 @@ creation_date = "2020/07/08"
 integration = ["endpoint"]
 maturity = "production"
 promotion = true
-updated_date = "2024/05/21"
+updated_date = "2024/10/07"
 
 [rule]
 author = ["Elastic"]
@@ -16,7 +16,7 @@ from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
 language = "kuery"
 license = "Elastic License v2"
-max_signals = 10000
+max_signals = 1000
 name = "Endpoint Security"
 risk_score = 47
 rule_id = "9a1a2dae-0b5f-4c3d-8305-a268d404c306"


### PR DESCRIPTION
The default Endpoint Security rule appears to have been set at 10,000 alerts which is beyond the Kibana alerting limit of 1,000.

This corrects that change but not sure why it is set so high in the first place.

![image](https://github.com/user-attachments/assets/a4cb048e-7383-4923-a167-e16c5098b921)

## Summary - What I changed

Decreased to 1,000 - Any reason why this is set to 10K in the first place?

You won't hurt my feelings if this is closed right away with a reasonable explanation why this should not be decreased. :)

