### PR TITLE
[New Rule] Initramfs Unpacking via unmkinitramfs

### DIFF
--- a/rules/linux/persistence_unpack_initramfs_via_unmkinitramfs.toml
+++ b/rules/linux/persistence_unpack_initramfs_via_unmkinitramfs.toml
@@ -1,0 +1,119 @@
+[metadata]
+creation_date = "2025/01/16"
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "production"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/16"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the unpacking of an initramfs image using the `unmkinitramfs` command on Linux systems. The
+`unmkinitramfs` command is used to extract the contents of an initramfs image, which is used to boot the
+system. Attackers may use `unmkinitramfs` to unpack an initramfs image and modify its contents to include
+malicious code or backdoors, allowing them to maintain persistence on the system.
+"""
+from = "now-9m"
+index = [
+    "logs-endpoint.events.*",
+    "endgame-*",
+    "auditbeat-*",
+    "logs-auditd_manager.auditd-*",
+    "logs-crowdstrike.fdr*",
+    "logs-sentinel_one_cloud_funnel.*"
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Initramfs Unpacking via unmkinitramfs"
+risk_score = 21
+rule_id = "c5fc788c-7576-4a02-b3d6-d2c016eb85a6"
+setup = """## Setup
+This rule requires data coming in from Elastic Defend.
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Data Source: Elastic Endgame",
+    "Data Source: Elastic Defend",
+    "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed") and
+process.name == "unmkinitramfs"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1542"
+name = "Pre-OS Boot"
+reference = "https://attack.mitre.org/techniques/T1542/"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+
+[[rule.threat.technique]]
+id = "T1574"
+name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/linux/persistence_unpack_initramfs_via_unmkinitramfs.toml
+++ b/rules/linux/persistence_unpack_initramfs_via_unmkinitramfs.toml
@@ -16,7 +16,7 @@ malicious code or backdoors, allowing them to maintain persistence on the system
 """
 from = "now-9m"
 index = [
-    "logs-endpoint.events.*",
+    "logs-endpoint.events.process*",
     "endgame-*",
     "auditbeat-*",
     "logs-auditd_manager.auditd-*",


### PR DESCRIPTION
## Summary
This rule detects the unpacking of an initramfs image using the `unmkinitramfs` command on Linux systems. The `unmkinitramfs` command is used to extract the contents of an initramfs image, which is used to boot the system. Attackers may use `unmkinitramfs` to unpack an initramfs image and modify its contents to include malicious code or backdoors, allowing them to maintain persistence on the system.

## Telemetry
0 hits in telemetry last 90d, only TPs in testing stack:
<img width="1903" alt="{A5100649-87E6-4DBA-8A14-A69A67E59166}" src="https://github.com/user-attachments/assets/6aa239e6-8397-48eb-acc2-408369cf2b1d" />
