### PR TITLE
[Hunt] Remove Default Namespace from indexes

### DIFF
--- a/hunting/windows/docs/persistence_via_startup_with_low_occurrence_frequency.md
+++ b/hunting/windows/docs/persistence_via_startup_with_low_occurrence_frequency.md
@@ -14,7 +14,7 @@
 ## Query
 
 ```sql
-from logs-endpoint.events.file-*, logs-windows.sysmon_operational-default-*
+from logs-endpoint.events.file-*, logs-windows.sysmon_operational-*
 | where  @timestamp > now() - 7 day
 | where host.os.family == "windows" and event.category == "file" and event.action in ("creation", "FileCreate") and
   file.path rlike """(C:\\Users\\.+\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\.+*|C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\StartUp\\.+)"""

--- a/hunting/windows/docs/scheduled_tasks_creation_for_unique_hosts_by_task_command.md
+++ b/hunting/windows/docs/scheduled_tasks_creation_for_unique_hosts_by_task_command.md
@@ -15,7 +15,7 @@
 ## Query
 
 ```sql
-from logs-system.security-default-*
+from logs-system.security-*
 | where  @timestamp > now() - 7 day
 | where host.os.family == "windows" and event.code == "4698" and event.action == "scheduled-task-created"
  /* parsing unstructured data from winlog message to extract a scheduled task Exec command */

--- a/hunting/windows/queries/persistence_via_startup_with_low_occurrence_frequency.toml
+++ b/hunting/windows/queries/persistence_via_startup_with_low_occurrence_frequency.toml
@@ -14,7 +14,7 @@ notes = [
 mitre = [ "T1547", "T1547.001"]
 query = [
 '''
-from logs-endpoint.events.file-*, logs-windows.sysmon_operational-default-*
+from logs-endpoint.events.file-*, logs-windows.sysmon_operational-*
 | where  @timestamp > now() - 7 day
 | where host.os.family == "windows" and event.category == "file" and event.action in ("creation", "FileCreate") and
   file.path rlike """(C:\\Users\\.+\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\.+*|C:\\ProgramData\\Microsoft\\Windows\\Start Menu\\Programs\\StartUp\\.+)"""

--- a/hunting/windows/queries/scheduled_tasks_creation_for_unique_hosts_by_task_command.toml
+++ b/hunting/windows/queries/scheduled_tasks_creation_for_unique_hosts_by_task_command.toml
@@ -15,7 +15,7 @@ notes = [
 mitre = [ "T1053", "T1053.005"]
 query = [
 '''
-from logs-system.security-default-*
+from logs-system.security-*
 | where  @timestamp > now() - 7 day
 | where host.os.family == "windows" and event.code == "4698" and event.action == "scheduled-task-created"
  /* parsing unstructured data from winlog message to extract a scheduled task Exec command */


### PR DESCRIPTION
## Summary

Quick PR to remove `default-*` from the index, so it would work with logs using other namespaces.

As reported in https://github.com/elastic/detection-rules/issues/4838