### PR TITLE
[New Rule] Polkit Policy Creation

### DIFF
--- a/rules/linux/persistence_polkit_policy_creation.toml
+++ b/rules/linux/persistence_polkit_policy_creation.toml
@@ -1,0 +1,92 @@
+[metadata]
+creation_date = "2025/01/16"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/01/16"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule monitors for the creation of Polkit policy files on Linux systems. Polkit policy files are used to
+define the permissions for system-wide services and applications. The creation of new Polkit policy files may
+indicate an attempt to modify the authentication process, which could be used for persistence by an adversary.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.file*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Polkit Policy Creation"
+risk_score = 21
+rule_id = "0f54e947-9ab3-4dff-9e8d-fb42493eaa2f"
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Tactic: Persistence",
+    "Data Source: Elastic Defend"
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
+file.extension in ("rules", "pkla", "policy") and file.path like~ (
+
+  // Rule files
+  "/etc/polkit-1/rules.d/*", "/usr/share/polkit-1/rules.d/*",
+
+  // pkla files
+  "/etc/polkit-1/localauthority/*", "/var/lib/polkit-1/localauthority/*",
+
+  // Action files
+  "/usr/share/polkit-1/actions/*",
+
+  // Misc. legacy paths
+  "/lib/polkit-1/rules.d/*", "/lib64/polkit-1/rules.d/*", "/var/lib/polkit-1/rules.d/*"
+) and not (
+  process.executable in (
+    "/bin/dpkg", "/usr/bin/dpkg", "/bin/dockerd", "/usr/bin/dockerd", "/usr/sbin/dockerd", "/bin/microdnf",
+    "/usr/bin/microdnf", "/bin/rpm", "/usr/bin/rpm", "/bin/snapd", "/usr/bin/snapd", "/bin/yum", "/usr/bin/yum",
+    "/bin/dnf", "/usr/bin/dnf", "/bin/podman", "/usr/bin/podman", "/bin/dnf-automatic", "/usr/bin/dnf-automatic",
+    "/bin/pacman", "/usr/bin/pacman", "/usr/bin/dpkg-divert", "/bin/dpkg-divert", "/sbin/apk", "/usr/sbin/apk",
+    "/usr/local/sbin/apk", "/usr/bin/apt", "/usr/sbin/pacman", "/bin/podman", "/usr/bin/podman", "/usr/bin/puppet",
+    "/bin/puppet", "/opt/puppetlabs/puppet/bin/puppet", "/usr/bin/chef-client", "/bin/chef-client",
+    "/bin/autossl_check", "/usr/bin/autossl_check", "/proc/self/exe", "/dev/fd/*",  "/usr/bin/pamac-daemon",
+    "/bin/pamac-daemon", "/usr/lib/snapd/snapd", "/usr/local/bin/dockerd", "/usr/bin/crio", "/usr/sbin/crond",
+    "/opt/puppetlabs/puppet/bin/ruby", "/usr/libexec/platform-python", "/kaniko/kaniko-executor",
+    "/usr/local/bin/dockerd", "/usr/bin/podman", "/bin/install", "/proc/self/exe", "/usr/lib/systemd/systemd",
+    "/usr/sbin/sshd", "/usr/bin/gitlab-runner", "/opt/gitlab/embedded/bin/ruby", "/usr/sbin/gdm", "/usr/bin/install",
+    "/usr/local/manageengine/uems_agent/bin/dcregister", "/usr/local/bin/pacman"
+  ) or
+process.executable like~ (
+    "/nix/store/*", "/var/lib/dpkg/*", "/tmp/vmis.*", "/snap/*", "/dev/fd/*", "/usr/lib/virtualbox/*"
+  )
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1556"
+name = "Modify Authentication Process"
+reference = "https://attack.mitre.org/techniques/T1556/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"


### PR DESCRIPTION
## Summary
This rule monitors for the creation of Polkit policy files on Linux systems. Polkit policy files are used to define the permissions for system-wide services and applications. The creation of new Polkit policy files may indicate an attempt to modify the authentication process, which could be used for persistence by an adversary.

## Telemetry
With the supplied exclusions, 0 hits in telemetry last 90d. Only TPs in testing stack.
<img width="1910" alt="{A2CA9C1D-0C9C-4EF9-BAE8-A70FC58D51AE}" src="https://github.com/user-attachments/assets/a8606b3c-6289-40ba-989f-4795db79a030" />
