### PR TITLE
[Rule Tuning] Sysmon rules that uses `event.action`

### DIFF
--- a/rules/windows/defense_evasion_injection_msbuild.toml
+++ b/rules/windows/defense_evasion_injection_msbuild.toml
@@ -33,7 +33,10 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "windows" and event.code == "8" and process.name: "MSBuild.exe"
+process where host.os.type == "windows" and
+  event.provider == "Microsoft-Windows-Sysmon" and
+  /* CreateRemoteThread */
+  event.code == "8" and process.name: "MSBuild.exe"
 '''
 note = """## Triage and analysis
 

--- a/rules/windows/defense_evasion_injection_msbuild.toml
+++ b/rules/windows/defense_evasion_injection_msbuild.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/03/25"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/02/25"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
@@ -33,8 +33,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "windows" and process.name: "MSBuild.exe" and
-    event.action:("CreateRemoteThread detected (rule: CreateRemoteThread)", "CreateRemoteThread")
+process where host.os.type == "windows" and event.code == "8" and process.name: "MSBuild.exe"
 '''
 note = """## Triage and analysis
 

--- a/rules/windows/defense_evasion_timestomp_sysmon.toml
+++ b/rules/windows/defense_evasion_timestomp_sysmon.toml
@@ -33,23 +33,26 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where host.os.type == "windows" and event.code == "2" and
- not process.executable :
-          ("?:\\Program Files\\*",
-           "?:\\Program Files (x86)\\*",
-           "?:\\Windows\\system32\\cleanmgr.exe",
-           "?:\\Windows\\system32\\msiexec.exe",
-           "?:\\Windows\\syswow64\\msiexec.exe",
-           "?:\\Windows\\system32\\svchost.exe",
-           "?:\\WINDOWS\\system32\\backgroundTaskHost.exe",
-           "?:\\Users\\*\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe",
-           "?:\\Users\\*\\AppData\\Local\\Mozilla Firefox\\firefox.exe",
-           "?:\\Users\\*\\AppData\\Local\\slack\\app-*\\slack.exe",
-           "?:\\Users\\*\\AppData\\Local\\GitHubDesktop\\app-*\\GitHubDesktop.exe",
-           "?:\\Users\\*\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe",
-           "?:\\Users\\*\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe") and
- not file.extension : ("temp", "tmp", "~tmp", "xml", "newcfg") and not user.name : ("SYSTEM", "Local Service", "Network Service") and
- not file.name : ("LOG", "temp-index", "license.rtf", "iconcache_*.db")
+file where host.os.type == "windows" and
+  event.provider == "Microsoft-Windows-Sysmon" and
+  /* File creation time change */
+  event.code == "2" and
+  not process.executable :
+           ("?:\\Program Files\\*",
+            "?:\\Program Files (x86)\\*",
+            "?:\\Windows\\system32\\cleanmgr.exe",
+            "?:\\Windows\\system32\\msiexec.exe",
+            "?:\\Windows\\syswow64\\msiexec.exe",
+            "?:\\Windows\\system32\\svchost.exe",
+            "?:\\WINDOWS\\system32\\backgroundTaskHost.exe",
+            "?:\\Users\\*\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe",
+            "?:\\Users\\*\\AppData\\Local\\Mozilla Firefox\\firefox.exe",
+            "?:\\Users\\*\\AppData\\Local\\slack\\app-*\\slack.exe",
+            "?:\\Users\\*\\AppData\\Local\\GitHubDesktop\\app-*\\GitHubDesktop.exe",
+            "?:\\Users\\*\\AppData\\Local\\Microsoft\\Teams\\current\\Teams.exe",
+            "?:\\Users\\*\\AppData\\Local\\Microsoft\\OneDrive\\OneDrive.exe") and
+  not file.extension : ("temp", "tmp", "~tmp", "xml", "newcfg") and not user.name : ("SYSTEM", "Local Service", "Network Service") and
+  not file.name : ("LOG", "temp-index", "license.rtf", "iconcache_*.db")
 '''
 note = """## Triage and analysis
 

--- a/rules/windows/defense_evasion_timestomp_sysmon.toml
+++ b/rules/windows/defense_evasion_timestomp_sysmon.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/17"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/02/25"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
@@ -33,11 +33,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where host.os.type == "windows" and event.code : "2" and
-
- /* Requires Sysmon EventID 2 - File creation time change */
- event.action : "File creation time changed*" and
-
+file where host.os.type == "windows" and event.code == "2" and
  not process.executable :
           ("?:\\Program Files\\*",
            "?:\\Program Files (x86)\\*",

--- a/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
+++ b/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/10/13"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/02/25"
 min_stack_version = "8.14.0"
 min_stack_comments = "Breaking change at 8.14.0 for the Windows Integration."
 
@@ -48,8 +48,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where host.os.type == "windows" and event.action : "Pipe Created*" and
- /* normal sysmon named pipe creation events truncate the pipe keyword */
+file where host.os.type == "windows" and event.code == 17 and
+  /* Sysmon truncates the "Pipe" keyword in normal named pipe creation events */
   file.name : "\\*\\Pipe\\*"
 '''
 note = """## Triage and analysis

--- a/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
+++ b/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
@@ -52,7 +52,7 @@ file where host.os.type == "windows" and
   event.provider == "Microsoft-Windows-Sysmon" and
   
   /* Named Pipe Creation */
-  event.code == 17 and
+  event.code == "17" and
   
   /* Sysmon truncates the "Pipe" keyword in normal named pipe creation events */
   file.name : "\\*\\Pipe\\*"

--- a/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
+++ b/rules/windows/privilege_escalation_via_rogue_named_pipe.toml
@@ -48,7 +48,12 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where host.os.type == "windows" and event.code == 17 and
+file where host.os.type == "windows" and
+  event.provider == "Microsoft-Windows-Sysmon" and
+  
+  /* Named Pipe Creation */
+  event.code == 17 and
+  
   /* Sysmon truncates the "Pipe" keyword in normal named pipe creation events */
   file.name : "\\*\\Pipe\\*"
 '''


### PR DESCRIPTION
## Summary

Some of our Sysmon rules uses `event.action` values that would never match as they were changed in the integrations: https://github.com/elastic/integrations/pull/6882

Moving to `event.code` only as it is reliable, and although integrations changed the `event.action` field, the new values would not be compatible with winlogbeat.