### PR TITLE
[New Rule] Kubernetes Forbidden Creation Request

### DIFF
--- a/rules/integrations/kubernetes/execution_forbidden_creation_request.toml
+++ b/rules/integrations/kubernetes/execution_forbidden_creation_request.toml
@@ -1,0 +1,42 @@
+[metadata]
+creation_date = "2025/06/24"
+integration = ["kubernetes"]
+maturity = "production"
+updated_date = "2025/06/24"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects attempts to create resources in Kubernetes clusters that are forbidden by the authorization policy. It
+specifically looks for creation requests that are denied with a "forbid" decision, indicating that the user or service
+account does not have the necessary permissions to perform the action. This activity is commonly associated with
+adversaries attempting to create resources in a Kubernetes environment without proper authorization, which can lead to
+unauthorized access, manipulation of cluster resources, lateral movement and/or privilege escalation.
+"""
+index = ["logs-kubernetes.audit_logs-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Kubernetes Forbidden Creation Request"
+risk_score = 47
+rule_id = "ec81962e-4bc8-48e6-bfb0-545fc97d8f6a"
+severity = "medium"
+tags = [
+    "Data Source: Kubernetes",
+    "Domain: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Execution"
+    ]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+any where host.os.type == "linux" and event.dataset == "kubernetes.audit_logs" and kubernetes.audit.verb == "create" and
+kubernetes.audit.stage == "ResponseComplete" and `kubernetes.audit.annotations.authorization_k8s_io/decision` == "forbid"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"


### PR DESCRIPTION
## Summary
This rule detects attempts to create resources in Kubernetes clusters that are forbidden by the authorization policy. It specifically looks for creation requests that are denied with a "forbid" decision, indicating that the user or service account does not have the necessary permissions to perform the action. This activity is commonly associated with adversaries attempting to create resources in a Kubernetes environment without proper authorization, which can lead to unauthorized access, manipulation of cluster resources, lateral movement and/or privilege escalation.

## Telemetry
4 TPs in my testing stack from attempting to create pods from unauthorized tokens. This activity is not common, as service accounts will not be forbidden by default, and will only be caused by devs testing, not fully understanding tokens or adversaries attempting to escalate privileges through pod creation. 

<img width="1904" alt="{7461BECA-C82E-40D5-AA0D-053AA6EED777}" src="https://github.com/user-attachments/assets/27fcf0bd-3e46-4916-b9e0-206dc6588a55" />

