### PR TITLE
[New Rule] Potential Process Name Stomping with Prctl

### DIFF
--- a/rules/linux/defense_evasion_prctl_process_name_tampering.toml
+++ b/rules/linux/defense_evasion_prctl_process_name_tampering.toml
@@ -1,0 +1,84 @@
+[metadata]
+creation_date = "2025/01/09"
+integration = ["auditd_manager"]
+maturity = "production"
+updated_date = "2025/01/09"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule leverages Auditd data to detect the use of the `prctl` syscall to potentially hide a process
+by changing its name. The `prctl` syscall is used to control various process attributes. Attackers can use
+this syscall to change the name of a process to a hidden directory or file, making it harder to detect. The query
+looks for the `prctl` syscall with the `PR_SET_NAME` argument set to `f` (PR_SET_NAME is used to set the name of a process).
+"""
+from = "now-9m"
+index = ["logs-auditd_manager.auditd-*", "auditbeat-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Process Name Stomping with Prctl"
+references = [
+    "https://haxrob.net/process-name-stomping/",
+    "https://haxrob.net/hiding-in-plain-sight-part-2/",
+    "https://www.elastic.co/security-labs/linux-detection-engineering-with-auditd",
+]
+risk_score = 47
+rule_id = "fef62ecf-0260-4b71-848b-a8624b304828"
+setup = """## Setup
+
+This rule requires data coming in from Auditd Manager.
+
+### Auditd Manager Integration Setup
+The Auditd Manager Integration receives audit events from the Linux Audit Framework which is a part of the Linux kernel.
+Auditd Manager provides a user-friendly interface and automation capabilities for configuring and monitoring system auditing through the auditd daemon. With `auditd_manager`, administrators can easily define audit rules, track system events, and generate comprehensive audit reports, improving overall security and compliance in the system.
+
+#### The following steps should be executed in order to add the Elastic Agent System integration "auditd_manager" on a Linux System:
+- Go to the Kibana home page and click “Add integrations”.
+- In the query bar, search for “Auditd Manager” and select the integration to see more details about it.
+- Click “Add Auditd Manager”.
+- Configure the integration name and optionally add a description.
+- Review optional and advanced settings accordingly.
+- Add the newly installed “auditd manager” to an existing or a new agent policy, and deploy the agent on a Linux system from which auditd log files are desirable.
+- Click “Save and Continue”.
+- For more details on the integration refer to the [helper guide](https://docs.elastic.co/integrations/auditd_manager).
+
+#### Rule Specific Setup Note
+Auditd Manager subscribes to the kernel and receives events as they occur without any additional configuration.
+However, if more advanced configuration is required to detect specific behavior, audit rules can be added to the integration in either the "audit rules" configuration box or the "auditd rule files" box by specifying a file to read the audit rules from.
+- For this detection rule the following additional audit rules are required to be added to the integration:
+  -- "-a exit,always -F arch=b64 -S prctl -k prctl_detection"
+"""
+severity = "medium"
+tags = [
+    "Data Source: Auditd Manager",
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+]
+type = "eql"
+query = '''
+process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
+process.executable like (
+  "/boot/*", "/dev/shm/*", "/etc/cron.*/*", "/etc/init.d/*", "/var/run/*", "/etc/update-motd.d/*",
+  "/tmp/*", "/var/log/*", "/var/tmp/*", "/home/*", "/run/shm/*", "/run/*", "./*"
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1036"
+name = "Masquerading"
+reference = "https://attack.mitre.org/techniques/T1036/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1036.005"
+name = "Match Legitimate Name or Location"
+reference = "https://attack.mitre.org/techniques/T1036/005/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/linux/defense_evasion_prctl_process_name_tampering.toml
+++ b/rules/linux/defense_evasion_prctl_process_name_tampering.toml
@@ -56,6 +56,7 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Defense Evasion",
 ]
+timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and


### PR DESCRIPTION
## Summary
This rule leverages Auditd data to detect the use of the `prctl` syscall to potentially hide a process by changing its name. The `prctl` syscall is used to control various process attributes. Attackers can use this syscall to change the name of a process to a hidden directory or file, making it harder to detect. The query looks for the `prctl` syscall with the `PR_SET_NAME` argument set to `f` (PR_SET_NAME is used to set the name of a process).

## Telemetry
<img width="1347" alt="{9A10309C-60E6-45E2-8E97-ACE5ACBBC060}" src="https://github.com/user-attachments/assets/420eee6f-9683-4ced-8aaa-00ce39399136" />
