### PR TITLE
fix: Cleaning up the hashable content for the rule

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -465,7 +465,7 @@ class Package(object):
         for rule in self.rules:
             summary_doc['rule_ids'].append(rule.id)
             summary_doc['rule_names'].append(rule.name)
-            summary_doc['rule_hashes'].append(rule.contents.sha256())
+            summary_doc['rule_hashes'].append(rule.contents.get_hash())
 
             if rule.id in self.new_ids:
                 status = 'new'
@@ -481,7 +481,7 @@ class Package(object):
             if relative_path is None:
                 raise ValueError(f"Could not find a valid relative path for the rule: {rule.id}")
 
-            rule_doc = dict(hash=rule.contents.sha256(),
+            rule_doc = dict(hash=rule.contents.get_hash(),
                             source='repo',
                             datetime_uploaded=now,
                             status=status,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1023,8 +1023,8 @@ class BaseRuleContents(ABC):
         if not existing_sha256:
             return False
 
-        rule_hash = self.get_hash()
-        rule_hash_with_integrations = self.get_hash(include_integrations=True)
+        rule_hash = self.get_hash(include_integrations=False)
+        rule_hash_with_integrations = self.get_hash()
 
         # Checking against current and previous version of the hash to avoid mass version bump
         is_dirty = existing_sha256 not in (rule_hash, rule_hash_with_integrations)
@@ -1142,7 +1142,7 @@ class BaseRuleContents(ABC):
         return hashable_dict
 
     @cached
-    def get_hash(self, include_version : bool = False, include_integrations: bool = False) -> str:
+    def get_hash(self, include_version : bool = False, include_integrations: bool = True) -> str:
         hashable_contents = self.get_hashable_content(
             include_version=include_version,
             include_integrations=include_integrations,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1144,7 +1144,6 @@ class BaseRuleContents(ABC):
 
     @cached
     def get_hash(self, include_version : bool = False, include_integrations: bool = False) -> str:
-        raise Exception("test")
         hashable_contents = self.get_hashable_content(
             include_version=include_version,
             include_integrations=include_integrations,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1026,6 +1026,8 @@ class BaseRuleContents(ABC):
         rule_hash = self.get_hash()
         rule_hash_with_integrations = self.get_hash(include_integrations=True)
 
+        print(">>>", existing_sha256, rule_hash, rule_hash_with_integrations, existing_sha256 in (rule_hash, rule_hash_with_integrations))
+
         # Checking against current and previous version of the hash to avoid mass version bump
         return existing_sha256 not in (rule_hash, rule_hash_with_integrations)
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1132,6 +1132,8 @@ class BaseRuleContents(ABC):
 
 
     def get_hashable_content(self, include_version: bool = False, include_integrations: bool = False) -> dict:
+        """Returns the rule content to be used for calculating the hash value for the rule"""
+
         # get the API dict without the version by default, otherwise it'll always be dirty.
         hashable_dict = self.to_api_format(include_version=include_version)
 
@@ -1143,6 +1145,7 @@ class BaseRuleContents(ABC):
 
     @cached
     def get_hash(self, include_version : bool = False, include_integrations: bool = False) -> str:
+        """Returns a sha256 hash of the rule contents"""
         hashable_contents = self.get_hashable_content(
             include_version=include_version,
             include_integrations=include_integrations,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1023,8 +1023,6 @@ class BaseRuleContents(ABC):
         if not existing_sha256:
             return False
 
-        return existing_sha256 != self.get_hash()
-
         rule_hash = self.get_hash()
         rule_hash_with_integrations = self.get_hash(include_integrations=True)
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1028,11 +1028,6 @@ class BaseRuleContents(ABC):
 
         # Checking against current and previous version of the hash to avoid mass version bump
         is_dirty = existing_sha256 not in (rule_hash, rule_hash_with_integrations)
-
-        if is_dirty:
-            print("DIRTY >>>", existing_sha256, rule_hash, rule_hash_with_integrations, existing_sha256 in (rule_hash, rule_hash_with_integrations))
-            import ipdb; ipdb.set_trace()
-
         return is_dirty
 
     @property

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1023,6 +1023,8 @@ class BaseRuleContents(ABC):
         if not existing_sha256:
             return False
 
+        return existing_sha256 != self.get_hash()
+
         rule_hash = self.get_hash()
         rule_hash_with_integrations = self.get_hash(include_integrations=True)
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1023,8 +1023,8 @@ class BaseRuleContents(ABC):
         if not existing_sha256:
             return False
 
-        rule_hash = self.get_hash(include_integrations=False)
-        rule_hash_with_integrations = self.get_hash()
+        rule_hash = self.get_hash()
+        rule_hash_with_integrations = self.get_hash(include_integrations=True)
 
         # Checking against current and previous version of the hash to avoid mass version bump
         is_dirty = existing_sha256 not in (rule_hash, rule_hash_with_integrations)
@@ -1142,7 +1142,7 @@ class BaseRuleContents(ABC):
         return hashable_dict
 
     @cached
-    def get_hash(self, include_version : bool = False, include_integrations: bool = True) -> str:
+    def get_hash(self, include_version : bool = False, include_integrations: bool = False) -> str:
         hashable_contents = self.get_hashable_content(
             include_version=include_version,
             include_integrations=include_integrations,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1031,6 +1031,7 @@ class BaseRuleContents(ABC):
 
         if is_dirty:
             print("DIRTY >>>", existing_sha256, rule_hash, rule_hash_with_integrations, existing_sha256 in (rule_hash, rule_hash_with_integrations))
+            import ipdb; ipdb.set_trace()
 
         return is_dirty
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1123,10 +1123,19 @@ class BaseRuleContents(ABC):
     def to_api_format(self, include_version: bool = True) -> dict:
         """Convert the rule to the API format."""
 
+
+    def get_hashable_content(self, include_version: bool = False, include_integrations: bool = True) -> dict:
+        # get the API dict without the version by default, otherwise it'll always be dirty.
+        hashable_dict = self.to_api_format(include_version=include_version)
+
+        # drop related integrations if present
+        if not include_integrations:
+            hashable_dict.pop("related_integrations", None)
+        return hashable_dict
+
     @cached
-    def sha256(self, include_version=False) -> str:
-        # get the hash of the API dict without the version by default, otherwise it'll always be dirty.
-        hashable_contents = self.to_api_format(include_version=include_version)
+    def sha256(self, include_version : bool = False) -> str:
+        hashable_contents = self.get_hashable_content(include_version=include_version, include_integrations=False)
         return utils.dict_hash(hashable_contents)
 
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1130,7 +1130,6 @@ class BaseRuleContents(ABC):
     def to_api_format(self, include_version: bool = True) -> dict:
         """Convert the rule to the API format."""
 
-
     def get_hashable_content(self, include_version: bool = False, include_integrations: bool = False) -> dict:
         """Returns the rule content to be used for calculating the hash value for the rule"""
 
@@ -1144,7 +1143,7 @@ class BaseRuleContents(ABC):
         return hashable_dict
 
     @cached
-    def get_hash(self, include_version : bool = False, include_integrations: bool = False) -> str:
+    def get_hash(self, include_version: bool = False, include_integrations: bool = False) -> str:
         """Returns a sha256 hash of the rule contents"""
         hashable_contents = self.get_hashable_content(
             include_version=include_version,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1026,10 +1026,13 @@ class BaseRuleContents(ABC):
         rule_hash = self.get_hash()
         rule_hash_with_integrations = self.get_hash(include_integrations=True)
 
-        print(">>>", existing_sha256, rule_hash, rule_hash_with_integrations, existing_sha256 in (rule_hash, rule_hash_with_integrations))
-
         # Checking against current and previous version of the hash to avoid mass version bump
-        return existing_sha256 not in (rule_hash, rule_hash_with_integrations)
+        is_dirty = existing_sha256 not in (rule_hash, rule_hash_with_integrations)
+
+        if is_dirty:
+            print("DIRTY >>>", existing_sha256, rule_hash, rule_hash_with_integrations, existing_sha256 in (rule_hash, rule_hash_with_integrations))
+
+        return is_dirty
 
     @property
     def lock_entry(self) -> Optional[dict]:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1144,6 +1144,7 @@ class BaseRuleContents(ABC):
 
     @cached
     def get_hash(self, include_version : bool = False, include_integrations: bool = False) -> str:
+        raise Exception("test")
         hashable_contents = self.get_hashable_content(
             include_version=include_version,
             include_integrations=include_integrations,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.0.18"
+version = "1.1.0"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -43,7 +43,7 @@ class TestPackages(BaseRuleTest):
         version_info = {
             rule.id: {
                 'rule_name': rule.name,
-                'sha256': rule.contents.sha256(),
+                'sha256': rule.contents.get_hash(),
                 'version': version
             } for rule in rules
         }
@@ -76,7 +76,7 @@ class TestPackages(BaseRuleTest):
         # test that no rules have versions defined
         for rule in rules:
             self.assertGreaterEqual(rule.contents.autobumped_version, 1, '{} - {}: version is not being set in package')
-            original_hashes.append(rule.contents.sha256())
+            original_hashes.append(rule.contents.get_hash())
 
         package = Package(rules, 'test-package')
 
@@ -87,7 +87,7 @@ class TestPackages(BaseRuleTest):
 
         # test that rules validate with version
         for rule in package.rules:
-            post_bump_hashes.append(rule.contents.sha256())
+            post_bump_hashes.append(rule.contents.get_hash())
 
         # test that no hashes changed as a result of the version bumps
         self.assertListEqual(original_hashes, post_bump_hashes, 'Version bumping modified the hash of a rule')


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:


## Summary - What I changed

- `related_integrations` field will be dropped from the dict that will be hashed to calculate the SHA256 hash of the rule.

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
