### PR TITLE
[Rule Tuning] Account Configured with Never-Expiring Password

### DIFF
--- a/rules/windows/persistence_dontexpirepasswd_account.toml
+++ b/rules/windows/persistence_dontexpirepasswd_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/22"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/01/22"
+updated_date = "2025/02/12"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
@@ -80,10 +80,16 @@ type = "eql"
 query = '''
 any where host.os.type == "windows" and
 (
-  (event.code == "4738" and winlog.event_data.NewUACList == "USER_DONT_EXPIRE_PASSWORD") or
+  (
+    event.code == "4738" and winlog.event_data.NewUACList == "USER_DONT_EXPIRE_PASSWORD" and not user.id == "S-1-5-18"
+  ) or
   (
     event.code == "5136" and winlog.event_data.AttributeLDAPDisplayName == "userAccountControl" and
-    winlog.event_data.AttributeValue in ("66048", "66080")
+    winlog.event_data.AttributeValue in ("66048", "66080") and winlog.event_data.OperationType == "%%14674" and
+    not (
+      winlog.event_data.SubjectUserName : "*svc*" or
+      winlog.event_data.ObjectDN : "*Service*"
+    )
   )
 )
 '''


### PR DESCRIPTION
## Summary

Excludes FP Patterns observed in the new logic, re-adds exclusion for SYSTEM activity that was wrongly removed (by me) previously.