### PR TITLE
fix: Fixing leftover references to `sha256` method

### DIFF
--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -416,7 +416,7 @@ def kibana_diff(rule_id, repo, branch, threads):
     else:
         rules = rules.filter(production_filter).id_map
 
-    repo_hashes = {r.id: r.contents.sha256(include_version=True) for r in rules.values()}
+    repo_hashes = {r.id: r.contents.get_hash(include_version=True) for r in rules.values()}
 
     kibana_rules = {r['rule_id']: r for r in get_kibana_rules(repo=repo, branch=branch, threads=threads).values()}
     kibana_hashes = {r['rule_id']: dict_hash(r) for r in kibana_rules.values()}

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -571,7 +571,7 @@ class RuleCollection(BaseCollection):
                 new_rules[rule.id] = rule
             else:
                 pre_rule = self.id_map[rule.id]
-                if rule.contents.sha256() != pre_rule.contents.sha256():
+                if rule.contents.get_hash() != pre_rule.contents.get_hash():
                     changed_rules[rule.id] = rule
 
         for rule in other.deprecated:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.1.4"
+version = "1.1.5"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

- https://github.com/elastic/detection-rules/pull/4621


## Summary - What I changed

Fixing the leftovers from #4621 - refactoring the usage of outdated `sha256()` method

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
