### PR TITLE
[Rule Tuning] Decrease Interval to 1m for Endpoint Promotions

### DIFF
--- a/rules/integrations/endpoint/defense_evasion_elastic_memory_threat_detected.toml
+++ b/rules/integrations/endpoint/defense_evasion_elastic_memory_threat_detected.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "Defend alerting adjustments patch to distinguish prevention and detection."
 min_stack_version = "8.16.0"
 promotion = true
-updated_date = "2025/01/17"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ memory signature detections only, and does not include prevention alerts.
 enabled = false
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
-interval = "5m"
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/integrations/endpoint/defense_evasion_elastic_memory_threat_prevented.toml
+++ b/rules/integrations/endpoint/defense_evasion_elastic_memory_threat_prevented.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "Defend alerting adjustments patch to distinguish prevention and detection."
 min_stack_version = "8.16.0"
 promotion = true
-updated_date = "2025/01/15"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ memory signature preventions only, and does not include detection only alerts.
 enabled = false
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
-interval = "5m"
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/integrations/endpoint/elastic_endpoint_security.toml
+++ b/rules/integrations/endpoint/elastic_endpoint_security.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "New fields added: required_fields, related_integrations, setup"
 min_stack_version = "8.3.0"
 promotion = true
-updated_date = "2025/01/15"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ immediately begin investigating your Endpoint alerts.
 enabled = true
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/integrations/endpoint/elastic_endpoint_security_behavior_detected.toml
+++ b/rules/integrations/endpoint/elastic_endpoint_security_behavior_detected.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "Defend alerting adjustments patch to distinguish prevention and detection."
 min_stack_version = "8.16.0"
 promotion = true
-updated_date = "2025/01/17"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ behavior detections only, and does not include prevention alerts.
 enabled = false
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
-interval = "5m"
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/integrations/endpoint/elastic_endpoint_security_behavior_prevented.toml
+++ b/rules/integrations/endpoint/elastic_endpoint_security_behavior_prevented.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "Defend alerting adjustments patch to distinguish prevention and detection."
 min_stack_version = "8.16.0"
 promotion = true
-updated_date = "2025/01/17"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ behavior preventions only, and does not include detection only alerts.
 enabled = false
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
-interval = "5m"
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/integrations/endpoint/execution_elastic_malicious_file_detected.toml
+++ b/rules/integrations/endpoint/execution_elastic_malicious_file_detected.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "Defend alerting adjustments patch to distinguish prevention and detection."
 min_stack_version = "8.16.0"
 promotion = true
-updated_date = "2025/01/17"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ malicious file detections only, and does not include prevention alerts.
 enabled = false
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
-interval = "5m"
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/integrations/endpoint/execution_elastic_malicious_file_prevented.toml
+++ b/rules/integrations/endpoint/execution_elastic_malicious_file_prevented.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "Defend alerting adjustments patch to distinguish prevention and detection."
 min_stack_version = "8.16.0"
 promotion = true
-updated_date = "2025/01/17"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ malicious file preventions only, and does not include detection only alerts.
 enabled = false
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
-interval = "5m"
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/integrations/endpoint/impact_elastic_ransomware_detected.toml
+++ b/rules/integrations/endpoint/impact_elastic_ransomware_detected.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "Defend alerting adjustments patch to distinguish prevention and detection."
 min_stack_version = "8.16.0"
 promotion = true
-updated_date = "2025/01/17"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ detections only, and does not include prevention alerts.
 enabled = false
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
-interval = "5m"
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000

--- a/rules/integrations/endpoint/impact_elastic_ransomware_prevented.toml
+++ b/rules/integrations/endpoint/impact_elastic_ransomware_prevented.toml
@@ -5,7 +5,7 @@ maturity = "production"
 min_stack_comments = "Defend alerting adjustments patch to distinguish prevention and detection."
 min_stack_version = "8.16.0"
 promotion = true
-updated_date = "2025/01/17"
+updated_date = "2025/02/06"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,7 @@ preventions only, and does not include detection only alerts.
 enabled = false
 from = "now-10m"
 index = ["logs-endpoint.alerts-*"]
-interval = "5m"
+interval = "1m"
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 10000


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: 
- Follow up to https://github.com/elastic/detection-rules/pull/3533
- Related to https://github.com/elastic/security-team/issues/10704

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

Decreased the interval to 1m per the original request missed [here](https://github.com/elastic/security-team/issues/10704#issuecomment-2435108683). 

This will help to ensure:
- Endpoint alerts show up very soon after they occur
- Reduce any potential user confusion that may occur when testing due to delays in alerts being displayed
- Addresses any potential delays in actions that may fire due to the delay in the endpoint alert.


## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation
