### PR TITLE
[New Rule] Dynamic IEX Reconstruction via Method String Access

### DIFF
--- a/rules/windows/defense_evasion_posh_obfuscation_iex_string_reconstruction.toml
+++ b/rules/windows/defense_evasion_posh_obfuscation_iex_string_reconstruction.toml
@@ -1,0 +1,105 @@
+[metadata]
+creation_date = "2025/04/16"
+integration = ["windows"]
+maturity = "production"
+updated_date = "2025/04/16"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies PowerShell scripts that reconstruct the IEX (Invoke-Expression) command by accessing and indexing the string
+representation of method references. This obfuscation technique uses constructs like ''.IndexOf.ToString() to expose
+method metadata as a string, then extracts specific characters through indexed access and joins them to form IEX,
+bypassing static keyword detection and evading defenses such as AMSI.
+"""
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Dynamic IEX Reconstruction via Method String Access"
+risk_score = 21
+rule_id = "9f432a8b-9588-4550-838e-1f77285580d3"
+setup = """## Setup
+
+The 'PowerShell Script Block Logging' logging policy must be enabled.
+Steps to implement the logging policy with Advanced Audit Configuration:
+
+```
+Computer Configuration >
+Administrative Templates >
+Windows PowerShell >
+Turn on PowerShell Script Block Logging (Enable)
+```
+
+Steps to implement the logging policy via registry:
+
+```
+reg add "hklm\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging" /v EnableScriptBlockLogging /t REG_DWORD /d 1
+```
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Windows",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Data Source: PowerShell Logs",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM logs-windows.powershell_operational* metadata _id, _version, _index
+| WHERE event.code == "4104"
+
+// Look for scripts with more than 500 chars that contain a related keyword
+| EVAL script_len = LENGTH(powershell.file.script_block_text)
+| WHERE script_len > 500
+
+// Replace string format expressions with 🔥 to enable counting the occurrence of the patterns we are looking for
+// The emoji is used because it's unlikely to appear in scripts and has a consistent character length of 1
+| EVAL replaced_with_fire = REPLACE(powershell.file.script_block_text, """(?i)['"]['"].(Insert|Normalize|Chars|SubString|Remove|LastIndexOfAny|LastIndexOf|IsNormalized|IndexOfAny|IndexOf)[^\[]+\[\d+,\d+,\d+\]""", "🔥")
+
+// Count how many patterns were detected by calculating the number of 🔥 characters inserted
+| EVAL count = LENGTH(replaced_with_fire) - LENGTH(REPLACE(replaced_with_fire, "🔥", ""))
+
+// Keep the fields relevant to the query, although this is not needed as the alert is populated using _id
+| KEEP count, replaced_with_fire, powershell.file.script_block_text, powershell.file.script_block_id, file.path, powershell.sequence, powershell.total, _id, _index, host.name, agent.id, user.id
+| WHERE count >= 1
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1027"
+name = "Obfuscated Files or Information"
+reference = "https://attack.mitre.org/techniques/T1027/"
+
+[[rule.threat.technique]]
+id = "T1140"
+name = "Deobfuscate/Decode Files or Information"
+reference = "https://attack.mitre.org/techniques/T1140/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.001"
+name = "PowerShell"
+reference = "https://attack.mitre.org/techniques/T1059/001/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+


### PR DESCRIPTION
## Issues

Part of https://github.com/elastic/ia-trade-team/issues/533

## Summary

Identifies PowerShell scripts that reconstruct the IEX (Invoke-Expression) command by accessing and indexing the string
representation of method references. This obfuscation technique uses constructs like ''.IndexOf.ToString() to expose
method metadata as a string, then extracts specific characters through indexed access and joins them to form IEX,
bypassing static keyword detection and evading defenses such as AMSI.

18 hits last 90d on telemetry all related to my testing, no FPs

## Additional information

From my testing, the | KEEP condition doesn’t need to specify any fields other than the metadata ones (_id and _index), as the engine appears to populate the alert using them. However, I’m keeping it as-is because it significantly improves performance in Discovery and makes the results more understandable if someone uses the query for hunting.

![image](https://github.com/user-attachments/assets/ebe65da9-2c33-4526-9a56-58f87cd75ee5)

## Sample Match

![image](https://github.com/user-attachments/assets/6dcccbe8-eb40-413e-b9fc-9b3451c52f12)

