### PR TITLE
[New Rule] Successful SSH Authentication from Unusual SSH Public Key

### DIFF
--- a/rules/linux/initial_access_first_time_public_key_authentication.toml
+++ b/rules/linux/initial_access_first_time_public_key_authentication.toml
@@ -12,6 +12,11 @@ key that has not been seen in the last 10 days. Public key authentication is a s
 authenticating users to a server. Monitoring unusual public key authentication events can help
 detect unauthorized access attempts or suspicious activity on the system.
 """
+false_positives = [
+    """
+    This rule may trigger in cases where a user has routine work patterns that result in infrequent authentications.
+    """,
+]
 from = "now-9m"
 index = ["logs-system.auth-*", "filebeat-*"]
 language = "kuery"

--- a/rules/linux/initial_access_first_time_public_key_authentication.toml
+++ b/rules/linux/initial_access_first_time_public_key_authentication.toml
@@ -7,15 +7,16 @@ updated_date = "2025/02/21"
 [rule]
 author = ["Elastic"]
 description = """
-This rule monitors the authentication logs for messages related to instances of a first-time public key authentication.
-Public key authentication is a secure method for authenticating users to a server. Monitoring first-time public key
-authentication events can help detect unauthorized access attempts or suspicious activity on the system.
+This rule leverages the new_terms rule type to detect successful SSH authentications via a public
+key that has not been seen in the last 10 days. Public key authentication is a secure method for
+authenticating users to a server. Monitoring unusual public key authentication events can help
+detect unauthorized access attempts or suspicious activity on the system.
 """
 from = "now-9m"
-index = ["logs-system.auth-*"]
+index = ["logs-system.auth-*", "filebeat-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "First Time Public Key Authentication"
+name = "Successful SSH Authentication from Unusual SSH Public Key"
 risk_score = 21
 rule_id = "267dace3-a4de-4c94-a7b5-dd6c0f5482e5"
 setup = """## Setup
@@ -48,10 +49,9 @@ tags = [
     "Data Source: Elastic Defend"
 ]
 timestamp_override = "event.ingested"
-type = "query"
+type = "new_terms"
 query = '''
-event.category:authentication and host.os.type:linux and event.action:ssh_login and event.outcome:success and
-message:"Accepted publickey"
+event.category:authentication and host.os.type:linux and event.action:ssh_login and event.outcome:success and system.auth.ssh.method:publickey
 '''
 
 [[rule.threat]]
@@ -66,3 +66,11 @@ reference = "https://attack.mitre.org/tactics/TA0001/"
 id = "T1078"
 name = "Valid Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/"
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["system.auth.ssh.signature"]
+
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-10d"

--- a/rules/linux/initial_access_first_time_public_key_authentication.toml
+++ b/rules/linux/initial_access_first_time_public_key_authentication.toml
@@ -1,0 +1,68 @@
+[metadata]
+creation_date = "2025/02/21"
+integration = ["system"]
+maturity = "production"
+updated_date = "2025/02/21"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule monitors the authentication logs for messages related to instances of a first-time public key authentication.
+Public key authentication is a secure method for authenticating users to a server. Monitoring first-time public key
+authentication events can help detect unauthorized access attempts or suspicious activity on the system.
+"""
+from = "now-9m"
+index = ["logs-system.auth-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "First Time Public Key Authentication"
+risk_score = 21
+rule_id = "267dace3-a4de-4c94-a7b5-dd6c0f5482e5"
+setup = """## Setup
+
+This rule requires data coming in from one of the following integrations:
+- Filebeat
+
+### Filebeat Setup
+Filebeat is a lightweight shipper for forwarding and centralizing log data. Installed as an agent on your servers, Filebeat monitors the log files or locations that you specify, collects log events, and forwards them either to Elasticsearch or Logstash for indexing.
+
+#### The following steps should be executed in order to add the Filebeat for the Linux System:
+- Elastic provides repositories available for APT and YUM-based distributions. Note that we provide binary packages, but no source packages.
+- To install the APT and YUM repositories follow the setup instructions in this [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/setup-repositories.html).
+- To run Filebeat on Docker follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-docker.html).
+- To run Filebeat on Kubernetes follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/running-on-kubernetes.html).
+- For quick start information for Filebeat refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/8.11/filebeat-installation-configuration.html).
+- For complete Setup and Run Filebeat information refer to the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/setting-up-and-running.html).
+
+#### Rule Specific Setup Note
+- This rule requires the Filebeat System Module to be enabled.
+- The system module collects and parses logs created by the system logging service of common Unix/Linux based distributions.
+- To run the system module of Filebeat on Linux follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-system.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Initial Access",
+    "Data Source: Elastic Defend"
+]
+timestamp_override = "event.ingested"
+type = "query"
+query = '''
+event.category:authentication and host.os.type:linux and event.action:ssh_login and event.outcome:success and
+message:"Accepted publickey"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"


### PR DESCRIPTION
## Summary
This rule monitors the authentication logs for messages related to instances of a first-time public key authentication. Public key authentication is a secure method for authenticating users to a server. Monitoring first-time public key authentication events can help detect unauthorized access attempts or suspicious activity on the system.

## Telemetry
<img width="1627" alt="{270CC691-E446-40BC-AC43-BD2BBA22136B}" src="https://github.com/user-attachments/assets/3ced0c42-c2d3-41da-8fa7-78b71ba897f8" />
