### PR TITLE
Add all historical versions for v8.17.0 and above packages

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -64,7 +64,8 @@ NAVIGATOR_BADGE = (
 )
 RULES_CONFIG = parse_rules_config()
 # The base package version that we will start to include all versions of historical rules
-BASE_PKG_VERSION = Version(major=8,minor=17,patch=0)
+BASE_PKG_VERSION = Version(major=8, minor=17, patch=0)
+
 
 def get_github_token() -> Optional[str]:
     """Get the current user's GitHub token."""
@@ -128,12 +129,15 @@ def build_release(ctx: click.Context, config_file, update_version_lock: bool, ge
     current_pkg_version = Version.parse(registry_data['version'])
     # pre-release versions are not included in the version comparison
     # Version 8.17.0-beta.1 is considered lower than 8.17.0
-    current_pkg_version_no_prerelease = Version(major=current_pkg_version.major,minor=current_pkg_version.minor,patch=current_pkg_version.patch)
-    if current_pkg_version_no_prerelease>= BASE_PKG_VERSION:
-        click.echo(f'[+] Adding all historical rule versions in our release package for version {current_pkg_version_no_prerelease}')
+    current_pkg_version_no_prerelease = Version(major=current_pkg_version.major,
+                                                minor=current_pkg_version.minor, patch=current_pkg_version.patch)
+    if current_pkg_version_no_prerelease >= BASE_PKG_VERSION:
+        click.echo(f'[+] Adding all historical rule versions in our release package for version \
+            {current_pkg_version_no_prerelease}')
         limited_historical_rules = historical_rules
     else:
-        click.echo(f'[+] Limit historical rule versions in our release package for version {current_pkg_version_no_prerelease}')
+        click.echo(f'[+] Limit historical rule versions in our release package for version \
+            {current_pkg_version_no_prerelease}')
         limited_historical_rules = sde.keep_latest_versions(historical_rules)
     package.add_historical_rules(limited_historical_rules, registry_data['version'])
     click.echo(f'[+] Adding historical rules from {previous_pkg_version} package')

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -63,7 +63,8 @@ NAVIGATOR_BADGE = (
     f'[![ATT&CK navigator coverage](https://img.shields.io/badge/ATT&CK-Navigator-red.svg)]({NAVIGATOR_URL})'
 )
 RULES_CONFIG = parse_rules_config()
-
+# The base package version that we will start to include all versions of historical rules
+BASE_PKG_VERSION = Version(major=8,minor=17,patch=0)
 
 def get_github_token() -> Optional[str]:
     """Get the current user's GitHub token."""
@@ -124,7 +125,16 @@ def build_release(ctx: click.Context, config_file, update_version_lock: bool, ge
                                                            registry_data['conditions']['kibana.version'].strip("^"))
     sde = SecurityDetectionEngine()
     historical_rules = sde.load_integration_assets(previous_pkg_version)
-    limited_historical_rules = sde.keep_latest_versions(historical_rules)
+    current_pkg_version = Version.parse(registry_data['version'])
+    # pre-release versions are not included in the version comparison
+    # Version 8.17.0-beta.1 is considered lower than 8.17.0
+    current_pkg_version_no_prerelease = Version(major=current_pkg_version.major,minor=current_pkg_version.minor,patch=current_pkg_version.patch)
+    if current_pkg_version_no_prerelease>= BASE_PKG_VERSION:
+        click.echo(f'[+] Adding all historical rule versions in our release package for version {current_pkg_version_no_prerelease}')
+        limited_historical_rules = historical_rules
+    else:
+        click.echo(f'[+] Limit historical rule versions in our release package for version {current_pkg_version_no_prerelease}')
+        limited_historical_rules = sde.keep_latest_versions(historical_rules)
     package.add_historical_rules(limited_historical_rules, registry_data['version'])
     click.echo(f'[+] Adding historical rules from {previous_pkg_version} package')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "0.2.1"
+version = "0.3.0"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/4150 Smart Limits is being available in 8.17.0 and above kibana version and we can now include all historical versions for our rule packages 

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

-  Smart Limits is being available in 8.17.0 and above kibana version and we can now include all historical versions for our rule packages 
- We will continue to limit the historical rule versions to latest and latest-1 for packages 8.16.0 and below
- We had considered the idea of introducing a flag for the build function which would require us to change all our workflows of build for supported versions. 
- This will introduce a constant version for comparison but have left comments for usage 

Please note this is a required PR for the next week release

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test

- Building 8.17.0 Package
```
❯ python -m detection_rules dev build-release 
Loaded config file: /Users/shashankks/elastic_workspace/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building package 8.17
 - 4 rules excluded from package
Rule changes detected!
 - 1 changed rules
 - 0 new rules
 - 0 newly deprecated rules
run `build-release --update-version-lock` to update version.lock.json and deprecated_rules.json
Package saved to: /Users/shashankks/elastic_workspace/detection-rules/releases/8.17
loaded security_detection_engine manifests from the following package versions: ['8.16.2', '8.16.1', '8.15.11', '8.15.10', '8.15.9', '8.15.8', '8.15.7', '8.15.6', '8.15.5', '8.15.4', '8.15.3', '8.15.2', '8.15.1', '8.14.17', '8.14.16', '8.14.15', '8.14.14', '8.14.13', '8.14.12', '8.14.11', '8.14.10', '8.14.9', '8.14.8', '8.14.7', '8.14.6', '8.14.5', '8.14.4', '8.14.3', '8.14.2', '8.14.1', '8.13.23', '8.13.22', '8.13.21', '8.13.20', '8.13.19', '8.13.18', '8.13.17', '8.13.16', '8.13.15', '8.13.14', '8.13.13', '8.13.12', '8.13.11', '8.13.10', '8.13.9', '8.13.8', '8.13.7', '8.13.6', '8.13.5', '8.13.4', '8.13.3', '8.13.2', '8.13.1', '8.12.26', '8.12.25', '8.12.24', '8.12.23', '8.12.22', '8.12.21', '8.12.20', '8.12.19', '8.12.18', '8.12.17', '8.12.16', '8.12.15', '8.12.14', '8.12.13', '8.12.12', '8.12.11', '8.12.10', '8.12.9', '8.12.8', '8.12.7', '8.12.6', '8.12.5', '8.12.4', '8.12.3', '8.12.2', '8.12.1', '8.11.21', '8.11.20', '8.11.19', '8.11.18', '8.11.17', '8.11.16', '8.11.15', '8.11.14', '8.11.13', '8.11.12', '8.11.11', '8.11.10', '8.11.9', '8.11.8', '8.11.7', '8.11.6', '8.11.5', '8.11.4', '8.11.3', '8.11.2', '8.11.1', '8.10.18', '8.10.17', '8.10.16', '8.10.15', '8.10.14', '8.10.13', '8.10.12', '8.10.11', '8.10.10', '8.10.9', '8.10.8', '8.10.7', '8.10.6', '8.10.5', '8.10.4', '8.10.3', '8.10.2', '8.10.1', '8.9.15', '8.9.14', '8.9.13', '8.9.12', '8.9.11', '8.9.10', '8.9.9', '8.9.8', '8.9.7', '8.9.6', '8.9.5', '8.9.4', '8.9.3', '8.9.2', '8.9.1', '8.8.15', '8.8.14', '8.8.13', '8.8.12', '8.8.11', '8.8.10', '8.8.9', '8.8.8', '8.8.7', '8.8.6', '8.8.5', '8.8.4', '8.8.3', '8.8.2', '8.8.1', '8.7.13', '8.7.12', '8.7.11', '8.7.10', '8.7.9', '8.7.8', '8.7.7', '8.7.6', '8.7.5', '8.7.4', '8.7.3', '8.7.2', '8.7.1', '8.6.10', '8.6.9', '8.6.8', '8.6.7', '8.6.6', '8.6.5', '8.6.4', '8.6.3', '8.6.2', '8.6.1', '8.5.8', '8.5.7', '8.5.6', '8.5.5', '8.5.4', '8.5.3', '8.5.2', '8.5.1', '8.4.5', '8.4.4', '8.4.3', '8.4.2', '8.4.1', '8.3.4', '8.3.3', '8.3.2', '8.3.1', '8.2.1', '8.1.1', '1.0.2', '1.0.1']
[+] Adding all historical rule versions in our release package for version 8.17.0
[+] Adding historical rules from 8.16.2 package
- sha256: 8bb4a464224ae076b577efd1bb9c5f0c0edc25beacc6f53c7df192d9ef6cc908
- 1256 rules included
```

Building 8.16.0 Package
```
❯ python -m detection_rules dev build-release 
Loaded config file: /Users/shashankks/elastic_workspace/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building package 8.16
 - 4 rules excluded from package
Rule changes detected!
 - 0 changed rules
 - 1 new rules
 - 0 newly deprecated rules
run `build-release --update-version-lock` to update version.lock.json and deprecated_rules.json
Package saved to: /Users/shashankks/elastic_workspace/detection-rules/releases/8.16
loaded security_detection_engine manifests from the following package versions: ['8.16.2', '8.16.1', '8.15.11', '8.15.10', '8.15.9', '8.15.8', '8.15.7', '8.15.6', '8.15.5', '8.15.4', '8.15.3', '8.15.2', '8.15.1', '8.14.17', '8.14.16', '8.14.15', '8.14.14', '8.14.13', '8.14.12', '8.14.11', '8.14.10', '8.14.9', '8.14.8', '8.14.7', '8.14.6', '8.14.5', '8.14.4', '8.14.3', '8.14.2', '8.14.1', '8.13.23', '8.13.22', '8.13.21', '8.13.20', '8.13.19', '8.13.18', '8.13.17', '8.13.16', '8.13.15', '8.13.14', '8.13.13', '8.13.12', '8.13.11', '8.13.10', '8.13.9', '8.13.8', '8.13.7', '8.13.6', '8.13.5', '8.13.4', '8.13.3', '8.13.2', '8.13.1', '8.12.26', '8.12.25', '8.12.24', '8.12.23', '8.12.22', '8.12.21', '8.12.20', '8.12.19', '8.12.18', '8.12.17', '8.12.16', '8.12.15', '8.12.14', '8.12.13', '8.12.12', '8.12.11', '8.12.10', '8.12.9', '8.12.8', '8.12.7', '8.12.6', '8.12.5', '8.12.4', '8.12.3', '8.12.2', '8.12.1', '8.11.21', '8.11.20', '8.11.19', '8.11.18', '8.11.17', '8.11.16', '8.11.15', '8.11.14', '8.11.13', '8.11.12', '8.11.11', '8.11.10', '8.11.9', '8.11.8', '8.11.7', '8.11.6', '8.11.5', '8.11.4', '8.11.3', '8.11.2', '8.11.1', '8.10.18', '8.10.17', '8.10.16', '8.10.15', '8.10.14', '8.10.13', '8.10.12', '8.10.11', '8.10.10', '8.10.9', '8.10.8', '8.10.7', '8.10.6', '8.10.5', '8.10.4', '8.10.3', '8.10.2', '8.10.1', '8.9.15', '8.9.14', '8.9.13', '8.9.12', '8.9.11', '8.9.10', '8.9.9', '8.9.8', '8.9.7', '8.9.6', '8.9.5', '8.9.4', '8.9.3', '8.9.2', '8.9.1', '8.8.15', '8.8.14', '8.8.13', '8.8.12', '8.8.11', '8.8.10', '8.8.9', '8.8.8', '8.8.7', '8.8.6', '8.8.5', '8.8.4', '8.8.3', '8.8.2', '8.8.1', '8.7.13', '8.7.12', '8.7.11', '8.7.10', '8.7.9', '8.7.8', '8.7.7', '8.7.6', '8.7.5', '8.7.4', '8.7.3', '8.7.2', '8.7.1', '8.6.10', '8.6.9', '8.6.8', '8.6.7', '8.6.6', '8.6.5', '8.6.4', '8.6.3', '8.6.2', '8.6.1', '8.5.8', '8.5.7', '8.5.6', '8.5.5', '8.5.4', '8.5.3', '8.5.2', '8.5.1', '8.4.5', '8.4.4', '8.4.3', '8.4.2', '8.4.1', '8.3.4', '8.3.3', '8.3.2', '8.3.1', '8.2.1', '8.1.1', '1.0.2', '1.0.1']
[+] Limit historical rule versions in our release package for version 8.16.0
[+] Adding historical rules from 8.16.2 package
- sha256: bc1bf8d7e607c8fe4361a60055f9e7667f228d885c371c78f4de6c87817ff892
- 1256 rules included
```


<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
