### PR TITLE
[Tuning] Suspicious WMI Event Subscription Created

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -82,8 +82,11 @@
     "process.Ext.relative_file_name_modify_time": "double",
     "process.Ext.relative_file_creation_time": "double",
     "Target.process.name": "keyword",
-    "process.Ext.api.name": "keyword",
-    "process.Ext.api.parameters.consumer_type": "keyword"
+    "process.Ext.api.name": "keyword"
+  },
+  "logs-endpoint.events.api-*": {
+    "process.Ext.api.parameters.consumer_type": "keyword",
+    "process.Ext.api.name": "keyword"
   },
   "logs-endpoint.events.file-*": {
     "file.Ext.header_bytes": "keyword",

--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -82,7 +82,8 @@
     "process.Ext.relative_file_name_modify_time": "double",
     "process.Ext.relative_file_creation_time": "double",
     "Target.process.name": "keyword",
-    "process.Ext.api.name": "keyword"
+    "process.Ext.api.name": "keyword",
+    "process.Ext.api.parameters.consumer_type": "keyword"
   },
   "logs-endpoint.events.file-*": {
     "file.Ext.header_bytes": "keyword",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "0.3.6"
+version = "0.3.7"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rules/windows/persistence_sysmon_wmi_event_subscription.toml
+++ b/rules/windows/persistence_sysmon_wmi_event_subscription.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/02/02"
-integration = ["windows"]
+integration = ["windows", "endpoint"]
 maturity = "production"
-updated_date = "2024/10/15"
+updated_date = "2024/12/23"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
@@ -13,7 +13,7 @@ Detects the creation of a WMI Event Subscription. Attackers can abuse this mecha
 SYSTEM privileges.
 """
 from = "now-9m"
-index = ["winlogbeat-*", "logs-windows.sysmon_operational-*"]
+index = ["winlogbeat-*", "logs-windows.sysmon_operational-*", "logs-endpoint.events.api-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious WMI Event Subscription Created"
@@ -30,13 +30,20 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Persistence",
     "Data Source: Sysmon",
+    "Data Source: Elastic Defend"
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where event.dataset == "windows.sysmon_operational" and event.code == "21" and
-    winlog.event_data.Operation : "Created" and winlog.event_data.Consumer : ("*subscription:CommandLineEventConsumer*", "*subscription:ActiveScriptEventConsumer*")
+any where 
+ (
+   (event.dataset == "windows.sysmon_operational" and event.code == "21" and
+    winlog.event_data.Operation : "Created" and winlog.event_data.Consumer : ("*subscription:CommandLineEventConsumer*", "*subscription:ActiveScriptEventConsumer*")) or 
+
+   (event.dataset == "endpoint.events.api" and event.provider == "Microsoft-Windows-WMI-Activity" and process.Ext.api.name == "IWbemServices::PutInstance" and 
+    process.Ext.api.parameters.consumer_type in ("ActiveScriptEventConsumer", "CommandLineEventConsumer"))
+ )
 '''
 
 

--- a/rules/windows/persistence_sysmon_wmi_event_subscription.toml
+++ b/rules/windows/persistence_sysmon_wmi_event_subscription.toml
@@ -3,8 +3,8 @@ creation_date = "2023/02/02"
 integration = ["windows", "endpoint"]
 maturity = "production"
 updated_date = "2024/12/23"
-min_stack_version = "8.14.0"
-min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
+min_stack_version = "8.15.0"
+min_stack_comments = "Elastic Defend WMI events were added in Elastic Defend 8.15.0."
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
added Elastic Defend Event 5861 (WMI Permanent  event subscription event) to this rule scope. this event is part of API events and is emitted by default to the stack/SIEM since it's a low volume event.

https://github.com/elastic/endpoint-rules/issues/3685