### PR TITLE
[Tuning] Elevation via SCM rules

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -37,6 +37,7 @@
         "SubjectUserName": "keyword",
         "SubjectUserSid": "keyword",
         "ServiceAccount": "keyword",
+        "ElevatedToken": "keyword",
         "TargetUserName": "keyword",
         "TargetImage": "keyword",
         "TargetLogonId": "keyword",

--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -36,6 +36,7 @@
         "SubjectLogonId": "keyword",
         "SubjectUserName": "keyword",
         "SubjectUserSid": "keyword",
+        "ServiceAccount": "keyword",
         "TargetUserName": "keyword",
         "TargetImage": "keyword",
         "TargetLogonId": "keyword",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.2.22"
+version = "1.2.23"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rules/windows/privilege_escalation_krbrelayup_service_creation.toml
+++ b/rules/windows/privilege_escalation_krbrelayup_service_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/04/27"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/06/19"
 
 [rule]
 author = ["Elastic"]
@@ -76,11 +76,10 @@ sequence by winlog.computer_name with maxspan=5m
  [authentication where
 
   /* event 4624 need to be logged */
-  event.action == "logged-in" and event.outcome == "success" and
+  event.action == "logged-in" and event.outcome == "success" and winlog.event_data.ElevatedToken == "%%1843" and process.pid == 0 and 
 
   /* authenticate locally using relayed kerberos Ticket */
-  winlog.event_data.AuthenticationPackageName :"Kerberos" and winlog.logon.type == "Network" and
-  cidrmatch(source.ip, "127.0.0.0/8", "::1") and source.port > 0] by winlog.event_data.TargetLogonId
+  winlog.event_data.AuthenticationPackageName :"Kerberos" and winlog.logon.type == "Network" and cidrmatch(source.ip, "127.0.0.0/8", "::1")] by winlog.event_data.TargetLogonId
 
   [any where
    /* event 4697 need to be logged */

--- a/rules/windows/privilege_escalation_windows_service_via_unusual_client.toml
+++ b/rules/windows/privilege_escalation_windows_service_via_unusual_client.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/07"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/06/19"
 
 [rule]
 author = ["Elastic"]
@@ -91,6 +91,7 @@ query = '''
 configuration where host.os.type == "windows" and
   event.action == "service-installed" and
   (winlog.event_data.ClientProcessId == "0" or winlog.event_data.ParentProcessId == "0") and
+  startswith~(user.domain, winlog.computer_name) and winlog.event_data.ServiceAccount == "LocalSystem" and 
   not winlog.event_data.ServiceFileName : (
     "?:\\Windows\\VeeamVssSupport\\VeeamGuestHelper.exe",
     "?:\\Windows\\VeeamLogShipper\\VeeamLogShipper.exe",


### PR DESCRIPTION
- Service Creation via Local Kerberos Authentication (added `winlog.event_data.ElevatedToken == "%%1843"` to filter for un-elevated token).
- Windows Service Installed via an Unusual Client (added `startswith~(user.domain, winlog.computer_name) and winlog.event_data.ServiceAccount == "LocalSystem"` to limit to elevation as system and logon with local creds)