### PR TITLE
[New Rule] Kubectl Secret Access

### DIFF
--- a/rules/linux/credential_access_kubectl_secret_access.toml
+++ b/rules/linux/credential_access_kubectl_secret_access.toml
@@ -68,7 +68,10 @@ type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "executed", "process_started") and
-process.name == "kubectl" and process.args in ("get", "describe") and process.args in ("secret", "secrets")
+process.name == "kubectl" and process.args in ("secret", "secrets") and (
+  (process.args == "get" and process.args in ("-o", "--output")) or
+  (process.args == "describe")
+)
 '''
 
 [[rule.threat]]

--- a/rules/linux/credential_access_kubectl_secret_access.toml
+++ b/rules/linux/credential_access_kubectl_secret_access.toml
@@ -1,0 +1,103 @@
+[metadata]
+creation_date = "2025/06/19"
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "production"
+updated_date = "2025/06/19"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects potential kubectl secret access activity by monitoring for process events where the
+kubectl command is executed with arguments that suggest an attempt to access Kubernetes secrets.
+This could indicate an adversary trying to gain unauthorized access to sensitive information stored
+in Kubernetes secrets.
+"""
+from = "now-9m"
+index = [
+    "endgame-*",
+    "logs-crowdstrike.fdr*",
+    "logs-endpoint.events.process*",
+    "logs-sentinel_one_cloud_funnel.*",
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Kubectl Secret Access"
+risk_score = 47
+rule_id = "7f6909ca-16ad-45a5-b3aa-e0bcc2e76ad1"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "Domain: Container",
+    "Domain: Kubernetes",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Tactic: Discovery",
+    "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+event.action ("exec", "exec_event", "start", "executed", "process_started") and
+process.name == "kubectl" and process.args in ("get", "describe") and process.args in ("secret", "secrets")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique]]
+id = "T1528"
+name = "Steal Application Access Token"
+reference = "https://attack.mitre.org/techniques/T1528/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1613"
+name = "Container and Resource Discovery"
+reference = "https://attack.mitre.org/techniques/T1613/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"

--- a/rules/linux/credential_access_kubectl_secret_access.toml
+++ b/rules/linux/credential_access_kubectl_secret_access.toml
@@ -22,7 +22,7 @@ index = [
 language = "eql"
 license = "Elastic License v2"
 name = "Kubectl Secret Access"
-risk_score = 47
+risk_score = 21
 rule_id = "7f6909ca-16ad-45a5-b3aa-e0bcc2e76ad1"
 setup = """## Setup
 
@@ -49,7 +49,7 @@ For more details on Elastic Agent configuration settings, refer to the [helper g
 - To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
 For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
 """
-severity = "medium"
+severity = "low"
 tags = [
     "Domain: Endpoint",
     "Domain: Container",

--- a/rules/linux/credential_access_kubectl_secret_access.toml
+++ b/rules/linux/credential_access_kubectl_secret_access.toml
@@ -67,7 +67,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and
-event.action ("exec", "exec_event", "start", "executed", "process_started") and
+event.action in ("exec", "exec_event", "start", "executed", "process_started") and
 process.name == "kubectl" and process.args in ("get", "describe") and process.args in ("secret", "secrets")
 '''
 


### PR DESCRIPTION
## Summary
This rule detects potential kubectl secret access activity by monitoring for process events where the kubectl command is executed with arguments that suggest an attempt to access Kubernetes secrets. This could indicate an adversary trying to gain unauthorized access to sensitive information stored in Kubernetes secrets.