### PR TITLE
[Rule Tunings] AWS Role Assumption By Service / User

### DIFF
--- a/rules/integrations/aws/privilege_escalation_role_assumption_by_service.toml
+++ b/rules/integrations/aws/privilege_escalation_role_assumption_by_service.toml
@@ -2,25 +2,18 @@
 creation_date = "2021/05/17"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/27"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic", "Austin Songer"]
 description = """
-Identifies when a service has assumed a role in AWS Security Token Service (STS). Services can assume a role to obtain
-temporary credentials and access AWS resources. Adversaries can use this technique for credential access and privilege
-escalation. This is a [New
-Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that identifies
-when a service assumes a role in AWS Security Token Service (STS) to obtain temporary credentials and access AWS
-resources. While often legitimate, adversaries may use this technique for unauthorized access, privilege escalation, or
-lateral movement within an AWS environment.
+Identifies when a service has assumed a role in AWS Security Token Service (STS). Services can assume a role to obtain temporary credentials and access AWS resources. Adversaries can use this technique for credential access and privilege escalation. This is a New Terms rule that identifies when a service assumes a role in AWS Security Token Service (STS) to obtain temporary credentials and access AWS resources. While often legitimate, adversaries may use this technique for unauthorized access, privilege escalation, or lateral movement within an AWS environment.
 """
 false_positives = [
-    "AWS administrators or automated processes might regularly assume roles for legitimate administrative purposes.",
-    "AWS services might assume roles to access AWS resources as part of their standard operations.",
-    "Automated workflows might assume roles to perform periodic tasks such as data backups, updates, or deployments.",
+    "AWS administrators or automated processes might regularly assume roles for legitimate administrative purposes. AWS services might assume roles to access AWS resources as part of their standard operations. Automated workflows might assume roles to perform periodic tasks such as data backups, updates, or deployments.",
 ]
-from = "now-9m"
+from = "now-6m"
+interval = "5m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
@@ -34,21 +27,16 @@ This rule identifies instances where AWS STS (Security Token Service) is used to
 #### Possible Investigation Steps
 
 - **Identify the Actor and Assumed Role**:
-  - **User Identity**: Review the `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.type` fields to determine who initiated the `AssumeRole` action.
-  - **Role Assumed**: Check the `aws.cloudtrail.flattened.request_parameters.roleArn` field to confirm the assumed role and ensure it aligns with expected responsibilities.
+  - **User Identity**: Review the `aws.cloudtrail.user_identity.invoked_by` field to determine which service initiated the `AssumeRole` action.
+  - **Role Assumed**: Check the `aws.cloudtrail.resources.arn` field to confirm the assumed role and ensure it aligns with expected responsibilities.
   - **Session Name**: Observe the `aws.cloudtrail.flattened.request_parameters.roleSessionName` for context on the session's intended purpose, if available.
-
-- **Analyze the Role Session and Duration**:
-  - **Session Context**: Look at the `aws.cloudtrail.user_identity.session_context.creation_date` to understand when the session began and check if multi-factor authentication (MFA) was used, indicated by the `aws.cloudtrail.user_identity.session_context.mfa_authenticated` field.
-  - **Credential Validity**: Examine the `aws.cloudtrail.flattened.request_parameters.durationSeconds` for the credential's validity period.
-  - **Expiration Time**: Verify `aws.cloudtrail.flattened.response_elements.credentials.expiration` to determine when the credentials expire or expired.
+ - **Expiration Time**: Verify `aws.cloudtrail.flattened.response_elements.credentials.expiration` to determine when the credentials expire or expired.
 
 - **Inspect the User Agent for Tooling Identification**:
   - **User Agent Details**: Review the `user_agent.original` field to identify the tool or SDK used for the role assumption. Indicators include:
     - **AWS SDKs (e.g., Boto3)**: Often used in automated workflows or scripts.
     - **AWS CLI**: Suggests command-line access, potentially indicating direct user interaction.
     - **Custom Tooling**: Unusual user agents may signify custom or suspicious tools.
-  - **Source IP and Location**: Evaluate the `source.address` and `source.geo` fields to confirm if the access source aligns with typical access locations for your environment.
 
 - **Contextualize with Related Events**:
   - **Review Event Patterns**: Check surrounding CloudTrail events to see if other actions coincide with this `AssumeRole` activity, such as attempts to access sensitive resources.
@@ -61,7 +49,7 @@ This rule identifies instances where AWS STS (Security Token Service) is used to
 ### False Positive Analysis
 
 - **Automated Workflows and Applications**: Many applications or scheduled tasks may assume roles for standard operations. Check user agents and ARNs for consistency with known workflows.
-- **Routine IAM Policy Actions**: Historical data may reveal if the same user or application assumes this specific role regularly as part of authorized operations.
+- **Routine AWS Service Actions**: Historical data may reveal if the same service assumes new roles regularly as part of authorized operations.
 
 ### Response and Remediation
 
@@ -86,6 +74,7 @@ tags = [
     "Resources: Investigation Guide",
     "Use Case: Identity and Access Audit",
     "Tactic: Privilege Escalation",
+    "Tactic: Lateral Movement",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"
@@ -113,16 +102,18 @@ event.dataset: "aws.cloudtrail"
 [rule.investigation_fields]
 field_names = [
     "@timestamp",
-    "aws.cloudtrail.user_identity.type",
-    "aws.cloudtrail.resources.arn",
-    "aws.cloudtrail.resources.type",
     "source.address",
+    "user_agent.original",
     "aws.cloudtrail.user_identity.invoked_by",
-    "aws.cloudtrail.flattened.request_parameters.roleArn",
-    "aws.cloudtrail.flattened.request_parameters.roleSessionName",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.flattened.response_elements.credentials.accessKeyId",
     "event.action",
     "event.outcome",
+    "aws.cloudtrail.resources.arn",
+    "aws.cloudtrail.resources.type",
+    "aws.cloudtrail.flattened.request_parameters.roleSessionName",
     "cloud.region",
+    "cloud.account.id",
     "aws.cloudtrail.request_parameters",
     "aws.cloudtrail.response_elements"
 ]
@@ -159,9 +150,9 @@ reference = "https://attack.mitre.org/tactics/TA0008/"
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["aws.cloudtrail.resources.arn", "aws.cloudtrail.user_identity.invoked_by"]
+value = ["aws.cloudtrail.user_identity.invoked_by", "aws.cloudtrail.resources.arn"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
-value = "now-14d"
+value = "now-10d"
 
 

--- a/rules/integrations/aws/privilege_escalation_role_assumption_by_user.toml
+++ b/rules/integrations/aws/privilege_escalation_role_assumption_by_user.toml
@@ -2,24 +2,18 @@
 creation_date = "2024/11/05"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/10"
+updated_date = "2025/06/18"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when a user or role has assumed a role in AWS Security Token Service (STS). Users can assume a role to obtain
-temporary credentials and access AWS resources. Adversaries can use this technique for credential access and privilege
-escalation. This is a [New
-Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that identifies
-when a service assumes a role in AWS Security Token Service (STS) to obtain temporary credentials and access AWS
-resources. While often legitimate, adversaries may use this technique for unauthorized access, privilege escalation, or
-lateral movement within an AWS environment.
+Identifies when a user or role has assumed a role in AWS Security Token Service (STS). Users can assume a role to obtain temporary credentials and access AWS resources. Adversaries can use this technique for credential access and privilege escalation. This is a New Terms rule that identifies when a service assumes a role in AWS Security Token Service (STS) to obtain temporary credentials and access AWS resources. While often legitimate, adversaries may use this technique for unauthorized access, privilege escalation, or lateral movement within an AWS environment.
 """
 false_positives = [
-    "AWS administrators or automated processes might regularly assume roles for legitimate administrative purposes.",
-    "Applications integrated with AWS might assume roles to access AWS resources.",
-    "Automated workflows might assume roles to perform periodic tasks such as data backups, updates, or deployments.",
+    "AWS administrators or automated processes might regularly assume roles for legitimate administrative purposes. Applications integrated with AWS might assume roles to access AWS resources. Automated workflows might assume roles to perform periodic tasks such as data backups, updates, or deployments.",
 ]
+from = "now-6m"
+interval = "5m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
@@ -34,17 +28,13 @@ This rule detects when a user assumes a role in AWS Security Token Service (STS)
 
 - **Identify the User and Assumed Role**:
   - **User Identity**: Check `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.type` for details about the initiator of the `AssumeRole` action.
-  - **Role Assumed**: Review `aws.cloudtrail.flattened.request_parameters.roleArn` to confirm the role assumed and ensure it aligns with the user’s standard permissions.
+  - **Role Assumed**: Review `aws.cloudtrail.resources.arn` to confirm the role assumed and ensure it aligns with the user’s standard permissions.
   - **Session Name**: Note `aws.cloudtrail.flattened.request_parameters.roleSessionName` for context on the purpose of the session.
-
-- **Evaluate Session Context and Credential Duration**:
-  - **Session Details**: Look into `aws.cloudtrail.user_identity.session_context.creation_date` for the start of the session and `aws.cloudtrail.user_identity.session_context.mfa_authenticated` to check for MFA usage.
-  - **Credential Validity**: Examine `aws.cloudtrail.flattened.request_parameters.durationSeconds` for how long the credentials are valid.
   - **Expiration Time**: Use `aws.cloudtrail.flattened.response_elements.credentials.expiration` to confirm the credential expiration.
 
 - **Inspect User Agent and Source Information**:
   - **User Agent**: Analyze the `user_agent.original` field to identify if specific tooling or SDKs like AWS CLI, Boto3, or custom agents were used.
-  - **Source IP and Geolocation**: Examine `source.address` and `source.geo` fields to determine the origin of the request, confirming if it aligns with expected locations.
+  - **Source IP and Geolocation**: Examine `source.ip` and `source.geo` fields to determine the origin of the request, confirming if it aligns with expected locations.
 
 - **Correlate with Related Events**:
   - **Identify Patterns**: Review related CloudTrail events for unusual access patterns, such as resource access or sensitive actions following this `AssumeRole` action.
@@ -57,7 +47,7 @@ This rule detects when a user assumes a role in AWS Security Token Service (STS)
 ### False Positive Analysis
 
 - **Automated Processes and Applications**: Applications or scheduled tasks may assume roles regularly for operational purposes. Validate the consistency of the `user_agent` or `roleArn` with known automated workflows.
-- **Standard IAM Policy Usage**: Confirm if the user or application routinely assumes this specific role for normal operations by reviewing historical activity.
+- **Standard IAM Policy Usage**: Confirm if the user or application routinely assumes new roles for normal operations by reviewing historical activity.
 
 ### Response and Remediation
 
@@ -82,6 +72,7 @@ tags = [
     "Resources: Investigation Guide",
     "Use Case: Identity and Access Audit",
     "Tactic: Privilege Escalation",
+    "Tactic: Lateral Movement",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"
@@ -99,16 +90,18 @@ field_names = [
     "@timestamp",
     "user.name",
     "user_agent.original",
-    "source.address",
+    "source.ip",
     "aws.cloudtrail.user_identity.arn",
     "aws.cloudtrail.user_identity.type",
-    "aws.cloudtrail.resources.arn",
-    "aws.cloudtrail.resources.type",
-    "aws.cloudtrail.flattened.request_parameters.roleArn",
-    "aws.cloudtrail.flattened.request_parameters.roleSessionName",
+    "aws.cloudtrail.user_identity.access_key_id",
     "event.action",
     "event.outcome",
+    "aws.cloudtrail.resources.arn",
+    "aws.cloudtrail.resources.type",
+    "aws.cloudtrail.flattened.request_parameters.roleSessionName",
+    "aws.cloudtrail.flattened.response_elements.credentials.accessKeyId",
     "cloud.region",
+    "cloud.account.id",
     "aws.cloudtrail.request_parameters",
     "aws.cloudtrail.response_elements"
 ]
@@ -145,7 +138,7 @@ reference = "https://attack.mitre.org/tactics/TA0008/"
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["user.name", "aws.cloudtrail.flattened.request_parameters.roleArn"]
+value = ["cloud.account.id", "user.name", "aws.cloudtrail.resources.arn"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-10d"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
https://github.com/elastic/ia-trade-team/issues/616

## Summary - What I changed

AWS Role Assumption By Service
The newest versions of this rule seem fine in telemetry and the rule executes as expected
- removed MD from description
- adjusted execution window for 1 m look back
- fixed inaccuracies in Investigation Guide
- added Lateral Movement tag
- adjusted highlighted fields
- reduced history window from 14 to 10 days

AWS Role Assumption By User
This rule seem fine in telemetry and the rule executes as expected
- removed MD from description
- fixed inaccuracies in Investigation Guide
- added Lateral Movement tag
- adjusted highlighted fields
- added `cloud.account.id` to new_terms field to account for duplicate user.names across cloud accounts
- replaced new terms flattened field for `aws.cloudtrail.resources.arn`, which gives the same result and remains consistent with the other rule.

## How To Test

[script](https://github.com/elastic/elastic-aws-ruleset-testing/blob/ecdf5a6502bbba7b3e9111556c8e6aefd6e8c598/STS/trigger_privilege_escalation_role_assumption_by_service.py) for AWS Role Assumption by Service

[script](https://github.com/elastic/elastic-aws-ruleset-testing/blob/ecdf5a6502bbba7b3e9111556c8e6aefd6e8c598/STS/trigger_privilege_escalation_role_assumption_by_user.py) for AWS Role Assumption by User

To test either of these rules manually you'll need to use the `AssumeRole` API to assume a role using either a role, a user account, or a service like EC2 or Lambda. All of these will need a trust policy attached to the target role you're attempting to assume which allows for your user or service to assume it. You'll also need to attach an inline policy to your user account, role or service to allow the `sts:AssumeRole` action against the target role. The test scripts set up new roles and all the appropriate trust policies and IAM policies. 