### PR TITLE
[Tuning] Lateral Movement Rules

### DIFF
--- a/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
+++ b/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/24"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/05/20"
 
 [rule]
 author = ["Elastic"]
@@ -78,7 +78,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=30s
    [network where host.os.type == "windows" and process.pid == 4 and network.direction : ("incoming", "ingress") and
-    destination.port in (5985, 5986) and network.protocol == "http" and source.ip != "127.0.0.1" and source.ip != "::1"]
+    destination.port in (5985, 5986) and source.ip != "127.0.0.1" and source.ip != "::1"]
    [process where host.os.type == "windows" and
     event.type == "start" and process.parent.name : "winrshost.exe" and not process.executable : "?:\\Windows\\System32\\conhost.exe"]
 '''


### PR DESCRIPTION
- Incoming Execution via WinRM Remote Shell (removed `network.protocol` condition (missing in events and causes FNs)
- Suspicious Cmd Execution via WMI - bump up severity to high
- lateral_movement_incoming_winrm_shell_execution.toml - bumped up maxspan to 20s