### PR TITLE
[Tuning] Multiple Alerts in Different ATT&CK Tactics on a Single Host

### DIFF
--- a/rules/cross-platform/multiple_alerts_different_tactics_host.toml
+++ b/rules/cross-platform/multiple_alerts_different_tactics_host.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2022/11/16"
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/06/27"
 
 [rule]
 author = ["Elastic"]
@@ -70,7 +70,7 @@ The detection rule identifies hosts with alerts across various attack phases, in
 
 
 [rule.threshold]
-field = ["host.id"]
+field = ["host.id", "host.name"]
 value = 1
 [[rule.threshold.cardinality]]
 field = "kibana.alert.rule.threat.tactic.id"


### PR DESCRIPTION
added `host.name` to ease alert reading without having to convert host.id to host.name using another manual query.

related ask https://elasticstack.slack.com/archives/C016E72DWDS/p1751017512951589