### PR TITLE
[New Rule] SSH via Backdoored System User

### DIFF
--- a/rules/linux/persistence_ssh_via_backdoored_system_user.toml
+++ b/rules/linux/persistence_ssh_via_backdoored_system_user.toml
@@ -1,0 +1,94 @@
+[metadata]
+creation_date = "2025/01/07"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/01/07"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule identifies successful SSH logins by system users that are uncommon to authenticate via SSH. These users
+have `nologin` set by default, and must be modified to allow SSH access. Adversaries may backdoor these users to
+gain unauthorized access to the system.
+"""
+from = "now-9m"
+index = ["filebeat-*", "logs-system.auth-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "SSH via Backdoored System User"
+risk_score = 47
+rule_id = "428e9109-dc13-4ae9-84cb-100464d4c6fa"
+setup = """## Setup
+
+This rule requires data coming in from Filebeat.
+
+### Filebeat Setup
+Filebeat is a lightweight shipper for forwarding and centralizing log data. Installed as an agent on your servers, Filebeat monitors the log files or locations that you specify, collects log events, and forwards them either to Elasticsearch or Logstash for indexing.
+
+#### The following steps should be executed in order to add the Filebeat on a Linux System:
+- Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
+- To install the APT and YUM repositories follow the setup instructions in this [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/setup-repositories.html).
+- To run Filebeat on Docker follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html).
+- To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-kubernetes.html).
+- For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
+- For complete “Setup and Run Filebeat” information refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/setting-up-and-running.html).
+
+#### Rule Specific Setup Note
+- This rule requires the “Filebeat System Module” to be enabled.
+- The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
+- To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-system.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Data Source: Elastic Defend",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+authentication where host.os.type == "linux" and event.action in ("ssh_login", "user_login") and
+user.name in (
+  "deamon", "bin", "sys", "games", "man", "lp", "mail", "news", "uucp", "proxy", "www-data", "backup",
+  "list", "irc", "gnats", "nobody", "systemd-timesync", "systemd-network", "systemd-resolve", "messagebus",
+  "avahi", "sshd", "dnsmasq"
+) and event.outcome == "success"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.004"
+name = "SSH Authorized Keys"
+reference = "https://attack.mitre.org/techniques/T1098/004/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+name = "Defense Evasion"
+id = "TA0005"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[[rule.threat.technique]]
+id = "T1564"
+name = "Hide Artifacts"
+reference = "https://attack.mitre.org/techniques/T1564/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1564.002"
+name = "Hidden Users"
+reference = "https://attack.mitre.org/techniques/T1564/002/"

--- a/rules/linux/persistence_ssh_via_backdoored_system_user.toml
+++ b/rules/linux/persistence_ssh_via_backdoored_system_user.toml
@@ -15,7 +15,7 @@ from = "now-9m"
 index = ["filebeat-*", "logs-system.auth-*"]
 language = "eql"
 license = "Elastic License v2"
-name = "SSH via Backdoored System User"
+name = "Login via Unusual System User"
 references = [
     "https://blog.exatrack.com/Perfctl-using-portainer-and-new-persistences/",
     "https://x.com/RFGroenewoud/status/1875112050218922010",

--- a/rules/linux/persistence_ssh_via_backdoored_system_user.toml
+++ b/rules/linux/persistence_ssh_via_backdoored_system_user.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2025/01/07"
-integration = ["endpoint"]
+integration = ["system"]
 maturity = "production"
 updated_date = "2025/01/07"
 
@@ -49,7 +49,7 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Persistence",
     "Tactic: Defense Evasion",
-    "Data Source: Elastic Defend",
+    "Data Source: System"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/linux/persistence_ssh_via_backdoored_system_user.toml
+++ b/rules/linux/persistence_ssh_via_backdoored_system_user.toml
@@ -47,6 +47,7 @@ tags = [
     "Domain: Endpoint",
     "OS: Linux",
     "Use Case: Threat Detection",
+    "Tactic: Persistence",
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
 ]

--- a/rules/linux/persistence_ssh_via_backdoored_system_user.toml
+++ b/rules/linux/persistence_ssh_via_backdoored_system_user.toml
@@ -16,6 +16,10 @@ index = ["filebeat-*", "logs-system.auth-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "SSH via Backdoored System User"
+references = [
+    "https://blog.exatrack.com/Perfctl-using-portainer-and-new-persistences/",
+    "https://x.com/RFGroenewoud/status/1875112050218922010",
+]
 risk_score = 47
 rule_id = "428e9109-dc13-4ae9-84cb-100464d4c6fa"
 setup = """## Setup

--- a/rules/linux/persistence_ssh_via_backdoored_system_user.toml
+++ b/rules/linux/persistence_ssh_via_backdoored_system_user.toml
@@ -7,7 +7,7 @@ updated_date = "2025/01/07"
 [rule]
 author = ["Elastic"]
 description = """
-This rule identifies successful SSH logins by system users that are uncommon to authenticate via SSH. These users
+This rule identifies successful logins by system users that are uncommon to authenticate. These users
 have `nologin` set by default, and must be modified to allow SSH access. Adversaries may backdoor these users to
 gain unauthorized access to the system.
 """


### PR DESCRIPTION
## Summary
This rule identifies successful SSH logins by system users that are uncommon to authenticate via SSH. These users have `nologin` set by default, and must be modified to allow SSH access. Adversaries may backdoor these users to gain unauthorized access to the system.

## Telemetry
<img width="1889" alt="{3911518C-85AF-4276-A7A3-ECB35D471F72}" src="https://github.com/user-attachments/assets/d73aa571-6549-43a8-bcdd-054a3f5046d2" />
