### PR TITLE
[New Rule] Potential Malware-Driven SSH Brute Force Attempt

### DIFF
--- a/rules/linux/impact_potential_bruteforce_malware_infection.toml
+++ b/rules/linux/impact_potential_bruteforce_malware_infection.toml
@@ -2,6 +2,8 @@
 creation_date = "2025/02/20"
 integration = ["endpoint"]
 maturity = "production"
+min_stack_comments = "ES|QL rule type in technical preview as of 8.13"
+min_stack_version = "8.13.0"
 updated_date = "2025/02/20"
 
 [rule]
@@ -56,6 +58,7 @@ tags = [
     "Tactic: Command and Control",
     "Data Source: Elastic Defend",
 ]
+timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.network-*

--- a/rules/linux/impact_potential_bruteforce_malware_infection.toml
+++ b/rules/linux/impact_potential_bruteforce_malware_infection.toml
@@ -14,9 +14,11 @@ brute-force attacks against external systems over SSH (port 22 and common altern
 looks for a high volume of outbound connection attempts to non-private IP addresses from a single process. A
 compromised host may be part of a botnet or controlled by an attacker, attempting to gain unauthorized access
 to remote systems. This behavior is commonly observed in SSH brute-force campaigns where malware hijacks
-vulnerable machines to expand its attack surface.
+vulnerable machines to expand its attack surface. ES|QL rules have limited fields available in its alert documents.
+Make sure to review the original documents to aid in the investigation of this alert.
 """
-from = "now-9m"
+from = "now-61m"
+interval = "1h"
 language = "esql"
 license = "Elastic License v2"
 name = "Potential Malware-Driven SSH Brute Force Attempt"
@@ -61,7 +63,8 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.network-*
-| keep @timestamp, host.os.type, event.type, event.action, destination.port, process.executable, destination.ip, process.entity_id, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, destination.port, process.executable, destination.ip, agent.id
+| where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
   destination.port in (22, 222, 2222, 10022, 2022, 2200, 62612, 8022) and not
      CIDR_MATCH(
@@ -70,7 +73,7 @@ from logs-endpoint.events.network-*
        "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24","198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4", "::1",
        "FE80::/10", "FF00::/8"
      )
-| stats cc = count(), agent_count = count_distinct(agent.id) by process.executable, destination.port, process.entity_id
+| stats cc = count(), agent_count = count_distinct(agent.id) by process.executable, destination.port
 | where agent_count == 1 and cc > 15
 | sort cc asc
 | limit 100

--- a/rules/linux/impact_potential_bruteforce_malware_infection.toml
+++ b/rules/linux/impact_potential_bruteforce_malware_infection.toml
@@ -1,0 +1,119 @@
+[metadata]
+creation_date = "2025/02/20"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/02/20"
+
+[rule]
+author = ["Elastic"]
+description = """
+This detection identifies a Linux host that has potentially been infected with malware and is being used to conduct
+brute-force attacks against external systems over SSH (port 22 and common alternative SSH ports). The detection
+looks for a high volume of outbound connection attempts to non-private IP addresses from a single process. A
+compromised host may be part of a botnet or controlled by an attacker, attempting to gain unauthorized access
+to remote systems. This behavior is commonly observed in SSH brute-force campaigns where malware hijacks
+vulnerable machines to expand its attack surface.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.network*"]
+language = "esql"
+license = "Elastic License v2"
+name = "Potential Malware-Driven SSH Brute Force Attempt"
+risk_score = 47
+rule_id = "77122db4-5876-4127-b91b-6c179eb21f88"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Impact",
+    "Tactic: Execution",
+    "Tactic: Command and Control",
+    "Data Source: Elastic Defend",
+]
+type = "esql"
+query = '''
+from logs-endpoint.events.network-*
+| keep @timestamp, host.os.type, event.type, event.action, destination.port, process.executable, destination.ip, process.entity_id, agent.id
+| where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
+  destination.port in (22, 222, 2222, 10022, 2022, 2200, 62612, 8022) and not
+     CIDR_MATCH(
+       destination.ip, "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.0.0.0/29", "192.0.0.8/32", "192.0.0.9/32",
+       "192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24", "192.168.0.0/16", "192.88.99.0/24",
+       "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24","198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4", "::1",
+       "FE80::/10", "FF00::/8"
+     )
+| stats cc = count(), agent_count = count_distinct(agent.id) by process.executable, destination.port, process.entity_id
+| where agent_count == 1 and cc > 15
+| sort cc asc
+| limit 100
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+  [rule.threat.tactic]
+  name = "Impact"
+  id = "TA0040"
+  reference = "https://attack.mitre.org/tactics/TA0040/"
+
+  [[rule.threat.technique]]
+  name = "Resource Hijacking"
+  id = "T1496"
+  reference = "https://attack.mitre.org/techniques/T1496/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+  [rule.threat.tactic]
+  name = "Execution"
+  id = "TA0002"
+  reference = "https://attack.mitre.org/tactics/TA0002/"
+
+  [[rule.threat.technique]]
+  name = "Command and Scripting Interpreter"
+  id = "T1059"
+  reference = "https://attack.mitre.org/techniques/T1059/"
+
+    [[rule.threat.technique.subtechnique]]
+    name = "Unix Shell"
+    id = "T1059.004"
+    reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+  [rule.threat.tactic]
+  id = "TA0011"
+  name = "Command and Control"
+  reference = "https://attack.mitre.org/tactics/TA0011/"
+
+  [[rule.threat.technique]]
+  id = "T1071"
+  name = "Application Layer Protocol"
+  reference = "https://attack.mitre.org/techniques/T1071/"

--- a/rules/linux/impact_potential_bruteforce_malware_infection.toml
+++ b/rules/linux/impact_potential_bruteforce_malware_infection.toml
@@ -17,7 +17,6 @@ to remote systems. This behavior is commonly observed in SSH brute-force campaig
 vulnerable machines to expand its attack surface.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.network*"]
 language = "esql"
 license = "Elastic License v2"
 name = "Potential Malware-Driven SSH Brute Force Attempt"


### PR DESCRIPTION
## Summary
This detection identifies a Linux host that has potentially been infected with malware and is being used to conduct brute-force attacks against external systems over SSH (port 22 and common alternative SSH ports). The detection looks for a high volume of outbound connection attempts to non-private IP addresses from a single process. A compromised host may be part of a botnet or controlled by an attacker, attempting to gain unauthorized access to remote systems. This behavior is commonly observed in SSH brute-force campaigns where malware hijacks vulnerable machines to expand its attack surface.

## Telemetry
Only TPs from DOTA3 malware in my testing stack:
<img width="1910" alt="{708A1E24-D30E-48EF-B20B-3C692C2051F1}" src="https://github.com/user-attachments/assets/ec5adada-0735-4f65-a125-7cc5dcd5d556" />

0 hits in telemetry last 30d.