### PR TITLE
[Rule Tuning] Shell Configuration Creation or Modification

### DIFF
--- a/rules/linux/persistence_shell_configuration_modification.toml
+++ b/rules/linux/persistence_shell_configuration_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/01/24"
+updated_date = "2025/06/03"
 
 [rule]
 author = ["Elastic"]
@@ -68,10 +68,10 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
   // root and user configurations
   "/home/*/.profile", "/home/*/.bashrc", "/home/*/.bash_login", "/home/*/.bash_logout", "/home/*/.bash_profile",
   "/root/.profile", "/root/.bashrc", "/root/.bash_login", "/root/.bash_logout", "/root/.bash_profile",
-  "/home/*/.zprofile", "/home/*/.zshrc", "/root/.zprofile", "/root/.zshrc",
-  "/home/*/.cshrc", "/home/*/.login", "/home/*/.logout", "/root/.cshrc", "/root/.login", "/root/.logout",
-  "/home/*/.config/fish/config.fish", "/root/.config/fish/config.fish",
-  "/home/*/.kshrc", "/root/.kshrc"
+  "/root/.bash_aliases", "/home/*/.bash_aliases", "/home/*/.zprofile", "/home/*/.zshrc", "/root/.zprofile",
+  "/root/.zshrc", "/home/*/.cshrc", "/home/*/.login", "/home/*/.logout", "/root/.cshrc", "/root/.login",
+  "/root/.logout", "/home/*/.config/fish/config.fish", "/root/.config/fish/config.fish", "/home/*/.kshrc",
+  "/root/.kshrc"
 ) and not (
   process.executable in (
     "/bin/dpkg", "/usr/bin/dpkg", "/bin/dockerd", "/usr/bin/dockerd", "/usr/sbin/dockerd", "/bin/microdnf",


### PR DESCRIPTION
## Summary
In [a recent report from Kaspersky](https://securelist.com/dero-miner-infects-containers-through-docker-api/116546/) Linux malware leveraging `.bash_aliases` as a persistence mechanism was identified. This entry was not yet listed in this detection rule, so I'm adding it here to increase coverage.