### PR TITLE
[New Rule] Systemd Shell Execution During Boot

### DIFF
--- a/rules/linux/persistence_systemd_shell_execution.toml
+++ b/rules/linux/persistence_systemd_shell_execution.toml
@@ -1,0 +1,98 @@
+[metadata]
+creation_date = "2025/01/16"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/01/16"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the execution of shell commands by systemd during the boot process on Linux systems. Systemd
+is a system and service manager for Linux operating systems. Attackers may execute shell commands during the
+boot process to maintain persistence on the system. This may be a sign of malicious systemd services, initramfs
+or GRUB bootloader manipulation, or other persistence mechanisms.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.process*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Systemd Shell Execution During Boot"
+risk_score = 47
+rule_id = "0b76ad27-c3f3-4769-9e7e-3237137fdf06"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+    "Data Source: Elastic Defend",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
+process.parent.name == "systemd" and process.name in ("bash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+process.parent.command_line == "/sbin/init" and process.args_count >= 2
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1543.002"
+name = "Systemd Service"
+reference = "https://attack.mitre.org/techniques/T1543/002/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Create or Modify System Process"
+reference = "https://attack.mitre.org/techniques/T1543/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1543.002"
+name = "Systemd Service"
+reference = "https://attack.mitre.org/techniques/T1543/002/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"


### PR DESCRIPTION
## Summary
This rule detects the execution of shell commands by systemd during the boot process on Linux systems. Systemd is a system and service manager for Linux operating systems. Attackers may execute shell commands during the boot process to maintain persistence on the system. This may be a sign of malicious systemd services, initramfs or GRUB bootloader manipulation, or other persistence mechanisms.

## Telemetry
7 hits in telemetry last 90d that I am not tuning out just yet. Other than that, only TPs in my testing stack related to malicious systemd services, rc local persistence, grub/initramfs boot manipulation and rootkits:
<img width="1899" alt="{D0684837-ECC9-4AFD-A1F8-4AAE1ECDE9F4}" src="https://github.com/user-attachments/assets/0bc6847a-9876-4cf9-a1ac-62d48e0e2f22" />


