### PR TITLE
[Rule Tuning] AWS SSM `SendCommand` Execution by Rare User

### DIFF
--- a/rules/integrations/aws/execution_ssm_sendcommand_by_rare_user.toml
+++ b/rules/integrations/aws/execution_ssm_sendcommand_by_rare_user.toml
@@ -2,26 +2,20 @@
 creation_date = "2020/07/06"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/27"
+updated_date = "2025/06/19"
 
 [rule]
 author = ["Elastic"]
 description = """
-Detects the execution of commands or scripts on EC2 instances using AWS Systems Manager (SSM), such as `RunShellScript`,
-`RunPowerShellScript` or custom documents. While legitimate users may employ these commands for management tasks, they
-can also be exploited by attackers with credentials to establish persistence, install malware, or execute reverse shells
-for further access to compromised instances. This is a [New
-Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that looks for
-the first instance of this behavior by the `aws.cloudtrail.user_identity.arn` field in the last 7 days.
+Detects the execution of commands or scripts on EC2 instances using AWS Systems Manager (SSM), such as RunShellScript, RunPowerShellScript or custom documents. While legitimate users may employ these commands for management tasks, they can also be exploited by attackers with credentials to establish persistence, install malware, or execute reverse shells for further access to compromised instances. This is a New Terms rule that looks for the first instance of this behavior by a user or role.
 """
 false_positives = [
     """
-    Verify whether the user identity, user agent, and/or hostname should be making changes in your environment.
-    Suspicious commands from unfamiliar users or hosts should be investigated. If known behavior is causing false
-    positives, it can be exempted from the rule.
+    Verify whether the user identity, user agent, and/or hostname should be making changes in your environment. Suspicious commands from unfamiliar users or hosts should be investigated. If known behavior is causing false positives, it can be exempted from the rule.
     """,
 ]
-from = "now-9m"
+from = "now-6m"
+interval = "5m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
@@ -35,7 +29,7 @@ This rule detects the execution of commands or scripts on EC2 instances using AW
 #### Possible Investigation Steps
 
 - **Identify the Target Instance**:
-  - **Instance ID**: Review the `aws.cloudtrail.flattened.request_parameters.targets` field to identify which EC2 instances were targeted by this command. Confirm if these instances are expected to be managed through SSM.
+  - **Instance ID**: Review the `aws.cloudtrail.flattened.request_parameters.instanceIds` field to identify which EC2 instances were targeted by this command. Confirm if these instances are expected to be managed through SSM.
   - **Document Used**: Check the `aws.cloudtrail.flattened.request_parameters.documentName` field, which specifies the document or script being executed. Commands such as `RunShellScript` or `RunPowerShellScript` can indicate interactive sessions or script-based interactions.
 
 - **Review User Context**:
@@ -48,7 +42,7 @@ This rule detects the execution of commands or scripts on EC2 instances using AW
 
 - **Check User Agent and Source IP**:
   - **User Agent Analysis**: Review the `user_agent.original` field to verify the tool or client used (e.g., `aws-cli`). This can provide insight into whether this action was automated, scripted, or executed manually.
-  - **Source IP and Geolocation**: Use `source.address` and `source.geo` fields to check if the IP address and geolocation align with expected regions for your organization. Unusual IP addresses or locations can indicate external adversaries.
+  - **Source IP and Geolocation**: Use `source.ip` and `source.geo` fields to check if the IP address and geolocation align with expected regions for your organization. Unusual IP addresses or locations can indicate external adversaries.
 
 - **Evaluate for Persistence Indicators**:
   - **Command Consistency**: Investigate if this action is part of a recurring pattern, such as repeated command executions across instances, which may suggest an attempt to maintain access.
@@ -56,7 +50,7 @@ This rule detects the execution of commands or scripts on EC2 instances using AW
 
 - **Correlate with Other CloudTrail Events**:
   - **Cross-Reference SSM Actions**: Look for other recent SSM actions like `CreateDocument`, `UpdateDocument`, or additional `SendCommand` events that could indicate preparation for further exploitation.
-  - **Monitor Data Access or Modification**: Correlate with `S3` access patterns, IAM changes, or EC2 modifications in recent events to detect broader malicious activities.
+  - **Monitor Data Access or Modification**: Correlate with S3 access patterns, IAM changes, or EC2 modifications in recent events to detect broader malicious activities.
 
 ### False Positive Analysis
 
@@ -96,7 +90,6 @@ event.dataset: "aws.cloudtrail"
     and event.provider: "ssm.amazonaws.com"
     and event.action: "SendCommand"
     and event.outcome: "success"
-    and not aws.cloudtrail.user_identity.arn: *AWSServiceRoleForAmazonSSM/StateManagerService*
     and not source.address: (
       "ssm-guiconnect.amazonaws.com" or
       "ssm.amazonaws.com" or
@@ -120,7 +113,7 @@ reference = "https://attack.mitre.org/tactics/TA0002/"
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["aws.cloudtrail.user_identity.arn"]
+value = ["cloud.account.id", "user.name"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-7d"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

- https://github.com/elastic/ia-trade-team/issues/616

## Summary - What I changed

Rule is triggering as expected, very low instances of alerts in telemetry
- adjusted execution window
- slight edits to IG for accuracy
- removed exclusion `and not aws.cloudtrail.user_identity.arn: *AWSServiceRoleForAmazonSSM/StateManagerService*` from the query. This is a service-linked role meant to be used by AWS internal services. Therefore, the existing exclusion `and not source.address: "ssm.amazonaws.com"` already excludes the use of this role by the SSM service. I show this in the screenshot below. This will remove the use of wildcards in the query and improve performance.
- changed the new terms fields to use combination of `cloud.account.id` and `user.name` so that only roles (and not individual role sessions) are being evaluated. adding `cloud.account.id` accounts for duplicate user.names across multiple accounts.
<img width="1416" alt="Screenshot 2025-06-19 at 1 59 14 AM" src="https://github.com/user-attachments/assets/198adf08-e2b9-4939-9cd7-790d216c2aa6" />
<img width="1302" alt="Screenshot 2025-06-19 at 1 29 18 AM" src="https://github.com/user-attachments/assets/be8d4ad9-7d35-40bf-a4f2-483c6ca520e3" />

## How To Test
You can use this [script](https://github.com/elastic/elastic-aws-ruleset-testing/blob/2b8256d7ccdc9eb0d3f273d894ec9f41bdcaa711/SSM/trigger_execution_ssm_sendcommand_by_rare_user.py) for testing, it will create an EC2 instance and a user along with access keys. Then use those keys to call `ssm sendcommand`. These are the steps you need to take to manually trigger this rule.
