### PR TITLE
[FN Rule Tuning] Kubernetes User Exec into Pod

### DIFF
--- a/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
+++ b/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/05/17"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/17"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,7 @@ false_positives = [
     """,
 ]
 index = ["logs-kubernetes.*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Kubernetes User Exec into Pod"
 note = """## Triage and analysis
@@ -73,27 +73,22 @@ rule_id = "14de811c-d60f-11ec-9fd7-f661ea17fbce"
 severity = "medium"
 tags = ["Data Source: Kubernetes", "Tactic: Execution", "Resources: Investigation Guide"]
 timestamp_override = "event.ingested"
-type = "query"
-
+type = "eql"
 query = '''
-event.dataset : "kubernetes.audit_logs"
-  and kubernetes.audit.annotations.authorization_k8s_io/decision:"allow"
-  and kubernetes.audit.verb:"create"
-  and kubernetes.audit.objectRef.resource:"pods"
-  and kubernetes.audit.objectRef.subresource:"exec"
+any where host.os.type == "linux" and event.dataset == "kubernetes.audit_logs" and
+kubernetes.audit.verb in ("get", "create") and kubernetes.audit.objectRef.subresource == "exec" and
+kubernetes.audit.stage == "ResponseComplete" and `kubernetes.audit.annotations.authorization_k8s_io/decision` == "allow"
 '''
-
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1609"
 name = "Container Administration Command"
 reference = "https://attack.mitre.org/techniques/T1609/"
 
-
 [rule.threat.tactic]
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
-


### PR DESCRIPTION
## Summary
This rule did not capture `exec` events where the verb used is `get` rather than `create`. This tuning adds coverage for this verb.

The rule is converted to EQL for easier maintenance. 

The rule is noisy in telemetry, however, 99% of alerts are associated to three clusters, and tunings for this activity will introduce FNs. I will remain the rule logic as-is.

<img width="1794" alt="{FF9BF8D3-F32E-4B7E-9195-2787B9A7F513}" src="https://github.com/user-attachments/assets/e7f4f304-d19e-4f8e-b164-b94eee54382f" />

