### PR TITLE
[New Rule] Python Path File (pth) Creation

### DIFF
--- a/rules/linux/persistence_pth_file_creation.toml
+++ b/rules/linux/persistence_pth_file_creation.toml
@@ -74,7 +74,7 @@ file.path like~ (
     "/usr/local/bin/pip2", "/usr/bin/restic", "/usr/bin/pacman", "/usr/bin/dockerd", "/usr/local/bin/pip3",
     "/usr/bin/pip3", "/usr/local/bin/pip", "/usr/bin/pip", "/usr/bin/podman", "/usr/local/bin/poetry",
     "/usr/bin/poetry", "/usr/bin/pamac-daemon", "/opt/venv/bin/pip", "/usr/bin/dnf", "./venv/bin/pip",
-    "/usr/bin/dnf5", "/bin/dnf5"
+    "/usr/bin/dnf5", "/bin/dnf5", "/bin/pip", "/bin/podman"
   ) or
   process.executable like~ (
     "/usr/bin/python*", "/usr/local/bin/python*", "/opt/venv/bin/python*",

--- a/rules/linux/persistence_pth_file_creation.toml
+++ b/rules/linux/persistence_pth_file_creation.toml
@@ -73,9 +73,13 @@ file.path like~ (
   process.executable in (
     "/usr/local/bin/pip2", "/usr/bin/restic", "/usr/bin/pacman", "/usr/bin/dockerd", "/usr/local/bin/pip3",
     "/usr/bin/pip3", "/usr/local/bin/pip", "/usr/bin/pip", "/usr/bin/podman", "/usr/local/bin/poetry",
-    "/usr/bin/poetry", "/usr/bin/pamac-daemon", "/opt/venv/bin/pip", "/usr/bin/dnf", "./venv/bin/pip"
+    "/usr/bin/poetry", "/usr/bin/pamac-daemon", "/opt/venv/bin/pip", "/usr/bin/dnf", "./venv/bin/pip",
+    "/usr/bin/dnf5", "/bin/dnf5"
   ) or
-  process.executable like~ ("/nix/store/*libexec/docker/dockerd", "/snap/docker/*dockerd")
+  process.executable like~ (
+    "/usr/bin/python*", "/usr/local/bin/python*", "/opt/venv/bin/python*",
+    "/nix/store/*libexec/docker/dockerd", "/snap/docker/*dockerd"
+  )
 )
 '''
 

--- a/rules/linux/persistence_pth_file_creation.toml
+++ b/rules/linux/persistence_pth_file_creation.toml
@@ -1,0 +1,124 @@
+[metadata]
+creation_date = "2025/02/26"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/02/26"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the creation of .pth files in system-wide and user-specific Python package
+directories, which can be abused for persistent code execution. .pth files automatically
+execute Python code when the interpreter starts, making them a stealthy persistence mechanism.
+Monitoring these paths helps identify unauthorized modifications that could indicate
+persistence by an attacker or malicious package injection.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.file*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Python Path File (pth) Creation"
+references = [
+    "https://dfir.ch/posts/publish_python_pth_extension/",
+    "https://www.volexity.com/blog/2024/04/12/zero-day-exploitation-of-unauthenticated-remote-code-execution-vulnerability-in-globalprotect-cve-2024-3400/",
+]
+risk_score = 21
+rule_id = "7f65f984-5642-4291-a0a0-2bbefce4c617"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Execution",
+    "Tactic: Defense Evasion",
+    "Data Source: Elastic Defend"
+]
+type = "eql"
+query = '''
+file where host.os.type == "linux" and event.action in ("creation", "rename") and file.extension == "pth" and
+file.path like~ (
+  "/usr/local/lib/python*/dist-packages/*", 
+  "/usr/lib/python*/dist-packages/*",
+  "/usr/local/lib/python*/site-packages/*",
+  "/usr/lib/python*/site-packages/*",
+  "/home/*/.local/lib/python*/site-packages/*",
+  "/opt/*/lib/python*/site-packages/*"
+) and process.executable != null and not (
+  process.executable in (
+    "/usr/local/bin/pip2", "/usr/bin/restic", "/usr/bin/pacman", "/usr/bin/dockerd", "/usr/local/bin/pip3",
+    "/usr/bin/pip3", "/usr/local/bin/pip", "/usr/bin/pip", "/usr/bin/podman", "/usr/local/bin/poetry",
+    "/usr/bin/poetry", "/usr/bin/pamac-daemon", "/opt/venv/bin/pip", "/usr/bin/dnf", "./venv/bin/pip"
+  ) or
+  process.executable like~ ("/nix/store/*libexec/docker/dockerd", "/snap/docker/*dockerd")
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1543"
+name = "Event Triggered Execution"
+reference = "https://attack.mitre.org/techniques/T1546/"
+
+[[rule.threat.technique]]
+id = "T1574"
+name = "Hijack Execution Flow"
+reference = "https://attack.mitre.org/techniques/T1574/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/linux/persistence_pth_file_creation.toml
+++ b/rules/linux/persistence_pth_file_creation.toml
@@ -87,7 +87,7 @@ file.path like~ (
 framework = "MITRE ATT&CK"
 
 [[rule.threat.technique]]
-id = "T1543"
+id = "T1546"
 name = "Event Triggered Execution"
 reference = "https://attack.mitre.org/techniques/T1546/"
 

--- a/rules/linux/persistence_pth_file_creation.toml
+++ b/rules/linux/persistence_pth_file_creation.toml
@@ -59,6 +59,7 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend"
 ]
+timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 file where host.os.type == "linux" and event.action in ("creation", "rename") and file.extension == "pth" and


### PR DESCRIPTION
## Summary
This rule detects the creation of .pth files in system-wide and user-specific Python package directories, which can be abused for persistent code execution. .pth files automatically execute Python code when the interpreter starts, making them a stealthy persistence mechanism. Monitoring these paths helps identify unauthorized modifications that could indicate persistence by an attacker or malicious package injection.

## Telemetry
<img width="1592" alt="{40E0332B-B343-4FA4-9E22-AA661E74A890}" src="https://github.com/user-attachments/assets/9ad81ff8-04eb-4816-b41b-c7830352faab" />
