### PR TITLE
[FR] [DAC] Add Arbitrary File location Support for Local Creation Date

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -106,6 +106,7 @@ Options:
   -snv, --strip-none-values       Strip None values from the rule
   -lc, --local-creation-date      Preserve the local creation date of the rule
   -lu, --local-updated-date       Preserve the local updated date of the rule
+  -lr, --load-rule-loading        Enable arbitrary rule loading from the rules directories (Can be very slow!)
   -h, --help                      Show this message and exit.
 ```
 
@@ -507,6 +508,7 @@ Options:
   -lu, --local-updated-date       Preserve the local updated date of the rule
   -cro, --custom-rules-only       Only export custom rules
   -eq, --export-query TEXT        Apply a query filter to exporting rules e.g. "alert.attributes.tags: \"test\"" to filter for rules that have the tag "test"
+  -lr, --load-rule-loading        Enable arbitrary rule loading from the rules directories (Can be very slow!)
   -h, --help                      Show this message and exit.
 
 ```

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -254,7 +254,7 @@ def kibana_import_rules(  # noqa: PLR0915
     "--load-rule-loading",
     "-lr",
     is_flag=True,
-    help="Enable arbitrary rule loading from the rules directory (Can be very slow!)",
+    help="Enable arbitrary rule loading from the rules directories (Can be very slow!)",
 )
 @click.pass_context
 def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -371,9 +371,11 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
 
             local_contents = None
             save_path = directory / f"{rule_name}"
-            if rules and params.get("rule_id") in rules.id_map:
-                save_path = rules.id_map[params["rule_id"]].path
-                local_contents = rules.id_map[params["rule_id"]].contents
+
+            rule = params.get("rule")
+            if rules and rule and rule.get("rule_id") in rules.id_map:
+                save_path = rules.id_map[rule["rule_id"]].path
+                local_contents = rules.id_map[rule["rule_id"]].contents
             params.update(
                 update_metadata_from_file(
                     {"creation_date": local_creation_date, "updated_date": local_updated_date},

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -161,7 +161,7 @@ def generate_rules_index(
     "--load-rule-loading",
     "-lr",
     is_flag=True,
-    help="Enable arbitrary rule loading from the rules directory (Can be very slow!)",
+    help="Enable arbitrary rule loading from the rules directories (Can be very slow!)",
 )
 def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
     input_file: tuple[Path, ...] | None,

--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -139,14 +139,20 @@ def load_locks_from_tag(
     return commit_hash, version, deprecated
 
 
-def update_metadata_from_file(rule_path: Path, fields_to_update: dict[str, Any]) -> dict[str, Any]:
-    """Update metadata fields for a rule with local contents."""
+def update_metadata_from_file(
+    fields_to_update: dict[str, Any], rule_path: Path | None = None, local_contents: TOMLRuleContents | None = None
+) -> dict[str, Any]:
+    """Update metadata fields for a rule with local contents or provided contents."""
 
     contents: dict[str, Any] = {}
-    if not rule_path.exists():
-        return contents
+    if not rule_path and not local_contents:
+        raise ValueError("Either 'rule_path' or 'local_contents' must be provided.")
 
-    rule_contents = RuleCollection().load_file(rule_path).contents
+    rule_contents = None
+    if rule_path:
+        if not rule_path.exists():
+            return contents
+        rule_contents = local_contents or RuleCollection().load_file(rule_path).contents
 
     if not isinstance(rule_contents, TOMLRuleContents):
         raise TypeError("TOML rule expected")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.3.10"
+version = "1.3.11"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/4891


## Summary - What I changed

Added the ability to specify `--load-rule-loading / -lr` to the `kibana export-rules` and `import-rules-to-repo` commands. This enables one to make use of the local folders specified in one's `config.yaml` when exporting rules from Kibana to the repo. 

For instance, if I specify
```yaml
rule_dirs:
- rules
- another_rules_dir

```

And have two rules 
- `dac_test/rules/my_test_rule.toml`
- `dac_test/another_rules_dir/high_number_of_process_and_or_service_terminations.toml` 

Rule updates from Kibana (when using the new `-lr` option) will now use these additional paths instead of exporting directly to the specified directory. 

So if I run  `python -m detection_rules kibana --space test_local export-rules -d dac_test/rules/ -sv -ac -e -lr` in a space with those two rules, `my_test_rule.toml` will be written to `dac_test/rules/` as it was already on disk there and `high_number_of_process_and_or_service_terminations.toml` will be written to `dac_test/another_rules_dir/` for the same reason. 

Note: This can be very slow with a high number of rules. For instance, it can take 5-10min to load 1-2k rules in this way depending on system resources. The reason for this is the need to load the rule in from disk prior to actually exporting the rules, in order to know the appropriate path for the rule to be written. 

## How To Test

Run the respective `kibana export-rules` and `import-rules-to-repo` commands with some rules already existing in different directories specified in the custom rules config yaml. 

e.g.

![export_rules_local_test](https://github.com/user-attachments/assets/e84c7ac8-c50a-4a80-9008-fa66909c4864)


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
