### PR TITLE
Modify Unit Test to Support Alert Suppression for EQL Sequences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "0.4.10"
+version = "0.4.11"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1449,8 +1449,9 @@ class TestAlertSuppression(BaseRuleTest):
                         self.fail(f"{self.rule_str(rule)} alert suppression field {fld} not \
                             found in ECS, Beats, or non-ecs schemas")
 
-    @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.14.0"),
-                     "Test only applicable to 8.14+ stacks for eql non-sequence rule alert suppression feature.")
+    @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.14.0") or 
+                     PACKAGE_STACK_VERSION >= Version.parse("8.18.0"),
+                     "Test only applicable to 8.14 to 8.17 stacks for eql non-sequence rule alert suppression feature.")
     def test_eql_non_sequence_support_only(self):
         for rule in self.all_rules:
             if (

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1450,8 +1450,8 @@ class TestAlertSuppression(BaseRuleTest):
                             found in ECS, Beats, or non-ecs schemas")
 
     @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.14.0") or  # noqa: W504
-                     PACKAGE_STACK_VERSION >= Version.parse("8.18.0"),  # noqa: W504
-                     "Test only applicable to 8.14 to 8.17 stacks for eql non-sequence rule alert suppression feature.")
+                     PACKAGE_STACK_VERSION >= Version.parse("8.18.0"),# noqa: W504
+                     "Test is applicable to 8.14 --> 8.17 stacks for eql non-sequence rule alert suppression feature.")
     def test_eql_non_sequence_support_only(self):
         for rule in self.all_rules:
             if (

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1450,7 +1450,7 @@ class TestAlertSuppression(BaseRuleTest):
                             found in ECS, Beats, or non-ecs schemas")
 
     @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.14.0") or  # noqa: W504
-                     PACKAGE_STACK_VERSION >= Version.parse("8.18.0"),# noqa: W504
+                     PACKAGE_STACK_VERSION >= Version.parse("8.18.0"),  # noqa: W504
                      "Test is applicable to 8.14 --> 8.17 stacks for eql non-sequence rule alert suppression feature.")
     def test_eql_non_sequence_support_only(self):
         for rule in self.all_rules:

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1449,8 +1449,8 @@ class TestAlertSuppression(BaseRuleTest):
                         self.fail(f"{self.rule_str(rule)} alert suppression field {fld} not \
                             found in ECS, Beats, or non-ecs schemas")
 
-    @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.14.0") or 
-                     PACKAGE_STACK_VERSION >= Version.parse("8.18.0"),
+    @unittest.skipIf(PACKAGE_STACK_VERSION < Version.parse("8.14.0") or  # noqa: W504
+                     PACKAGE_STACK_VERSION >= Version.parse("8.18.0"),  # noqa: W504
                      "Test only applicable to 8.14 to 8.17 stacks for eql non-sequence rule alert suppression feature.")
     def test_eql_non_sequence_support_only(self):
         for rule in self.all_rules:


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/4326

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

- For stack versions 8.18 and above the Unit Test `test_eql_non_sequence_support_only` can be safely ignored.
- We don't have to test if alert suppression is used in sequences only , With https://github.com/elastic/kibana/pull/189725 starting in 8.18 alert suppression for eql sequences is available.
- Code change is made to skip the test accordingly 
<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test

<details><summary>8.18 Testing </summary>

```console 
detection-rules on  issue-4326 [$!?] is 📦 v0.4.10 via 🐍 v3.12.8 (.venv) on ☁️  shashank.suryanarayana@elastic.co 
❯ pytest  -v tests/test_all_rules.py::TestAlertSuppression::test_eql_non_sequence_support_only
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.12.8, pytest-8.1.1, pluggy-1.4.0 -- /Users/shashankks/elastic_workspace/detection-rules/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /Users/shashankks/elastic_workspace/detection-rules
configfile: pyproject.toml
plugins: typeguard-3.0.2
collected 1 item                                                                                                                                          

tests/test_all_rules.py::TestAlertSuppression::test_eql_non_sequence_support_only SKIPPED (Test only applicable to 8.14 to 8.17 stacks for eql ...) [100%]

============================================================== 1 skipped in 62.44s (0:01:02) ==============================================================

```
</details> 

<details><summary>8.17 Testing</summary>

```console
 pytest  -v tests/test_all_rules.py::TestAlertSuppression::test_eql_non_sequence_support_only
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.12.8, pytest-8.1.1, pluggy-1.4.0 -- /Users/shashankks/elastic_workspace/detection-rules/.venv/bin/python3.12
cachedir: .pytest_cache
rootdir: /Users/shashankks/elastic_workspace/detection-rules
configfile: pyproject.toml
plugins: typeguard-3.0.2
collected 1 item                                                                                                                                          

tests/test_all_rules.py::TestAlertSuppression::test_eql_non_sequence_support_only PASSED                                                            [100%]

=================================================================== 1 passed in 54.16s ====================================================================
(.venv) 
```
</details> 

- Remote Unit Tests are also skipping the test appropriately 

![image](https://github.com/user-attachments/assets/2800e7b6-1e2d-4df3-a304-f17c0d3eaf4b)

- Unit test to pass 
<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
