### PR TITLE
[New Rule] Kubectl Apply Pod from URL

### DIFF
--- a/rules/linux/execution_kubectl_apply_pod_from_url.toml
+++ b/rules/linux/execution_kubectl_apply_pod_from_url.toml
@@ -1,0 +1,62 @@
+[metadata]
+creation_date = "2025/06/27"
+integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "production"
+updated_date = "2025/06/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the execution of the "kubectl apply" command with a URL argument. This command is often used to
+apply configurations or deploy resources in a Kubernetes cluster. Attackers may use this command to deploy malicious
+pods or modify existing ones, potentially leading to unauthorized access or data exfiltration.
+"""
+from = "now-9m"
+index = [
+    "endgame-*",
+    "logs-crowdstrike.fdr*",
+    "logs-endpoint.events.process*",
+    "logs-sentinel_one_cloud_funnel.*",
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Kubectl Apply Pod from URL"
+risk_score = 21
+rule_id = "eef9f8b5-48ec-44b5-b8bd-7b9b7d71853c"
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "Domain: Container",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Execution",
+    "Data Source: Elastic Endgame",
+    "Data Source: Elastic Defend",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+process.name == "kubectl" and process.args == "apply" and process.args like "http*"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1610"
+name = "Deploy Container"
+reference = "https://attack.mitre.org/techniques/T1610/"
+
+[[rule.threat.technique]]
+id = "T1609"
+name = "Container Administration Command"
+reference = "https://attack.mitre.org/techniques/T1609/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"


### PR DESCRIPTION
## Summary
This rule detects the execution of the "kubectl apply" command with a URL argument. This command is often used to apply configurations or deploy resources in a Kubernetes cluster. Attackers may use this command to deploy malicious pods or modify existing ones, potentially leading to unauthorized access or data exfiltration.

## Telemetry
This activity is not inherently malicious, but security teams can whitelist allowed endpoints/URLs easily.

<img width="1490" alt="{2B54224B-0184-4F19-BA6F-6357292D6743}" src="https://github.com/user-attachments/assets/e6d7d267-4187-49e9-aa6d-7204a3972925" />
