### PR TITLE
[Rule Tuning] Linux 3rd Party EDR Support - Crowdstrike and S1 - 7

### DIFF
--- a/rules/linux/discovery_process_capabilities.toml
+++ b/rules/linux/discovery_process_capabilities.toml
@@ -58,7 +58,7 @@ type = "eql"
 
 query = '''
 process where host.os.type == "linux" and event.type == "start" and
-  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  event.action in ("exec", "exec_event", "ProcessRollup2") and
   process.name == "getcap" and process.args == "-r" and process.args == "/" and
   process.args_count == 3 and user.id != "0"
 '''

--- a/rules/linux/discovery_process_capabilities.toml
+++ b/rules/linux/discovery_process_capabilities.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2024/01/09"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike"]
 maturity = "production"
-updated_date = "2024/11/07"
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ Identifies recursive process capability enumeration of the entire filesystem thr
 may manipulate identified capabilities to gain root privileges.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-crowdstrike.fdr*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Process Capability Enumeration"
@@ -51,14 +51,16 @@ tags = [
     "Tactic: Discovery",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
-process.name == "getcap" and process.args == "-r" and process.args == "/" and process.args_count == 3 and
-user.id != "0"
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  process.name == "getcap" and process.args == "-r" and process.args == "/" and
+  process.args_count == 3 and user.id != "0"
 '''
 
 

--- a/rules/linux/discovery_security_file_access_via_common_utility.toml
+++ b/rules/linux/discovery_security_file_access_via_common_utility.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/11/04"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/11/04"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +13,7 @@ This rule detects sensitive security file access via common utilities on Linux s
 from sensitive files using common utilities to gather information about the system and its security configuration.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Security File Access via Common Utilities"
@@ -48,20 +50,24 @@ tags = [
         "OS: Linux",
         "Use Case: Threat Detection",
         "Tactic: Discovery",
-        "Data Source: Elastic Defend"
+        "Data Source: Elastic Defend",
+        "Data Source: Crowdstrike",
+        "Data Source: SentinelOne",
+        "Data Source: Elastic Endgame"
         ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.name in ("cat", "grep", "less", "more", "strings", "awk", "find", "xargs") and
-process.args like (
-  "/etc/security/*", "/etc/pam.d/*", "/etc/login.defs", "/lib/security/*", "/lib64/security/*",
-  "/usr/lib/security/*", "/usr/lib64/security/*", "/usr/lib/x86_64-linux-gnu/security/*",
-  "/home/*/.aws/credentials", "/home/*/.aws/config", "/home/*/.config/gcloud/*credentials.json",
-  "/home/*/.config/gcloud/configurations/config_default", "/home/*/.azure/accessTokens.json",
-  "/home/*/.azure/azureProfile.json"
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  process.name in ("cat", "grep", "less", "more", "strings", "awk", "find", "xargs") and
+  process.args like (
+    "/etc/security/*", "/etc/pam.d/*", "/etc/login.defs", "/lib/security/*", "/lib64/security/*",
+    "/usr/lib/security/*", "/usr/lib64/security/*", "/usr/lib/x86_64-linux-gnu/security/*",
+    "/home/*/.aws/credentials", "/home/*/.aws/config", "/home/*/.config/gcloud/*credentials.json",
+    "/home/*/.config/gcloud/configurations/config_default", "/home/*/.azure/accessTokens.json",
+    "/home/*/.azure/azureProfile.json"
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/discovery_sudo_allowed_command_enumeration.toml
+++ b/rules/linux/discovery_sudo_allowed_command_enumeration.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/08/30"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ the invoking user. Attackers may execute this command to enumerate commands allo
 permissions, potentially allowing to escalate privileges to root.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Sudo Command Enumeration Detected"
@@ -50,14 +52,17 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Discovery",
     "Data Source: Elastic Defend",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
-process.name == "sudo" and process.args == "-l" and process.args_count == 2 and
-process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
-not process.args == "dpkg"
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and process.name == "sudo" and process.args == "-l" and
+  process.args_count == 2 and process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
+  not process.args == "dpkg"
 '''
 
 [[rule.threat]]

--- a/rules/linux/discovery_suspicious_memory_grep_activity.toml
+++ b/rules/linux/discovery_suspicious_memory_grep_activity.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/02/05"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/18"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ specific process, detailing the memory segments, permissions, and what files are
 read a process's memory map to identify memory addresses for code injection or process hijacking.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Memory grep Activity"
@@ -27,12 +29,15 @@ tags = [
     "Tactic: Discovery",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
-process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack]", "[vdso]", "[heap]")
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack]", "[vdso]", "[heap]")
 '''
 
 [[rule.threat]]

--- a/rules/linux/discovery_suspicious_which_command_execution.toml
+++ b/rules/linux/discovery_suspicious_which_command_execution.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/08/30"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ leverage the which command to enumerate the system for useful installed utilitie
 system to escalate privileges or move latteraly across the network.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious which Enumeration"
@@ -26,16 +28,18 @@ tags = [
     "Tactic: Discovery",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
-process.name == "which" and process.args_count >= 10 and not (
-  process.parent.name == "jem" or
-  process.parent.executable like ("/vz/root/*", "/var/lib/docker/*") or
-  process.args == "--tty-only"
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start") and 
+  process.name == "which" and process.args_count >= 10 and not (
+    process.parent.name == "jem" or
+    process.parent.executable like ("/vz/root/*", "/var/lib/docker/*") or
+    process.args == "--tty-only"
+  )
 
 /* potential tuning if rule would turn out to be noisy
 and process.args in ("nmap", "nc", "ncat", "netcat", nc.traditional", "gcc", "g++", "socat") and 

--- a/rules/linux/discovery_yum_dnf_plugin_detection.toml
+++ b/rules/linux/discovery_yum_dnf_plugin_detection.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/06/25"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/09/23"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ to search for YUM/DNF configurations and/or plugins with an enabled state. This 
 attempting to establish persistence in a YUM or DNF plugin.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Yum/DNF Plugin Status Discovery"
@@ -52,16 +54,19 @@ tags = [
     "Tactic: Discovery",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
-process.name == "grep" and process.args : "plugins*" and process.args : (
-  "/etc/yum.conf", "/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*",
-  "/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugins/*", "/etc/dnf/dnf.conf"
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  process.name == "grep" and process.args : "plugins*" and process.args : (
+    "/etc/yum.conf", "/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*",
+    "/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugins/*", "/etc/dnf/dnf.conf"
+  )
 '''
 
 

--- a/rules/linux/execution_cupsd_foomatic_rip_file_creation.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_file_creation.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/09/27"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/09/30"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +16,7 @@ and foomatic-rip, allowing remote unauthenticated attackers to manipulate IPP UR
 crafted UDP packets or network spoofing. This can result in arbitrary command execution when a print job is initiated.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "File Creation by Cups or Foomatic-rip Child"
@@ -104,11 +106,12 @@ tags = [
     "Use Case: Vulnerability",
     "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 query = '''
 sequence by host.id with maxspan=10s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
    process.parent.name == "foomatic-rip" and
    process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")] by process.entity_id
   [file where host.os.type == "linux" and event.type != "deletion" and

--- a/rules/linux/execution_cupsd_foomatic_rip_lp_user_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_lp_user_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/09/27"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/10/17"
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +15,7 @@ through crafted UDP packets or network spoofing. This can result in arbitrary co
 initiated.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Printer User (lp) Shell Execution"
@@ -105,19 +105,21 @@ tags = [
     "Use Case: Vulnerability",
     "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and user.name == "lp" and
-process.parent.name in ("cupsd", "foomatic-rip", "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
-process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and not (
-  process.command_line like (
-    "*/tmp/foomatic-*", "*-sDEVICE=ps2write*", "*printf*", "/bin/sh -e -c cat", "/bin/bash -c cat",
-    "/bin/bash -e -c cat"
-  ) or
-  process.args like "gs*"
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event") and user.name == "lp" and
+  process.parent.name in ("cupsd", "foomatic-rip", "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and not (
+    process.command_line like (
+      "*/tmp/foomatic-*", "*-sDEVICE=ps2write*", "*printf*", "/bin/sh -e -c cat", "/bin/bash -c cat",
+      "/bin/bash -e -c cat"
+    ) or
+    process.args like "gs*"
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/execution_cupsd_foomatic_rip_shell_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_shell_execution.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/09/27"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +16,7 @@ remote unauthenticated attackers to manipulate IPP URLs or inject malicious data
 spoofing. This can result in arbitrary command execution when a print job is initiated.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Cupsd or Foomatic-rip Shell Execution"
@@ -104,19 +106,22 @@ tags = [
     "Use Case: Vulnerability",
     "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.parent.name == "foomatic-rip" and
-process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and not (
-  process.command_line like (
-    "*/tmp/foomatic-*", "*-sDEVICE=ps2write*", "*printf*", "/bin/sh -e -c cat", "/bin/bash -c cat",
-    "/bin/bash -e -c cat"
-  ) or
-  process.args like "gs*"
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and process.parent.name == "foomatic-rip" and
+  process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and not (
+    process.command_line like (
+      "*/tmp/foomatic-*", "*-sDEVICE=ps2write*", "*printf*", "/bin/sh -e -c cat", "/bin/bash -c cat",
+      "/bin/bash -e -c cat"
+    ) or
+    process.args like "gs*"
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/execution_cupsd_foomatic_rip_suspicious_child_execution.toml
+++ b/rules/linux/execution_cupsd_foomatic_rip_suspicious_child_execution.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/09/27"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/07"
 
 [rule]
 author = ["Elastic"]
@@ -15,7 +17,7 @@ through crafted UDP packets or network spoofing. This can result in arbitrary co
 initiated.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Execution from Foomatic-rip or Cupsd Parent"
@@ -105,11 +107,14 @@ tags = [
     "Use Case: Vulnerability",
     "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
 process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
   // persistence
   "*cron*", "*/etc/rc.local*", "*/dev/tcp/*", "*/etc/init.d*", "*/etc/update-motd.d*", "*/etc/sudoers*",


### PR DESCRIPTION
## Issues

https://github.com/elastic/ia-trade-team/issues/503
https://github.com/elastic/ia-trade-team/issues/505

## Summary

Introduces rule modifications to add support to SentinelOne and Crowdstrike where possible.

Crowdstrike events are pending integration adjustments (documented [here](https://docs.google.com/document/d/1NSMazu9cgEJMsUHnUT8Z6NrNfwDSF91cSbhjwySK7vk/edit?usp=sharing)), but they often lack enough context when comparing to S1 and Elastic Defend.

While these rules were not tested by generating alerts due to the lack of access to a CrowdStrike environment, the following steps were taken to ensure accuracy:
* Verified that the fields used are populated by the target EDR in the specified event category, which is documented here at the [Linux EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1nNWenQzmdxj73OYoxfZQztEcMEGwkrQrPbFRvpXrh_c/edit?usp=sharing)
* Checked for and resolved any base field (e.g., `event.type`, `event.action`, `host.os.type`, etc.) incompatibilities.
* Manually tested the queries with small modifications in the field values to ensure the logic worked.