### PR TITLE
[Rule Tuning] Adapt Rules to work with Sysmon

### DIFF
--- a/rules/windows/command_and_control_tool_transfer_via_curl.toml
+++ b/rules/windows/command_and_control_tool_transfer_via_curl.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/03"
 integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/02/21"
+updated_date = "2025/02/22"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 

--- a/rules/windows/command_and_control_tool_transfer_via_curl.toml
+++ b/rules/windows/command_and_control_tool_transfer_via_curl.toml
@@ -20,6 +20,7 @@ index = [
     "logs-sentinel_one_cloud_funnel.*",
     "logs-system.security*",
     "logs-windows.forwarded*",
+    "logs-windows.sysmon_operational-*",
     "winlogbeat-*",
 ]
 language = "eql"
@@ -76,13 +77,14 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
     "Data Source: Crowdstrike",
+    "Data Source: Sysmon",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
+process where host.os.type == "windows" and event.type == "start" and
   process.executable : (
     "?:\\Windows\\System32\\curl.exe",
     "?:\\Windows\\SysWOW64\\curl.exe"
@@ -94,6 +96,11 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
     "conhost.exe", "forfiles.exe",
     "wscript.exe", "cscript.exe",
     "mshta.exe", "hh.exe", "mmc.exe"
+  ) and 
+  not (
+    user.id == "S-1-5-18" and
+    /* Don't apply the user.id exclusion to Sysmon for compatibility */
+    not event.dataset : ("windows.sysmon_operational", "windows.sysmon")
   )
 '''
 

--- a/rules/windows/command_and_control_tool_transfer_via_curl.toml
+++ b/rules/windows/command_and_control_tool_transfer_via_curl.toml
@@ -101,7 +101,9 @@ process where host.os.type == "windows" and event.type == "start" and
     user.id == "S-1-5-18" and
     /* Don't apply the user.id exclusion to Sysmon for compatibility */
     not event.dataset : ("windows.sysmon_operational", "windows.sysmon")
-  )
+  ) and
+  /* Exclude System Integrity Processes for Sysmon */
+  not ?winlog.event_data.IntegrityLevel == "System"
 '''
 
 

--- a/rules/windows/command_and_control_tool_transfer_via_curl.toml
+++ b/rules/windows/command_and_control_tool_transfer_via_curl.toml
@@ -20,7 +20,6 @@ index = [
     "logs-sentinel_one_cloud_funnel.*",
     "logs-system.security*",
     "logs-windows.forwarded*",
-    "logs-windows.sysmon_operational-*",
     "winlogbeat-*",
 ]
 language = "eql"
@@ -75,7 +74,6 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Windows Security Event Logs",
     "Data Source: Microsoft Defender for Endpoint",
-    "Data Source: Sysmon",
     "Data Source: SentinelOne",
     "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
@@ -85,9 +83,18 @@ type = "eql"
 
 query = '''
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
- process.executable : ("?:\\Windows\\System32\\curl.exe", "?:\\Windows\\SysWOW64\\curl.exe") and
- process.command_line : "*http*" and
- process.parent.name : ("cmd.exe", "powershell.exe", "rundll32.exe", "explorer.exe", "conhost.exe", "forfiles.exe", "wscript.exe", "cscript.exe", "mshta.exe", "hh.exe", "mmc.exe")
+  process.executable : (
+    "?:\\Windows\\System32\\curl.exe",
+    "?:\\Windows\\SysWOW64\\curl.exe"
+  ) and
+  process.command_line : "*http*" and
+  process.parent.name : (
+    "cmd.exe", "powershell.exe",
+    "rundll32.exe", "explorer.exe",
+    "conhost.exe", "forfiles.exe",
+    "wscript.exe", "cscript.exe",
+    "mshta.exe", "hh.exe", "mmc.exe"
+  )
 '''
 
 

--- a/rules/windows/discovery_enumerating_domain_trusts_via_nltest.toml
+++ b/rules/windows/discovery_enumerating_domain_trusts_via_nltest.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/05/31"
 integration = ["endpoint", "windows", "system", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/02/21"
+updated_date = "2025/02/22"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 

--- a/rules/windows/discovery_enumerating_domain_trusts_via_nltest.toml
+++ b/rules/windows/discovery_enumerating_domain_trusts_via_nltest.toml
@@ -27,6 +27,7 @@ index = [
     "logs-m365_defender.event-*",
     "logs-system.security*",
     "logs-windows.forwarded*",
+    "logs-windows.sysmon_operational-*",
     "winlogbeat-*",
 ]
 language = "eql"
@@ -81,6 +82,7 @@ tags = [
     "Data Source: Windows Security Event Logs",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: Crowdstrike",
+    "Data Source: Sysmon",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -92,8 +94,12 @@ process where host.os.type == "windows" and event.type == "start" and
         "/LSAQUERYFTI:*", "/PARENTDOMAIN",
         "/DOMAIN_TRUSTS", "/BDC_QUERY:*"
         ) and 
-not process.parent.name : "PDQInventoryScanner.exe" and 
-not user.id in ("S-1-5-18", "S-1-5-19", "S-1-5-20")
+not process.parent.name : "PDQInventoryScanner.exe" and
+not (
+  user.id in ("S-1-5-18", "S-1-5-19", "S-1-5-20") and
+  /* Don't apply the user.id exclusion to Sysmon for compatibility */
+  not event.dataset : ("windows.sysmon_operational", "windows.sysmon")
+)
 '''
 
 

--- a/rules/windows/discovery_enumerating_domain_trusts_via_nltest.toml
+++ b/rules/windows/discovery_enumerating_domain_trusts_via_nltest.toml
@@ -27,7 +27,6 @@ index = [
     "logs-m365_defender.event-*",
     "logs-system.security*",
     "logs-windows.forwarded*",
-    "logs-windows.sysmon_operational-*",
     "winlogbeat-*",
 ]
 language = "eql"
@@ -81,7 +80,6 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Windows Security Event Logs",
     "Data Source: Microsoft Defender for Endpoint",
-    "Data Source: Sysmon",
     "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "system", "windows", "m365_defender"]
 maturity = "production"
-updated_date = "2025/02/21"
+updated_date = "2025/02/22"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -25,6 +25,7 @@ index = [
     "logs-m365_defender.event-*",
     "logs-system.security*",
     "logs-windows.forwarded*",
+    "logs-windows.sysmon_operational-*",
     "winlogbeat-*",
 ]
 language = "eql"
@@ -74,6 +75,7 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Sysmon",
     "Data Source: Windows Security Event Logs"
 ]
 timestamp_override = "event.ingested"
@@ -85,9 +87,15 @@ process where host.os.type == "windows" and event.type == "start" and process.na
   (
     /* scoped for whoami execution under system privileges */
     (
-      user.domain : ("NT *", "* NT", "IIS APPPOOL") and
-      user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20", "S-1-5-82-*") and
-      not ?winlog.event_data.SubjectUserName : "*$"
+      (
+        user.domain : ("NT *", "* NT", "IIS APPPOOL") and
+        user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20", "S-1-5-82-*") and
+        not ?winlog.event_data.SubjectUserName : "*$" and
+
+        /* Sysmon will always populate user.id as S-1-5-18, leading to FPs */
+        not event.dataset : ("windows.sysmon_operational", "windows.sysmon")
+      ) or
+      (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System")
     ) and
     not (
       process.parent.name : "cmd.exe" and

--- a/rules/windows/discovery_whoami_command_activity.toml
+++ b/rules/windows/discovery_whoami_command_activity.toml
@@ -25,7 +25,6 @@ index = [
     "logs-m365_defender.event-*",
     "logs-system.security*",
     "logs-windows.forwarded*",
-    "logs-windows.sysmon_operational-*",
     "winlogbeat-*",
 ]
 language = "eql"
@@ -75,8 +74,7 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: Microsoft Defender for Endpoint",
-    "Data Source: Windows Security Event Logs",
-    "Data Source: Sysmon",
+    "Data Source: Windows Security Event Logs"
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/11/15"
-integration = ["endpoint", "windows"]
+integration = ["endpoint"]
 maturity = "production"
 updated_date = "2025/01/15"
 min_stack_version = "8.14.0"
@@ -13,12 +13,7 @@ Identifies processes executed via Windows Management Instrumentation (WMI) on a 
 adversary lateral movement, but could be noisy if administrators use WMI to remotely manage hosts.
 """
 from = "now-9m"
-index = [
-    "logs-endpoint.events.process-*",
-    "logs-endpoint.events.network-*",
-    "winlogbeat-*",
-    "logs-windows.sysmon_operational-*",
-]
+index = ["logs-endpoint.events.process-*", "logs-endpoint.events.network-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "WMI Incoming Lateral Movement"
@@ -31,7 +26,6 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Lateral Movement",
     "Data Source: Elastic Defend",
-    "Data Source: Sysmon",
     "Resources: Investigation Guide",
 ]
 type = "eql"
@@ -48,7 +42,7 @@ sequence by host.id with maxspan = 2s
   /* Excluding Common FPs Nessus and SCCM */
 
   [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "WmiPrvSE.exe" and
-   not (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System") and
+   not process.Ext.token.integrity_level_name == "System" and
    not user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20") and
    not process.executable :
                ("?:\\Program Files\\HPWBEM\\Tools\\hpsum_swdiscovery.exe",

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/15"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/02/22"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -42,7 +42,7 @@ sequence by host.id with maxspan = 2s
   /* Excluding Common FPs Nessus and SCCM */
 
   [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "WmiPrvSE.exe" and
-   not process.Ext.token.integrity_level_name == "System" and
+   not process.Ext.token.integrity_level_name == "system" and
    not user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20") and
    not process.executable :
                ("?:\\Program Files\\HPWBEM\\Tools\\hpsum_swdiscovery.exe",

--- a/rules/windows/lateral_movement_incoming_wmi.toml
+++ b/rules/windows/lateral_movement_incoming_wmi.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2020/11/15"
-integration = ["endpoint"]
+integration = ["endpoint", "windows"]
 maturity = "production"
 updated_date = "2025/02/22"
 min_stack_version = "8.14.0"
@@ -13,7 +13,7 @@ Identifies processes executed via Windows Management Instrumentation (WMI) on a 
 adversary lateral movement, but could be noisy if administrators use WMI to remotely manage hosts.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process-*", "logs-endpoint.events.network-*"]
+index = ["logs-endpoint.events.process-*", "logs-endpoint.events.network-*", "logs-windows.sysmon_operational-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "WMI Incoming Lateral Movement"
@@ -26,6 +26,7 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Lateral Movement",
     "Data Source: Elastic Defend",
+    "Data Source: Sysmon",
     "Resources: Investigation Guide",
 ]
 type = "eql"
@@ -42,8 +43,12 @@ sequence by host.id with maxspan = 2s
   /* Excluding Common FPs Nessus and SCCM */
 
   [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "WmiPrvSE.exe" and
-   not process.Ext.token.integrity_level_name == "system" and
-   not user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20") and
+   not (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System") and
+   not (
+         user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20") and
+         /* Don't apply the user.id exclusion to Sysmon for compatibility */
+         not event.dataset : ("windows.sysmon_operational", "windows.sysmon")
+   ) and
    not process.executable :
                ("?:\\Program Files\\HPWBEM\\Tools\\hpsum_swdiscovery.exe",
                 "?:\\Windows\\CCM\\Ccm32BitLauncher.exe",


### PR DESCRIPTION
## Summary

Some rules exclude all SYSTEM activity by excluding the `S-1-5-18` user.id, the problem is that every sysmon event contains that SID ([ref](https://github.com/elastic/detection-rules/issues/1770)), so these rules could never trigger on its events. Here are 2 examples:

### When we use the SID but can still support the datasource:

```
registry where host.os.type == "windows" and
    registry.path : (
        "HKLM\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\LocalDumps\\DumpType",
        "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\LocalDumps\\DumpType"
    ) and
    registry.data.strings : ("2", "0x00000002") and
    not (process.executable : "?:\\Windows\\system32\\svchost.exe" and user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20"))
```

Here we are excluding a specific process, so we still support the data source as that exclusion will hit on any occurrence of `"?:\\Windows\\system32\\svchost.exe"`, so alerts will still be generated otherwise.

### When it will never trigger:

```
[...]
  [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "WmiPrvSE.exe" and
   not (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System") and
   not user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20") and
[...]
```

The `not user.id : ("S-1-5-18", "S-1-5-19", "S-1-5-20"` condition applies to all of the events, it is not specific to a process, so it will always match and the rule will never be triggered.