### PR TITLE
[New BBR] Kubectl Workload and Cluster Discovery

### DIFF
--- a/rules_building_block/discovery_kubectl_workload_and_cluster_discovery.toml
+++ b/rules_building_block/discovery_kubectl_workload_and_cluster_discovery.toml
@@ -42,7 +42,7 @@ process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "executed", "process_started") and
 process.name == "kubectl" and (
   (process.args in ("cluster-info", "api-resources", "api-versions", "version")) or
-  (process.args == "get" and process.args in (
+  (process.args in ("get", "describe") and process.args in (
     "namespaces", "nodes", "pods", "pod", "deployments", "deployment",
     "replicasets", "statefulsets", "daemonsets", "services", "service",
     "ingress", "ingresses", "endpoints", "configmaps", "events", "svc",


### PR DESCRIPTION
## Summary
This rule detects the execution of kubectl commands that are commonly used for workload and cluster discovery in Kubernetes environments. It looks for process events where kubectl is executed with arguments that query cluster information, such as namespaces, nodes, pods, deployments, and other resources. In environments where kubectl is not expected to be used, this could indicate potential reconnaissance activity by an adversary.