### PR TITLE
[New Rule] Unusual Remote File Creation

### DIFF
--- a/rules/linux/lateral_movement_unusual_remote_file_creation.toml
+++ b/rules/linux/lateral_movement_unusual_remote_file_creation.toml
@@ -23,7 +23,6 @@ setup = """## Setup
 
 This rule requires data coming in from one of the following integrations:
 - Elastic Defend
-- Auditbeat
 
 ### Elastic Defend Integration Setup
 Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
@@ -45,16 +44,6 @@ For more details on Elastic Agent configuration settings, refer to the [helper g
 - Click "Save and Continue".
 - To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
 For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
-
-### Auditbeat Setup
-Auditbeat is a lightweight shipper that you can install on your servers to audit the activities of users and processes on your systems. For example, you can use Auditbeat to collect and centralize audit events from the Linux Audit Framework. You can also use Auditbeat to detect changes to critical files, like binaries and configuration files, and identify potential security policy violations.
-
-#### The following steps should be executed in order to add the Auditbeat on a Linux System:
-- Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
-- To install the APT and YUM repositories follow the setup instructions in this [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setup-repositories.html).
-- To run Auditbeat on Docker follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-docker.html).
-- To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-kubernetes.html).
-- For complete “Setup and Run Auditbeat” information refer to the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setting-up-and-running.html).
 """
 severity = "medium"
 tags = [

--- a/rules/linux/lateral_movement_unusual_remote_file_creation.toml
+++ b/rules/linux/lateral_movement_unusual_remote_file_creation.toml
@@ -7,10 +7,10 @@ updated_date = "2025/02/20"
 [rule]
 author = ["Elastic"]
 description = """
-This rule leverages the new_terms rule type to detect the creation of a file through a service 
-that is commonly used for file transfer. Through the new_terms rule type, the rule will exclude
-common remote file creation activity. This behavior is often associated with lateral movement
-and can be an indicator of an attacker attempting to move laterally within a network.
+This rule leverages the new_terms rule type to detect file creation via a commonly used file
+transfer service while excluding typical remote file creation activity. This behavior is
+often linked to lateral movement, potentially indicating an attacker attempting to move
+within a network.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.file*"]

--- a/rules/linux/lateral_movement_unusual_remote_file_creation.toml
+++ b/rules/linux/lateral_movement_unusual_remote_file_creation.toml
@@ -1,0 +1,103 @@
+[metadata]
+creation_date = "2025/02/20"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/02/20"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule leverages the new_terms rule type to detect the creation of a file through a service 
+that is commonly used for file transfer. Through the new_terms rule type, the rule will exclude
+common remote file creation activity. This behavior is often associated with lateral movement
+and can be an indicator of an attacker attempting to move laterally within a network.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.file*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Unusual Remote File Creation"
+risk_score = 47
+rule_id = "ed3fedc3-dd10-45a5-a485-34a8b48cea46"
+setup = """## Setup
+
+This rule requires data coming in from one of the following integrations:
+- Elastic Defend
+- Auditbeat
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+
+### Auditbeat Setup
+Auditbeat is a lightweight shipper that you can install on your servers to audit the activities of users and processes on your systems. For example, you can use Auditbeat to collect and centralize audit events from the Linux Audit Framework. You can also use Auditbeat to detect changes to critical files, like binaries and configuration files, and identify potential security policy violations.
+
+#### The following steps should be executed in order to add the Auditbeat on a Linux System:
+- Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
+- To install the APT and YUM repositories follow the setup instructions in this [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setup-repositories.html).
+- To run Auditbeat on Docker follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-docker.html).
+- To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-kubernetes.html).
+- For complete “Setup and Run Auditbeat” information refer to the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setting-up-and-running.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Lateral Movement",
+    "Data Source: Elastic Defend",
+]
+type = "new_terms"
+query = '''
+event.category:file and host.os.type:linux and event.action:creation and
+process.name:(scp or ftp or sftp or vsftpd or sftp-server or sync) and
+not file.path:(/dev/ptmx or /run/* or /var/run/*)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1021"
+name = "Remote Services"
+reference = "https://attack.mitre.org/techniques/T1021/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1021.004"
+name = "SSH"
+reference = "https://attack.mitre.org/techniques/T1021/004/"
+
+[[rule.threat.technique]]
+id = "T1570"
+name = "Lateral Tool Transfer"
+reference = "https://attack.mitre.org/techniques/T1570/"
+
+[rule.threat.tactic]
+id = "TA0008"
+name = "Lateral Movement"
+reference = "https://attack.mitre.org/tactics/TA0008/"
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["process.executable", "host.id"]
+
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-10d"

--- a/rules/linux/lateral_movement_unusual_remote_file_creation.toml
+++ b/rules/linux/lateral_movement_unusual_remote_file_creation.toml
@@ -64,6 +64,7 @@ tags = [
     "Tactic: Lateral Movement",
     "Data Source: Elastic Defend",
 ]
+timestamp_override = "event.ingested"
 type = "new_terms"
 query = '''
 event.category:file and host.os.type:linux and event.action:creation and

--- a/rules/linux/lateral_movement_unusual_remote_file_creation.toml
+++ b/rules/linux/lateral_movement_unusual_remote_file_creation.toml
@@ -13,7 +13,7 @@ often linked to lateral movement, potentially indicating an attacker attempting 
 within a network.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.file*"]
+index = ["logs-endpoint.events.file*", "auditbeat-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Unusual Remote File Creation"
@@ -23,6 +23,7 @@ setup = """## Setup
 
 This rule requires data coming in from one of the following integrations:
 - Elastic Defend
+- Auditbeat
 
 ### Elastic Defend Integration Setup
 Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
@@ -44,6 +45,16 @@ For more details on Elastic Agent configuration settings, refer to the [helper g
 - Click "Save and Continue".
 - To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
 For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+
+### Auditbeat Setup
+Auditbeat is a lightweight shipper that you can install on your servers to audit the activities of users and processes on your systems. For example, you can use Auditbeat to collect and centralize audit events from the Linux Audit Framework. You can also use Auditbeat to detect changes to critical files, like binaries and configuration files, and identify potential security policy violations.
+
+#### The following steps should be executed in order to add the Auditbeat on a Linux System:
+- Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
+- To install the APT and YUM repositories follow the setup instructions in this [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setup-repositories.html).
+- To run Auditbeat on Docker follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-docker.html).
+- To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-kubernetes.html).
+- For complete “Setup and Run Auditbeat” information refer to the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setting-up-and-running.html).
 """
 severity = "medium"
 tags = [


### PR DESCRIPTION
## Summary
This rule leverages the new_terms rule type to detect file creation via a commonly used file transfer service while excluding typical remote file creation activity. This behavior is often linked to lateral movement, potentially indicating an attacker attempting to move within a network.

## Telemetry
In my own stack, only TPs. In telemetry, a large list of FPs, but these will be excluded through the new_terms rule type, as they are all by the same host/process.