### PR TITLE
[New Rule] Initramfs Extraction via CPIO

### DIFF
--- a/rules/linux/persistence_extract_initramfs_via_cpio.toml
+++ b/rules/linux/persistence_extract_initramfs_via_cpio.toml
@@ -1,0 +1,95 @@
+[metadata]
+creation_date = "2025/01/16"
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "production"
+min_stack_version = "8.13.0"
+min_stack_comments = "Breaking change at 8.13.0 for SentinelOne Integration."
+updated_date = "2025/01/16"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the extraction of an initramfs image using the `cpio` command on Linux systems. The
+`cpio` command is used to create or extract cpio archives. Attackers may extract the initramfs image to
+modify the contents or add malicious files, which can be leveraged to maintain persistence on the system.
+"""
+from = "now-9m"
+index = [
+    "logs-endpoint.events.*",
+    "endgame-*",
+    "auditbeat-*",
+    "logs-auditd_manager.auditd-*",
+    "logs-crowdstrike.fdr*",
+    "logs-sentinel_one_cloud_funnel.*"
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Initramfs Extraction via CPIO"
+risk_score = 21
+rule_id = "17b3fcd1-90fb-4f5d-858c-dc1d998fa368"
+setup = """## Setup
+This rule requires data coming in from Elastic Defend.
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Data Source: Elastic Endgame",
+    "Data Source: Elastic Defend",
+    "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed") and
+process.name == "cpio" and process.args in ("-H", "--format") and process.args == "newc" and not (
+  process.parent.name in ("mkinitramfs", "dracut") or
+  process.parent.executable like~ ("/usr/share/initramfs-tools/*", "/nix/store/*")
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1542"
+name = "Pre-OS Boot"
+reference = "https://attack.mitre.org/techniques/T1542/"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+
+[[rule.threat.technique]]
+id = "T1574"
+name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"

--- a/rules/linux/persistence_extract_initramfs_via_cpio.toml
+++ b/rules/linux/persistence_extract_initramfs_via_cpio.toml
@@ -15,7 +15,7 @@ modify the contents or add malicious files, which can be leveraged to maintain p
 """
 from = "now-9m"
 index = [
-    "logs-endpoint.events.*",
+    "logs-endpoint.events.process*",
     "endgame-*",
     "auditbeat-*",
     "logs-auditd_manager.auditd-*",


### PR DESCRIPTION
## Note
For FP handling, I created this rule seperate from: https://github.com/elastic/detection-rules/pull/4387

## Summary
This rule detects the extraction of an initramfs image using the `cpio` command on Linux systems. The `cpio` command is used to create or extract cpio archives. Attackers may extract the initramfs image to modify the contents or add malicious files, which can be leveraged to maintain persistence on the system.

## Telemetry
8 hits in telemetry last 90d, which I will not tune out just yet, because I might alter the logic slightly if necessary (change of `process.args` requirements). Other than that, only TPs in testing stack:

<img width="1891" alt="{33544E37-F7C7-4585-BFF6-658EC005D800}" src="https://github.com/user-attachments/assets/ff227c68-c619-4d84-80fa-a4468977dec5" />
