### PR TITLE
[Rule Tuning] AWS EC2 User Data Retrieval for EC2 Instance

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -168,7 +168,8 @@
     "aws.cloudtrail.flattened.request_parameters.dryRun": "boolean",
     "aws.cloudtrail.flattened.request_parameters.clientToken": "keyword",
     "aws.cloudtrail.flattened.response_elements.s3BucketName": "keyword",
-    "aws.cloudtrail.flattened.response_elements.tableArn": "keyword"
+    "aws.cloudtrail.flattened.response_elements.tableArn": "keyword",
+    "aws.cloudtrail.flattened.request_parameters.attribute": "keyword"
   },
   "logs-azure.signinlogs-*": {
     "azure.signinlogs.properties.conditional_access_audiences.application_id": "keyword",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.2.15"
+version = "1.2.16"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rules/integrations/aws/discovery_ec2_userdata_request_for_ec2_instance.toml
+++ b/rules/integrations/aws/discovery_ec2_userdata_request_for_ec2_instance.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/14"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/02/03"
+updated_date = "2025/06/17"
 
 [rule]
 author = ["Elastic"]
@@ -10,11 +10,10 @@ description = """
 Identifies discovery request `DescribeInstanceAttribute` with the attribute userData and instanceId in AWS CloudTrail
 logs. This may indicate an attempt to retrieve user data from an EC2 instance. Adversaries may use this information to
 gather sensitive data from the instance such as hardcoded credentials or to identify potential vulnerabilities. This is
-a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that
-identifies when `aws.cloudtrail.user_identity.arn` requests the user data for a specific
-`aws.cloudtrail.flattened.request_parameters.instanceId` from an EC2 instance in the last 14 days.
+a New Terms rule that identifies the first time an IAM user or role requests the user data for a specific EC2 instance in the last 14 days.
 """
-from = "now-9m"
+from = "now-6m"
+interval = "5m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
@@ -36,12 +35,7 @@ This rule detects requests to retrieve the `userData` attribute of an EC2 instan
   - **User Identity**: Inspect the `aws.cloudtrail.user_identity.arn` field to identify the user or role that executed the `DescribeInstanceAttribute` action. Investigate whether this user typically performs such actions.
   - **Access Patterns**: Validate whether the user or role has the necessary permissions and whether the frequency of this action aligns with expected behavior.
   - **Access Key ID**: Check the `aws.cloudtrail.user_identity.access_key_id` field to determine the key used to make the request as it may be compromised.
-
-- **Analyze Request Details**:
-  - **Parameters**: Verify that the `attribute=userData` parameter was explicitly requested. This indicates intentional access to user data.
   - **Source IP and Geolocation**: Check the `source.address` and `source.geo` fields to validate whether the request originated from a trusted location or network. Unexpected geolocations can indicate adversarial activity.
-
-- **Review Source Tool**:
   - **User Agent**: Inspect the `user_agent.original` field to determine the tool or client used (e.g., Terraform, AWS CLI). Legitimate automation tools may trigger this activity, but custom or unknown user agents may indicate malicious intent.
 
 - **Check for Related Activity**:
@@ -94,13 +88,30 @@ event.dataset: "aws.cloudtrail"
     and event.provider: "ec2.amazonaws.com"
     and event.action: "DescribeInstanceAttribute"
     and event.outcome: "success"
-    and aws.cloudtrail.request_parameters: (*attribute=userData* and *instanceId*)
+    and aws.cloudtrail.flattened.request_parameters.instanceId: * 
+    and aws.cloudtrail.flattened.request_parameters.attribute: "userData"
     and not aws.cloudtrail.user_identity.invoked_by: (
         "AWS Internal" or
         "cloudformation.amazonaws.com"
     )
 '''
 
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
@@ -134,7 +145,7 @@ reference = "https://attack.mitre.org/tactics/TA0006/"
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["aws.cloudtrail.user_identity.arn", "aws.cloudtrail.flattened.request_parameters.instanceId"]
+value = ["user.name", "aws.cloudtrail.flattened.request_parameters.instanceId"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-14d"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/616
## Summary - What I changed
- changed execution window
- explicitly added flattened fields to query, to reduce wildcard usage
- added investigation fields
- changed new terms field to evaluate `user.name` over `aws.cloudtrail.user_identity.arn` so that only the role name for Assumed Role identitites is being evaluated instead of each individual session. This should greatly impact performance as most instances of this rule in telemetry is triggered by Assumed Roles.

<img width="1713" alt="Screenshot 2025-06-17 at 3 16 16 AM" src="https://github.com/user-attachments/assets/27397e01-97aa-421f-943c-59d51d87d6b8" />
<img width="1713" alt="Screenshot 2025-06-17 at 3 15 04 AM" src="https://github.com/user-attachments/assets/d6c20ae4-0a34-4e01-b39d-f5377e7fd8ed" />

## How To Test
You can use this [script](https://github.com/elastic/elastic-aws-ruleset-testing/blob/fafb6a64157102f816e1fbeb5a7e8f37acac1bac/EC2/trigger_discovery_ec2_userdata_request_for_ec2_instance.py) to test the rule using both an IAM user and a Role

To test manually launch an EC2 instance and use your user or role to access it's user data with the following command:
```
aws ec2 describe-instance-attribute --instance-id i-1234567890abcdef0 --attribute userData
```
