### PR TITLE
[New Rule] Suspicious Usage of bpf_probe_write_user Helper

### DIFF
--- a/rules/linux/persistence_bpf_probe_write_user.toml
+++ b/rules/linux/persistence_bpf_probe_write_user.toml
@@ -16,6 +16,42 @@ index = ["logs-system.syslog-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Suspicious Usage of bpf_probe_write_user Helper"
+note = """## Triage and analysis
+
+> **Disclaimer**:
+> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
+
+### Investigating Suspicious Usage of bpf_probe_write_user Helper
+
+The `bpf_probe_write_user` helper is a function within the eBPF (extended Berkeley Packet Filter) framework, allowing BPF programs to write data to user space. While useful for legitimate monitoring and debugging, adversaries can exploit it to manipulate user space memory, potentially deploying rootkits or evading defenses. The detection rule monitors syslog entries for kernel processes invoking this helper, flagging potential unauthorized use indicative of malicious activity.
+
+### Possible investigation steps
+
+- Review the syslog entries for the specific message "bpf_probe_write_user" to identify the exact time and context of the event.
+- Correlate the timestamp of the alert with other logs and system activities to identify any unusual behavior or patterns around the same time.
+- Investigate the process details associated with the kernel at the time of the alert to determine if there are any anomalies or unauthorized modifications.
+- Check for any recent changes or installations on the system that could have introduced unauthorized BPF programs.
+- Assess the system for signs of persistence mechanisms or defense evasion tactics, as indicated by the MITRE ATT&CK framework references.
+- Conduct a thorough review of user accounts and permissions to ensure no unauthorized access or privilege escalation has occurred.
+- If suspicious activity is confirmed, isolate the affected system and perform a comprehensive forensic analysis to understand the scope and impact of the potential compromise.
+
+### False positive analysis
+
+- Legitimate monitoring tools may use the bpf_probe_write_user helper for debugging purposes. Identify and whitelist these tools by verifying their source and ensuring they are part of authorized software packages.
+- Kernel developers and system administrators might use this helper during system diagnostics or performance tuning. Establish a baseline of expected usage patterns and create exceptions for known maintenance activities.
+- Automated scripts or system processes that perform regular system checks could trigger this rule. Review the scripts and processes to confirm their legitimacy and exclude them from alerts if they are verified as safe.
+- Security software or intrusion detection systems might utilize this helper as part of their normal operations. Coordinate with your security team to recognize these activities and adjust the rule to prevent unnecessary alerts.
+
+### Response and remediation
+
+- Immediately isolate the affected system from the network to prevent further unauthorized access or data manipulation.
+- Terminate any suspicious processes associated with the `bpf_probe_write_user` helper to halt potential malicious activity.
+- Conduct a thorough review of recent system changes and installed software to identify unauthorized modifications or installations.
+- Restore affected systems from a known good backup to ensure the integrity of user space memory and system files.
+- Implement stricter access controls and monitoring on systems with eBPF capabilities to prevent unauthorized use of the `bpf_probe_write_user` helper.
+- Escalate the incident to the security operations team for further analysis and to determine if additional systems are affected.
+- Update detection mechanisms to include additional indicators of compromise related to eBPF rootkits and similar threats, enhancing future threat detection capabilities.
+"""
 risk_score = 21
 rule_id = "c37ffc64-da75-447e-ad1c-cbc64727b3b8"
 setup = """## Setup

--- a/rules/linux/persistence_bpf_probe_write_user.toml
+++ b/rules/linux/persistence_bpf_probe_write_user.toml
@@ -1,0 +1,85 @@
+[metadata]
+creation_date = "2025/01/28"
+integration = ["system"]
+maturity = "production"
+updated_date = "2025/01/28"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule monitors the syslog log file for messages related to instances of a program using the `bpf_probe_write_user` helper.
+The `bpf_probe_write_user` helper is used to write data to user space from a BPF program. Unauthorized use of this helper can
+be indicative of an eBPF rootkit or other malicious activity.
+"""
+from = "now-9m"
+index = ["logs-system.syslog-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Suspicious Usage of bpf_probe_write_user Helper"
+risk_score = 21
+rule_id = "c37ffc64-da75-447e-ad1c-cbc64727b3b8"
+setup = """## Setup
+
+This rule requires data coming in from one of the following integrations:
+- Filebeat
+
+### Filebeat Setup
+Filebeat is a lightweight shipper for forwarding and centralizing log data. Installed as an agent on your servers, Filebeat monitors the log files or locations that you specify, collects log events, and forwards them either to Elasticsearch or Logstash for indexing.
+
+#### The following steps should be executed in order to add the Filebeat for the Linux System:
+- Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
+- To install the APT and YUM repositories follow the setup instructions in this [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/setup-repositories.html).
+- To run Filebeat on Docker follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html).
+- To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-kubernetes.html).
+- For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
+- For complete Setup and Run Filebeat information refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/setting-up-and-running.html).
+
+#### Rule Specific Setup Note
+- This rule requires the Filebeat System Module to be enabled.
+- The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
+- To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-system.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Defense Evasion",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+query = '''
+host.os.type:linux and event.dataset:"system.syslog" and process.name:kernel and message:"bpf_probe_write_user"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1547"
+name = "Boot or Logon Autostart Execution"
+reference = "https://attack.mitre.org/techniques/T1547/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1547.006"
+name = "Kernel Modules and Extensions"
+reference = "https://attack.mitre.org/techniques/T1547/006/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1014"
+name = "Rootkit"
+reference = "https://attack.mitre.org/techniques/T1014/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"


### PR DESCRIPTION
## Summary
This rule monitors the syslog log file for messages related to instances of a program using the `bpf_probe_write_user` helper. The `bpf_probe_write_user` helper is used to write data to user space from a BPF program. Unauthorized use of this helper can be indicative of an eBPF rootkit or other malicious activity.