### PR TITLE
Add setuptools as project dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ PIP := $(VENV_BIN)/pip
 all: release
 
 $(VENV):
-	python3.12 -m pip install --upgrade pip setuptools
 	python3.12 -m venv $(VENV)
 
 .PHONY: clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
 	"XlsxWriter~=3.2.0",
 	"semver==3.0.2",
 	"detection-rules-kql @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql",
-	"detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana"
+	"detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana",
+	"setuptools==75.2.0"
 ]
 [project.optional-dependencies]
 dev = ["pep8-naming==0.13.0", "PyGithub==2.2.0", "flake8==7.0.0", "pyflakes==3.2.0", "pytest>=8.1.1", "nodeenv==1.8.0", "pre-commit==3.6.2"]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/4083

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

- Add setuptools==75.2.0 as project dependency

The alternatives to the above solution which requires in depth planning and execution are as below

- Refactor the overall data modelling to pydantic. 
- Refactor the code dependant on the deprecated package and move it into a separate repository
- Fork the `marshmallow-jsonschema` as a internal private repository and apply patches that would resolve the pkg_resources dependency.
- Also the package upstream has a fix opened in [PR](https://github.com/fuhrysteve/marshmallow-jsonschema/pull/183), which would also fix our issue , but it is stale from. April 2.

While there is a refactor meta for detection rules already tracking such larger improvements https://github.com/elastic/security-team/issues/8718, this PR is focused on fixing the make installation method of detection rules.


<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

- Unit test should pass
- pip installation will install setuptools and commands work
<details><summary>Details</summary>
<p>

```console
detection-rules on  issue-4083 [$?] is 📦 v0.1.0 via 🐍 v3.12.5 on ☁️  shashank.suryanarayana@elastic.co 
❯ python3 -m venv .venv_new 

detection-rules on  issue-4083 [$?] is 📦 v0.1.0 via 🐍 v3.12.5 on ☁️  shashank.suryanarayana@elastic.co 
❯ source .venv_new/bin/activate

detection-rules on  issue-4083 [$?] is 📦 v0.1.0 via 🐍 v3.12.5 (.venv_new) on ☁️  shashank.suryanarayana@elastic.co 
❯ pip install .
Looking in indexes: https://pypi.org/simple, https://shashank.suryanarayana%40elastic.co:****@artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/simple
Processing /Users/shashankks/elastic_workspace/detection-rules
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting detection-rules-kql@ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql (from detection_rules==0.1.0)
  Cloning https://github.com/elastic/detection-rules.git to /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-install-xq1aric4/detection-rules-kql_33e64a8e8ae044dbb2498bbd465b8e1e
  Running command git clone --filter=blob:none --quiet https://github.com/elastic/detection-rules.git /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-install-xq1aric4/detection-rules-kql_33e64a8e8ae044dbb2498bbd465b8e1e
  Resolved https://github.com/elastic/detection-rules.git to commit 4b4b2cc9c852d15f7c1801ffee8c556a38b9bd5a
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting detection-rules-kibana@ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana (from detection_rules==0.1.0)
  Cloning https://github.com/elastic/detection-rules.git to /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-install-xq1aric4/detection-rules-kibana_cd2205ac3f2c491e94e380dd28a0c3ec
  Running command git clone --filter=blob:none --quiet https://github.com/elastic/detection-rules.git /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-install-xq1aric4/detection-rules-kibana_cd2205ac3f2c491e94e380dd28a0c3ec
  Resolved https://github.com/elastic/detection-rules.git to commit 4b4b2cc9c852d15f7c1801ffee8c556a38b9bd5a
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting Click~=8.1.7 (from detection_rules==0.1.0)
  Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
Collecting elasticsearch~=8.12.1 (from detection_rules==0.1.0)
  Using cached elasticsearch-8.12.1-py3-none-any.whl.metadata (5.3 kB)
Collecting eql==0.9.19 (from detection_rules==0.1.0)
  Using cached eql-0.9.19-py2.py3-none-any.whl.metadata (3.7 kB)
Collecting jsl==0.2.4 (from detection_rules==0.1.0)
  Using cached jsl-0.2.4-py3-none-any.whl
Collecting jsonschema>=4.21.1 (from detection_rules==0.1.0)
  Using cached jsonschema-4.23.0-py3-none-any.whl.metadata (7.9 kB)
Collecting marko==2.0.3 (from detection_rules==0.1.0)
  Using cached marko-2.0.3-py3-none-any.whl.metadata (4.6 kB)
Collecting marshmallow-dataclass~=8.6.0 (from marshmallow-dataclass[union]~=8.6.0->detection_rules==0.1.0)
  Using cached marshmallow_dataclass-8.6.1-py3-none-any.whl.metadata (12 kB)
Collecting marshmallow-jsonschema~=0.13.0 (from detection_rules==0.1.0)
  Using cached marshmallow_jsonschema-0.13.0-py3-none-any.whl.metadata (7.5 kB)
Collecting marshmallow-union~=0.1.15 (from detection_rules==0.1.0)
  Using cached marshmallow_union-0.1.15.post1-py2.py3-none-any.whl.metadata (2.9 kB)
Collecting marshmallow~=3.21.1 (from detection_rules==0.1.0)
  Using cached marshmallow-3.21.3-py3-none-any.whl.metadata (7.1 kB)
Collecting pytoml==0.1.21 (from detection_rules==0.1.0)
  Using cached pytoml-0.1.21-py2.py3-none-any.whl.metadata (2.0 kB)
Collecting PyYAML~=6.0.1 (from detection_rules==0.1.0)
  Using cached PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl.metadata (2.1 kB)
Collecting requests~=2.31.0 (from detection_rules==0.1.0)
  Using cached requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
Collecting toml==0.10.2 (from detection_rules==0.1.0)
  Using cached toml-0.10.2-py2.py3-none-any.whl.metadata (7.1 kB)
Collecting typing-inspect==0.9.0 (from detection_rules==0.1.0)
  Using cached typing_inspect-0.9.0-py3-none-any.whl.metadata (1.5 kB)
Collecting typing-extensions==4.10.0 (from detection_rules==0.1.0)
  Using cached typing_extensions-4.10.0-py3-none-any.whl.metadata (3.0 kB)
Collecting XlsxWriter~=3.2.0 (from detection_rules==0.1.0)
  Using cached XlsxWriter-3.2.0-py3-none-any.whl.metadata (2.6 kB)
Collecting semver==3.0.2 (from detection_rules==0.1.0)
  Using cached semver-3.0.2-py3-none-any.whl.metadata (5.0 kB)
Collecting setuptools==75.2.0 (from detection_rules==0.1.0)
  Using cached setuptools-75.2.0-py3-none-any.whl.metadata (6.9 kB)
Collecting lark-parser~=0.12.0 (from eql==0.9.19->detection_rules==0.1.0)
  Using cached https://artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/lark-parser/0.12.0/lark_parser-0.12.0-py2.py3-none-any.whl (103 kB)
Collecting mypy-extensions>=0.3.0 (from typing-inspect==0.9.0->detection_rules==0.1.0)
  Using cached mypy_extensions-1.0.0-py3-none-any.whl.metadata (1.1 kB)
Collecting elastic-transport<9,>=8 (from elasticsearch~=8.12.1->detection_rules==0.1.0)
  Using cached elastic_transport-8.15.1-py3-none-any.whl.metadata (3.7 kB)
Collecting attrs>=22.2.0 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached attrs-24.2.0-py3-none-any.whl.metadata (11 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached jsonschema_specifications-2024.10.1-py3-none-any.whl.metadata (3.0 kB)
Collecting referencing>=0.28.4 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached referencing-0.35.1-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.7.1 (from jsonschema>=4.21.1->detection_rules==0.1.0)
  Using cached rpds_py-0.20.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (4.2 kB)
Collecting packaging>=17.0 (from marshmallow~=3.21.1->detection_rules==0.1.0)
  Using cached packaging-24.1-py3-none-any.whl.metadata (3.2 kB)
Collecting typeguard<4.0.0,>=2.4.1 (from marshmallow-dataclass[union]~=8.6.0->detection_rules==0.1.0)
  Using cached typeguard-3.0.2-py3-none-any.whl.metadata (3.7 kB)
Collecting charset-normalizer<4,>=2 (from requests~=2.31.0->detection_rules==0.1.0)
  Using cached charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl.metadata (34 kB)
Collecting idna<4,>=2.5 (from requests~=2.31.0->detection_rules==0.1.0)
  Using cached idna-3.10-py3-none-any.whl.metadata (10 kB)
Collecting urllib3<3,>=1.21.1 (from requests~=2.31.0->detection_rules==0.1.0)
  Using cached urllib3-2.2.3-py3-none-any.whl.metadata (6.5 kB)
Collecting certifi>=2017.4.17 (from requests~=2.31.0->detection_rules==0.1.0)
  Using cached certifi-2024.8.30-py3-none-any.whl.metadata (2.2 kB)
Using cached eql-0.9.19-py2.py3-none-any.whl (105 kB)
Using cached marko-2.0.3-py3-none-any.whl (42 kB)
Using cached pytoml-0.1.21-py2.py3-none-any.whl (8.5 kB)
Using cached semver-3.0.2-py3-none-any.whl (17 kB)
Using cached setuptools-75.2.0-py3-none-any.whl (1.2 MB)
Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
Using cached typing_extensions-4.10.0-py3-none-any.whl (33 kB)
Using cached typing_inspect-0.9.0-py3-none-any.whl (8.8 kB)
Using cached click-8.1.7-py3-none-any.whl (97 kB)
Using cached elasticsearch-8.12.1-py3-none-any.whl (432 kB)
Using cached jsonschema-4.23.0-py3-none-any.whl (88 kB)
Using cached marshmallow-3.21.3-py3-none-any.whl (49 kB)
Using cached marshmallow_dataclass-8.6.1-py3-none-any.whl (18 kB)
Using cached marshmallow_jsonschema-0.13.0-py3-none-any.whl (11 kB)
Using cached marshmallow_union-0.1.15.post1-py2.py3-none-any.whl (4.6 kB)
Using cached PyYAML-6.0.2-cp312-cp312-macosx_11_0_arm64.whl (173 kB)
Using cached requests-2.31.0-py3-none-any.whl (62 kB)
Using cached XlsxWriter-3.2.0-py3-none-any.whl (159 kB)
Using cached attrs-24.2.0-py3-none-any.whl (63 kB)
Using cached certifi-2024.8.30-py3-none-any.whl (167 kB)
Using cached charset_normalizer-3.4.0-cp312-cp312-macosx_11_0_arm64.whl (119 kB)
Using cached elastic_transport-8.15.1-py3-none-any.whl (64 kB)
Using cached idna-3.10-py3-none-any.whl (70 kB)
Using cached jsonschema_specifications-2024.10.1-py3-none-any.whl (18 kB)
Using cached mypy_extensions-1.0.0-py3-none-any.whl (4.7 kB)
Using cached packaging-24.1-py3-none-any.whl (53 kB)
Using cached referencing-0.35.1-py3-none-any.whl (26 kB)
Using cached rpds_py-0.20.0-cp312-cp312-macosx_11_0_arm64.whl (313 kB)
Using cached typeguard-3.0.2-py3-none-any.whl (30 kB)
Using cached urllib3-2.2.3-py3-none-any.whl (126 kB)
Building wheels for collected packages: detection_rules, detection-rules-kibana, detection-rules-kql
  Building wheel for detection_rules (pyproject.toml) ... done
  Created wheel for detection_rules: filename=detection_rules-0.1.0-py3-none-any.whl size=47730512 sha256=b4ffc6d1440313e19784e1ba33d7378076eafb19ea6ba842628dba316aa1b874
  Stored in directory: /Users/shashankks/Library/Caches/pip/wheels/3c/7f/bb/1273517229a8e34daadcd208fec85ac1b3ea2df226e5acfbf9
  Building wheel for detection-rules-kibana (pyproject.toml) ... done
  Created wheel for detection-rules-kibana: filename=detection_rules_kibana-0.4.0-py3-none-any.whl size=9476 sha256=e2eb3ec2cbd8ec3797c184fa71413661bdc76a0ef617050bbbaec979ae2b7132
  Stored in directory: /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-ephem-wheel-cache-ablhds6p/wheels/08/96/aa/385e2ed061d591561ceb888c9cc4321cda2494a338957e581e
  Building wheel for detection-rules-kql (pyproject.toml) ... done
  Created wheel for detection-rules-kql: filename=detection_rules_kql-0.1.7-py3-none-any.whl size=16336 sha256=7dee02d0876b0a7ac01e0de6fdfd93de30696a13a278c74dd000397a72bdd097
  Stored in directory: /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-ephem-wheel-cache-ablhds6p/wheels/c7/d2/87/aadf9d1987eecf9ca470145b5d3a08c6ba65c43738212f5c8c
Successfully built detection_rules detection-rules-kibana detection-rules-kql
Installing collected packages: pytoml, lark-parser, jsl, XlsxWriter, urllib3, typing-extensions, typeguard, toml, setuptools, semver, rpds-py, PyYAML, packaging, mypy-extensions, marko, idna, eql, Click, charset-normalizer, certifi, attrs, typing-inspect, requests, referencing, marshmallow, elastic-transport, detection-rules-kql, marshmallow-union, marshmallow-jsonschema, marshmallow-dataclass, jsonschema-specifications, elasticsearch, jsonschema, detection-rules-kibana, detection_rules
Successfully installed Click-8.1.7 PyYAML-6.0.2 XlsxWriter-3.2.0 attrs-24.2.0 certifi-2024.8.30 charset-normalizer-3.4.0 detection-rules-kibana-0.4.0 detection-rules-kql-0.1.7 detection_rules-0.1.0 elastic-transport-8.15.1 elasticsearch-8.12.1 eql-0.9.19 idna-3.10 jsl-0.2.4 jsonschema-4.23.0 jsonschema-specifications-2024.10.1 lark-parser-0.12.0 marko-2.0.3 marshmallow-3.21.3 marshmallow-dataclass-8.6.1 marshmallow-jsonschema-0.13.0 marshmallow-union-0.1.15.post1 mypy-extensions-1.0.0 packaging-24.1 pytoml-0.1.21 referencing-0.35.1 requests-2.31.0 rpds-py-0.20.0 semver-3.0.2 setuptools-75.2.0 toml-0.10.2 typeguard-3.0.2 typing-extensions-4.10.0 typing-inspect-0.9.0 urllib3-2.2.3
```

```console
# /Users/shashankks/elastic_workspace/detection-rules/detection_rules/__pycache__/ml.cpython-312.pyc matches /Users/shashankks/elastic_workspace/detection-rules/detection_rules/ml.py
# code object from '/Users/shashankks/elastic_workspace/detection-rules/detection_rules/__pycache__/ml.cpython-312.pyc'
import 'detection_rules.ml' # <_frozen_importlib_external.SourceFileLoader object at 0x120279910>
import 'detection_rules' # <_frozen_importlib_external.SourceFileLoader object at 0x1031b6ea0>
>>> 
```
</p>
</details> 

- make command testing to check setuptools inclusion
<details><summary>Details</summary>
<p>

```console
❯ make
Makefile:30: warning: overriding commands for target `deps'
Makefile:23: warning: ignoring old commands for target `deps'
Makefile:62: warning: overriding commands for target `test-remote-cli'
Makefile:57: warning: ignoring old commands for target `test-remote-cli'
Installing all dependencies...
./env/detection-rules-build/bin/pip install .[hunting]
Looking in indexes: https://pypi.org/simple, https://shashank.suryanarayana%40elastic.co:****@artifactory.elastic.dev/artifactory/api/pypi/pypi-endgame/simple
Processing /Users/shashankks/elastic_workspace/detection-rules
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting detection-rules-kql@ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql (from detection_rules==0.1.0)
  Cloning https://github.com/elastic/detection-rules.git to /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-install-428kzdtf/detection-rules-kql_58bcab6d0bf341b68ec0a63ede2eb618
  Running command git clone --filter=blob:none --quiet https://github.com/elastic/detection-rules.git /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-install-428kzdtf/detection-rules-kql_58bcab6d0bf341b68ec0a63ede2eb618
  Resolved https://github.com/elastic/detection-rules.git to commit 4b4b2cc9c852d15f7c1801ffee8c556a38b9bd5a
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting detection-rules-kibana@ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana (from detection_rules==0.1.0)
  Cloning https://github.com/elastic/detection-rules.git to /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-install-428kzdtf/detection-rules-kibana_30758a7ccde44515b43df2a1eac51cbd
  Running command git clone --filter=blob:none --quiet https://github.com/elastic/detection-rules.git /private/var/folders/jk/t_tlgnwx4w998xqw3_kjzyx00000gn/T/pip-install-428kzdtf/detection-rules-kibana_30758a7ccde44515b43df2a1eac51cbd
  Resolved https://github.com/elastic/detection-rules.git to commit 4b4b2cc9c852d15f7c1801ffee8c556a38b9bd5a
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: Click~=8.1.7 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (8.1.7)
Requirement already satisfied: elasticsearch~=8.12.1 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (8.12.1)
Requirement already satisfied: eql==0.9.19 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (0.9.19)
Requirement already satisfied: jsl==0.2.4 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (0.2.4)
Requirement already satisfied: jsonschema>=4.21.1 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (4.23.0)
Requirement already satisfied: marko==2.0.3 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (2.0.3)
Requirement already satisfied: marshmallow-dataclass~=8.6.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from marshmallow-dataclass[union]~=8.6.0->detection_rules==0.1.0) (8.6.1)
Requirement already satisfied: marshmallow-jsonschema~=0.13.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (0.13.0)
Requirement already satisfied: marshmallow-union~=0.1.15 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (0.1.15.post1)
Requirement already satisfied: marshmallow~=3.21.1 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (3.21.3)
Requirement already satisfied: pytoml==0.1.21 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (0.1.21)
Requirement already satisfied: PyYAML~=6.0.1 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (6.0.2)
Requirement already satisfied: requests~=2.31.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (2.31.0)
Requirement already satisfied: toml==0.10.2 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (0.10.2)
Requirement already satisfied: typing-inspect==0.9.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (0.9.0)
Requirement already satisfied: typing-extensions==4.10.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (4.10.0)
Requirement already satisfied: XlsxWriter~=3.2.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (3.2.0)
Requirement already satisfied: semver==3.0.2 in ./env/detection-rules-build/lib/python3.12/site-packages (from detection_rules==0.1.0) (3.0.2)
Collecting setuptools==75.2.0 (from detection_rules==0.1.0)
  Using cached setuptools-75.2.0-py3-none-any.whl.metadata (6.9 kB)
Requirement already satisfied: lark-parser~=0.12.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from eql==0.9.19->detection_rules==0.1.0) (0.12.0)
Requirement already satisfied: mypy-extensions>=0.3.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from typing-inspect==0.9.0->detection_rules==0.1.0) (1.0.0)
Collecting tabulate==0.9.0 (from detection_rules==0.1.0)
  Using cached tabulate-0.9.0-py3-none-any.whl.metadata (34 kB)
Requirement already satisfied: elastic-transport<9,>=8 in ./env/detection-rules-build/lib/python3.12/site-packages (from elasticsearch~=8.12.1->detection_rules==0.1.0) (8.15.0)
Requirement already satisfied: attrs>=22.2.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from jsonschema>=4.21.1->detection_rules==0.1.0) (24.2.0)
Requirement already satisfied: jsonschema-specifications>=2023.03.6 in ./env/detection-rules-build/lib/python3.12/site-packages (from jsonschema>=4.21.1->detection_rules==0.1.0) (2023.12.1)
Requirement already satisfied: referencing>=0.28.4 in ./env/detection-rules-build/lib/python3.12/site-packages (from jsonschema>=4.21.1->detection_rules==0.1.0) (0.35.1)
Requirement already satisfied: rpds-py>=0.7.1 in ./env/detection-rules-build/lib/python3.12/site-packages (from jsonschema>=4.21.1->detection_rules==0.1.0) (0.20.0)
Requirement already satisfied: packaging>=17.0 in ./env/detection-rules-build/lib/python3.12/site-packages (from marshmallow~=3.21.1->detection_rules==0.1.0) (24.1)
Requirement already satisfied: typeguard<4.0.0,>=2.4.1 in ./env/detection-rules-build/lib/python3.12/site-packages (from marshmallow-dataclass[union]~=8.6.0->detection_rules==0.1.0) (3.0.2)
Requirement already satisfied: charset-normalizer<4,>=2 in ./env/detection-rules-build/lib/python3.12/site-packages (from requests~=2.31.0->detection_rules==0.1.0) (3.3.2)
Requirement already satisfied: idna<4,>=2.5 in ./env/detection-rules-build/lib/python3.12/site-packages (from requests~=2.31.0->detection_rules==0.1.0) (3.8)
Requirement already satisfied: urllib3<3,>=1.21.1 in ./env/detection-rules-build/lib/python3.12/site-packages (from requests~=2.31.0->detection_rules==0.1.0) (2.2.2)
Requirement already satisfied: certifi>=2017.4.17 in ./env/detection-rules-build/lib/python3.12/site-packages (from requests~=2.31.0->detection_rules==0.1.0) (2024.8.30)
Using cached setuptools-75.2.0-py3-none-any.whl (1.2 MB)
Using cached tabulate-0.9.0-py3-none-any.whl (35 kB)
Building wheels for collected packages: detection_rules
  Building wheel for detection_rules (pyproject.toml) ... done
  Created wheel for detection_rules: filename=detection_rules-0.1.0-py3-none-any.whl size=47730512 sha256=cb5ccb72232bb79364c81e3c20e5c05a89ba0d65e28d104ab6784fb5b464d016
  Stored in directory: /Users/shashankks/Library/Caches/pip/wheels/3c/7f/bb/1273517229a8e34daadcd208fec85ac1b3ea2df226e5acfbf9
Successfully built detection_rules
Installing collected packages: tabulate, setuptools, detection_rules
  Attempting uninstall: setuptools
    Found existing installation: setuptools 74.1.2
    Uninstalling setuptools-74.1.2:
      Successfully uninstalled setuptools-74.1.2
  Attempting uninstall: detection_rules
    Found existing installation: detection_rules 0.1.0
    Uninstalling detection_rules-0.1.0:
      Successfully uninstalled detection_rules-0.1.0
Successfully installed detection_rules-0.1.0 setuptools-75.2.0 tabulate-0.9.0
```

</p>
</details> 
## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
