### PR TITLE
fix: temporarily reverting "Cleaning up the hashable content for the rule (#4621)"

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -465,7 +465,7 @@ class Package(object):
         for rule in self.rules:
             summary_doc['rule_ids'].append(rule.id)
             summary_doc['rule_names'].append(rule.name)
-            summary_doc['rule_hashes'].append(rule.contents.get_hash())
+            summary_doc['rule_hashes'].append(rule.contents.sha256())
 
             if rule.id in self.new_ids:
                 status = 'new'
@@ -481,7 +481,7 @@ class Package(object):
             if relative_path is None:
                 raise ValueError(f"Could not find a valid relative path for the rule: {rule.id}")
 
-            rule_doc = dict(hash=rule.contents.get_hash(),
+            rule_doc = dict(hash=rule.contents.sha256(),
                             source='repo',
                             datetime_uploaded=now,
                             status=status,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1010,25 +1010,18 @@ class BaseRuleContents(ABC):
 
     def lock_info(self, bump=True) -> dict:
         version = self.autobumped_version if bump else (self.saved_version or 1)
-        contents = {"rule_name": self.name, "sha256": self.get_hash(), "version": version, "type": self.type}
+        contents = {"rule_name": self.name, "sha256": self.sha256(), "version": version, "type": self.type}
 
         return contents
 
     @property
-    def is_dirty(self) -> bool:
+    def is_dirty(self) -> Optional[bool]:
         """Determine if the rule has changed since its version was locked."""
         min_stack = Version.parse(self.get_supported_version(), optional_minor_and_patch=True)
         existing_sha256 = self.version_lock.get_locked_hash(self.id, f"{min_stack.major}.{min_stack.minor}")
 
-        if not existing_sha256:
-            return False
-
-        rule_hash = self.get_hash()
-        rule_hash_with_integrations = self.get_hash(include_integrations=True)
-
-        # Checking against current and previous version of the hash to avoid mass version bump
-        is_dirty = existing_sha256 not in (rule_hash, rule_hash_with_integrations)
-        return is_dirty
+        if existing_sha256 is not None:
+            return existing_sha256 != self.sha256()
 
     @property
     def lock_entry(self) -> Optional[dict]:
@@ -1130,25 +1123,10 @@ class BaseRuleContents(ABC):
     def to_api_format(self, include_version: bool = True) -> dict:
         """Convert the rule to the API format."""
 
-    def get_hashable_content(self, include_version: bool = False, include_integrations: bool = False) -> dict:
-        """Returns the rule content to be used for calculating the hash value for the rule"""
-
-        # get the API dict without the version by default, otherwise it'll always be dirty.
-        hashable_dict = self.to_api_format(include_version=include_version)
-
-        # drop related integrations if present
-        if not include_integrations:
-            hashable_dict.pop("related_integrations", None)
-
-        return hashable_dict
-
     @cached
-    def get_hash(self, include_version: bool = False, include_integrations: bool = False) -> str:
-        """Returns a sha256 hash of the rule contents"""
-        hashable_contents = self.get_hashable_content(
-            include_version=include_version,
-            include_integrations=include_integrations,
-        )
+    def sha256(self, include_version=False) -> str:
+        # get the hash of the API dict without the version by default, otherwise it'll always be dirty.
+        hashable_contents = self.to_api_format(include_version=include_version)
         return utils.dict_hash(hashable_contents)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.1.0"
+version = "1.0.18"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -43,7 +43,7 @@ class TestPackages(BaseRuleTest):
         version_info = {
             rule.id: {
                 'rule_name': rule.name,
-                'sha256': rule.contents.get_hash(),
+                'sha256': rule.contents.sha256(),
                 'version': version
             } for rule in rules
         }
@@ -76,7 +76,7 @@ class TestPackages(BaseRuleTest):
         # test that no rules have versions defined
         for rule in rules:
             self.assertGreaterEqual(rule.contents.autobumped_version, 1, '{} - {}: version is not being set in package')
-            original_hashes.append(rule.contents.get_hash())
+            original_hashes.append(rule.contents.sha256())
 
         package = Package(rules, 'test-package')
 
@@ -87,7 +87,7 @@ class TestPackages(BaseRuleTest):
 
         # test that rules validate with version
         for rule in package.rules:
-            post_bump_hashes.append(rule.contents.get_hash())
+            post_bump_hashes.append(rule.contents.sha256())
 
         # test that no hashes changed as a result of the version bumps
         self.assertListEqual(original_hashes, post_bump_hashes, 'Version bumping modified the hash of a rule')


### PR DESCRIPTION
This reverts commit 80c4f7eacc9176b7f33051edb62266a6f4b6a126.

<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
