### PR TITLE
[Rule Tuning] MsBuild Making Network Connections

### DIFF
--- a/rules/windows/defense_evasion_msbuild_making_network_connections.toml
+++ b/rules/windows/defense_evasion_msbuild_making_network_connections.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/02/03"
+updated_date = "2025/02/21"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
@@ -39,12 +39,7 @@ Identifies MsBuild.exe making outbound network connections. This may indicate ad
 leveraged by adversaries to execute code and evade detection.
 """
 from = "now-9m"
-index = [
-    "winlogbeat-*",
-    "logs-endpoint.events.process-*",
-    "logs-endpoint.events.network-*",
-    "logs-windows.sysmon_operational-*",
-]
+index = ["logs-endpoint.events.process-*", "logs-endpoint.events.network-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "MsBuild Making Network Connections"
@@ -118,7 +113,6 @@ tags = [
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
-    "Data Source: Sysmon",
 ]
 type = "eql"
 
@@ -127,22 +121,22 @@ sequence by process.entity_id with maxspan=30s
 
   /* Look for MSBuild.exe process execution */
   /* The events for this first sequence may be noisy, consider adding exceptions */
-  [process where host.os.type == "windows"
-    and (
-          process.pe.original_file_name: "MSBuild.exe" or
-          process.name: "MSBuild.exe"
-        )
-    and event.type == "start" and user.id != "S-1-5-18"]
+  [process where host.os.type == "windows" and event.type == "start" and
+    (
+      process.pe.original_file_name: "MSBuild.exe" or
+      process.name: "MSBuild.exe"
+    ) and
+    not user.id == "S-1-5-18"]
 
   /* Followed by a network connection to an external address */
   /* Exclude domains that are known to be benign */
-  [network where host.os.type == "windows"
-    and event.action: ("connection_attempted", "lookup_requested")
-    and (
-          process.pe.original_file_name: "MSBuild.exe" or
-          process.name: "MSBuild.exe"
-        )
-    and not user.id != "S-1-5-18" and
+  [network where host.os.type == "windows" and
+    event.action: ("connection_attempted", "lookup_requested") and
+    (
+      process.pe.original_file_name: "MSBuild.exe" or
+      process.name: "MSBuild.exe"
+    ) and
+    not user.id == "S-1-5-18" and
     not cidrmatch(destination.ip, "127.0.0.1", "::1") and
     not dns.question.name : (
       "localhost",

--- a/rules/windows/defense_evasion_msbuild_making_network_connections.toml
+++ b/rules/windows/defense_evasion_msbuild_making_network_connections.toml
@@ -3,8 +3,6 @@ creation_date = "2020/02/18"
 integration = ["endpoint"]
 maturity = "production"
 updated_date = "2025/02/21"
-min_stack_version = "8.14.0"
-min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/defense_evasion_msbuild_making_network_connections.toml
+++ b/rules/windows/defense_evasion_msbuild_making_network_connections.toml
@@ -3,6 +3,8 @@ creation_date = "2020/02/18"
 integration = ["endpoint"]
 maturity = "production"
 updated_date = "2025/02/21"
+min_stack_version = "8.14.0"
+min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
 [transform]
 [[transform.osquery]]


### PR DESCRIPTION
## Summary

When tuning the rule for performance in https://github.com/elastic/detection-rules/pull/3482, we ended up with breaking it is logic when `and not user.id != "S-1-5-18" and` was used. So I'm fixing that

I'm also removing the Sysmon support for it as user.id in sysmon logs will always be S-1-5-18, ref: https://github.com/elastic/detection-rules/issues/1770