### PR TITLE
[Bug] [DaC] Actions Connector Defaults to None

### DIFF
--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -279,7 +279,7 @@ def kibana_export_rules(ctx: click.Context, directory: Path, action_connectors_d
             exceptions_containers,
             exceptions_items,
             exception_list_rule_table,
-            exceptions_directory,
+            exceptions_directory if exceptions_directory else None,
             save_toml=False,
             skip_errors=skip_errors,
             verbose=False,
@@ -297,7 +297,7 @@ def kibana_export_rules(ctx: click.Context, directory: Path, action_connectors_d
         action_connectors, ac_output, ac_errors = build_action_connector_objects(
             action_connector_results,
             action_connector_rule_table,
-            action_connectors_directory=None,
+            action_connectors_directory=action_connectors_directory if action_connectors_directory else None,
             save_toml=False,
             skip_errors=skip_errors,
             verbose=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "0.3.15"
+version = "0.3.16"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/4375


## Summary - What I changed

When specifying an actions connector for Kibana export rules, the value is not used and is not honored. Instead it is [set to none](https://github.com/elastic/detection-rules/blob/e822af47a496084beb698f905e6d28d300488cc9/detection_rules/kbwrap.py#L300), this should be set to the incoming parameter if the parameter is available otherwise it should be none. 


## How To Test

Use the export rules command while not having an action connector directory set in your config file, but instead have it passed via the CLI.

`python -m detection_rules kibana --space customer --ignore-ssl-errors true export-rules -d demo/rules/ -sv -ac -acd dac_test/action_connectors/`

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
