### PR TITLE
[New Rule] Kubeconfig File Discovery

### DIFF
--- a/rules/linux/discovery_kubeconfig_file_discovery.toml
+++ b/rules/linux/discovery_kubeconfig_file_discovery.toml
@@ -9,7 +9,7 @@ author = ["Elastic"]
 description = """
 The kubeconfig file is a critical component in Kubernetes environments, containing configuration
 details for accessing and managing Kubernetes clusters. Attackers may attempt to get access to,
-create or modify kubeconfig files to gain unauthorized initial access to Kubernetes clusters or
+create, or modify kubeconfig files to gain unauthorized initial access to Kubernetes clusters or
 move laterally within the cluster. This rule detects process discovery executions that involve
 kubeconfig files, particularly those executed from common shell environments or world-writeable
 directories.

--- a/rules/linux/discovery_kubeconfig_file_discovery.toml
+++ b/rules/linux/discovery_kubeconfig_file_discovery.toml
@@ -1,0 +1,103 @@
+[metadata]
+creation_date = "2025/06/17"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/06/17"
+
+[rule]
+author = ["Elastic"]
+description = """
+The kubeconfig file is a critical component in Kubernetes environments, containing configuration
+details for accessing and managing Kubernetes clusters. Attackers may attempt to get access to,
+create or modify kubeconfig files to gain unauthorized initial access to Kubernetes clusters or
+move laterally within the cluster. This rule detects process discovery executions that involve
+kubeconfig files, particularly those executed from common shell environments or world-writeable
+directories.
+"""
+from = "now-9m"
+index = [
+    "logs-endpoint.events.process*",
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Kubeconfig File Discovery"
+references = [
+    "https://kubernetes-threat-matrix.redguard.ch/initial-access/kubeconfig-file/",
+    "https://kubenomicon.com/Initial_access/Kubeconfig_file.html",
+    ]
+risk_score = 21
+rule_id = "9a6f5d74-c7e7-4a8b-945e-462c102daee4"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "Domain: Container",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Discovery",
+    "Data Source: Elastic Defend",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") or
+  (
+    process.parent.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/root/*", "/home/*") or
+    process.parent.name like (".*", "*.sh")
+  )
+) and
+(
+  (
+    process.working_directory like ("/etc/kubernetes", "/root/.kube", "/home/*/.kube") and
+    process.args in ("kubeconfig", "admin.conf", "super-admin.conf", "kubelet.conf", "controller-manager.conf", "scheduler.conf")
+  ) or
+  process.args like (
+    "/etc/kubernetes/admin.conf",
+    "/etc/kubernetes/super-admin.conf",
+    "/etc/kubernetes/kubelet.conf",
+    "/etc/kubernetes/controller-manager.conf",
+    "/etc/kubernetes/scheduler.conf",
+    "/home/*/.kube/config",
+    "/root/.kube/config",
+    "/var/lib/*/kubeconfig"
+  )
+) and not process.name in ("stat", "md5sum", "dirname")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1613"
+name = "Container and Resource Discovery"
+reference = "https://attack.mitre.org/techniques/T1613/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"


### PR DESCRIPTION
## Summary
The kubeconfig file is a critical component in Kubernetes environments, containing configuration details for accessing and managing Kubernetes clusters. Attackers may attempt to get access to, create or modify kubeconfig files to gain unauthorized initial access to Kubernetes clusters or move laterally within the cluster. This rule detects process discovery executions that involve kubeconfig files, particularly those executed from common shell environments or world-writeable directories.

## Telemetry
Last 30d only 9 hits in telemetry. In my testing stack, only TPs related to manual testing and running reconnaissance tools such as `dredge.sh` and `linpeas.sh`.

<img width="1127" alt="{914F1098-2719-4256-87ED-82C73B26A2F0}" src="https://github.com/user-attachments/assets/8353dcb3-bae4-4bd0-b434-a36b1a823260" />
