### PR TITLE
[Rule Tuning] Remove hardcoded logic from description

### DIFF
--- a/rules/network/discovery_potential_network_sweep_detected.toml
+++ b/rules/network/discovery_potential_network_sweep_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/05/17"
 integration = ["network_traffic", "panw"]
 maturity = "production"
-updated_date = "2025/02/04"
+updated_date = "2025/02/28"
 
 [rule]
 author = ["Elastic"]
@@ -10,8 +10,8 @@ description = """
 This rule identifies a potential network sweep. A network sweep is a method used by attackers to scan a target network,
 identifying active hosts, open ports, and available services to gather information on vulnerabilities and weaknesses.
 This reconnaissance helps them plan subsequent attacks and exploit potential entry points for unauthorized access, data
-theft, or other malicious activities. This rule proposes threshold logic to check for connection attempts from one
-source host to 100 or more destination hosts on commonly used network services.
+theft, or other malicious activities. This rule defines a threshold-based approach to detect multiple connection
+attempts from a single host to numerous destination hosts over commonly used network services.
 """
 from = "now-9m"
 index = ["packetbeat-*", "filebeat-*", "logs-network_traffic.*", "logs-panw.panos*"]

--- a/rules/network/discovery_potential_port_scan_detected.toml
+++ b/rules/network/discovery_potential_port_scan_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/05/17"
 integration = ["network_traffic", "panw"]
 maturity = "production"
-updated_date = "2025/02/04"
+updated_date = "2025/02/28"
 
 [rule]
 author = ["Elastic"]
@@ -11,8 +11,8 @@ This rule identifies a potential port scan. A port scan is a method utilized by 
 target system or network for open ports, allowing them to identify available services and potential vulnerabilities. By
 mapping out the open ports, attackers can gather critical information to plan and execute targeted attacks, gaining
 unauthorized access, compromising security, and potentially leading to data breaches, unauthorized control, or further
-exploitation of the targeted system or network. This rule proposes threshold logic to check for connection attempts from
-one source host to 250 or more destination ports.
+exploitation of the targeted system or network. This rule defines a threshold-based approach to detect connection
+attempts from a single source to a wide range of destination ports.
 """
 from = "now-9m"
 index = ["logs-network_traffic.*", "packetbeat-*", "filebeat-*", "logs-panw.panos*"]

--- a/rules/network/discovery_potential_syn_port_scan_detected.toml
+++ b/rules/network/discovery_potential_syn_port_scan_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/05/17"
 integration = ["network_traffic", "panw"]
 maturity = "production"
-updated_date = "2025/02/04"
+updated_date = "2025/02/28"
 
 [rule]
 author = ["Elastic"]
@@ -11,8 +11,8 @@ This rule identifies a potential SYN-Based port scan. A SYN port scan is a techn
 target network for open ports by sending SYN packets to multiple ports and observing the response. Attackers use this
 method to identify potential entry points or services that may be vulnerable to exploitation, allowing them to launch
 targeted attacks or gain unauthorized access to the system or network, compromising its security and potentially leading
-to data breaches or further malicious activities. This rule proposes threshold logic to check for connection attempts
-from one source host to 250 or more destination ports using 2 or less packets per port.
+to data breaches or further malicious activities. This rule defines a threshold-based approach to detect connection
+attempts from a single source to a large number of unique destination ports, while limiting the number of packets per port.
 """
 from = "now-9m"
 index = ["logs-network_traffic.*", "packetbeat-*", "filebeat-*", "logs-panw.panos*"]


### PR DESCRIPTION
## Issues

https://github.com/elastic/sdh-protections/issues/557

## Summary

Removes the hardcoded numbers/threshold from the rule description to avoid confusion if the rule is tuned but the description is not.