### PR TITLE
Deprecate Cloud Defend Rules

### DIFF
--- a/rules/_deprecated/container_workload_protection.toml
+++ b/rules/_deprecated/container_workload_protection.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/04/05"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/credential_access_aws_creds_search_inside_a_container.toml
+++ b/rules/_deprecated/credential_access_aws_creds_search_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/06/28"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/credential_access_collection_sensitive_files_compression_inside_a_container.toml
+++ b/rules/_deprecated/credential_access_collection_sensitive_files_compression_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/05/12"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/credential_access_sensitive_keys_or_passwords_search_inside_a_container.toml
+++ b/rules/_deprecated/credential_access_sensitive_keys_or_passwords_search_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/05/12"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/defense_evasion_ld_preload_shared_object_modified_inside_a_container.toml
+++ b/rules/_deprecated/defense_evasion_ld_preload_shared_object_modified_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/06/06"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/discovery_suspicious_network_tool_launched_inside_a_container.toml
+++ b/rules/_deprecated/discovery_suspicious_network_tool_launched_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/04/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/execution_container_management_binary_launched_inside_a_container.toml
+++ b/rules/_deprecated/execution_container_management_binary_launched_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/04/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/execution_file_made_executable_via_chmod_inside_a_container.toml
+++ b/rules/_deprecated/execution_file_made_executable_via_chmod_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/04/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/execution_interactive_exec_to_container.toml
+++ b/rules/_deprecated/execution_interactive_exec_to_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/05/12"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/execution_interactive_shell_spawned_from_inside_a_container.toml
+++ b/rules/_deprecated/execution_interactive_shell_spawned_from_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/04/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/execution_netcat_listener_established_inside_a_container.toml
+++ b/rules/_deprecated/execution_netcat_listener_established_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/04/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/initial_access_ssh_connection_established_inside_a_container.toml
+++ b/rules/_deprecated/initial_access_ssh_connection_established_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/05/12"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/lateral_movement_ssh_process_launched_inside_a_container.toml
+++ b/rules/_deprecated/lateral_movement_ssh_process_launched_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/05/12"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/persistence_ssh_authorized_keys_modification_inside_a_container.toml
+++ b/rules/_deprecated/persistence_ssh_authorized_keys_modification_inside_a_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/05/12"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
+++ b/rules/_deprecated/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/10/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/privilege_escalation_mount_launched_inside_a_privileged_container.toml
+++ b/rules/_deprecated/privilege_escalation_mount_launched_inside_a_privileged_container.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/10/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/privilege_escalation_potential_container_escape_via_modified_notify_on_release_file.toml
+++ b/rules/_deprecated/privilege_escalation_potential_container_escape_via_modified_notify_on_release_file.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/10/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/privilege_escalation_potential_container_escape_via_modified_release_agent_file.toml
+++ b/rules/_deprecated/privilege_escalation_potential_container_escape_via_modified_release_agent_file.toml
@@ -1,8 +1,9 @@
 [metadata]
 creation_date = "2023/10/26"
 integration = ["cloud_defend"]
-maturity = "production"
-updated_date = "2025/02/06"
+deprecation_date = "2025/03/14"
+maturity = "deprecated"
+updated_date = "2025/03/14"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Summary - What I changed

- As part of PR https://github.com/elastic/detection-rules/pull/4520 , we have modified the rules names to send deprecation notice via release https://github.com/elastic/ia-trade-team/issues/568. 
- This PR actually deprecates the rule for future releases 
<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

- Unit test to pass 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
