### PR TITLE
[New Rule] Remote File Creation in World Writeable Directory

### DIFF
--- a/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
+++ b/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
@@ -1,0 +1,94 @@
+[metadata]
+creation_date = "2025/02/20"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/02/20"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the creation of a file in a world-writeable directory through a service that is
+commonly used for file transfer. This behavior is often associated with lateral movement and can
+be an indicator of an attacker attempting to move laterally within a network.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.file*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Remote File Creation in World Writeable Directory"
+risk_score = 47
+rule_id = "3e528511-7316-4a6e-83da-61b5f1c07fd4"
+setup = """## Setup
+
+This rule requires data coming in from one of the following integrations:
+- Elastic Defend
+- Auditbeat
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+
+### Auditbeat Setup
+Auditbeat is a lightweight shipper that you can install on your servers to audit the activities of users and processes on your systems. For example, you can use Auditbeat to collect and centralize audit events from the Linux Audit Framework. You can also use Auditbeat to detect changes to critical files, like binaries and configuration files, and identify potential security policy violations.
+
+#### The following steps should be executed in order to add the Auditbeat on a Linux System:
+- Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
+- To install the APT and YUM repositories follow the setup instructions in this [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setup-repositories.html).
+- To run Auditbeat on Docker follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-docker.html).
+- To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-kubernetes.html).
+- For complete “Setup and Run Auditbeat” information refer to the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setting-up-and-running.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Lateral Movement",
+    "Data Source: Elastic Defend",
+]
+type = "eql"
+query = '''
+file where host.os.type == "linux" and event.action == "creation" and
+process.name in ("scp", "sshd", "ssh", "ftp", "sftp", "vsftpd", "sftp-server", "rsync") and
+file.path like~ ("/tmp*", "/var/tmp*", "/dev/shm/*", "/home/.*") and user.id != 0
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1021"
+name = "Remote Services"
+reference = "https://attack.mitre.org/techniques/T1021/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1021.004"
+name = "SSH"
+reference = "https://attack.mitre.org/techniques/T1021/004/"
+
+[[rule.threat.technique]]
+id = "T1570"
+name = "Lateral Tool Transfer"
+reference = "https://attack.mitre.org/techniques/T1570/"
+
+[rule.threat.tactic]
+id = "TA0008"
+name = "Lateral Movement"
+reference = "https://attack.mitre.org/tactics/TA0008/"

--- a/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
+++ b/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
@@ -67,7 +67,7 @@ type = "eql"
 query = '''
 file where host.os.type == "linux" and event.action == "creation" and
 process.name in ("scp", "sshd", "ssh", "ftp", "sftp", "vsftpd", "sftp-server", "rsync") and
-file.path like~ ("/tmp*", "/var/tmp*", "/dev/shm/*", "/home/.*") and user.id != 0
+file.path like~ ("/tmp*", "/var/tmp*", "/dev/shm/*", "/home/.*") and user.id != "0"
 '''
 
 [[rule.threat]]

--- a/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
+++ b/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
@@ -12,7 +12,7 @@ commonly used for file transfer. This behavior is often associated with lateral 
 be an indicator of an attacker attempting to move laterally within a network.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.file*"]
+index = ["logs-endpoint.events.file*", "auditbeat-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Remote File Creation in World Writeable Directory"

--- a/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
+++ b/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
@@ -63,6 +63,7 @@ tags = [
     "Tactic: Lateral Movement",
     "Data Source: Elastic Defend",
 ]
+timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 file where host.os.type == "linux" and event.action == "creation" and


### PR DESCRIPTION
## Summary
This rule detects the creation of a file in a world-writeable directory through a service that is commonly used for file transfer. This behavior is often associated with lateral movement and can be an indicator of an attacker attempting to move laterally within a network.

## Telemetry
3 hits in telemetry last 30d (as I excluded root), and only TPs in my testing stack from DOTA3 malware post infection chain:
<img width="1910" alt="{B28FDBF4-5DFC-40BC-A6A0-8A495AD05B96}" src="https://github.com/user-attachments/assets/62c3e278-5010-4c85-b1e6-4b17abe72684" />
