### PR TITLE
[Rule Tuning] O365 Exchange Suspicious Mailbox Right Delegation

### DIFF
--- a/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
+++ b/rules/integrations/o365/persistence_exchange_suspicious_mailbox_right_delegation.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/05/17"
 integration = ["o365"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/04/01"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
@@ -64,7 +64,7 @@ type = "query"
 query = '''
 event.dataset:o365.audit and event.provider:Exchange and event.action:Add-MailboxPermission and
 o365.audit.Parameters.AccessRights:(FullAccess or SendAs or SendOnBehalf) and event.outcome:success and
-not user.id : "NT AUTHORITY\SYSTEM (Microsoft.Exchange.Servicehost)"
+not user.id : "NT AUTHORITY\SYSTEM (Microsoft.Exchange.ServiceHost)"
 '''
 
 


### PR DESCRIPTION
## Summary

As per SDH 564 (and confirmed via telemetry), this fixes the case difference that makes the exception invalid.