### PR TITLE
[Tuning] Remote File Copy to a Hidden Share

### DIFF
--- a/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
+++ b/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
@@ -51,7 +51,7 @@ type = "eql"
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
   process.name : ("cmd.exe", "powershell.exe", "xcopy.exe", "pwsh.exe", "powershell_ise.exe") and 
-  process.args : ("*copy*", "move*", "cp", "mv") and process.args : "*\\\\*\\*$*"
+  process.command_line : "*\\\\*\\*$*" and process.command_line : ("*copy*", "*move*", "* cp *", "* mv *")
 '''
 note = """## Triage and analysis
 

--- a/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
+++ b/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/04"
 integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/02/21"
+updated_date = "2025/02/25"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
@@ -50,11 +50,8 @@ type = "eql"
 
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
-  (
-    process.name : ("cmd.exe", "powershell.exe", "xcopy.exe") and
-    process.args : ("copy*", "move*", "cp", "mv") or
-    process.name : "robocopy.exe"
-  ) and process.args : "*\\\\*\\*$*"
+  process.name : ("cmd.exe", "powershell.exe", "xcopy.exe", "pwsh.exe", "powershell_ise.exe") and 
+  process.args : ("copy*", "move*", "cp", "mv") and process.args : "*\\\\*\\*$*"
 '''
 note = """## Triage and analysis
 

--- a/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
+++ b/rules/windows/lateral_movement_remote_file_copy_hidden_share.toml
@@ -51,7 +51,7 @@ type = "eql"
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
   process.name : ("cmd.exe", "powershell.exe", "xcopy.exe", "pwsh.exe", "powershell_ise.exe") and 
-  process.args : ("copy*", "move*", "cp", "mv") and process.args : "*\\\\*\\*$*"
+  process.args : ("*copy*", "move*", "cp", "mv") and process.args : "*\\\\*\\*$*"
 '''
 note = """## Triage and analysis
 


### PR DESCRIPTION
added `powershell_ise.exe` and `pwsh.exe` and removed `Robocopy.exe` (very noisy) and added a wildcard to the `copy` arg match to extend coverage where `process.args` is not starting with `copy`.

https://elasticstack.slack.com/archives/C016E72DWDS/p1740438047909159