### PR TITLE
[New Rule] Potential Malicious PowerShell Based on Alert Correlation

### DIFF
--- a/rules/windows/execution_posh_malicious_script_agg.toml
+++ b/rules/windows/execution_posh_malicious_script_agg.toml
@@ -1,0 +1,64 @@
+[metadata]
+creation_date = "2025/04/16"
+maturity = "production"
+updated_date = "2025/04/16"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies PowerShell script blocks associated with multiple distinct detections, indicating likely malicious behavior.
+"""
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Potential Malicious PowerShell Based on Alert Correlation"
+risk_score = 73
+rule_id = "f770ce79-05fd-4d74-9866-1c5d66c9b34b"
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Windows",
+    "Use Case: Threat Detection",
+    "Tactic: Execution",
+    "Rule Type: Higher-Order Rule"
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM .alerts-security.* metadata _id
+
+// Filter for PowerShell related alerts
+| WHERE kibana.alert.rule.name LIKE "*PowerShell*"
+
+// As alerts don't have non-ECS fields, parse the script block ID using GROK
+| GROK message "ScriptBlock ID: (?<powershell.file.script_block_id>.+)"
+| WHERE powershell.file.script_block_id IS NOT NULL
+
+| KEEP kibana.alert.rule.name, powershell.file.script_block_id, _id
+
+// Count distinct alerts and filter for matches above the threshold
+| STATS distinct_alerts = COUNT_DISTINCT(kibana.alert.rule.name), rules_triggered = VALUES(kibana.alert.rule.name), alert_ids = VALUES(_id) BY powershell.file.script_block_id
+| WHERE distinct_alerts >= 5
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.001"
+name = "PowerShell"
+reference = "https://attack.mitre.org/techniques/T1059/001/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+

--- a/rules/windows/execution_posh_malicious_script_agg.toml
+++ b/rules/windows/execution_posh_malicious_script_agg.toml
@@ -3,6 +3,31 @@ creation_date = "2025/04/16"
 maturity = "production"
 updated_date = "2025/04/16"
 
+[transform]
+[[transform.osquery]]
+label = "Osquery - Retrieve DNS Cache"
+query = "SELECT * FROM dns_cache"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve All Services"
+query = "SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services"
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Services Running on User Accounts"
+query = """
+SELECT description, display_name, name, path, pid, service_type, start_type, status, user_account FROM services WHERE
+NOT (user_account LIKE '%LocalSystem' OR user_account LIKE '%LocalService' OR user_account LIKE '%NetworkService' OR
+user_account == null)
+"""
+
+[[transform.osquery]]
+label = "Osquery - Retrieve Service Unsigned Executables with Virustotal Link"
+query = """
+SELECT concat('https://www.virustotal.com/gui/file/', sha1) AS VtLink, name, description, start_type, status, pid,
+services.path FROM services JOIN authenticode ON services.path = authenticode.path OR services.module_path =
+authenticode.path JOIN hash ON services.path = hash.path WHERE authenticode.result != 'trusted'
+"""
+
 [rule]
 author = ["Elastic"]
 description = """
@@ -12,6 +37,61 @@ from = "now-9m"
 language = "esql"
 license = "Elastic License v2"
 name = "Potential Malicious PowerShell Based on Alert Correlation"
+note = """## Triage and analysis
+
+### Investigating Potential Malicious PowerShell Based on Alert Correlation
+
+This detection rule aggregates alert data to identify PowerShell Scripts that have triggered various PowerShell-related detection logic, thereby producing higher-fidelity results.
+
+> **Note**:
+> This investigation guide uses the [Osquery Markdown Plugin](https://www.elastic.co/guide/en/security/current/invest-guide-run-osquery.html) introduced in Elastic Stack version 8.5.0. Older Elastic Stack versions will display unrendered Markdown in this guide.
+
+### Possible investigation steps
+
+- Analyzing the detections triggered by the script should offer insight into the suspicious behaviors it exhibits. This information can be found in the `distinct_alerts` field.
+- Examine the script content that triggered the detection; look for suspicious DLL imports, collection or exfiltration capabilities, suspicious functions, encoded or compressed data, and other potentially malicious characteristics.
+- Investigate the script execution chain (parent process tree) for unknown processes. Examine their executable files for prevalence, whether they are located in expected locations, and if they are signed with valid digital signatures.
+- Examine the script's execution context, such as the user account, privileges, the role of the system on which it was executed, and any relevant timestamps.
+- Investigate other alerts associated with the user/host during the past 48 hours.
+- Evaluate whether the user needs to use PowerShell to complete tasks.
+- Investigate the origin of the PowerShell script, including its source, download method, and any associated URLs or IP addresses.
+- Examine the host for derived artifacts that indicate suspicious activities:
+  - Analyze the script using a private sandboxed analysis system.
+  - Observe and collect information about the following activities in both the sandbox and the alert subject host:
+    - Attempts to contact external domains and addresses.
+      - Use the Elastic Defend network events to determine domains and addresses contacted by the subject process by filtering by the process's `process.entity_id`.
+      - Examine the DNS cache for suspicious or anomalous entries.
+        - $osquery_0
+    - Use the Elastic Defend registry events to examine registry keys accessed, modified, or created by the related processes in the process tree.
+    - Examine the host services for suspicious or anomalous entries.
+      - $osquery_1
+      - $osquery_2
+      - $osquery_3
+  - Retrieve the files' SHA-256 hash values using the PowerShell `Get-FileHash` cmdlet and search for the existence and reputation of the hashes in resources like VirusTotal, Hybrid-Analysis, CISCO Talos, Any.run, etc.
+- Investigate potentially compromised accounts. Analysts can do this by searching for login events (for example, 4624) to the target host after the registry modification.
+
+### False positive analysis
+
+- This rule is unlikely to trigger on legitimate activity. Benign true positives (B-TPs) can be added as exceptions if necessary.
+
+### Response and Remediation
+
+- Initiate the incident response process based on the outcome of the triage.
+  - If malicious activity is confirmed, perform a broader investigation to identify the scope of the compromise and determine the appropriate remediation steps.
+- Isolate the involved hosts to prevent further post-compromise behavior.
+- If the triage identified malware, search the environment for additional compromised hosts.
+  - Implement temporary network rules, procedures, and segmentation to contain the malware.
+  - Stop suspicious processes.
+  - Immediately block the identified indicators of compromise (IoCs).
+  - Inspect the affected systems for additional malware backdoors like reverse shells, reverse proxies, or droppers that attackers could use to reinfect the system.
+- Remove and block malicious artifacts identified during triage.
+- Reimage the host operating system or restore the compromised files to clean versions.
+- Restrict PowerShell usage outside of IT and engineering business units using GPOs, AppLocker, Intune, or similar software.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords for these accounts and other potentially compromised credentials, such as email, business systems, and web services.
+- Run a full antimalware scan. This may reveal additional artifacts left in the system, persistence mechanisms, and malware components.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection through the same vector.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
+"""
 risk_score = 73
 rule_id = "f770ce79-05fd-4d74-9866-1c5d66c9b34b"
 severity = "high"
@@ -20,7 +100,8 @@ tags = [
     "OS: Windows",
     "Use Case: Threat Detection",
     "Tactic: Execution",
-    "Rule Type: Higher-Order Rule"
+    "Rule Type: Higher-Order Rule",
+    "Resources: Investigation Guide"
 ]
 timestamp_override = "event.ingested"
 type = "esql"


### PR DESCRIPTION
## Summary

Alert correlation-like rule that parses the script_block_id from the message field so we can alert when PowerShell scripts trigger multiple PowerShell rules.

Shorter description:
Identifies PowerShell script blocks associated with multiple distinct detections, indicating likely malicious behavior.

## Sample Match

![image](https://github.com/user-attachments/assets/972f6635-59d0-411a-8193-b79fbd3c3016)

![image](https://github.com/user-attachments/assets/d040f098-032d-4f3f-ac73-143c74cc1527)

