### PR TITLE
Update attack-coverage-update.yml

### DIFF
--- a/.github/workflows/attack-coverage-update.yml
+++ b/.github/workflows/attack-coverage-update.yml
@@ -45,7 +45,7 @@ jobs:
          git add docs-dev/"ATT\&CK-coverage.md"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7.0.3
+        uses: peter-evans/create-pull-request@6cd32fd93684475c31847837f87bb135d40a2b79  # v7.0.3
         with:
           assignees: '${{github.actor}}'
           delete-branch: true


### PR DESCRIPTION
Pinning action to a full length commit SHA [see](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

