### PR TITLE
[Rule Tuning] Linux 3rd Party EDR Support - Crowdstrike and S1 - 10

### DIFF
--- a/rules/linux/persistence_linux_user_added_to_privileged_group.toml
+++ b/rules/linux/persistence_linux_user_added_to_privileged_group.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/02/13"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/24"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [transform]
 [[transform.osquery]]
@@ -29,7 +31,7 @@ Identifies attempts to add a user to a privileged group. Attackers may add users
 establish persistence on a system.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Linux User Added to Privileged Group"
@@ -117,18 +119,21 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
- and process.args in (
-  "root", "admin", "wheel", "staff", "sudo","disk", "video", "shadow", "lxc", "lxd"
-) and
-(
-  process.name in ("usermod", "adduser") or
-  (process.name == "gpasswd" and process.args in ("-a", "--add", "-M", "--members")) 
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+  process.args in (
+    "root", "admin", "wheel", "staff", "sudo","disk", "video", "shadow", "lxc", "lxd"
+  ) and
+  (
+    process.name in ("usermod", "adduser") or
+    (process.name == "gpasswd" and process.args in ("-a", "--add", "-M", "--members")) 
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/persistence_message_of_the_day_execution.toml
+++ b/rules/linux/persistence_message_of_the_day_execution.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/02/28"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/31"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [transform]
 [[transform.osquery]]
@@ -41,7 +43,7 @@ a backdoor script or command. This rule detects the execution of potentially mal
 utility.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process*", "endgame-*"]
+index = ["logs-endpoint.events.process*", "endgame-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Process Spawned from Message-of-the-Day (MOTD)"
@@ -142,42 +144,60 @@ tags = [
     "Data Source: Elastic Endgame",
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where event.type == "start" and host.os.type == "linux" and event.action : ("exec", "exec_event") and
-  process.parent.executable : "/etc/update-motd.d/*" and (
-  (process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
-    (process.args : ("-i", "-l")) or (process.parent.name == "socat" and process.parent.args : "*exec*"))) or
-  (process.name : ("nc", "ncat", "netcat", "nc.openbsd") and process.args_count >= 3 and 
-    not process.args : ("-*z*", "-*l*")) or
-  (process.name : "python*" and process.args : "-c" and process.args : (
-     "*import*pty*spawn*", "*import*subprocess*call*"
-  )) or
-  (process.name : "perl*" and process.args : "-e" and process.args : "*socket*" and process.args : (
-     "*exec*", "*system*"
-  )) or
-  (process.name : "ruby*" and process.args : ("-e", "-rsocket") and process.args : (
-     "*TCPSocket.new*", "*TCPSocket.open*"
-  )) or
-  (process.name : "lua*" and process.args : "-e" and process.args : "*socket.tcp*" and process.args : (
-     "*io.popen*", "*os.execute*"
-  )) or
-  (process.name : "php*" and process.args : "-r" and process.args : "*fsockopen*" and process.args : "*/bin/*sh*") or 
-  (process.name : ("awk", "gawk", "mawk", "nawk") and process.args : "*/inet/tcp/*") or 
-  (process.name in ("openssl", "telnet")) or
-  (process.args : (
-    "./*", "/boot/*", "/dev/shm/*", "/etc/cron.*/*", "/etc/init.d/*", "/etc/update-motd.d/*", "/run/*", "/srv/*",
-    "/tmp/*", "/var/tmp/*", "/var/log/*", "/opt/*"
-    ) and process.args_count == 1
+process where event.type == "start" and host.os.type == "linux" and event.action : ("exec", "exec_event", "start") and
+  process.parent.executable : "/etc/update-motd.d/*" and
+  (
+    (
+      process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+      (
+        process.args : ("-i", "-l") or
+        (process.parent.name == "socat" and process.parent.args : "*exec*")
+      )
+    ) or
+    (
+      process.name : ("nc", "ncat", "netcat", "nc.openbsd") and process.args_count >= 3 and 
+      not process.args : ("-*z*", "-*l*")
+    ) or
+    (
+      process.name : "python*" and process.args : "-c" and process.args : (
+        "*import*pty*spawn*", "*import*subprocess*call*"
+      )
+    ) or
+    (
+      process.name : "perl*" and process.args : "-e" and process.args : "*socket*" and process.args : (
+        "*exec*", "*system*"
+      )
+    ) or
+    (
+      process.name : "ruby*" and process.args : ("-e", "-rsocket") and process.args : (
+        "*TCPSocket.new*", "*TCPSocket.open*"
+      )
+    ) or
+    (
+      process.name : "lua*" and process.args : "-e" and process.args : "*socket.tcp*" and process.args : (
+        "*io.popen*", "*os.execute*"
+      )
+    ) or
+    (process.name : "php*" and process.args : "-r" and process.args : "*fsockopen*" and process.args : "*/bin/*sh*") or 
+    (process.name : ("awk", "gawk", "mawk", "nawk") and process.args : "*/inet/tcp/*") or 
+    (process.name in ("openssl", "telnet")) or
+    (
+      process.args : (
+        "./*", "/boot/*", "/dev/shm/*", "/etc/cron.*/*", "/etc/init.d/*", "/etc/update-motd.d/*", "/run/*", "/srv/*",
+        "/tmp/*", "/var/tmp/*", "/var/log/*", "/opt/*"
+      ) and process.args_count == 1
+    )
+  ) and 
+  not (
+    process.parent.args == "--force" or
+    process.args in ("/usr/games/lolcat", "/usr/bin/screenfetch") or
+    process.parent.name == "system-crash-notification"
   )
-) and 
-not (
-  process.parent.args == "--force" or
-  process.args in ("/usr/games/lolcat", "/usr/bin/screenfetch") or
-  process.parent.name == "system-crash-notification"
-)
 '''
 
 [[rule.threat]]

--- a/rules/linux/persistence_potential_persistence_script_executable_bit_set.toml
+++ b/rules/linux/persistence_potential_persistence_script_executable_bit_set.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/06/03"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/09/23"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ environment. Adversaries may create these scripts to execute malicious code at s
 persistence onto the system.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process*", "endgame-*"]
+index = ["logs-endpoint.events.process*", "endgame-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Executable Bit Set for Potential Persistence Script"
@@ -58,12 +60,13 @@ tags = [
     "Tactic: Persistence",
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
 process.args : (
   // Misc.
   "/etc/rc.local", "/etc/rc.common", "/etc/rc.d/rc.local", "/etc/init.d/*", "/etc/update-motd.d/*",

--- a/rules/linux/persistence_process_capability_set_via_setcap.toml
+++ b/rules/linux/persistence_process_capability_set_via_setcap.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/06/03"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/06/03"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ by attackers to establish persistence by creating a backdoor, or escalate privil
 system.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process*", "endgame-*"]
+index = ["logs-endpoint.events.process*", "endgame-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Process Capability Set via setcap Utility"
@@ -53,12 +55,13 @@ tags = [
     "Tactic: Persistence",
     "Tactic: Privilege Escalation",
     "Data Source: Elastic Endgame",
-    "Data Source: Elastic Defend"
+    "Data Source: Elastic Defend",
+    "Data Source: SentinelOne"
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
 process.name == "setcap" and not (
   process.parent.executable == null or
   process.parent.executable : ("/var/lib/dpkg/*", "/var/lib/docker/*", "/tmp/newroot/*", "/var/tmp/newroot/*") or 

--- a/rules/linux/persistence_setuid_setgid_capability_set.toml
+++ b/rules/linux/persistence_setuid_setgid_capability_set.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/09/05"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [transform]
 [[transform.osquery]]
@@ -39,7 +41,7 @@ file owner or group. Threat actors can exploit these attributes to achieve persi
 allowing them to maintain control over a compromised system with elevated permissions.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Setcap setuid/setgid Capability Set"
@@ -138,15 +140,18 @@ tags = [
     "Tactic: Persistence",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
-process.name == "setcap" and process.args : "cap_set?id+ep" and not (
-  process.parent.name in ("jem", "vzctl") or
-  process.args like "/usr/bin/new?idmap"
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and 
+  process.name == "setcap" and process.args : "cap_set?id+ep" and not (
+    process.parent.name in ("jem", "vzctl") or
+    process.args like "/usr/bin/new?idmap"
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/persistence_simple_web_server_creation.toml
+++ b/rules/linux/persistence_simple_web_server_creation.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/12/17"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/12/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ simple HTTP web servers to establish persistence on a compromised system by uplo
 to the server web root, allowing them to regain remote access to the system if lost. 
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process*"]
+index = ["logs-endpoint.events.process*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Simple HTTP Web Server Creation"
@@ -52,14 +54,19 @@ tags = [
     "Tactic: Execution",
     "Tactic: Command and Control",
     "Data Source: Elastic Defend",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
-  (process.name regex~ """php?[0-9]?\.?[0-9]{0,2}""" and process.args == "-S") or
-  (process.name like "python*" and process.args in ("--cgi", "CGIHTTPServer"))
-)
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+  (
+    (process.name regex~ """php?[0-9]?\.?[0-9]{0,2}""" and process.args == "-S") or
+    (process.name like "python*" and process.args in ("--cgi", "CGIHTTPServer"))
+  )
 '''
 
 [[rule.threat]]

--- a/rules/linux/privilege_escalation_chown_chmod_unauthorized_file_read.toml
+++ b/rules/linux/privilege_escalation_chown_chmod_unauthorized_file_read.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/07/28"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ commands or input containing wildcards (e.g., *, ?, []) to execute unintended op
 tricking the system into interpreting the wildcard characters in unexpected ways.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Unauthorized Access via Wildcard Injection Detected"
@@ -55,13 +57,16 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
- and process.name in ("chown", "chmod") and process.args == "-R" and process.args : "--reference=*"
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+  process.name in ("chown", "chmod") and process.args == "-R" and process.args : "--reference=*"
 '''
 
 

--- a/rules/linux/privilege_escalation_docker_mount_chroot_container_escape.toml
+++ b/rules/linux/privilege_escalation_docker_mount_chroot_container_escape.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2024/01/15"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ within a container is capable of mounting the root file system of the host, and 
 containarized environment. This behavior pattern is very uncommon and should be investigated.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Chroot Container Escape via Mount"
@@ -64,15 +66,16 @@ tags = [
     "Tactic: Privilege Escalation",
     "Domain: Container",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 
 query = '''
 sequence by host.id, process.parent.entity_id with maxspan=5m
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
    process.name == "mount" and process.args : "/dev/sd*" and process.args_count >= 3 and
    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")]
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
    process.name == "chroot"]
 '''
 

--- a/rules/linux/privilege_escalation_linux_uid_int_max_bug.toml
+++ b/rules/linux/privilege_escalation_linux_uid_int_max_bug.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/07/27"
-integration = ["endpoint"]
+integration = ["endpoint", "crowdstrike"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ allowed UID size (INT_MAX). Some older Linux versions were affected by a bug whi
 greater than INT_MAX to escalate privileges by spawning a shell through systemd-run.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "logs-crowdstrike.fdr*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privilege Escalation via UID INT_MAX Bug Detected"
@@ -56,13 +56,15 @@ tags = [
     "Tactic: Privilege Escalation",
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and 
-process.name == "systemd-run" and process.args == "-t" and process.args_count >= 3 and user.id >= "1000000000"
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "ProcessRollup2") and
+  process.name == "systemd-run" and process.args == "-t" and process.args_count >= 3 and user.id >= "1000000000"
 '''
 
 

--- a/rules/linux/privilege_escalation_load_and_unload_of_kernel_via_kexec.toml
+++ b/rules/linux/privilege_escalation_load_and_unload_of_kernel_via_kexec.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/06/09"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/10/17"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +16,7 @@ escalate privileges, establish persistence or hide their activities by loading a
 tamper with the system's trusted state, allowing e.g. a VM Escape.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Kernel Load or Unload via Kexec Detected"
@@ -61,13 +63,16 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Elastic Endgame",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
- and process.name == "kexec" and process.args in ("--exec", "-e", "--load", "-l", "--unload", "-u") and not
- process.parent.name in ("kdumpctl", "unload.sh")
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+  process.name == "kexec" and process.args in ("--exec", "-e", "--load", "-l", "--unload", "-u") and
+  not process.parent.name in ("kdumpctl", "unload.sh")
 '''
 
 [[rule.threat]]

--- a/rules/linux/privilege_escalation_potential_wildcard_shell_spawn.toml
+++ b/rules/linux/privilege_escalation_potential_wildcard_shell_spawn.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/07/28"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/07/18"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ vulnerability where attackers manipulate commands or input containing wildcards 
 operations or access sensitive data by tricking the system into interpreting the wildcard characters in unexpected ways.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*"]
+index = ["logs-endpoint.events.*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Shell via Wildcard Injection Detected"
@@ -53,18 +55,19 @@ tags = [
     "Tactic: Privilege Escalation",
     "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 
 query = '''
 sequence by host.id with maxspan=1s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and (
     (process.name == "tar" and process.args : "--checkpoint=*" and process.args : "--checkpoint-action=*") or
     (process.name == "rsync" and process.args : "-e*") or
     (process.name == "zip" and process.args == "--unzip-command")
    ) and not process.executable : "/tmp/newroot/*"
   ]  by process.entity_id
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
+  [process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and 
      process.parent.name : ("tar", "rsync", "zip") and 
      process.name : ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")
   ] by process.parent.entity_id

--- a/rules/linux/privilege_escalation_sudo_cve_2019_14287.toml
+++ b/rules/linux/privilege_escalation_sudo_cve_2019_14287.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2023/08/30"
-integration = ["endpoint", "auditd_manager"]
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -13,7 +15,7 @@ that can be chosen arbitrarily. By using the sudo privileges, the command "sudo 
 representing the root user. This exploit may work for sudo versions prior to v1.28.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*"]
+index = ["logs-endpoint.events.*", "endgame-*", "auditbeat-*", "logs-auditd_manager.auditd-*", "logs-crowdstrike.fdr*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Sudo Privilege Escalation via CVE-2019-14287"
@@ -55,13 +57,16 @@ tags = [
     "Use Case: Vulnerability",
     "Data Source: Elastic Endgame",
     "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started")
- and process.name == "sudo" and process.args == "-u#-1"
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+  process.name == "sudo" and process.args == "-u#-1"
 '''
 
 

--- a/rules/linux/privilege_escalation_unshare_namespace_manipulation.toml
+++ b/rules/linux/privilege_escalation_unshare_namespace_manipulation.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2022/08/30"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2024/05/21"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/08"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +14,7 @@ or escape container security boundaries. Threat actors have utilized this binary
 host and access other resources or escalate privileges.
 """
 from = "now-9m"
-index = ["auditbeat-*", "logs-endpoint.events.*", "endgame-*"]
+index = ["auditbeat-*", "logs-endpoint.events.*", "endgame-*", "logs-sentinel_one_cloud_funnel.*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Namespace Manipulation Using Unshare"
@@ -67,12 +69,13 @@ tags = [
     "Tactic: Privilege Escalation",
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "exec_event") and
+process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "exec_event", "start") and
 process.executable: "/usr/bin/unshare" and
 not process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") and
 not process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java")


### PR DESCRIPTION
## Issues

https://github.com/elastic/ia-trade-team/issues/503
https://github.com/elastic/ia-trade-team/issues/505

## Summary

Introduces rule modifications to add support to SentinelOne and Crowdstrike where possible.

Crowdstrike events are pending integration adjustments (documented [here](https://docs.google.com/document/d/1NSMazu9cgEJMsUHnUT8Z6NrNfwDSF91cSbhjwySK7vk/edit?usp=sharing)), but they often lack enough context when comparing to S1 and Elastic Defend.

While these rules were not tested by generating alerts due to the lack of access to a CrowdStrike environment, the following steps were taken to ensure accuracy:
* Verified that the fields used are populated by the target EDR in the specified event category, which is documented here at the [Linux EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1nNWenQzmdxj73OYoxfZQztEcMEGwkrQrPbFRvpXrh_c/edit?usp=sharing)
* Checked for and resolved any base field (e.g., `event.type`, `event.action`, `host.os.type`, etc.) incompatibilities.
* Manually tested the queries with small modifications in the field values to ensure the logic worked.