### PR TITLE
[Rule Tunings] AWS EC2 Flow Log Deletion and Network ACL Activity

### DIFF
--- a/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_flow_log_deletion.toml
@@ -2,13 +2,12 @@
 creation_date = "2020/06/15"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2024/05/21"
+updated_date = "2025/06/05"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the deletion of one or more flow logs in AWS Elastic Compute Cloud (EC2). An adversary may delete flow logs
-in an attempt to evade defenses.
+Identifies the deletion of one or more flow logs in AWS Elastic Compute Cloud (EC2). An adversary may delete flow logs in an attempt to evade defenses.
 """
 false_positives = [
     """
@@ -17,9 +16,9 @@ false_positives = [
     be exempted from the rule.
     """,
 ]
-from = "now-60m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
-interval = "10m"
+interval = "5m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS VPC Flow Logs Deletion"
@@ -81,6 +80,7 @@ tags = [
     "Domain: Cloud",
     "Data Source: AWS",
     "Data Source: Amazon Web Services",
+    "Data Source: AWS EC2",
     "Use Case: Log Auditing",
     "Resources: Investigation Guide",
     "Tactic: Defense Evasion",
@@ -92,6 +92,22 @@ query = '''
 event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and event.action:DeleteFlowLogs and event.outcome:success
 '''
 
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.address",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
@@ -100,9 +116,9 @@ id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
 [[rule.threat.technique.subtechnique]]
-id = "T1562.001"
-name = "Disable or Modify Tools"
-reference = "https://attack.mitre.org/techniques/T1562/001/"
+id = "T1562.008"
+name = "Disable or Modify Cloud Logs"
+reference = "https://attack.mitre.org/techniques/T1562/008/"
 
 
 

--- a/rules/integrations/aws/defense_evasion_ec2_network_acl_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_network_acl_deletion.toml
@@ -2,24 +2,21 @@
 creation_date = "2020/05/26"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/05"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the deletion of an Amazon Elastic Compute Cloud (EC2) network access control list (ACL) or one of its
-ingress/egress entries.
+Identifies the deletion of an Amazon Elastic Compute Cloud (EC2) network access control list (ACL) or one of its ingress/egress entries.
 """
 false_positives = [
     """
-    Network ACL's may be deleted by a network administrator. Verify whether the user identity, user agent, and/or
-    hostname should be making changes in your environment. Network ACL deletions by unfamiliar users or hosts should be
-    investigated. If known behavior is causing false positives, it can be exempted from the rule.
+    Network ACL's may be deleted by a network administrator. Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. Network ACL deletions by unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
-from = "now-60m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
-interval = "10m"
+interval = "5m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Network Access Control List Deletion"
@@ -75,6 +72,7 @@ tags = [
     "Domain: Cloud",
     "Data Source: AWS",
     "Data Source: Amazon Web Services",
+    "Data Source: AWS EC2",
     "Use Case: Network Security Monitoring",
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
@@ -85,7 +83,22 @@ type = "query"
 query = '''
 event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and event.action:(DeleteNetworkAcl or DeleteNetworkAclEntry) and event.outcome:success
 '''
-
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.address",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
@@ -94,10 +107,9 @@ id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
 [[rule.threat.technique.subtechnique]]
-id = "T1562.001"
-name = "Disable or Modify Tools"
-reference = "https://attack.mitre.org/techniques/T1562/001/"
-
+id = "T1562.007"
+name = "Disable or Modify Cloud Firewall"
+reference = "https://attack.mitre.org/techniques/T1562/007/"
 
 
 [rule.threat.tactic]

--- a/rules/integrations/aws/persistence_ec2_network_acl_creation.toml
+++ b/rules/integrations/aws/persistence_ec2_network_acl_creation.toml
@@ -2,24 +2,21 @@
 creation_date = "2020/06/04"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/05"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the creation of an AWS Elastic Compute Cloud (EC2) network access control list (ACL) or an entry in a network
-ACL with a specified rule number.
+Identifies the creation of an AWS EC2 network access control list (ACL) or an entry in a network ACL with a specified rule number. Adversaries may exploit ACLs to establish persistence or exfiltrate data by creating permissive rules.
 """
 false_positives = [
     """
-    Network ACL's may be created by a network administrator. Verify whether the user identity, user agent, and/or
-    hostname should be making changes in your environment. Network ACL creations by unfamiliar users or hosts should be
-    investigated. If known behavior is causing false positives, it can be exempted from the rule.
+    Network ACL's may be created by a network administrator. Verify whether the user identity should be making changes in your environment. Network ACL creations by unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
-from = "now-60m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
-interval = "10m"
+interval = "5m"
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS EC2 Network Access Control List Creation"
@@ -78,6 +75,7 @@ tags = [
     "Data Source: AWS EC2",
     "Use Case: Network Security Monitoring",
     "Tactic: Persistence",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -87,6 +85,22 @@ query = '''
 event.dataset:aws.cloudtrail and event.provider:ec2.amazonaws.com and event.action:(CreateNetworkAcl or CreateNetworkAclEntry) and event.outcome:success
 '''
 
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.address",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
@@ -100,4 +114,20 @@ reference = "https://attack.mitre.org/techniques/T1133/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+[[rule.threat.technique.subtechnique]]
+id = "T1562.007"
+name = "Disable or Modify Cloud Firewall"
+reference = "https://attack.mitre.org/techniques/T1562/007/"
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: 
- https://github.com/elastic/ia-trade-team/issues/616

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed
**"AWS VPC Flow Logs Deletion"**
Rule Triggers as expected
Telemetry looks fine
- changed time window
- added AWS EC2 tag
- Added highlighted fields
- updated Mitre technique
<img width="1554" alt="Delete VPC Flow Logs" src="https://github.com/user-attachments/assets/bf90fe43-66e3-4472-99cf-9afa0f3b4cfc" />

-----
**"AWS EC2 Network Access Control List Deletion"**
Rule Triggers as expected
Telemetry looks fine
- changed time window
- added AWS EC2 tag
- Added highlighted fields
- updated Mitre technique

<img width="1634" alt="Delete Network ACL" src="https://github.com/user-attachments/assets/4065efec-19f9-4cc7-8c3d-42e73d3388cb" />

-----
**"AWS EC2 Network Access Control List Creation"**
Rule Triggers as expected
Telemetry looks fine
- changed time window
- Added highlighted fields
- added Defense Evasion Mitre technique and tag
- _I Considered removing `event.action: CreateNetworkAclEntry` so this rule would only trigger for new ACL creation rather than new entries in an existing ACL. This would reduce some noise but I don't think it outweighs the benefit of capturing attackers who may add permissive rules to existing ACLs. Better to let users investigate this on their own and add exclusions for frequently modified ACLs._ 

<img width="1634" alt="Create Network ACL" src="https://github.com/user-attachments/assets/ddc8b4be-6286-455c-a002-524b44348181" />


## How To Test
I have scripts available and linked with each rule below. You can run the script with Python and an AWS credentials profile or use the manual commands below if you already have the necessary infrastructure setup. 

To trigger rules manually:
**"AWS VPC Flow Logs Deletion"** [(execution script)](https://github.com/elastic/elastic-aws-ruleset-testing/blob/main/EC2/trigger_defense_evasion_ec2_flow_log_deletion.py)
``` 
aws ec2 delete-flow-logs --flow-log-id <flow log id>
```

**"AWS EC2 Network Access Control List Creation"** [(execution script)](https://github.com/elastic/elastic-aws-ruleset-testing/blob/main/EC2/trigger_persistence_ec2_network_acl_creation.py)
```
# use within an existing VPC or create a new VPC first
aws ec2 create-network-acl --vpc-id <vpc-id>
OR
# add a rule to an existing ACL
aws ec2 create-network-acl-entry --network-acl-id <acl-id> --ingress --rule-number 100 --protocol udp --port-range From=53,To=53 --cidr-block 0.0.0.0/0 --rule-action allow
```

**"AWS EC2 Network Access Control List Deletion"** [(execution script)](https://github.com/elastic/elastic-aws-ruleset-testing/blob/main/EC2/trigger_defense_evasion_ec2_network_acl_deletion.py)
```
# use within an existing VPC or create a new VPC first and add an ACL to delete
aws ec2 delete-network-acl --network-acl-id <acl-id>
OR
# delete a rule from an existing ACL (specify whether it's an ingress or egress rule)
aws ec2 delete-network-acl-entry --network-acl-id <acl-id> --ingress | --egress --rule-number <#>
```
