### PR TITLE
[Rule Tuning] AWS IAM API Calls via Temporary Session Tokens

### DIFF
--- a/rules/integrations/aws/persistence_iam_api_calls_via_user_session_token.toml
+++ b/rules/integrations/aws/persistence_iam_api_calls_via_user_session_token.toml
@@ -2,20 +2,19 @@
 creation_date = "2025/04/16"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/04/16"
+updated_date = "2025/07/10"
 
 [rule]
 author = ["Elastic"]
 description = """
-Detects use of sensitive AWS STS or IAM API operations using temporary credentials (session tokens starting with 'ASIA').
-This may indicate credential theft or abuse of elevated access via a stolen session. It is not common for legitimate users to perform sensitive IAM operations with temporary session tokens.
+Detects use of sensitive AWS IAM API operations using temporary credentials (session tokens starting with 'ASIA'). This may indicate credential theft or abuse of elevated access via a stolen session. It is not common for legitimate users to perform sensitive IAM operations with temporary session tokens.
 """
 false_positives = [
     """
     Some CI/CD pipelines or administrative users may use session tokens. Review user context, IP, and timing to validate.
     """,
 ]
-from = "now-9m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
@@ -29,15 +28,15 @@ This rule detects sensitive IAM API operations performed using temporary AWS cre
 
 #### Possible investigation steps:
 
-- Review aws.cloudtrail.user_identity.arn to determine which IAM user or assumed role initiated the request.
-- Check aws.cloudtrail.user_identity.access_key_id to confirm if the credential starts with 'ASIA', indicating a temporary session token.
-- Examine aws.cloudtrail.user_identity.session_context.mfa_authenticated to verify whether MFA was present during session creation.
-- Investigate source.ip to assess whether the request originated from a known network, office IP, or corporate VPN.
-- Look at user_agent.original to determine if the API call came from a known CLI version or unexpected tool (e.g., unknown SDK, custom script).
+- Review `aws.cloudtrail.user_identity.arn` to determine which IAM user or assumed role initiated the request.
+- Check `aws.cloudtrail.user_identity.access_key_id` to confirm if the credential starts with 'ASIA', indicating a temporary session token.
+- Examine `aws.cloudtrail.user_identity.session_context.mfa_authenticated` to verify whether MFA was present during session creation.
+- Investigate `source.ip` to assess whether the request originated from a known network, office IP, or corporate VPN.
+- Look at `user_agent.original` to determine if the API call came from a known CLI version or unexpected tool (e.g., unknown SDK, custom script).
 - Confirm whether a recent sts:GetSessionToken, sts:AssumeRole, or AWS SSO login event issued the temporary credential.
 - Correlate other events using the same access key ID to identify additional privileged actions, such as iam:CreateAccessKey, iam:PutUserPolicy, or iam:EnableMFADevice.
 - Analyze timing via @timestamp to determine if the action occurred during off-hours or deviates from normal user behavior.
-- Review the event.outcome to check if the API call was successful or failed, which may indicate unauthorized access attempts.
+- Review the `event.outcome` to check if the API call was successful or failed, which may indicate unauthorized access attempts.
 - Check for related events in the same session, such as iam:CreateUser, iam:AttachUserPolicy, or sts:GetCallerIdentity, to identify potential lateral movement or privilege escalation.
 
 ### False positive analysis:
@@ -77,9 +76,26 @@ type = "new_terms"
 query = '''
 event.dataset: aws.cloudtrail
     and event.provider: ("iam.amazonaws.com")
+    and event.outcome: "success"
     and aws.cloudtrail.user_identity.type: "IAMUser"
     and aws.cloudtrail.user_identity.access_key_id: ASIA*
 '''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters"
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/616

## Summary - What I changed

rule triggers as expected, however its triggering for failed requests. Telemetry is low for this rule since it's new terms.
- added `event.outcome: success` to query
- added highlighted fields
- adjusted rule execution window

## How To Test
You can use this script for triggering this rule. You will need to create a new user with MFA enabled for this rule to work. Due to the nature of the session tokens created by `GetSessionToken`, "You cannot call any IAM API operations unless MFA authentication information is included in the request"

Here is a screenshot of updated working query

<img width="1657" height="285" alt="Screenshot 2025-07-10 at 6 55 36 PM" src="https://github.com/user-attachments/assets/37343bc1-f308-40f4-b2b1-5e69dc24f8da" />
