### PR TITLE
[Rule Tuning] Microsoft Entra ID Exccessive Account Lockouts Detected

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.2.24"
+version = "1.2.25"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rules/integrations/azure/credential_access_entra_id_excessive_account_lockouts.toml
+++ b/rules/integrations/azure/credential_access_entra_id_excessive_account_lockouts.toml
@@ -1,10 +1,10 @@
 [metadata]
-creation_date = "2026/06/06"
+creation_date = "2025/06/06"
 integration = ["azure"]
 maturity = "production"
 min_stack_comments = "Elastic ES|QL values aggregation is more performant in 8.16.5 and above."
 min_stack_version = "8.17.0"
-updated_date = "2026/06/06"
+updated_date = "2025/06/26"
 
 [rule]
 author = ["Elastic"]

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -10,6 +10,7 @@ import unittest
 import uuid
 import warnings
 from collections import defaultdict
+from datetime import datetime, timezone
 from pathlib import Path
 
 import eql.ast
@@ -583,6 +584,26 @@ class TestRuleFiles(BaseRuleTest):
 
 class TestRuleMetadata(BaseRuleTest):
     """Test the metadata of rules."""
+
+    def test_dates_not_in_future(self):
+        """Ensure creation and updated dates are not in the future."""
+        invalid = []
+        today = datetime.now(timezone.utc).date()
+
+        for rule in self.all_rules:
+            created_str = rule.contents.metadata.creation_date
+            updated_str = rule.contents.metadata.updated_date
+
+            created = datetime.strptime(created_str, "%Y/%m/%d").date()
+            updated = datetime.strptime(updated_str, "%Y/%m/%d").date()
+
+            if created > today or updated > today:
+                invalid.append(rule)
+
+        if invalid:
+            rules_str = '\n '.join(self.rule_str(r, trailer=None) for r in invalid)
+            err_msg = f"The following rules have a creation_date or updated_date in the future:\n {rules_str}"
+            self.fail(err_msg)
 
     def test_updated_date_newer_than_creation(self):
         """Test that the updated_date is newer than the creation date."""


### PR DESCRIPTION
## Summary - What I changed
Fixes date in `Microsoft Entra ID Exccessive Account Lockouts Detected`. Adds a unit test for this.

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test
For testing the unit test, we can run `pytest tests tests/test_all_rules.py::TestRuleMetadata::test_dates_not_in_future`. A date can be set in any valid rule to a future date and test re-ran to ensure it flags it.

<img width="1649" alt="Screenshot 2025-06-26 at 10 03 07 AM" src="https://github.com/user-attachments/assets/73893f2a-0717-4164-b570-5b0f631e4b57" />
<img width="1656" alt="Screenshot 2025-06-26 at 9 58 59 AM" src="https://github.com/user-attachments/assets/90d743d1-ee69-432f-a59d-c4ef3fd549ea" />


<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
