### PR TITLE
[New Rule] Potential Kubectl Masquerading

### DIFF
--- a/rules/linux/defense_evasion_potential_kubectl_masquerading.toml
+++ b/rules/linux/defense_evasion_potential_kubectl_masquerading.toml
@@ -1,0 +1,110 @@
+[metadata]
+creation_date = "2025/06/19"
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "production"
+updated_date = "2025/06/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects potential kubectl masquerading activity by monitoring for process events where the process name
+is not "kubectl" but the command line arguments include kubectl-related commands. This could indicate an adversary
+attempting to masquerade as legitimate kubectl activity to evade detection. This rule covers evasion gaps
+introduced by renaming the kubectl binary.
+"""
+from = "now-9m"
+index = [
+    "endgame-*",
+    "logs-crowdstrike.fdr*",
+    "logs-endpoint.events.process*",
+    "logs-sentinel_one_cloud_funnel.*",
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Kubectl Masquerading"
+references = ["https://kubernetes.io/docs/reference/kubectl/"]
+risk_score = 47
+rule_id = "2388c687-cb2c-4b7b-be8f-6864a2385048"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "Domain: Container",
+    "Domain: Kubernetes",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+event.action ("exec", "exec_event", "start", "executed", "process_started") and
+process.name != "kubectl" and process.command_line like~ (
+
+  // get and describe commands
+  " *get po*", " *get deploy*", " *get node*", " *get svc*", " *get service*", " *get secret*", " *get clusterrole*", " *get ingress*",
+  " *get configmap*", " *describe po*", " *describe deploy*", " *describe node*", " *describe svc*", " *describe service*",
+  " *describe secret*", " *describe configmap*", " *describe clusterrole*", " *describe ingress*",
+  
+  // exec commands
+  " *exec -it*", " *exec --stdin*", " *exec --tty*",
+  
+  // networking commands
+  " *port-forward* ", " *proxy --port*", " *run --image=*", " *expose*",
+
+  // authentication/impersonation commands
+  " *auth can-i*", " *--kubeconfig*", " *--as*", " *--as-group*", " *--as-uid*"
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1036"
+name = "Masquerading"
+reference = "https://attack.mitre.org/techniques/T1036/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1036.003"
+name = "Rename Legitimate Utilities"
+reference = "https://attack.mitre.org/techniques/T1036/003/"
+
+[[rule.threat.technique]]
+id = "T1564"
+name = "Hide Artifacts"
+reference = "https://attack.mitre.org/techniques/T1564/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"


### PR DESCRIPTION
## Summary
This rule detects potential kubectl masquerading activity by monitoring for process events where the process name is not "kubectl" but the command line arguments include kubectl-related commands. This could indicate an adversary attempting to masquerade as legitimate kubectl activity to evade detection. This rule covers evasion gaps introduced by renaming the kubectl binary.

## Telemetry
An endpoint rule was tuned to contain kubectl copy/move activity. This will further reduce evasion capabilities related to kubectl usage, as this is a common red teamers' trick.

In my own stack, 0 hits last 365 day. In telemetry, 0 hits last 30d. If this gets noisy, I will just remove/modify the noisy patterns.