### PR TITLE
fix: Making `PyGithub` a default dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,13 @@ dependencies = [
 	"typing-extensions==4.10.0",
 	"XlsxWriter~=3.2.0",
 	"semver==3.0.2",
+    "PyGithub==2.2.0",
 	"detection-rules-kql @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql",
 	"detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana",
 	"setuptools==75.2.0"
 ]
 [project.optional-dependencies]
-dev = ["pep8-naming==0.13.0", "PyGithub==2.2.0", "flake8==7.0.0", "pyflakes==3.2.0", "pytest>=8.1.1", "nodeenv==1.8.0", "pre-commit==3.6.2"]
+dev = ["pep8-naming==0.13.0", "flake8==7.0.0", "pyflakes==3.2.0", "pytest>=8.1.1", "nodeenv==1.8.0", "pre-commit==3.6.2"]
 hunting = ["tabulate==0.9.0"]
 
 [project.urls]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

- https://github.com/elastic/detection-rules/issues/4724

## Summary - What I changed

Moving pinned `PyGithub` dependency from `dev` group to a main group since it is used in non-dev flows.

## How To Test

Covered by default CI/CD setup.

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
