### PR TITLE
Bringing back "fix: Cleaning up the hashable content for the rule" (#4621)

### DIFF
--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -465,7 +465,7 @@ class Package(object):
         for rule in self.rules:
             summary_doc['rule_ids'].append(rule.id)
             summary_doc['rule_names'].append(rule.name)
-            summary_doc['rule_hashes'].append(rule.contents.sha256())
+            summary_doc['rule_hashes'].append(rule.contents.get_hash())
 
             if rule.id in self.new_ids:
                 status = 'new'
@@ -481,7 +481,7 @@ class Package(object):
             if relative_path is None:
                 raise ValueError(f"Could not find a valid relative path for the rule: {rule.id}")
 
-            rule_doc = dict(hash=rule.contents.sha256(),
+            rule_doc = dict(hash=rule.contents.get_hash(),
                             source='repo',
                             datetime_uploaded=now,
                             status=status,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.1.2"
+version = "1.2.2"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.2.0"
+version = "1.1.3"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.2.2"
+version = "1.2.0"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -43,7 +43,7 @@ class TestPackages(BaseRuleTest):
         version_info = {
             rule.id: {
                 'rule_name': rule.name,
-                'sha256': rule.contents.sha256(),
+                'sha256': rule.contents.get_hash(),
                 'version': version
             } for rule in rules
         }
@@ -76,7 +76,7 @@ class TestPackages(BaseRuleTest):
         # test that no rules have versions defined
         for rule in rules:
             self.assertGreaterEqual(rule.contents.autobumped_version, 1, '{} - {}: version is not being set in package')
-            original_hashes.append(rule.contents.sha256())
+            original_hashes.append(rule.contents.get_hash())
 
         package = Package(rules, 'test-package')
 
@@ -87,7 +87,7 @@ class TestPackages(BaseRuleTest):
 
         # test that rules validate with version
         for rule in package.rules:
-            post_bump_hashes.append(rule.contents.sha256())
+            post_bump_hashes.append(rule.contents.get_hash())
 
         # test that no hashes changed as a result of the version bumps
         self.assertListEqual(original_hashes, post_bump_hashes, 'Version bumping modified the hash of a rule')


### PR DESCRIPTION

This reverts commit b7a324b2e8e512678d5aa18da9b692f7d00586cd and brings back https://github.com/elastic/detection-rules/pull/4621


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
