### PR TITLE
[Rule Tuning] Linux 3rd Party EDR Support - Crowdstrike and S1 - 9

### DIFF
--- a/rules/linux/exfiltration_potential_data_splitting_for_exfiltration.toml
+++ b/rules/linux/exfiltration_potential_data_splitting_for_exfiltration.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/11/04"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/11/04"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ for exfiltration on Linux systems. Data splitting is a technique used by adversa
 avoid detection and exfiltrate data.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Data Splitting Detected"
@@ -49,25 +51,33 @@ tags = [
     "OS: Linux",
     "Use Case: Threat Detection",
     "Tactic: Exfiltration",
-    "Data Source: Elastic Defend"
+    "Data Source: Elastic Defend",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame"
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
-  (process.name == "dd" and process.args like "bs=*" and process.args like "if=*") or
-  (process.name in ("split", "rsplit") and (
-    (process.args == "-b" or process.args like "--bytes*") or
-    (process.args == "-C" or process.args like "--line-bytes*")
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  (
+    (process.name == "dd" and process.args like "bs=*" and process.args like "if=*") or
+    (
+      process.name in ("split", "rsplit") and
+      (
+        (process.args == "-b" or process.args like "--bytes*") or
+        (process.args == "-C" or process.args like "--line-bytes*")
+      )
+    )
+  ) and
+  not (
+    process.parent.name in ("apport", "overlayroot") or
+    process.args like (
+      "if=/tmp/nvim*", "if=/boot/*", "if=/dev/random", "if=/dev/urandom", "/dev/mapper/*",
+      "if=*.iso", "of=/dev/stdout", "if=/dev/zero", "if=/dev/sda", "/proc/sys/kernel/*"
     )
   )
-) and not (
-  process.parent.name in ("apport", "overlayroot") or
-  process.args like (
-    "if=/tmp/nvim*", "if=/boot/*", "if=/dev/random", "if=/dev/urandom", "/dev/mapper/*",
-    "if=*.iso", "of=/dev/stdout", "if=/dev/zero", "if=/dev/sda", "/proc/sys/kernel/*"
-  )
-)
 '''
 
 [[rule.threat]]

--- a/rules/linux/impact_memory_swap_modification.toml
+++ b/rules/linux/impact_memory_swap_modification.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/11/04"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/11/04"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ the system's memory and potentially impact the system's performance. This behavi
 deploys miner software such as XMRig.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Memory Swap Modification"
@@ -53,11 +55,13 @@ tags = [
     "Tactic: Impact",
     "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
 process.parent.executable != null and
 process.name in ("swapon", "swapoff") or (
   process.command_line like ("*vm.swappiness*", "*/proc/sys/vm/swappiness*") and (

--- a/rules/linux/lateral_movement_ssh_it_worm_download.toml
+++ b/rules/linux/lateral_movement_ssh_it_worm_download.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/09/21"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +13,7 @@ Identifies processes that are capable of downloading files with command line arg
 autonomous SSH worm. This worm intercepts outgoing SSH connections every time a user uses ssh.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential SSH-IT SSH Worm Downloaded"
@@ -53,13 +55,16 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
- and process.name in ("curl", "wget") and process.args : (
+process where host.os.type == "linux" and event.type == "start" and
+ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+ process.name in ("curl", "wget") and process.args : (
   "https://thc.org/ssh-it/x", "http://nossl.segfault.net/ssh-it-deploy.sh", "https://gsocket.io/x",
   "https://thc.org/ssh-it/bs", "http://nossl.segfault.net/bs"
 )

--- a/rules/linux/persistence_apt_package_manager_execution.toml
+++ b/rules/linux/persistence_apt_package_manager_execution.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/02/01"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/09/23"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +16,7 @@ repositories. Attackers can backdoor APT to gain persistence by injecting malici
 thereby ensuring continued unauthorized access or control each time APT is used for package management.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious APT Package Manager Execution"
@@ -56,17 +58,18 @@ tags = [
     "Tactic: Execution",
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 
 query = '''
 sequence by host.id with maxspan=5s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
    process.parent.name == "apt" and process.args == "-c" and process.name in (
      "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish"
    )
   ] by process.entity_id
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name : (
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and process.name : (
      "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "python*", "php*",
      "perl", "ruby", "lua*", "openssl", "nc", "netcat", "ncat", "telnet", "awk"
    )

--- a/rules/linux/persistence_chkconfig_service_add.toml
+++ b/rules/linux/persistence_chkconfig_service_add.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2022/07/22"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [transform]
 [[transform.osquery]]
@@ -53,7 +55,7 @@ either a start or a kill entry in every runlevel and when the system is rebooted
 providing long-term persistence.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Chkconfig Service Add"
@@ -169,11 +171,12 @@ tags = [
     "Threat: Lightning Framework",
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.action in ("exec", "exec_event") and
+process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
 ( 
   (process.executable : "/usr/sbin/chkconfig" and process.args : "--add") or
   (process.args : "*chkconfig" and process.args : "--add")

--- a/rules/linux/persistence_dnf_package_manager_plugin_file_creation.toml
+++ b/rules/linux/persistence_dnf_package_manager_plugin_file_creation.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/06/25"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/09/23"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +16,7 @@ persistence by injecting malicious code into plugins that DNF runs, thereby ensu
 control each time DNF is used for package management.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.file*"]
+index = ["logs-endpoint.events.file*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "DNF Package Manager Plugin File Creation"
@@ -58,6 +60,8 @@ tags = [
     "Tactic: Persistence",
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/linux/persistence_git_hook_execution.toml
+++ b/rules/linux/persistence_git_hook_execution.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/07/15"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/09/23"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ executes before or after events such as: commit, push, and receive. An attacker 
 commands on the system and establish persistence.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process*"]
+index = ["logs-endpoint.events.process*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Git Hook Command Execution"
@@ -56,16 +58,17 @@ tags = [
     "Tactic: Execution",
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 
 query = '''
 sequence by host.id with maxspan=3s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
    process.parent.name == "git" and process.args : ".git/hooks/*" and
    process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")
   ] by process.entity_id
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")] by process.parent.entity_id
 '''
 

--- a/rules/linux/persistence_git_hook_process_execution.toml
+++ b/rules/linux/persistence_git_hook_process_execution.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/06/26"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/09/23"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ spawned by the Git process itself. This behavior may indicate an attacker attemp
 leveraging the legitimate Git process to execute unauthorized commands.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process*"]
+index = ["logs-endpoint.events.process*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Git Hook Child Process"
@@ -57,24 +59,31 @@ tags = [
     "Tactic: Execution",
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.parent.name in (
-  "applypatch-msg", "commit-msg", "fsmonitor-watchman", "post-update", "post-checkout", "post-commit",
-  "pre-applypatch", "pre-commit", "pre-merge-commit", "prepare-commit-msg", "pre-push", "pre-rebase", "pre-receive",
-  "push-to-checkout", "update", "post-receive", "pre-auto-gc", "post-rewrite", "sendemail-validate", "p4-pre-submit",
-  "post-index-change", "post-merge", "post-applypatch"
-) and (
-  process.name in ("nohup", "setsid", "disown", "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") or 
-  process.name : ("php*", "perl*", "ruby*", "lua*") or 
-  process.executable : (
-    "/boot/*", "/dev/shm/*", "/etc/cron.*/*", "/etc/init.d/*", "/etc/update-motd.d/*",
-    "/run/*", "/srv/*", "/tmp/*", "/var/tmp/*", "/var/log/*"
-  )
-) and not process.name in ("git", "dirname")
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  process.parent.name in (
+    "applypatch-msg", "commit-msg", "fsmonitor-watchman", "post-update", "post-checkout", "post-commit",
+    "pre-applypatch", "pre-commit", "pre-merge-commit", "prepare-commit-msg", "pre-push", "pre-rebase", "pre-receive",
+    "push-to-checkout", "update", "post-receive", "pre-auto-gc", "post-rewrite", "sendemail-validate", "p4-pre-submit",
+    "post-index-change", "post-merge", "post-applypatch"
+  ) and
+  (
+    process.name in ("nohup", "setsid", "disown", "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") or 
+    process.name : ("php*", "perl*", "ruby*", "lua*") or 
+    process.executable : (
+      "/boot/*", "/dev/shm/*", "/etc/cron.*/*", "/etc/init.d/*", "/etc/update-motd.d/*",
+      "/run/*", "/srv/*", "/tmp/*", "/var/tmp/*", "/var/log/*"
+    )
+  ) and
+  not process.name in ("git", "dirname")
 '''
 
 

--- a/rules/linux/persistence_linux_backdoor_user_creation.toml
+++ b/rules/linux/persistence_linux_backdoor_user_creation.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/03/07"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/09/23"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [transform]
 [[transform.osquery]]
@@ -36,7 +38,7 @@ Identifies the attempt to create a new backdoor user by setting the user's UID t
 0 to establish persistence on a system.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Linux Backdoor User Account Creation"
@@ -125,12 +127,15 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
+process where host.os.type == "linux" and event.type == "start" and
+ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
  and process.name == "usermod" and process.args : "-u" and process.args : "0" and process.args : "-o"
 '''
 

--- a/rules/linux/persistence_linux_shell_activity_via_web_server.toml
+++ b/rules/linux/persistence_linux_shell_activity_via_web_server.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/03/04"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [transform]
 [[transform.osquery]]
@@ -40,7 +42,7 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Remote Code Execution via Web Server"
@@ -139,13 +141,14 @@ tags = [
     "Use Case: Vulnerability",
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event") and process.parent.executable : (
+event.action in ("exec", "exec_event", "start") and process.parent.executable : (
   "/usr/sbin/nginx", "/usr/local/sbin/nginx",
   "/usr/sbin/apache", "/usr/local/sbin/apache",
   "/usr/sbin/apache2", "/usr/local/sbin/apache2",


### PR DESCRIPTION
## Issues

https://github.com/elastic/ia-trade-team/issues/503
https://github.com/elastic/ia-trade-team/issues/505

## Summary

Introduces rule modifications to add support to SentinelOne and Crowdstrike where possible.

Crowdstrike events are pending integration adjustments (documented [here](https://docs.google.com/document/d/1NSMazu9cgEJMsUHnUT8Z6NrNfwDSF91cSbhjwySK7vk/edit?usp=sharing)), but they often lack enough context when comparing to S1 and Elastic Defend.

While these rules were not tested by generating alerts due to the lack of access to a CrowdStrike environment, the following steps were taken to ensure accuracy:
* Verified that the fields used are populated by the target EDR in the specified event category, which is documented here at the [Linux EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1nNWenQzmdxj73OYoxfZQztEcMEGwkrQrPbFRvpXrh_c/edit?usp=sharing)
* Checked for and resolved any base field (e.g., `event.type`, `event.action`, `host.os.type`, etc.) incompatibilities.
* Manually tested the queries with small modifications in the field values to ensure the logic worked.