### PR TITLE
Enhance Readability of validation check failures

### DIFF
--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -17,6 +17,7 @@ from marshmallow import ValidationError
 from semver import Version
 
 import kql
+import click
 
 from . import ecs, endgame
 from .config import CUSTOM_RULES_DIR, load_current_package_version, parse_rules_config
@@ -371,7 +372,15 @@ class EQLValidator(QueryValidator):
                         # auto add the field and re-validate
                         self.auto_add_field(validation_checks["stack"], data.index_or_dataview[0])
                     else:
-                        raise ValueError(f"Error in both stack and integrations checks: {validation_checks}")
+                        stack_error_msg = validation_checks["stack"].error_msg
+                        integration_error_msg = validation_checks["integrations"].error_msg
+                        stack_error_trace = validation_checks["stack"]
+                        integration_trace = validation_checks["integrations"]
+                        click.echo(f"Stack Error Message: {stack_error_msg}")
+                        click.echo(f"Stack Error Trace: {stack_error_trace}")
+                        click.echo(f"Integrations Error Message: {integration_error_msg}")
+                        click.echo(f"Integrations Error Trace: {integration_trace}")
+                        raise ValueError(f"Error in both stack and integrations checks")
 
                 else:
                     break

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -374,7 +374,9 @@ class EQLValidator(QueryValidator):
                     else:
                         click.echo(f"Stack Error Trace: {validation_checks["stack"]}")
                         click.echo(f"Integrations Error Trace: {validation_checks["integrations"]}")
-                        raise ValueError("Error in both stack and integrations checks")
+                        raise ValueError(f"Error in both stack and integrations checks: \n" \
+                                         f"Stack Error : {validation_checks["stack"].error_msg} \n" \
+                                         f"Integrations Error : {validation_checks["integrations"].error_msg}")
 
                 else:
                     break

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -380,7 +380,7 @@ class EQLValidator(QueryValidator):
                         click.echo(f"Stack Error Trace: {stack_error_trace}")
                         click.echo(f"Integrations Error Message: {integration_error_msg}")
                         click.echo(f"Integrations Error Trace: {integration_trace}")
-                        raise ValueError(f"Error in both stack and integrations checks")
+                        raise ValueError("Error in both stack and integrations checks")
 
                 else:
                     break

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -372,14 +372,10 @@ class EQLValidator(QueryValidator):
                         # auto add the field and re-validate
                         self.auto_add_field(validation_checks["stack"], data.index_or_dataview[0])
                     else:
-                        stack_error_msg = validation_checks["stack"].error_msg
-                        integration_error_msg = validation_checks["integrations"].error_msg
-                        stack_error_trace = validation_checks["stack"]
-                        integration_trace = validation_checks["integrations"]
-                        click.echo(f"Stack Error Message: {stack_error_msg}")
-                        click.echo(f"Stack Error Trace: {stack_error_trace}")
-                        click.echo(f"Integrations Error Message: {integration_error_msg}")
-                        click.echo(f"Integrations Error Trace: {integration_trace}")
+                        click.echo(f"Stack Error Message: {validation_checks["stack"].error_msg}")
+                        click.echo(f"Stack Error Trace: {validation_checks["stack"]}")
+                        click.echo(f"Integrations Error Message: {validation_checks["integrations"].error_msg}")
+                        click.echo(f"Integrations Error Trace: {validation_checks["integrations"]}")
                         raise ValueError("Error in both stack and integrations checks")
 
                 else:

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -374,9 +374,7 @@ class EQLValidator(QueryValidator):
                     else:
                         click.echo(f"Stack Error Trace: {validation_checks["stack"]}")
                         click.echo(f"Integrations Error Trace: {validation_checks["integrations"]}")
-                        raise ValueError(f"Error in both stack and integrations checks: \n" \
-                                         f"Stack Error : {validation_checks["stack"].error_msg} \n" \
-                                         f"Integrations Error : {validation_checks["integrations"].error_msg}")
+                        raise ValueError("Error in both stack and integrations checks")
 
                 else:
                     break

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -372,9 +372,7 @@ class EQLValidator(QueryValidator):
                         # auto add the field and re-validate
                         self.auto_add_field(validation_checks["stack"], data.index_or_dataview[0])
                     else:
-                        click.echo(f"Stack Error Message: {validation_checks["stack"].error_msg}")
                         click.echo(f"Stack Error Trace: {validation_checks["stack"]}")
-                        click.echo(f"Integrations Error Message: {validation_checks["integrations"].error_msg}")
                         click.echo(f"Integrations Error Trace: {validation_checks["integrations"]}")
                         raise ValueError("Error in both stack and integrations checks")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "0.3.5"
+version = "0.3.6"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_python_library.py
+++ b/tests/test_python_library.py
@@ -55,7 +55,7 @@ class TestEQLInSet(BaseRuleTest):
                 """,
             },
         }
-        expected_error_message = r"Error in both stack and integrations checks:.*Unable to compare ip to string.*"
+        expected_error_message = r"Error in both stack and integrations checks"
         with self.assertRaisesRegex(ValueError, expected_error_message):
             rc.load_dict(eql_rule)
         # Change to appropriate destination.address field


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: - https://github.com/elastic/detection-rules/issues/3195

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

- Have a static error message which is a unique string and describe the error
- The details of the error are logged properly before we throw the error and the format of the error details are outside of ValueError scope

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test

- Simulated a Local validation Failure 
- Clear log messages and trace are simulated. 

```console
===================================================================== FAILURES =====================================================================
_____________________________________________ TestAlertSuppression.test_eql_non_sequence_support_only ______________________________________________
tests/base.py:85: in setUp
    self.fail(f'Rule loader failure: \n{RULE_LOADER_FAIL_MSG}')
E   AssertionError: Rule loader failure: 
E   Error in both stack and integrations checks
-------------------------------------------------------------- Captured stdout setup ---------------------------------------------------------------
Stack Error Trace: Error at line:3,column:4
Field not recognized for authentication event
sequence by host.id, source.ip, user.name with maxspan=15s
  [ authentication where host.os.type == "linux" and 
   event.actionS in ("ssh_login", "user_login") and event.outcome == "failure" and
   ^^^^^^^^^^^^^
stack: 8.18.0, beats: 8.16.1,ecs: 8.16.0, endgame: 8.4.0
Integrations Error Trace: Error at line:3,column:4
Field not recognized for authentication event
sequence by host.id, source.ip, user.name with maxspan=15s
  [ authentication where host.os.type == "linux" and 
   event.actionS in ("ssh_login", "user_login") and event.outcome == "failure" and
   ^^^^^^^^^^^^^
stack: 8.12.0, integration: None,ecs: 8.11.0, package: system, package_version: 1.63.0
Error loading rule in /Users/shashankks/elastic_workspace/detection-rules/rules/linux/credential_access_potential_linux_ssh_bruteforce_external.toml
================================================================= warnings summary =================================================================
.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1276
.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1276
  /Users/shashankks/elastic_workspace/detection-rules/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1276: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: typeguard
    self._mark_plugins_for_rewrite(hook)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================= short test summary info ==============================================================
FAILED tests/test_all_rules.py::TestAlertSuppression::test_eql_non_sequence_support_only - AssertionError: Rule loader failure: 
============================================== 1 failed, 91 passed, 63 skipped, 2 warnings in 13.67s ===============================================
(.venv) 
detection-rules on  issue-3195 [$!?] is 📦 v0.3.6 via 🐍 v3.12.5 (.venv) on ☁️  shashank.suryanarayana@elastic.co took 14s 
❯ 
```

- On no failures all Unit test should pass. 

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
