### PR TITLE
[Rule Tuning] AWS EC2 Unauthorized Admin Credential Fetch via Assumed Role

### DIFF
--- a/rules/integrations/aws/credential_access_aws_getpassword_for_ec2_instance.toml
+++ b/rules/integrations/aws/credential_access_aws_getpassword_for_ec2_instance.toml
@@ -2,37 +2,36 @@
 creation_date = "2024/04/10"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/10"
+updated_date = "2025/06/04"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the first occurrence of a user identity in AWS using `GetPassword` for the administrator password of an EC2
-instance with an assumed role. Adversaries may use this API call to escalate privileges or move laterally within EC2
-instances.
+Identifies the first occurrence of an unauthorized attempt by an AWS role to use `GetPassword` to access the administrator password of an EC2 instance. 
+Adversaries may use this API call to escalate privileges or move laterally within EC2 instances.
 """
-from = "now-9m"
+from = "now-6m"
+interval = "5m"
 index = ["filebeat-*", "logs-aws.cloudtrail*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "AWS EC2 Admin Credential Fetch via Assumed Role"
+name = "AWS EC2 Unauthorized Admin Credential Fetch via Assumed Role"
 note = """
 ## Triage and analysis
 
-### Investigating AWS EC2 Admin Credential Fetch via Assumed Role
+### Investigating AWS EC2 Unauthorized Admin Credential Fetch via Assumed Role
 
-This rule detects the first occurrence of a user identity using the `GetPasswordData` API call in AWS, which retrieves the administrator password of an EC2 instance. This can be an indicator of an adversary attempting to escalate privileges or move laterally within EC2 instances.
+This rule detects the first occurrence of a role using the `GetPasswordData` API call, which retrieves the administrator password, against an unauthorized EC2 instance in AWS. This can be an indicator of an adversary attempting to escalate privileges or move laterally within EC2 instances.
 
 This is a New Terms rule, which means it will only trigger once for each unique value of the `aws.cloudtrail.user_identity.session_context.session_issuer.arn` field that has not been seen making this API request within the last 7 days. This field contains the Amazon Resource Name (ARN) of the assumed role that triggered the API call.
 
 #### Possible Investigation Steps
 
 - **Identify the User Identity and Role**: Examine the AWS CloudTrail logs to determine the user identity that made the `GetPasswordData` request. Pay special attention to the role and permissions associated with the user.
-- **Review Request and Response Parameters**: Analyze the `aws.cloudtrail.request_parameters` and `aws.cloudtrail.response_elements` fields to understand the context of the API call and the retrieved password.
-- **Contextualize with User Behavior**: Compare this activity against the user's typical behavior patterns. Look for unusual login times, IP addresses, or other anomalous actions taken by the user or role prior to and following the incident.
-- **Review EC2 Instance Details**: Check the details of the EC2 instance from which the password was retrieved. Assess the criticality and sensitivity of the applications running on this instance.
-- **Examine Related CloudTrail Events**: Search for other API calls made by the same user identity, especially those modifying security groups, network access controls, or instance metadata.
-- **Check for Lateral Movement**: Look for evidence that the obtained credentials have been used to access other resources or services within AWS.
+- **Review Request Parameters**: Analyze the `aws.cloudtrail.request_parameters` and `aws.cloudtrail.error_message` fields to understand the context of the API call.
+- **Contextualize with User Behavior**: Compare this activity against the role's typical behavior patterns. Look for unusual login times, IP addresses, or other anomalous actions taken by the role prior to and following the incident.
+- **Review EC2 Instance Details**: Check the details of the EC2 instance from which the password retrieval was attempted. Assess the criticality and sensitivity of the applications running on this instance.
+- **Examine Related CloudTrail Events**: Search for other API calls made by the same role, especially those modifying security groups, network access controls, or instance metadata.
 - **Investigate the Origin of the API Call**: Analyze the IP address and geographical location from which the request originated. Determine if it aligns with expected locations for legitimate administrative activity.
 
 ### False Positive Analysis
@@ -42,8 +41,6 @@ This is a New Terms rule, which means it will only trigger once for each unique 
 
 ### Response and Remediation
 
-- **Immediate Isolation**: If suspicious, isolate the affected instance to prevent any potential lateral movement or further unauthorized actions.
-- **Credential Rotation**: Rotate credentials of the affected instance or assumed role and any other potentially compromised credentials.
 - **User Account Review**: Review the permissions of the implicated user identity. Apply the principle of least privilege by adjusting permissions to prevent misuse.
 - **Enhanced Monitoring**: Increase monitoring on the user identity that triggered the rule and similar EC2 instances.
 - **Incident Response**: If malicious intent is confirmed, initiate the incident response protocol. This includes further investigation, containment of the threat, eradication of any threat actor presence, and recovery of affected systems.
@@ -78,6 +75,22 @@ event.dataset:"aws.cloudtrail"
     and aws.cloudtrail.user_identity.type:"AssumedRole" and aws.cloudtrail.error_code:"Client.UnauthorizedOperation"
 '''
 
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.address",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.session_context.session_issuer.arn",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "aws.cloudtrail.error_code",
+    "aws.cloudtrail.request_parameters",
+    "cloud.region"
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: 
- https://github.com/elastic/ia-trade-team/issues/616

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - Ruleset Audit
Telemetry for this rule looks to be only true positives from pentesting tools 
Rule executes as expected
- Edited Rule Name, Description, and Investigation Guide to better align with the behavior captured by this rule
- adjusted execution window for only 1 m additional lookback
- added highlighted fields for better alert context
<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->
<img width="1634" alt="aws ec2 admin credential fetch via assumed role" src="https://github.com/user-attachments/assets/65b6de15-64e3-4c8e-bd29-559f1bc3f7aa" />

## How To Test

I have a script available upon request to test this rule. The script will setup an EC2 instance using provided creds, then attempt to get the password from that instance using a specified unprivileged role. 

If you have an EC2 instance already stood up and an unauthorized role,  you can assume that role and attempt to retrieve the EC2 password via `GetPasswordData`. This should fail and trigger the rule. 
```
aws ec2 get-password-data --instance-id <instance-id>
```
