### PR TITLE
[Tuning] SDH - Removing timestamp_overide for Threat Match Rules

### DIFF
--- a/rules/threat_intel/threat_intel_indicator_match_address.toml
+++ b/rules/threat_intel/threat_intel_indicator_match_address.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2023/05/22"
 maturity = "production"
-updated_date = "2024/06/10"
+updated_date = "2024/12/05"
 
 [transform]
 [[transform.osquery]]
@@ -123,7 +123,7 @@ labels.is_ioc_transform_source:"true"
 """
 timeline_id = "495ad7a7-316e-4544-8a0f-9c098daee76e"
 timeline_title = "Generic Threat Match Timeline"
-timestamp_override = "event.ingested"
+ 
 type = "threat_match"
 
 query = '''

--- a/rules/threat_intel/threat_intel_indicator_match_hash.toml
+++ b/rules/threat_intel/threat_intel_indicator_match_hash.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2023/05/22"
 maturity = "production"
-updated_date = "2024/06/10"
+updated_date = "2024/12/05"
 
 [transform]
 [[transform.osquery]]
@@ -122,7 +122,7 @@ threat.indicator.file.pe.imphash:*) and not labels.is_ioc_transform_source:"true
 """
 timeline_id = "495ad7a7-316e-4544-8a0f-9c098daee76e"
 timeline_title = "Generic Threat Match Timeline"
-timestamp_override = "event.ingested"
+ 
 type = "threat_match"
 
 query = '''

--- a/rules/threat_intel/threat_intel_indicator_match_registry.toml
+++ b/rules/threat_intel/threat_intel_indicator_match_registry.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2023/05/22"
 maturity = "production"
-updated_date = "2024/06/10"
+updated_date = "2024/12/05"
 
 [transform]
 [[transform.osquery]]
@@ -117,7 +117,7 @@ labels.is_ioc_transform_source:"true"
 """
 timeline_id = "495ad7a7-316e-4544-8a0f-9c098daee76e"
 timeline_title = "Generic Threat Match Timeline"
-timestamp_override = "event.ingested"
+ 
 type = "threat_match"
 
 query = '''

--- a/rules/threat_intel/threat_intel_indicator_match_url.toml
+++ b/rules/threat_intel/threat_intel_indicator_match_url.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2023/05/22"
 maturity = "production"
-updated_date = "2024/06/10"
+updated_date = "2024/12/05"
 
 [transform]
 [[transform.osquery]]
@@ -126,7 +126,7 @@ labels.is_ioc_transform_source:"true"
 """
 timeline_id = "495ad7a7-316e-4544-8a0f-9c098daee76e"
 timeline_title = "Generic Threat Match Timeline"
-timestamp_override = "event.ingested"
+ 
 type = "threat_match"
 
 query = '''

--- a/rules/threat_intel/threat_intel_rapid7_threat_command.toml
+++ b/rules/threat_intel/threat_intel_rapid7_threat_command.toml
@@ -4,7 +4,7 @@ integration = ["ti_rapid7_threat_command"]
 maturity = "production"
 min_stack_comments = "Breaking change at 8.13.0 for Rapid7 Threat Command Integration"
 min_stack_version = "8.13.0"
-updated_date = "2024/08/06"
+updated_date = "2024/12/05"
 
 [rule]
 author = ["Elastic"]
@@ -84,7 +84,7 @@ threat_language = "kuery"
 threat_query = """
 @timestamp >= "now-30d/d" and vulnerability.id : * and event.module: ti_rapid7_threat_command
 """
-timestamp_override = "event.ingested"
+ 
 type = "threat_match"
 
 query = '''


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
https://github.com/elastic/sdh-protections/issues/539 
<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed
Removing `timestamp_override = "event.ingested"` from threat match rules as the `event.ingested` field is no longer ingested as part of the APM ingest pipeline causing rule failure for customers as of 8.15. This change should fix the issue and back port to the necessary stacks with our next rules release. The use of `event.ingested` is a best practice we use at the team level but is not a requirement at the rule level so this change should not cause any issues as the default `@timestamp` field will still work.