### PR TITLE
[Rule Tuning] Linux 3rd Party EDR Support - Crowdstrike and S1 - 6

### DIFF
--- a/rules/linux/defense_evasion_potential_proot_exploits.toml
+++ b/rules/linux/defense_evasion_potential_proot_exploits.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/03/07"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +20,7 @@ malicious payload or elevate privileges or perform network scans or orchestrate 
 Although PRoot was originally not developed with malicious intent it can be easily tuned to work for one.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Defense Evasion via PRoot"
@@ -58,12 +60,14 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
 process.parent.name == "proot"
 '''
 

--- a/rules/linux/defense_evasion_root_certificate_installation.toml
+++ b/rules/linux/defense_evasion_root_certificate_installation.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/08/28"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ in public key cryptography to identify a root certificate authority (CA). When a
 system or application will trust certificates in the root's chain of trust that have been signed by the root certificate.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process*"]
+index = ["logs-endpoint.events.process*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Root Certificate Installation"
@@ -52,11 +54,13 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
 process.name in ("update-ca-trust", "update-ca-certificates") and not (
   process.parent.name like (
     "ca-certificates.postinst", "ca-certificates-*.trigger", "pacman", "pamac-daemon", "autofirma.postinst",

--- a/rules/linux/defense_evasion_sus_utility_executed_via_tmux_or_screen.toml
+++ b/rules/linux/defense_evasion_sus_utility_executed_via_tmux_or_screen.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/09/04"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ directly, the commands will be executed in the background via its parent process
 to execute commands while attempting to evade detection.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potentially Suspicious Process Started via tmux or screen"
@@ -26,15 +28,18 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
-process.parent.name in ("screen", "tmux") and process.name like (
-  "nmap", "nc", "ncat", "netcat", "socat", "nc.openbsd", "ngrok", "ping", "java", "php*", "perl", "ruby", "lua*",
-  "openssl", "telnet", "wget", "curl", "id"
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and 
+  process.parent.name in ("screen", "tmux") and process.name like (
+    "nmap", "nc", "ncat", "netcat", "socat", "nc.openbsd", "ngrok", "ping", "java", "php*", "perl", "ruby", "lua*",
+    "openssl", "telnet", "wget", "curl", "id"
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/discovery_dynamic_linker_via_od.toml
+++ b/rules/linux/discovery_dynamic_linker_via_od.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/02/01"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ for examining and debugging binary files or data streams. Attackers can leverage
 identifying injection points and craft exploits based on the observed behaviors and structures within these files.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Dynamic Linker Discovery via od"
@@ -55,12 +57,14 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
  and process.name == "od" and process.args in (
   "/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2", "/etc/ld.so.preload", "/lib64/ld-linux-x86-64.so.2",
   "/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2", "/usr/lib64/ld-linux-x86-64.so.2"

--- a/rules/linux/discovery_esxi_software_via_find.toml
+++ b/rules/linux/discovery_esxi_software_via_find.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/04/11"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ software, and their presence in the find command arguments may indicate that a t
 analyze, or manipulate VM-related files and configurations on the system.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "ESXI Discovery via Find"
@@ -56,14 +58,15 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
     "Data Source: Auditd Manager",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "executed", "process_started") and process.name == "find" and
-process.args : ("/etc/vmware/*", "/usr/lib/vmware/*", "/vmfs/*") and 
-not process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewagent.sh"
+  event.action in ("exec", "exec_event", "start", "executed", "process_started") and
+  process.name == "find" and process.args : ("/etc/vmware/*", "/usr/lib/vmware/*", "/vmfs/*") and 
+  not process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewagent.sh"
 '''
 
 [[rule.threat]]

--- a/rules/linux/discovery_esxi_software_via_grep.toml
+++ b/rules/linux/discovery_esxi_software_via_grep.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/04/11"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ related to virtual machine (VM) files, such as "vmdk", "vmx", "vmxf", "vmsd", "v
 may indicate that a threat actor is attempting to search for, analyze, or manipulate VM files on the system.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "ESXI Discovery via Grep"
@@ -56,15 +58,16 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
     "Data Source: Auditd Manager",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "executed", "process_started") and
-process.name in ("grep", "egrep", "pgrep") and
-process.args in ("vmdk", "vmx", "vmxf", "vmsd", "vmsn", "vswp", "vmss", "nvram", "vmem") and
-not process.parent.executable == "/usr/share/qemu/init/qemu-kvm-init"
+  event.action in ("exec", "exec_event", "start", "executed", "process_started") and
+  process.name in ("grep", "egrep", "pgrep") and
+  process.args in ("vmdk", "vmx", "vmxf", "vmsd", "vmsn", "vswp", "vmss", "nvram", "vmem") and
+  not process.parent.executable == "/usr/share/qemu/init/qemu-kvm-init"
 '''
 
 [[rule.threat]]

--- a/rules/linux/discovery_linux_hping_activity.toml
+++ b/rules/linux/discovery_linux_hping_activity.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +19,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Hping Process Activity"
@@ -70,13 +72,16 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
- and process.name in ("hping", "hping2", "hping3")
+process where host.os.type == "linux" and event.type == "start" and
+ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+ process.name in ("hping", "hping2", "hping3")
 '''
 
 

--- a/rules/linux/discovery_linux_nping_activity.toml
+++ b/rules/linux/discovery_linux_nping_activity.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +19,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Nping Process Activity"
@@ -70,13 +72,16 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
- and process.name == "nping"
+process where host.os.type == "linux" and event.type == "start" and
+ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+ process.name == "nping"
 '''
 
 

--- a/rules/linux/discovery_pam_version_discovery.toml
+++ b/rules/linux/discovery_pam_version_discovery.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/12/16"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/12/16"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +13,7 @@ This rule detects PAM version discovery activity on Linux systems. PAM version d
 attacker attempting to backdoor the authentication process through malicious PAM modules.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Pluggable Authentication Module (PAM) Version Discovery"
@@ -56,14 +58,18 @@ tags = [
     "Tactic: Credential Access",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
-  (process.name in ("dpkg", "dpkg-query") and process.args == "libpam-modules") or
-  (process.name == "rpm" and process.args == "pam")
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  (
+    (process.name in ("dpkg", "dpkg-query") and process.args == "libpam-modules") or
+    (process.name == "rpm" and process.args == "pam")
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/discovery_private_key_password_searching_activity.toml
+++ b/rules/linux/discovery_private_key_password_searching_activity.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/11/04"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/11/04"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +13,7 @@ This rule detects private key searching activity on Linux systems. Searching for
 attacker attempting to escalate privileges or exfiltrate sensitive information.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Private Key Searching Activity"
@@ -48,14 +50,18 @@ tags = [
         "OS: Linux",
         "Use Case: Threat Detection",
         "Tactic: Discovery",
-        "Data Source: Elastic Defend"
+        "Data Source: Elastic Defend",
+        "Data Source: Crowdstrike",
+        "Data Source: SentinelOne",
+        "Data Source: Elastic Endgame"
         ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "find" and
-process.command_line like ("*id_dsa*", "*id_rsa*", "*id_ed*", "*id_ecdsa*", "*id_xmss*", "*id_dh*") and
-process.command_line like ("*/home/*", "*/etc/ssh*", "*/root/*", "/")
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and process.name == "find" and
+  process.command_line like ("*id_dsa*", "*id_rsa*", "*id_ed*", "*id_ecdsa*", "*id_xmss*", "*id_dh*") and
+  process.command_line like ("*/home/*", "*/etc/ssh*", "*/root/*", "/")
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Issues

https://github.com/elastic/ia-trade-team/issues/503
https://github.com/elastic/ia-trade-team/issues/505

## Summary

Introduces rule modifications to add support to SentinelOne and Crowdstrike where possible.

Crowdstrike events are pending integration adjustments (documented [here](https://docs.google.com/document/d/1NSMazu9cgEJMsUHnUT8Z6NrNfwDSF91cSbhjwySK7vk/edit?usp=sharing)), but they often lack enough context when comparing to S1 and Elastic Defend.

While these rules were not tested by generating alerts due to the lack of access to a CrowdStrike environment, the following steps were taken to ensure accuracy:
* Verified that the fields used are populated by the target EDR in the specified event category, which is documented here at the [Linux EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1nNWenQzmdxj73OYoxfZQztEcMEGwkrQrPbFRvpXrh_c/edit?usp=sharing)
* Checked for and resolved any base field (e.g., `event.type`, `event.action`, `host.os.type`, etc.) incompatibilities.
* Manually tested the queries with small modifications in the field values to ensure the logic worked.