### PR TITLE
[Rule Tuning] AWS IAM Assume Role Policy Update

### DIFF
--- a/rules/integrations/aws/privilege_escalation_iam_update_assume_role_policy.toml
+++ b/rules/integrations/aws/privilege_escalation_iam_update_assume_role_policy.toml
@@ -2,27 +2,21 @@
 creation_date = "2020/07/06"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/27"
+updated_date = "2025/06/12"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies AWS CloudTrail events where an IAM role's trust policy has been updated. The trust policy is a JSON document
-that defines which principals are allowed to assume the role. An attacker may attempt to modify this policy to gain the
-privileges of the role. This is a [New
-Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule, which means it
-will only trigger once for each unique value of the `aws.cloudtrail.user_identity.arn` and
-`aws.cloudtrail.flattened.request_parameters.roleName` fields that has not been seen making this API request within the
-last 14 days.
+Identifies AWS CloudTrail events where an IAM role's trust policy has been updated by an IAM user or Assumed Role identity. The trust policy is a JSON document that defines which principals are allowed to assume the role. An attacker may attempt to modify this policy to gain the privileges of the role. This is a [New
+Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule, which means it will only trigger once for each unique combination of the `cloud.account.id`, `user.name` and `aws.cloudtrail.flattened.request_parameters.roleName` fields, that have not been seen making this API request within the last 14 days.
 """
 false_positives = [
     """
-    Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. Policy
-    updates from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can
-    be exempted from the rule.
+    Verify whether the user identity should be making changes in your environment. Policy updates from unfamiliar users should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
-from = "now-9m"
+from = "now-6m"
+interval = "5m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
@@ -37,7 +31,8 @@ The role trust policy is a JSON document in which you define the principals you 
 
 #### Possible investigation steps
 
-- Review the `aws.cloudtrail.user_identity.arn` field to determine the user identity that performed the action.
+- Review the `aws.cloudtrail.user_identity.arn` to determine the IAM User that performed the action. 
+- If an AssumedRole identity type performed the action review the `aws.cloudtrail.user_identity.session_context.session_issuer.arn` field to determine which role was used.
 - Review the `aws.cloudtrail.flattened.request_parameters.roleName` field to confirm the role that was updated.
 - Within the `aws.cloudtrail.request_parameters` field, review the `policyDocument` to understand the changes made to the trust policy.
 - If `aws.cloudtrail.user_identity.access_key_id` is present, investigate the access key used to perform the action as it may be compromised.
@@ -95,13 +90,34 @@ event.dataset: "aws.cloudtrail"
 '''
 
 
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.session_context.session_issuer.arn",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "target.entity.id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters"
+]
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
 id = "T1078"
 name = "Valid Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/"
-
+[[rule.threat.technique.subtechnique]]
+id = "T1078.004"
+name = "Cloud Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/004/"
 
 [rule.threat.tactic]
 id = "TA0004"
@@ -110,9 +126,8 @@ reference = "https://attack.mitre.org/tactics/TA0004/"
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["aws.cloudtrail.user_identity.arn", "aws.cloudtrail.flattened.request_parameters.roleName"]
+value = ["cloud.account.id", "user.name", "aws.cloudtrail.flattened.request_parameters.roleName"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-14d"
-
 

--- a/rules/integrations/aws/privilege_escalation_iam_update_assume_role_policy.toml
+++ b/rules/integrations/aws/privilege_escalation_iam_update_assume_role_policy.toml
@@ -7,8 +7,7 @@ updated_date = "2025/06/12"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies AWS CloudTrail events where an IAM role's trust policy has been updated by an IAM user or Assumed Role identity. The trust policy is a JSON document that defines which principals are allowed to assume the role. An attacker may attempt to modify this policy to gain the privileges of the role. This is a [New
-Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule, which means it will only trigger once for each unique combination of the `cloud.account.id`, `user.name` and `aws.cloudtrail.flattened.request_parameters.roleName` fields, that have not been seen making this API request within the last 14 days.
+Identifies AWS CloudTrail events where an IAM role's trust policy has been updated by an IAM user or Assumed Role identity. The trust policy is a JSON document that defines which principals are allowed to assume the role. An attacker may attempt to modify this policy to gain the privileges of the role. This is a New Terms rule, which means it will only trigger once for each unique combination of the "cloud.account.id", "user.name" and "aws.cloudtrail.flattened.request_parameters.roleName" fields, that have not been seen making this API request within the last 14 days.
 """
 false_positives = [
     """


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: 
- https://github.com/elastic/ia-trade-team/issues/616

## Summary - What I changed

Roles are identities in AWS that are granted a set of permissions and can then be assumed by various users across many different sessions. Each of these sessions is given a session name which is attached to the end of the role's `aws.cloudtrail.user_identity.arn`. This means that each time a Role is assumed, there is a unique `aws.cloudtrail.user_identity.arn` created. 

This rule is meant to capture new instances of the Role updating role policies. Right now it's analyzing each session used with the Role, resulting in false positives. To capture the role itself we can use the `user.name` field. `cloud.account.id` has been added to the new_terms fields to account for organizations with multiple AWS account ids, which may reuse certain user.names across accounts.


- changed time window to have only 1 minute lookback
- changed the new terms field to look at combination of cloud.account.id, user.name, and roleName. (This is to account for the problem with using `aws.cloudtrail.user_identity.arn` for AssumedRoles.)
- added investigation fields
- updated mitre techniques

 
This will improve performance and detection accuracy especially in environments where there are many users assuming the same role and updating it's trust policy as a part of normal operations.

## How To Test
 You can use this [script](https://github.com/elastic/elastic-aws-ruleset-testing/blob/f05ad3e14fd2ded3d2a85f4aa39ba788480dc2da/IAM/trigger_privilege_escalation_update_assume_role_policy.py) to test this rule against both IAM user and Assumed Role Identity types. 

For manual testing use an existing user or role to update a new policy (to trigger new_terms combination)
```
aws iam update-assume-role-policy \
    --role-name Test-Role \
    --policy-document file://Test-Role-Trust-Policy.json
```
<img width="1678" alt="Screenshot 2025-06-13 at 12 55 32 AM" src="https://github.com/user-attachments/assets/dcd946f0-6a6d-4984-8ffe-d9806fbf1ef4" />


