### PR TITLE
Hunting - add `generate-json` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ exports/
 ML-models/
 surveys/
 machine-learning/
+
+
+# hunting json output
+hunting/*/json/*.json

--- a/hunting/__main__.py
+++ b/hunting/__main__.py
@@ -16,6 +16,7 @@ from detection_rules.misc import parse_user_config
 
 from .definitions import HUNTING_DIR
 from .markdown import MarkdownGenerator
+from .json import JSONGenerator
 from .run import QueryRunner
 from .search import QueryIndex
 from .utils import (filter_elasticsearch_params, get_hunt_path, load_all_toml,
@@ -50,6 +51,26 @@ def generate_markdown(path: Path = None):
 
     # After processing, update the index
     markdown_generator.update_index_md()
+
+@hunting.command('generate-json')
+@click.argument('path', required=False)
+def generate_json(path: Path = None):
+    """Convert TOML hunting queries to JSON format."""
+    json_generator = JSONGenerator(HUNTING_DIR)
+
+    if path:
+        path = Path(path)
+        if path.is_file() and path.suffix == '.toml':
+            click.echo(f"Generating JSON for single file: {path}")
+            json_generator.process_file(path)
+        elif (HUNTING_DIR / path).is_dir():
+            click.echo(f"Generating JSON for folder: {path}")
+            json_generator.process_folder(path)
+        else:
+            raise ValueError(f"Invalid path provided: {path}")
+    else:
+        click.echo("Generating JSON for all files.")
+        json_generator.process_all_files()
 
 
 @hunting.command('refresh-index')

--- a/hunting/json.py
+++ b/hunting/json.py
@@ -1,0 +1,178 @@
+from pathlib import Path
+import click
+from .definitions import ATLAS_URL, ATTACK_URL, STATIC_INTEGRATION_LINK_MAP, Hunt
+from .utils import load_index_file, load_toml, save_index_file, validate_link
+
+class JSONGenerator:
+    """Class to generate or update JSON documentation from TOML or YAML files."""
+    def __init__(self, base_path: Path):
+        """Initialize with the base path and load the hunting index."""
+        self.base_path = base_path
+        self.hunting_index = load_index_file()
+
+    def process_file(self, file_path: Path) -> None:
+        """Process a single TOML file and generate its JSON representation."""
+        if not file_path.is_file() or file_path.suffix != '.toml':
+            raise ValueError(f"The provided path is not a valid TOML file: {file_path}")
+
+        click.echo(f"Processing specific TOML file: {file_path}")
+        hunt_config = load_toml(file_path)
+        json_content = self.convert_toml_to_json(hunt_config, file_path)
+
+        docs_folder = self.create_docs_folder(file_path)
+        json_path = docs_folder / f"{file_path.stem}.json"
+        self.save_json(json_path, json_content)
+
+        self.update_or_add_entry(hunt_config, file_path)
+
+    def process_folder(self, folder: str) -> None:
+        """Process all TOML files in a specified folder and generate their JSON representations."""
+        folder_path = self.base_path / folder / "queries"
+        docs_folder = self.base_path / folder / "docs"
+
+        if not folder_path.is_dir() or not docs_folder.is_dir():
+            raise ValueError(f"Queries folder {folder_path} or docs folder {docs_folder} does not exist.")
+
+        click.echo(f"Processing all TOML files in folder: {folder_path}")
+        toml_files = folder_path.rglob("*.toml")
+
+        for toml_file in toml_files:
+            self.process_file(toml_file)
+
+    def process_all_files(self) -> None:
+        """Process all TOML files in the base directory and subfolders."""
+        click.echo("Processing all TOML files in the base directory and subfolders.")
+        toml_files = self.base_path.rglob("queries/*.toml")
+
+        for toml_file in toml_files:
+            self.process_file(toml_file)
+
+    def convert_toml_to_json(self, hunt_config: Hunt, file_path: Path) -> dict:
+        """Convert a Hunt configuration to JSON format."""
+        integration_links = self.generate_integration_links(hunt_config.integration)
+        integration_data = []
+        
+        for integration in hunt_config.integration:
+            link = None
+            for link_entry in integration_links:
+                if integration in link_entry:
+                    link = link_entry.split('(')[1].rstrip(')')
+                    break
+            
+            integration_data.append({
+                "name": integration,
+                "link": link
+            })
+            
+        mitre_data = []
+        if hunt_config.mitre:
+            for tech in hunt_config.mitre:
+                url = ATLAS_URL if tech.startswith('AML') else ATTACK_URL
+                if tech.startswith('T'):
+                    url += tech.replace('.', '/')
+                else:
+                    url += tech
+                    
+                mitre_data.append({
+                    "technique": tech,
+                    "url": url
+                })
+                
+        json_data = {
+            "name": hunt_config.name,
+            "metadata": {
+                "author": hunt_config.author,
+                "description": hunt_config.description,
+                "uuid": hunt_config.uuid,
+                "integrations": integration_data,
+                "language": str(hunt_config.language).replace("'", "").replace('"', ""),
+                "source_file": {
+                    "name": hunt_config.name,
+                    "path": (Path('../queries') / file_path.name).as_posix()
+                }
+            },
+            "queries": hunt_config.query,
+            "notes": hunt_config.notes if hunt_config.notes else [],
+            "mitre_techniques": mitre_data,
+            "references": hunt_config.references if hunt_config.references else [],
+            "license": hunt_config.license
+        }
+        
+        return json_data
+
+    def save_json(self, json_path: Path, content: dict) -> None:
+        """Save the JSON content to a file."""
+        import json
+        with open(json_path, 'w', encoding='utf-8') as f:
+            json.dump(content, f, indent=2, ensure_ascii=False)
+        click.echo(f"JSON generated: {json_path}")
+
+    def update_or_add_entry(self, hunt_config: Hunt, toml_path: Path) -> None:
+        """Update or add the entry for a TOML file in the hunting index."""
+        folder_name = toml_path.parent.parent.name
+        uuid = hunt_config.uuid
+
+        entry = {
+            'name': hunt_config.name,
+            'path': f"./{toml_path.relative_to(self.base_path).as_posix()}",
+            'mitre': hunt_config.mitre
+        }
+
+        if folder_name not in self.hunting_index:
+            self.hunting_index[folder_name] = {uuid: entry}
+        else:
+            self.hunting_index[folder_name][uuid] = entry
+
+        save_index_file(self.base_path, self.hunting_index)
+
+    def create_docs_folder(self, file_path: Path) -> Path:
+        """Create the docs folder if it doesn't exist and return the path."""
+        docs_folder = file_path.parent.parent / "docs"
+        docs_folder.mkdir(parents=True, exist_ok=True)
+        return docs_folder
+
+    def generate_integration_links(self, integrations: list[str]) -> list[str]:
+        """Generate integration links for the documentation."""
+        base_url = 'https://docs.elastic.co/integrations'
+        generated = []
+        for integration in integrations:
+            if integration in STATIC_INTEGRATION_LINK_MAP:
+                link_str = STATIC_INTEGRATION_LINK_MAP[integration]
+            else:
+                link_str = integration.replace('.', '/')
+            link = f'{base_url}/{link_str}'
+            validate_link(link)
+            generated.append(f'[{integration}]({link})')
+        return generated
+
+    def update_index_json(self) -> None:
+        """Update the index.json file based on the entries in index.yml."""
+        import json
+        index_file = self.base_path / "index.yml"
+        
+        if not index_file.exists():
+            click.echo(f"No index.yml found at {index_file}. Skipping index.json update.")
+            return
+            
+        index_json = {"categories": []}
+
+        for folder, files in sorted(self.hunting_index.items()):
+            category = {
+                "name": folder,
+                "files": []
+            }
+            
+            for file_info in sorted(files.values(), key=lambda x: x['name']):
+                json_path = file_info['path'].replace('queries', 'docs').replace('.toml', '.json')
+                category["files"].append({
+                    "name": file_info['name'],
+                    "path": json_path,
+                    "type": "ES|QL"
+                })
+                
+            index_json["categories"].append(category)
+
+        index_json_path = self.base_path / "index.json"
+        with open(index_json_path, 'w', encoding='utf-8') as f:
+            json.dump(index_json, f, indent=2, ensure_ascii=False)
+        click.echo(f"Index JSON updated at: {index_json_path}")

--- a/hunting/json.py
+++ b/hunting/json.py
@@ -55,53 +55,6 @@ class JSONGenerator:
     def convert_toml_to_json(self, hunt_config: Hunt) -> dict:
         """Convert a Hunt configuration to JSON format."""
         return json.dumps(asdict(hunt_config), indent=4)
-    
-    @staticmethod
-    def extract_indices_from_esql(esql_query):
-        """
-        Extract indices from an ESQL query.
-        
-        Args:
-            esql_query (str): The ESQL query.
-            
-        Returns:
-            list: A list of indices found in the query.
-        """
-        # Normalize whitespace by removing extra spaces and newlines
-        normalized_query = ' '.join(esql_query.split())
-        
-        # Check if the query starts with "from"
-        if not normalized_query.lower().startswith('from '):
-            return []
-        
-        # Extract the part after "from" and before the first pipe (|)
-        from_part = normalized_query[5:].split('|', 1)[0].strip()
-        
-        # Split by commas if multiple indices are provided
-        indices = [index.strip() for index in from_part.split(',')]
-        
-        return indices
-    
-    def format_queries(self, queries: list[str]) -> list[dict]:
-        """
-        Format the queries for JSON output.
-        
-        Args:
-            queries (list[str]): List of ESQL queries.
-        Returns:
-            list[dict]: List of dictionaries containing the query and its indices.
-        """
-        formatted_queries = []
-
-        for query in queries:
-            formatted_queries.append({
-                "query": query,
-                "indices": self.extract_indices_from_esql(query),
-            })
-
-        return formatted_queries
-
-
 
     def save_json(self, json_path: Path, content: dict) -> None:
         """Save the JSON content to a file."""

--- a/hunting/json.py
+++ b/hunting/json.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 import click
 from .definitions import ATLAS_URL, ATTACK_URL, STATIC_INTEGRATION_LINK_MAP, Hunt
-from .utils import load_index_file, load_toml, save_index_file, validate_link
+from .utils import load_index_file, load_toml, validate_link
 
 class JSONGenerator:
     """Class to generate or update JSON documentation from TOML or YAML files."""
@@ -27,8 +27,6 @@ class JSONGenerator:
         json_folder = self.create_json_folder(file_path)
         json_path = json_folder / f"{file_path.stem}.json"
         self.save_json(json_path, json_content)
-
-        self.update_or_add_entry(hunt_config, file_path)
 
     def process_folder(self, folder: str) -> None:
         """Process all TOML files in a specified folder and generate their JSON representations."""
@@ -83,72 +81,8 @@ class JSONGenerator:
             json.dump(content, f, indent=2, ensure_ascii=False)
         click.echo(f"JSON generated: {json_path}")
 
-    def update_or_add_entry(self, hunt_config: Hunt, toml_path: Path) -> None:
-        """Update or add the entry for a TOML file in the hunting index."""
-        folder_name = toml_path.parent.parent.name
-        uuid = hunt_config.uuid
-
-        entry = {
-            'name': hunt_config.name,
-            'path': f"./{toml_path.relative_to(self.base_path).as_posix()}",
-            'mitre': hunt_config.mitre
-        }
-
-        if folder_name not in self.hunting_index:
-            self.hunting_index[folder_name] = {uuid: entry}
-        else:
-            self.hunting_index[folder_name][uuid] = entry
-
-        save_index_file(self.base_path, self.hunting_index)
-
     def create_json_folder(self, file_path: Path) -> Path:
         """Create the docs folder if it doesn't exist and return the path."""
         json_folder = file_path.parent.parent / "json"
         json_folder.mkdir(parents=True, exist_ok=True)
         return json_folder
-
-    def generate_integration_links(self, integrations: list[str]) -> list[str]:
-        """Generate integration links for the documentation."""
-        base_url = 'https://docs.elastic.co/integrations'
-        generated = []
-        for integration in integrations:
-            if integration in STATIC_INTEGRATION_LINK_MAP:
-                link_str = STATIC_INTEGRATION_LINK_MAP[integration]
-            else:
-                link_str = integration.replace('.', '/')
-            link = f'{base_url}/{link_str}'
-            validate_link(link)
-            generated.append(f'[{integration}]({link})')
-        return generated
-
-    def update_index_json(self) -> None:
-        """Update the index.json file based on the entries in index.yml."""
-        import json
-        index_file = self.base_path / "index.yml"
-        
-        if not index_file.exists():
-            click.echo(f"No index.yml found at {index_file}. Skipping index.json update.")
-            return
-            
-        index_json = {"categories": []}
-
-        for folder, files in sorted(self.hunting_index.items()):
-            category = {
-                "name": folder,
-                "files": []
-            }
-            
-            for file_info in sorted(files.values(), key=lambda x: x['name']):
-                json_path = file_info['path'].replace('queries', 'docs').replace('.toml', '.json')
-                category["files"].append({
-                    "name": file_info['name'],
-                    "path": json_path,
-                    "type": "ES|QL"
-                })
-                
-            index_json["categories"].append(category)
-
-        index_json_path = self.base_path / "index.json"
-        with open(index_json_path, 'w', encoding='utf-8') as f:
-            json.dump(index_json, f, indent=2, ensure_ascii=False)
-        click.echo(f"Index JSON updated at: {index_json_path}")

--- a/hunting/json.py
+++ b/hunting/json.py
@@ -1,3 +1,8 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
 from pathlib import Path
 import click
 from .definitions import ATLAS_URL, ATTACK_URL, STATIC_INTEGRATION_LINK_MAP, Hunt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.0.5"
+version = "1.0.6"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
# Pull Request

## Summary - What I changed

Add a `generate-json` command which converts the hunting toml files to json.

JSON files are added to the `json` directory next to in the same way docs generates the `docs` folder.

I have added this output to the git ignore.

I have added this because I am investigating adding these prebuilt queries to kibana and wanted them in JSON format.

## How To Test

```
python3.12 -m hunting generate-json
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [x] Documentation and comments were added for features that require explanation
