### PR TITLE
[Rule Tuning] Port Scan Rules

### DIFF
--- a/rules/network/discovery_potential_network_sweep_detected.toml
+++ b/rules/network/discovery_potential_network_sweep_detected.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/05/17"
-integration = ["endpoint", "network_traffic", "panw"]
+integration = ["network_traffic", "panw"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/02/04"
 
 [rule]
 author = ["Elastic"]
@@ -11,10 +11,10 @@ This rule identifies a potential network sweep. A network sweep is a method used
 identifying active hosts, open ports, and available services to gather information on vulnerabilities and weaknesses.
 This reconnaissance helps them plan subsequent attacks and exploit potential entry points for unauthorized access, data
 theft, or other malicious activities. This rule proposes threshold logic to check for connection attempts from one
-source host to 10 or more destination hosts on commonly used network services.
+source host to 100 or more destination hosts on commonly used network services.
 """
 from = "now-9m"
-index = ["packetbeat-*", "auditbeat-*", "filebeat-*", "logs-network_traffic.*", "logs-endpoint.events.network-*", "logs-panw.panos*"]
+index = ["packetbeat-*", "filebeat-*", "logs-network_traffic.*", "logs-panw.panos*"]
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 5
@@ -27,16 +27,14 @@ tags = [
     "Tactic: Discovery",
     "Tactic: Reconnaissance",
     "Use Case: Network Security Monitoring",
-    "Data Source: Elastic Defend",
     "Data Source: PAN-OS",
     "Resources: Investigation Guide"
 ]
 timestamp_override = "event.ingested"
 type = "threshold"
-
 query = '''
-destination.port : (21 or 22 or 23 or 25 or 139 or 445 or 3389 or 5985 or 5986) and
-source.ip : (10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+event.action:network_flow and destination.port:(21 or 22 or 23 or 25 or 139 or 445 or 3389 or 5985 or 5986) and
+source.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
 '''
 note = """## Triage and analysis
 
@@ -80,31 +78,31 @@ Network sweeps are reconnaissance techniques where attackers scan networks to id
 
 - Document and report: Record all findings, actions taken, and lessons learned in an incident report to inform future response strategies and improve network defenses."""
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1046"
 name = "Network Service Discovery"
 reference = "https://attack.mitre.org/techniques/T1046/"
 
-
 [rule.threat.tactic]
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1595"
 name = "Active Scanning"
 reference = "https://attack.mitre.org/techniques/T1595/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1595.001"
 name = "Scanning IP Blocks"
 reference = "https://attack.mitre.org/techniques/T1595/001/"
-
-
 
 [rule.threat.tactic]
 id = "TA0043"
@@ -114,8 +112,7 @@ reference = "https://attack.mitre.org/tactics/TA0043/"
 [rule.threshold]
 field = ["source.ip"]
 value = 1
+
 [[rule.threshold.cardinality]]
 field = "destination.ip"
 value = 100
-
-

--- a/rules/network/discovery_potential_port_scan_detected.toml
+++ b/rules/network/discovery_potential_port_scan_detected.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/05/17"
-integration = ["endpoint", "network_traffic", "panw"]
+integration = ["network_traffic", "panw"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/02/04"
 
 [rule]
 author = ["Elastic"]
@@ -12,10 +12,10 @@ target system or network for open ports, allowing them to identify available ser
 mapping out the open ports, attackers can gather critical information to plan and execute targeted attacks, gaining
 unauthorized access, compromising security, and potentially leading to data breaches, unauthorized control, or further
 exploitation of the targeted system or network. This rule proposes threshold logic to check for connection attempts from
-one source host to 20 or more destination ports.
+one source host to 250 or more destination ports.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.network-*", "logs-network_traffic.*", "packetbeat-*", "filebeat-*", "auditbeat-*", "logs-panw.panos*"]
+index = ["logs-network_traffic.*", "packetbeat-*", "filebeat-*", "logs-panw.panos*"]
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 5
@@ -28,7 +28,6 @@ tags = [
     "Tactic: Discovery",
     "Tactic: Reconnaissance",
     "Use Case: Network Security Monitoring",
-    "Data Source: Elastic Defend",
     "Data Source: PAN-OS",
     "Resources: Investigation Guide"
 ]
@@ -36,7 +35,7 @@ timestamp_override = "event.ingested"
 type = "threshold"
 
 query = '''
-destination.port : * and event.action : "network_flow" and source.ip : (10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+event.action:network_flow and destination.port:* and source.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
 '''
 note = """## Triage and analysis
 
@@ -74,31 +73,31 @@ Network scanning is a technique used to identify open ports and services on a ne
 - Escalate to security operations: If the scan is part of a larger attack or if sensitive data is at risk, escalate the incident to the security operations team for further analysis and response.
 - Review and enhance detection capabilities: Evaluate the effectiveness of current detection mechanisms and consider integrating additional threat intelligence sources to improve early detection of similar threats."""
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1046"
 name = "Network Service Discovery"
 reference = "https://attack.mitre.org/techniques/T1046/"
 
-
 [rule.threat.tactic]
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1595"
 name = "Active Scanning"
 reference = "https://attack.mitre.org/techniques/T1595/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1595.001"
 name = "Scanning IP Blocks"
 reference = "https://attack.mitre.org/techniques/T1595/001/"
-
-
 
 [rule.threat.tactic]
 id = "TA0043"
@@ -108,8 +107,7 @@ reference = "https://attack.mitre.org/tactics/TA0043/"
 [rule.threshold]
 field = ["destination.ip", "source.ip"]
 value = 1
+
 [[rule.threshold.cardinality]]
 field = "destination.port"
 value = 250
-
-

--- a/rules/network/discovery_potential_syn_port_scan_detected.toml
+++ b/rules/network/discovery_potential_syn_port_scan_detected.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/05/17"
-integration = ["endpoint", "network_traffic", "panw"]
+integration = ["network_traffic", "panw"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/02/04"
 
 [rule]
 author = ["Elastic"]
@@ -12,10 +12,10 @@ target network for open ports by sending SYN packets to multiple ports and obser
 method to identify potential entry points or services that may be vulnerable to exploitation, allowing them to launch
 targeted attacks or gain unauthorized access to the system or network, compromising its security and potentially leading
 to data breaches or further malicious activities. This rule proposes threshold logic to check for connection attempts
-from one source host to 10 or more destination ports using 2 or less packets per port.
+from one source host to 250 or more destination ports using 2 or less packets per port.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.network-*", "logs-network_traffic.*", "packetbeat-*", "auditbeat-*", "filebeat-*", "logs-panw.panos*"]
+index = ["logs-network_traffic.*", "packetbeat-*", "filebeat-*", "logs-panw.panos*"]
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 5
@@ -28,15 +28,13 @@ tags = [
     "Tactic: Discovery",
     "Tactic: Reconnaissance",
     "Use Case: Network Security Monitoring",
-    "Data Source: Elastic Defend",
     "Data Source: PAN-OS",
     "Resources: Investigation Guide"
 ]
 timestamp_override = "event.ingested"
 type = "threshold"
-
 query = '''
-destination.port : * and network.packets <= 2 and source.ip : (10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
+event.action:network_flow and destination.port:* and network.packets <= 2 and source.ip:(10.0.0.0/8 or 172.16.0.0/12 or 192.168.0.0/16)
 '''
 note = """## Triage and analysis
 
@@ -74,31 +72,31 @@ SYN-based port scanning is a reconnaissance technique where attackers send SYN p
 - Update intrusion detection and prevention systems to enhance detection capabilities for similar SYN-based port scanning activities.
 - Review and update network segmentation policies to limit the exposure of critical services and systems to internal reconnaissance activities."""
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1046"
 name = "Network Service Discovery"
 reference = "https://attack.mitre.org/techniques/T1046/"
 
-
 [rule.threat.tactic]
 id = "TA0007"
 name = "Discovery"
 reference = "https://attack.mitre.org/tactics/TA0007/"
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1595"
 name = "Active Scanning"
 reference = "https://attack.mitre.org/techniques/T1595/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1595.001"
 name = "Scanning IP Blocks"
 reference = "https://attack.mitre.org/techniques/T1595/001/"
-
-
 
 [rule.threat.tactic]
 id = "TA0043"
@@ -108,8 +106,7 @@ reference = "https://attack.mitre.org/tactics/TA0043/"
 [rule.threshold]
 field = ["destination.ip", "source.ip"]
 value = 1
+
 [[rule.threshold.cardinality]]
 field = "destination.port"
 value = 250
-
-


### PR DESCRIPTION
## Summary
These rules have been tuned several times, and in one tuning, I bricked the rule logic:

- https://github.com/elastic/detection-rules/pull/2985

Through community slack, concerns about this rule were presented:

- https://elasticstack.slack.com/archives/C016E72DWDS/p1738608222619009?thread_ts=1738598045.453139&cid=C016E72DWDS

This PR addresses these issues by:

- Removing Elastic Defend from the rule entirely (this is needed, as Elastic Defend does not properly log the network connections needed to detect this port scanning behavior without being prone to FPs)
- Add the `network_flow` `event.action` field to ensure flow data captured by the NPC is used to trigger the rule. I kept PANW integration, as I checked rules such as [this](https://github.com/elastic/detection-rules/blob/f1dee060b644956d67a23aecfa2f782fd1adf1c8/rules/network/command_and_control_nat_traversal_port_activity.toml), which seem to be compatible with the same `event.action`. I don't have a dataset to test this with myself, however.
- I addressed the rule tunings in the rule descriptions, as these were not yet reflected.
- I fixed the indices that are queried, the associated tags, and the formatting of the rules.