### PR TITLE
Bumping number of versions per rule to 4 in total

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -67,8 +67,9 @@ RULES_CONFIG = parse_rules_config()
 # The rule diff feature is available in 8.18 but needs to be tested in pre-release versions
 MIN_DIFF_FEATURE_VERSION = Version(major=8, minor=17, patch=0)
 
-MAX_VERSIONS_FOR_DIFF = 3
-MAX_VERSIONS_PRE_DIFF = 1
+# The caps for the historical versions of the rules
+MAX_HISTORICAL_VERSIONS_FOR_DIFF = 3
+MAX_HISTORICAL_VERSIONS_PRE_DIFF = 1
 
 
 def get_github_token() -> Optional[str]:
@@ -139,9 +140,9 @@ def build_release(ctx: click.Context, config_file, update_version_lock: bool, ge
 
     click.echo(f'[+] Limit rule versions in the release package for version {current_pkg_version_no_prerelease}')
     if current_pkg_version_no_prerelease >= MIN_DIFF_FEATURE_VERSION:
-        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_FOR_DIFF)
+        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_HISTORICAL_VERSIONS_FOR_DIFF)
     else:
-        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_PRE_DIFF)
+        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_HISTORICAL_VERSIONS_PRE_DIFF)
 
     package.add_historical_rules(limited_historical_rules, registry_data['version'])
     click.echo(f'[+] Adding historical rules from {previous_pkg_version} package')

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -138,9 +138,13 @@ def build_release(ctx: click.Context, config_file, update_version_lock: bool, ge
                                                 minor=current_pkg_version.minor, patch=current_pkg_version.patch)
 
     hist_versions_num = (
-        MAX_HISTORICAL_VERSIONS_FOR_DIFF if current_pkg_version_no_prerelease >= MIN_DIFF_FEATURE_VERSION else MAX_HISTORICAL_VERSIONS_PRE_DIFF
+        MAX_HISTORICAL_VERSIONS_FOR_DIFF
+        if current_pkg_version_no_prerelease >= MIN_DIFF_FEATURE_VERSION
+        else MAX_HISTORICAL_VERSIONS_PRE_DIFF
     )
-    click.echo(f'[+] Limit historical rule versions in the release package for version {current_pkg_version_no_prerelease}: {hist_versions_num} versions')
+    click.echo(
+        '[+] Limit historical rule versions in the release package for '
+        f'version {current_pkg_version_no_prerelease}: {hist_versions_num} versions')
     limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=hist_versions_num)
 
     package.add_historical_rules(limited_historical_rules, registry_data['version'])

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -136,7 +136,7 @@ def build_release(ctx: click.Context, config_file, update_version_lock: bool, ge
                                                 minor=current_pkg_version.minor, patch=current_pkg_version.patch)
 
 
-    click.echo(f'[+] Limit historical rule versions in our release package for version {current_pkg_version_no_prerelease}')
+    click.echo(f'[+] Limit rule versions in the release package for version {current_pkg_version_no_prerelease}')
     if current_pkg_version_no_prerelease >= BASE_PKG_VERSION:
         limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_NEW_STACK)
     else:

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -66,6 +66,9 @@ RULES_CONFIG = parse_rules_config()
 # The base package version that we will start to include all versions of historical rules
 BASE_PKG_VERSION = Version(major=8, minor=17, patch=0)
 
+MAX_VERSIONS_NEW_STACK = 3
+MAX_VERSIONS_OLD_STACK = 1
+
 
 def get_github_token() -> Optional[str]:
     """Get the current user's GitHub token."""
@@ -131,14 +134,14 @@ def build_release(ctx: click.Context, config_file, update_version_lock: bool, ge
     # Version 8.17.0-beta.1 is considered lower than 8.17.0
     current_pkg_version_no_prerelease = Version(major=current_pkg_version.major,
                                                 minor=current_pkg_version.minor, patch=current_pkg_version.patch)
+
+
+    click.echo(f'[+] Limit historical rule versions in our release package for version {current_pkg_version_no_prerelease}')
     if current_pkg_version_no_prerelease >= BASE_PKG_VERSION:
-        click.echo(f'[+] Adding all historical rule versions in our release package for version \
-            {current_pkg_version_no_prerelease}')
-        limited_historical_rules = historical_rules
+        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_NEW_STACK)
     else:
-        click.echo(f'[+] Limit historical rule versions in our release package for version \
-            {current_pkg_version_no_prerelease}')
-        limited_historical_rules = sde.keep_latest_versions(historical_rules)
+        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_OLD_STACK)
+
     package.add_historical_rules(limited_historical_rules, registry_data['version'])
     click.echo(f'[+] Adding historical rules from {previous_pkg_version} package')
 

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -63,11 +63,11 @@ NAVIGATOR_BADGE = (
     f'[![ATT&CK navigator coverage](https://img.shields.io/badge/ATT&CK-Navigator-red.svg)]({NAVIGATOR_URL})'
 )
 RULES_CONFIG = parse_rules_config()
-# The base package version that we will start to include all versions of historical rules
-BASE_PKG_VERSION = Version(major=8, minor=17, patch=0)
 
-MAX_VERSIONS_NEW_STACK = 3
-MAX_VERSIONS_OLD_STACK = 1
+MIN_DIFF_FEATURE_VERSION = Version(major=8, minor=18, patch=0)
+
+MAX_VERSIONS_FOR_DIFF = 3
+MAX_VERSIONS_PRE_DIFF = 1
 
 
 def get_github_token() -> Optional[str]:
@@ -137,10 +137,10 @@ def build_release(ctx: click.Context, config_file, update_version_lock: bool, ge
 
 
     click.echo(f'[+] Limit rule versions in the release package for version {current_pkg_version_no_prerelease}')
-    if current_pkg_version_no_prerelease >= BASE_PKG_VERSION:
-        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_NEW_STACK)
+    if current_pkg_version_no_prerelease >= MIN_DIFF_FEATURE_VERSION:
+        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_FOR_DIFF)
     else:
-        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_OLD_STACK)
+        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_VERSIONS_PRE_DIFF)
 
     package.add_historical_rules(limited_historical_rules, registry_data['version'])
     click.echo(f'[+] Adding historical rules from {previous_pkg_version} package')

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -64,7 +64,8 @@ NAVIGATOR_BADGE = (
 )
 RULES_CONFIG = parse_rules_config()
 
-MIN_DIFF_FEATURE_VERSION = Version(major=8, minor=18, patch=0)
+# The rule diff feature is available in 8.18 but needs to be tested in pre-release versions
+MIN_DIFF_FEATURE_VERSION = Version(major=8, minor=17, patch=0)
 
 MAX_VERSIONS_FOR_DIFF = 3
 MAX_VERSIONS_PRE_DIFF = 1

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -137,12 +137,11 @@ def build_release(ctx: click.Context, config_file, update_version_lock: bool, ge
     current_pkg_version_no_prerelease = Version(major=current_pkg_version.major,
                                                 minor=current_pkg_version.minor, patch=current_pkg_version.patch)
 
-
-    click.echo(f'[+] Limit rule versions in the release package for version {current_pkg_version_no_prerelease}')
-    if current_pkg_version_no_prerelease >= MIN_DIFF_FEATURE_VERSION:
-        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_HISTORICAL_VERSIONS_FOR_DIFF)
-    else:
-        limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=MAX_HISTORICAL_VERSIONS_PRE_DIFF)
+    hist_versions_num = (
+        MAX_HISTORICAL_VERSIONS_FOR_DIFF if current_pkg_version_no_prerelease >= MIN_DIFF_FEATURE_VERSION else MAX_HISTORICAL_VERSIONS_PRE_DIFF
+    )
+    click.echo(f'[+] Limit historical rule versions in the release package for version {current_pkg_version_no_prerelease}: {hist_versions_num} versions')
+    limited_historical_rules = sde.keep_latest_versions(historical_rules, num_versions=hist_versions_num)
 
     package.add_historical_rules(limited_historical_rules, registry_data['version'])
     click.echo(f'[+] Adding historical rules from {previous_pkg_version} package')

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -26,7 +26,7 @@ from .utils import cached, get_etc_path, read_gzip, unzip
 from .schemas import definitions
 
 MANIFEST_FILE_PATH = get_etc_path('integration-manifests.json.gz')
-NUM_LATEST_RULE_VERSIONS = 1
+DEFAULT_MAX_RULE_VERSIONS = 1
 SCHEMA_FILE_PATH = get_etc_path('integration-schemas.json.gz')
 _notified_integrations = set()
 
@@ -417,7 +417,7 @@ class SecurityDetectionEngine:
                       for x in asset_file_names}
         return assets
 
-    def keep_latest_versions(self, assets: dict, num_versions: int = NUM_LATEST_RULE_VERSIONS) -> dict:
+    def keep_latest_versions(self, assets: dict, num_versions: int = DEFAULT_MAX_RULE_VERSIONS) -> dict:
         """Keeps only the latest N versions of each rule to limit historical rule versions in our release package."""
 
         # Dictionary to hold the sorted list of versions for each base rule ID

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -26,7 +26,7 @@ from .utils import cached, get_etc_path, read_gzip, unzip
 from .schemas import definitions
 
 MANIFEST_FILE_PATH = get_etc_path('integration-manifests.json.gz')
-NUM_LATEST_RULE_VERSIONS = 3
+NUM_LATEST_RULE_VERSIONS = 1
 SCHEMA_FILE_PATH = get_etc_path('integration-schemas.json.gz')
 _notified_integrations = set()
 

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -26,7 +26,7 @@ from .utils import cached, get_etc_path, read_gzip, unzip
 from .schemas import definitions
 
 MANIFEST_FILE_PATH = get_etc_path('integration-manifests.json.gz')
-NUM_LATEST_RULE_VERSIONS = 1
+NUM_LATEST_RULE_VERSIONS = 3
 SCHEMA_FILE_PATH = get_etc_path('integration-schemas.json.gz')
 _notified_integrations = set()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "0.4.8"
+version = "0.4.9"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
# Pull Request

## Summary - What I changed

We're limiting the number of historical rules shipped in a package to accommodate future growth and simplify the release process.

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
