### PR TITLE
[Tuning] Potential SYN-Based Network Scan Detected

### DIFF
--- a/rules/network/discovery_potential_syn_port_scan_detected.toml
+++ b/rules/network/discovery_potential_syn_port_scan_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/05/17"
 integration = ["endpoint", "network_traffic", "panw"]
 maturity = "production"
-updated_date = "2024/09/18"
+updated_date = "2025/01/10"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ index = ["logs-endpoint.events.network-*", "logs-network_traffic.*", "packetbeat
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 5
-name = "Potential SYN-Based Network Scan Detected"
+name = "Potential SYN-Based Port Scan Detected"
 risk_score = 21
 rule_id = "bbaa96b9-f36c-4898-ace2-581acb00a409"
 severity = "low"


### PR DESCRIPTION
renamed rule to `Potential SYN-Based Port Scan Detected` to align better with rule description.

context: https://elastic.slack.com/archives/C011H2BCRRN/p1736521605088419