### PR TITLE
[Rule Tuning] Container Management Utility Run Inside A Container

### DIFF
--- a/rules/linux/execution_container_management_binary_launched_inside_container.toml
+++ b/rules/linux/execution_container_management_binary_launched_inside_container.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/12"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/12"
+updated_date = "2025/06/17"
 
 [rule]
 author = ["Elastic"]
@@ -65,8 +65,9 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.entry_leader.entry_meta.type == "container" and
-process.name in ("dockerd", "docker", "kubelet", "kube-proxy", "kubectl", "containerd", "runc", "systemd", "crictl")
+process.entry_leader.entry_meta.type == "container" and process.interactive == true and
+process.name in ("dockerd", "docker", "kubelet", "kube-proxy", "kubectl", "containerd", "systemd", "crictl") and
+not process.parent.executable == "/sbin/init"
 '''
 note = """## Triage and analysis
 

--- a/rules/linux/execution_container_management_binary_launched_inside_container.toml
+++ b/rules/linux/execution_container_management_binary_launched_inside_container.toml
@@ -67,7 +67,7 @@ query = '''
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.entry_leader.entry_meta.type == "container" and process.interactive == true and
 process.name in ("dockerd", "docker", "kubelet", "kube-proxy", "kubectl", "containerd", "systemd", "crictl") and
-not process.parent.executable == "/sbin/init"
+not process.parent.executable in ("/sbin/init", "/usr/bin/dockerd")
 '''
 note = """## Triage and analysis
 


### PR DESCRIPTION
## Summary
This rule is very noisy, as `runc` and other management tools are constantly ran through non-interactive shells, via e.g. busybox in minikube. This tuning reduces noise from 30k+ alerts last 30d to 40. 

