### PR TITLE
[New Rule] Threat Intel Email Indicator Match

### DIFF
--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -253,6 +253,7 @@ EsDataTypes = Literal[
 IGNORE_IDS = ["eb079c62-4481-4d6e-9643-3ca499df7aaa", "699e9fdb-b77c-4c01-995c-1c15019b9c43",
               "0c9a14d9-d65d-486f-9b5b-91e4e6b22bd0", "a198fbbd-9413-45ec-a269-47ae4ccf59ce",
               "0c41e478-5263-4c69-8f9e-7dfd2c22da64", "aab184d3-72b3-4639-b242-6597c99d8bca",
-              "a61809f3-fb5b-465c-8bff-23a8a068ac60", "f3e22c8b-ea47-45d1-b502-b57b6de950b3"]
+              "a61809f3-fb5b-465c-8bff-23a8a068ac60", "f3e22c8b-ea47-45d1-b502-b57b6de950b3",
+              "fcf18de8-ad7d-4d01-b3f7-a11d5b3883af"]
 IGNORE_INDICES = ['.alerts-security.*', 'logs-*', 'metrics-*', 'traces-*', 'endgame-*',
                   'filebeat-*', 'packetbeat-*', 'auditbeat-*', 'winlogbeat-*']

--- a/rules/threat_intel/threat_intel_indicator_match_email.toml
+++ b/rules/threat_intel/threat_intel_indicator_match_email.toml
@@ -1,0 +1,119 @@
+[metadata]
+creation_date = "2025/02/04"
+maturity = "production"
+updated_date = "2025/02/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule is triggered when a Email indicator from the Threat Intel Filebeat module or integrations has a match against an
+event that contains URL data, like DNS events, network logs, etc.
+"""
+from = "now-65m"
+index = ["filebeat-*", "logs-*"]
+interval = "1h"
+language = "kuery"
+license = "Elastic License v2"
+name = "Threat Intel Email Indicator Match"
+references = [
+    "https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-threatintel.html",
+    "https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html",
+    "https://www.elastic.co/security/tip",
+]
+risk_score = 99
+rule_id = "fcf18de8-ad7d-4d01-b3f7-a11d5b3883af"
+setup = """## Setup
+
+This rule needs threat intelligence indicators to work.
+Threat intelligence indicators can be collected using an [Elastic Agent integration](https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html#agent-ti-integration),
+the [Threat Intel module](https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html#ti-mod-integration),
+or a [custom integration](https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html#custom-ti-integration).
+
+More information can be found [here](https://www.elastic.co/guide/en/security/current/es-threat-intel-integrations.html).
+"""
+severity = "critical"
+tags = ["Rule Type: Threat Match"]
+threat_index = ["filebeat-*", "logs-ti_*"]
+threat_indicator_path = "threat.indicator"
+threat_language = "kuery"
+threat_query = """
+@timestamp >= "now-30d/d" and event.module:(threatintel or ti_*) and threat.indicator.email.address:* and not
+labels.is_ioc_transform_source:"true"
+"""
+timeline_id = "495ad7a7-316e-4544-8a0f-9c098daee76e"
+timeline_title = "Generic Threat Match Timeline"
+timestamp_override = "event.ingested"
+type = "threat_match"
+
+query = '''
+email.from.address:* or email.sender.address:* or email.reply_to.address:* or email.to.address:*
+'''
+
+
+[[rule.threat_filters]]
+
+[rule.threat_filters."$state"]
+store = "appState"
+[rule.threat_filters.meta]
+disabled = false
+key = "event.category"
+negate = false
+type = "phrase"
+[rule.threat_filters.meta.params]
+query = "threat"
+[rule.threat_filters.query.match_phrase]
+"event.category" = "threat"
+[[rule.threat_filters]]
+
+[rule.threat_filters."$state"]
+store = "appState"
+[rule.threat_filters.meta]
+disabled = false
+key = "event.kind"
+negate = false
+type = "phrase"
+[rule.threat_filters.meta.params]
+query = "enrichment"
+[rule.threat_filters.query.match_phrase]
+"event.kind" = "enrichment"
+[[rule.threat_filters]]
+
+[rule.threat_filters."$state"]
+store = "appState"
+[rule.threat_filters.meta]
+disabled = false
+key = "event.type"
+negate = false
+type = "phrase"
+[rule.threat_filters.meta.params]
+query = "indicator"
+[rule.threat_filters.query.match_phrase]
+"event.type" = "indicator"
+[[rule.threat_mapping]]
+
+[[rule.threat_mapping.entries]]
+type = "mapping"
+field = "email.from.address"
+value = "threat.indicator.email.address"
+
+[[rule.threat_mapping]]
+
+[[rule.threat_mapping.entries]]
+type = "mapping"
+field = "email.to.address"
+value = "threat.indicator.email.address"
+
+
+[[rule.threat_mapping]]
+
+[[rule.threat_mapping.entries]]
+type = "mapping"
+field = "email.sender.address"
+value = "threat.indicator.email.address"
+
+[[rule.threat_mapping]]
+
+[[rule.threat_mapping.entries]]
+type = "mapping"
+field = "email.reply_to.address"
+value = "threat.indicator.email.address"

--- a/rules/threat_intel/threat_intel_indicator_match_email.toml
+++ b/rules/threat_intel/threat_intel_indicator_match_email.toml
@@ -6,8 +6,8 @@ updated_date = "2025/02/04"
 [rule]
 author = ["Elastic"]
 description = """
-This rule is triggered when a Email indicator from the Threat Intel Filebeat module or integrations has a match against an
-event that contains URL data, like DNS events, network logs, etc.
+This rule is triggered when an email indicator from the Threat Intel Filebeat module or integrations matches an event
+containing email-related data, such as logs from email security gateways or email service providers.
 """
 from = "now-65m"
 index = ["filebeat-*", "logs-*"]


### PR DESCRIPTION
## Issues

Resolves #2890 

## Summary

Adds a new Indicator match rule for email IoCs, configured to match the relevant [ECS email fields](https://www.elastic.co/guide/en/ecs/current/ecs-email.html).

Alert Fired:

![image](https://github.com/user-attachments/assets/ab66e668-f759-4d76-b5fd-648f97a533dd)

## How to test

As I didn't had any email related logs, tests can be done using synthetic data:

1- Create the test indexes:

```
PUT logs-ti_test
PUT _data_stream/logs-test-rule
```

2- Ingest an indicator with the needed data
```
POST logs-ti_test/_doc
{
  "threat.indicator.email.address": "malicious@phishing.xyz",
  "event": {
    "category": "threat",
    "kind": "enrichment",
    "type": "indicator",
    "module": "threatintel",
    "ingested": "2025-04-04T17:00:00.162825789Z"
  },
  "@timestamp": "2025-04-04T17:00:00.162825789Z"
}
```

3- Ingest an event to be matched (Modify the timestamps to be within 1h less than current time)
```
POST logs-test-rule/_doc
{
  "email.from.address": "malicious@phishing.xyz",
  "event": {
    "kind": "event",
    "ingested": "2025-04-03T17:01:00.162825789Z"
  },
  "@timestamp": "2025-04-03T17:01:00.162825789Z"
}
```

4- Import the rule and enable it:

Rename it back to ndjson and import it in the SIEM
[20250404T155029L.json](https://github.com/user-attachments/files/19609093/20250404T155029L.json)
