### PR TITLE
[Rule Tuning] Added Kubernetes Domain Tag

### DIFF
--- a/rules/linux/credential_access_kubernetes_service_account_secret_access.toml
+++ b/rules/linux/credential_access_kubernetes_service_account_secret_access.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/17"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/06/17"
+updated_date = "2025/06/19"
 
 [rule]
 author = ["Elastic"]
@@ -49,6 +49,7 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "Domain: Container",
+    "Domain: Kubernetes",
     "OS: Linux",
     "Use Case: Threat Detection",
     "Tactic: Credential Access",

--- a/rules/linux/discovery_kubeconfig_file_discovery.toml
+++ b/rules/linux/discovery_kubeconfig_file_discovery.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/17"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/06/17"
+updated_date = "2025/06/19"
 
 [rule]
 author = ["Elastic"]
@@ -56,6 +56,7 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "Domain: Container",
+    "Domain: Kubernetes",
     "OS: Linux",
     "Use Case: Threat Detection",
     "Tactic: Discovery",

--- a/rules/linux/discovery_kubectl_permission_discovery.toml
+++ b/rules/linux/discovery_kubectl_permission_discovery.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/17"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/06/17"
+updated_date = "2025/06/19"
 
 [rule]
 author = ["Elastic"]
@@ -52,6 +52,7 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "Domain: Container",
+    "Domain: Kubernetes",
     "OS: Linux",
     "Use Case: Threat Detection",
     "Tactic: Discovery",

--- a/rules/linux/lateral_movement_kubeconfig_file_activity.toml
+++ b/rules/linux/lateral_movement_kubeconfig_file_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/17"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/06/17"
+updated_date = "2025/06/19"
 
 [rule]
 author = ["Elastic"]
@@ -53,6 +53,7 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "Domain: Container",
+    "Domain: Kubernetes",
     "OS: Linux",
     "Use Case: Threat Detection",
     "Tactic: Lateral Movement",


### PR DESCRIPTION
## Summary
I noticed we have Kubernetes Domain tags available, so I will add this tag to the kubernetes/kubectl related rules to ensure customers can easily find all rules related to k8s within the Linux ruleset. 