### PR TITLE
[New Rule] Boot File Copy

### DIFF
--- a/rules/linux/persistence_boot_file_copy.toml
+++ b/rules/linux/persistence_boot_file_copy.toml
@@ -1,0 +1,122 @@
+[metadata]
+creation_date = "2025/01/16"
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "production"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/16"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the process of copying or moving files from or to the `/boot` directory on Linux systems. The
+`/boot` directory contains files that are essential for the system to boot, such as the kernel and initramfs
+images. Attackers may copy or move files to the `/boot` directory to modify the boot process, which can be
+leveraged to maintain access to the system.
+"""
+from = "now-9m"
+index = [
+    "logs-endpoint.events.*",
+    "endgame-*",
+    "auditbeat-*",
+    "logs-auditd_manager.auditd-*",
+    "logs-crowdstrike.fdr*",
+    "logs-sentinel_one_cloud_funnel.*"
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Boot File Copy"
+risk_score = 21
+rule_id = "5bda8597-69a6-4b9e-87a2-69a7c963ea83"
+setup = """## Setup
+This rule requires data coming in from Elastic Defend.
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Data Source: Elastic Endgame",
+    "Data Source: Elastic Defend",
+    "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process.name in ("cp", "mv") and process.parent.executable != null and process.args like~ "/boot/*" and not (
+  process.parent.name in ("update-initramfs", "dracut", "grub-mkconfig", "shim-install", "sudo", "activate-theme") or
+  process.parent.executable like~ ("/usr/lib/kernel/install.d/*", "/tmp/newroot/*", "/var/lib/dpkg/info/*") or
+  process.parent.args like~ ("/usr/bin/mkinitcpio", "/var/tmp/rpm-tmp.*")
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1542"
+name = "Pre-OS Boot"
+reference = "https://attack.mitre.org/techniques/T1542/"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+
+[[rule.threat.technique]]
+id = "T1574"
+name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/linux/persistence_boot_file_copy.toml
+++ b/rules/linux/persistence_boot_file_copy.toml
@@ -16,7 +16,7 @@ leveraged to maintain access to the system.
 """
 from = "now-9m"
 index = [
-    "logs-endpoint.events.*",
+    "logs-endpoint.events.process*",
     "endgame-*",
     "auditbeat-*",
     "logs-auditd_manager.auditd-*",

--- a/rules/linux/persistence_boot_file_copy.toml
+++ b/rules/linux/persistence_boot_file_copy.toml
@@ -64,7 +64,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed") and
 process.name in ("cp", "mv") and process.parent.executable != null and process.args like~ "/boot/*" and not (
   process.parent.name in ("update-initramfs", "dracut", "grub-mkconfig", "shim-install", "sudo", "activate-theme") or
   process.parent.executable like~ ("/usr/lib/kernel/install.d/*", "/tmp/newroot/*", "/var/lib/dpkg/info/*") or


### PR DESCRIPTION
## Summary
This rule detects the process of copying or moving files from or to the `/boot` directory on Linux systems. The `/boot` directory contains files that are essential for the system to boot, such as the kernel and initramfs images. Attackers may copy or move files to the `/boot` directory to modify the boot process, which can be leveraged to maintain access to the system.

## Telemetry
8 hits in telemetry, that I don't want to tune out just yet. Only TPs in testing stack:
<img width="1912" alt="{18B7C041-969E-4DCC-8714-1E0BFDD2A8DC}" src="https://github.com/user-attachments/assets/35e8168e-15e7-44c8-9834-974c88482cdf" />
