### PR TITLE
[Rule Tuning] Sharpening Kubernetes Rules Indices

### DIFF
--- a/rules/integrations/kubernetes/discovery_denied_service_account_request.toml
+++ b/rules/integrations/kubernetes/discovery_denied_service_account_request.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/09/13"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ false_positives = [
     problem within the cluster. This behavior should be investigated further.
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Denied Service Account Request"

--- a/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml
+++ b/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/06/30"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ false_positives = [
     privileges of another token other than that of the compromised account.
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Suspicious Self-Subject Review"

--- a/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
+++ b/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/05/17"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/06/17"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -22,7 +22,7 @@ false_positives = [
     connected to the terminal: kubectl exec -i -t cassandra -- sh
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Kubernetes User Exec into Pod"

--- a/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
+++ b/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/09/13"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -18,7 +18,7 @@ false_positives = [
     investigated.
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Anonymous Request Authorized"

--- a/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml
+++ b/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,7 @@ false_positives = [
     expose one or more node's IPs directly.
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Exposed Service Created With Type NodePort"

--- a/rules/integrations/kubernetes/privilege_escalation_container_created_with_excessive_linux_capabilities.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_container_created_with_excessive_linux_capabilities.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/09/20"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -19,7 +19,7 @@ false_positives = [
     kubernetes.audit.requestObject.spec.containers.image.
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Container Created with Excessive Linux Capabilities"

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -22,7 +22,7 @@ false_positives = [
     "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Pod Created With HostIPC"

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -21,7 +21,7 @@ false_positives = [
     "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Pod Created With HostNetwork"

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -22,7 +22,7 @@ false_positives = [
     "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Pod Created With HostPID"

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hostpath_volume.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hostpath_volume.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/11"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -22,7 +22,7 @@ false_positives = [
     "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Pod created with a Sensitive hostPath Volume"

--- a/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -22,7 +22,7 @@ false_positives = [
     trusted container images using the query field "kubernetes.audit.requestObject.spec.container.image"
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Privileged Pod Created"

--- a/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/09/13"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
@@ -20,7 +20,7 @@ false_positives = [
     legitimate use-cases and should result in very few false positives.
     """,
 ]
-index = ["logs-kubernetes.*"]
+index = ["logs-kubernetes.audit_logs-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Kubernetes Suspicious Assignment of Controller Service Account"


### PR DESCRIPTION
## Summary
As per [comment](https://github.com/elastic/detection-rules/pull/4818#discussion_r2152897060) in my previous PR, all existing k8s rules that only leverage the audit ruleset can be scoped down to `"logs-kubernetes.audit_logs-*"` to increase query performance.
