### PR TITLE
[Tuning] SDH - Possible Consent Grant Attack via Azure-Registered Application

### DIFF
--- a/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -87,8 +87,7 @@ query = '''
 event.dataset:(azure.activitylogs or azure.auditlogs or o365.audit) and
   (
     azure.activitylogs.operation_name:"Consent to application" or
-    azure.auditlogs.operation_name:"Consent to application" or
-    o365.audit.Operation:"Consent to application." or 
+    azure.auditlogs.operation_name:"Consent to application" or 
     event.action:"Consent to application."
   ) and
   event.outcome:(Success or success)

--- a/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
+++ b/rules/integrations/azure/initial_access_consent_grant_attack_via_azure_registered_application.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/01"
 integration = ["azure", "o365"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2024/12/05"
 
 [rule]
 author = ["Elastic"]
@@ -88,7 +88,8 @@ event.dataset:(azure.activitylogs or azure.auditlogs or o365.audit) and
   (
     azure.activitylogs.operation_name:"Consent to application" or
     azure.auditlogs.operation_name:"Consent to application" or
-    o365.audit.Operation:"Consent to application."
+    o365.audit.Operation:"Consent to application." or 
+    event.action:"Consent to application."
   ) and
   event.outcome:(Success or success)
 '''


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
https://github.com/elastic/sdh-protections/issues/538 

## Summary - What I changed
o365 integration had a field pipeline change that renamed the `o365.audit.Operation` field as `event.action`. Because of this the rule as it exists does not trigger for `o365.audit` data stream. I'm adding the `event.action` field as an additional OR clause which should correct the false negative. This is a simple tuning that should work as expected below is a screenshot from @arturmouraa with the working query in his test environment as I do not have one set up for this at the moment and would like to push the change in time for our upcoming release. 

## How To Test
target event provided in SDH ticket

```json
{
  "_index": ".ds-logs-o365.audit-default-2024.11.04-000012",
  "_id": "vl440zYeEpalgR8UR1CV0hQKN8o=",
  "_version": 1,
  "_score": 0,
  "_source": {
    "agent": {
      "name": "<redacted>",
      "id": "e2217be3-95df-428e-a88f-7aa92434b2df",
      "ephemeral_id": "bbbee566-5893-4453-a4e3-b5bc29e0f308",
      "type": "filebeat",
      "version": "8.14.3"
    },
trimmed
"event": {
      "agent_id_status": "verified",
      "ingested": "2024-11-25T22:15:23Z",
      "code": "AzureActiveDirectory",
      "provider": "AzureActiveDirectory",
      "kind": "event",
      "action": "Consent to application.",
      "id": "443457b8-1942-4b60-98f5-a7c643e25c0d",
      "type": [
        "info"
      ],
      "category": [
        "web"
      ],
      "dataset": "o365.audit",
      "outcome": "success"
    },
"o365.audit.ModifiedProperties.ConsentContext_IsAdminConsent.NewValue": [
      "False"
    ],
    "o365.audit.ModifiedProperties.ConsentContext_IsAppOnly.OldValue": [
      ""
    ],
    "o365.audit.ModifiedProperties.TargetId_ServicePrincipalNames.NewValue": [
      "https://<redacted>"
    ],
    "event.action": [
      "Consent to application."
    ],
    "event.ingested": [
      "2024-11-25T22:15:23.000Z"
    ],
    "o365.audit.ResultStatus": [
      "Success"
    ],
``` 
### SCREENSHOTS
Here is the screenshot of the alert after changing the rule query.

![Image](https://github.com/user-attachments/assets/19ebc024-f8c7-4d1d-8948-66398b9371e6)

And here is the rule cloned and changed:

![Image](https://github.com/user-attachments/assets/365c2f31-402f-4052-83e9-e94493c34de7)
