### PR TITLE
[Rule Tuning] Add Host Metadata to ES|QL Aggregation Rules

### DIFF
--- a/rules/linux/command_and_control_frequent_egress_netcon_from_sus_executable.toml
+++ b/rules/linux/command_and_control_frequent_egress_netcon_from_sus_executable.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -57,7 +57,7 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.network-*
-| keep @timestamp, host.os.type, event.type, event.action, process.name, process.executable, destination.ip, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, process.name, process.executable, destination.ip, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and (
      (
@@ -78,7 +78,7 @@ from logs-endpoint.events.network-*
      process.executable like "/tmp/.mount*" or
      process.executable like "/tmp/go-build*"
    )
-| stats cc = count(), agent_count = count_distinct(agent.id) by process.executable
+| stats cc = count(), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.executable
 | where agent_count == 1 and cc > 15
 | sort cc asc
 | limit 100

--- a/rules/linux/defense_evasion_base64_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base64_decoding_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -58,7 +58,7 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.process-*
-| keep @timestamp, host.os.type, event.type, event.action, process.name, process.args, process.command_line, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, process.name, process.args, process.command_line, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name in ("base64", "base64plain", "base64url", "base64mime", "base64pem", "base32", "base16") and process.command_line like "*-*d*") or
@@ -70,7 +70,7 @@ from logs-endpoint.events.process-*
   (process.name like "perl*" and process.command_line like "*decode_base64*") or
   (process.name like "ruby*" and process.args == "-e" and process.command_line like "*Base64.decode64*")
 )
-| stats cc = count(), agent_count = count_distinct(agent.id) by process.name, process.command_line
+| stats cc = count(), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.name, process.command_line
 | where agent_count == 1 and cc < 15
 | sort cc asc
 | limit 100

--- a/rules/linux/discovery_port_scanning_activity_from_compromised_host.toml
+++ b/rules/linux/discovery_port_scanning_activity_from_compromised_host.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -59,10 +59,10 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.network-*
-| keep @timestamp, host.os.type, event.type, event.action, destination.port, process.executable, destination.ip, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, destination.port, process.executable, destination.ip, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted"
-| stats cc = count(), port_count = count_distinct(destination.port), agent_count = count_distinct(agent.id) by process.executable, destination.ip
+| stats cc = count(), port_count = count_distinct(destination.port), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.executable, destination.ip
 | where agent_count == 1 and port_count > 100
 | sort cc asc
 | limit 100

--- a/rules/linux/discovery_subnet_scanning_activity_from_compromised_host.toml
+++ b/rules/linux/discovery_subnet_scanning_activity_from_compromised_host.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -59,10 +59,10 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.network-*
-| keep @timestamp, host.os.type, event.type, event.action, process.executable, destination.ip, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, process.executable, destination.ip, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted"
-| stats cc = count(), dest_count = count_distinct(destination.ip), agent_count = count_distinct(agent.id) by process.executable
+| stats cc = count(), dest_count = count_distinct(destination.ip), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.executable
 | where agent_count == 1 and dest_count > 250
 | sort cc asc
 | limit 100

--- a/rules/linux/exfiltration_unusual_file_transfer_utility_launched.toml
+++ b/rules/linux/exfiltration_unusual_file_transfer_utility_launched.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -58,11 +58,11 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.process-*
-| keep @timestamp, host.os.type, event.type, event.action, process.name, process.executable, process.parent.executable, process.command_line, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, process.name, process.executable, process.parent.executable, process.command_line, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
   process.name in ("scp", "ftp", "sftp", "vsftpd", "sftp-server", "rsync")
-| stats cc = count(), agent_count = count_distinct(agent.id) by process.executable, process.parent.executable, process.command_line
+| stats cc = count(), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.executable, process.parent.executable, process.command_line
 | where agent_count == 1 and cc < 5
 | sort cc asc
 | limit 100

--- a/rules/linux/impact_potential_bruteforce_malware_infection.toml
+++ b/rules/linux/impact_potential_bruteforce_malware_infection.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -62,7 +62,7 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.network-*
-| keep @timestamp, host.os.type, event.type, event.action, destination.port, process.executable, destination.ip, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, destination.port, process.executable, destination.ip, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
   destination.port in (22, 222, 2222, 10022, 2022, 2200, 62612, 8022) and not
@@ -72,7 +72,7 @@ from logs-endpoint.events.network-*
        "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24","198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4", "::1",
        "FE80::/10", "FF00::/8"
      )
-| stats cc = count(), agent_count = count_distinct(agent.id) by process.executable, destination.port
+| stats cc = count(), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.executable, destination.port
 | where agent_count == 1 and cc > 15
 | sort cc asc
 | limit 100

--- a/rules/linux/persistence_web_server_sus_child_spawned.toml
+++ b/rules/linux/persistence_web_server_sus_child_spawned.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -60,7 +60,7 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.process-*
-| keep @timestamp, host.os.type, event.type, event.action, process.parent.name, user.name, user.id, process.working_directory, process.name, process.executable, process.command_line, process.parent.executable, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, process.parent.name, user.name, user.id, process.working_directory, process.name, process.executable, process.command_line, process.parent.executable, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   process.parent.name in (
@@ -83,7 +83,7 @@ not (
   process.working_directory like "/" or
   process.parent.executable like "/vscode/vscode-server/*"
 )
-| stats cc = count(), agent_count = count_distinct(agent.id) by process.executable, process.working_directory, process.parent.executable
+| stats cc = count(), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.executable, process.working_directory, process.parent.executable
 | where agent_count == 1 and cc < 5
 | sort cc asc
 | limit 100

--- a/rules/linux/persistence_web_server_sus_command_execution.toml
+++ b/rules/linux/persistence_web_server_sus_command_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -61,7 +61,7 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.process-*
-| keep @timestamp, host.os.type, event.type, event.action, process.parent.name, user.name, user.id, process.working_directory, process.name, process.command_line, process.parent.executable, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, process.parent.name, user.name, user.id, process.working_directory, process.name, process.command_line, process.parent.executable, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   process.parent.name in (
@@ -87,7 +87,7 @@ from logs-endpoint.events.process-*
   process.parent.executable like "/vscode/vscode-server/*" or
   process.parent.executable == "/usr/bin/xfce4-terminal"
 )
-| stats cc = count(), agent_count = count_distinct(agent.id) by process.command_line, process.working_directory, process.parent.executable
+| stats cc = count(), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.command_line, process.working_directory, process.parent.executable
 | where agent_count == 1 and cc < 5
 | sort cc asc
 | limit 100

--- a/rules_building_block/persistence_web_server_sus_file_creation.toml
+++ b/rules_building_block/persistence_web_server_sus_file_creation.toml
@@ -3,7 +3,7 @@ bypass_bbr_timing = true
 creation_date = "2025/03/06"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/04/03"
 
 [rule]
 author = ["Elastic"]
@@ -62,7 +62,7 @@ type = "esql"
 
 query = '''
 from logs-endpoint.events.file-*
-| keep @timestamp, host.os.type, event.type, event.action, user.name, user.id, process.name, process.executable, file.path, agent.id
+| keep @timestamp, host.os.type, event.type, event.action, user.name, user.id, process.name, process.executable, file.path, agent.id, host.name
 | where @timestamp > now() - 1 hours
 | where host.os.type == "linux" and event.type == "change" and event.action in ("rename", "creation") and (
      user.name in (
@@ -80,7 +80,7 @@ from logs-endpoint.events.file-*
     process.name like "ruby*" or
     process.name like "perl*"
    )
-| stats cc = count(), agent_count = count_distinct(agent.id) by process.executable, file.path
+| stats cc = count(), agent_count = count_distinct(agent.id), host.name = VALUES(host.name), agent.id = VALUES(agent.id) by process.executable, file.path
 | where agent_count == 1 and cc < 5
 | sort cc asc
 | limit 100


### PR DESCRIPTION
## Summary

Uses [VALUES()](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-functions-operators.html#esql-values) to populate host.name and agent.id when performing aggregations to enable triage. I've tested this change with `Unusual Process Spawned from Web Server Parent` and it didn't change the number of hits.

Context: https://elastic.slack.com/archives/C6E3MTCD7/p1743668810646349?thread_ts=1734453588.389389&cid=C6E3MTCD7

Important to note that this is a temporary alternative until we get INLINESTATS, which solves this kind of problem, but still on design.

### Screenshot

![image](https://github.com/user-attachments/assets/0ae4352a-ec28-4cd0-87cb-5f1061ed6021)
