### PR TITLE
[Bug] [DAC] Kibana Export Rules Rule Name Filter Exports All Rules 

### DIFF
--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -282,6 +282,12 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
         if rule_name:
             found = RuleResource.find(filter=f"alert.attributes.name:{rule_name}")  # type: ignore[reportUnknownMemberType]
             rule_id = [r["rule_id"] for r in found]  # type: ignore[reportUnknownVariableType]
+            if not rule_id:
+                click.echo(
+                    f"No rules found to export matching the provided name '{rule_name}' "
+                    f"using filter 'alert.attributes.name:{rule_name}'"
+                )
+                return []
         query = (
             export_query
             if not custom_rules_only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.3.10"
+version = "1.3.11"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/4916

## Summary - What I changed

Added a simple check to see if the requested Kibana filter returns any rule_ids associated with the provided name for `kibana export-rules` via the `-rn` flag.  

## How To Test

Run the export rules command with a filter for a rule name that does not exist. This should no longer export any rules and print a message identifying that no rules were exported.

E.g.

`python -m detection_rules kibana --space test_local export-rules -rn "My Test Rule" -d dac_test/rules/ -sv`

<img width="883" height="215" alt="Screenshot from 2025-07-17 11-17-30" src="https://github.com/user-attachments/assets/6c7c434f-46cf-4286-901f-a732d9435d28" />

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
