### PR TITLE
[Tuning] Potential Evasion via Filter Manager

### DIFF
--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows", "m365_defender", "system"]
 maturity = "production"
-updated_date = "2025/02/21"
+updated_date = "2025/02/24"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
@@ -124,18 +124,14 @@ type = "eql"
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
   process.name : "fltMC.exe" and process.args : "unload" and
-  not
-  (
-    (
-      process.executable : "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\DCFAService64.exe" and
-      process.args : ("DFMFilter", "DRMFilter")
-    ) or
-    (
-      process.executable : "?:\\Windows\\SysWOW64\\msiexec.exe" and
-      process.args : ("BrFilter_*", "BrCow_*") and
-      user.id : "S-1-5-18"
-    )
-  )
+  not process.parent.executable : 
+                   ("?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\DCFAService64.exe", 
+                    "?:\\Windows\\SysWOW64\\msiexec.exe", 
+                    "?:\\Program Files\\Bitdefender\\Endpoint Security\\installer\\installer.exe", 
+                    "?:\\Program Files\\Bitdefender\\Endpoint Security\\EPSecurityService.exe", 
+                    "?:\\Program Files\\Bitdefender\\Bitdefender Security\\productcfg.exe", 
+                    "?:\\Program Files\\Bitdefender\\Bitdefender Security\\bdservicehost.exe", 
+                    "?:\\Program Files\\Bitdefender\\EndpointSetupInformation\\{*}\\Installer.exe")
 '''
 
 


### PR DESCRIPTION
https://elasticstack.slack.com/archives/C016E72DWDS/p1740414962991809

- fixed the FPs exclusion logic (replaced `process.executable` by `process.parent.executable`)
- added also some other Bitdefender related FPs 

