### PR TITLE
[Rule Tuning] Microsoft Entra ID MFA TOTP Brute Force Attempts

### DIFF
--- a/rules/integrations/azure/credential_access_azure_entra_totp_brute_force_attempts.toml
+++ b/rules/integrations/azure/credential_access_azure_entra_totp_brute_force_attempts.toml
@@ -130,7 +130,7 @@ from logs-azure.signinlogs* metadata _id, _version, _index
     Esql.user_id_values = VALUES(user.id)
     by user.id
 
-| where Esql.event_count > 20 and Esql.azure_signinlogs_properties.session_id_count_distinct >= 10
+| where Esql.event_count >= 20 and Esql.azure_signinlogs_properties.session_id_count_distinct >= 10
 
 | keep
     Esql.event_count,


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/sdh-protections/issues/599

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed
Tunes the `Microsoft Entra ID MFA TOTP Brute Force Attempts` rule for the following:

- Update name to `Microsoft Entra ID MFA TOTP Brute Force Attempts`
- Updated description as query logic has been adjusted
- Investigation guide updates to stay consistent with investigation guide formats and be more agnostic
- Updated tags to stay consistent with naming
- Updated rule query
    - Only filter on `azure.signinlogs.properties.mfa_detail.auth_method == "OATH verification code"` and not MFA. This infers MFA was used.
    - Added `azure.signinlogs.properties.user_type == "Member"` to ensure it only flags on user accounts.
    - Focus on failure attempts reported for login or error code `500121` which reflects `STS500121`
    - Added several `VALUES()` statements to retain field values for alert
    - IMPORTANT - Added `Esql.azure_signinlogs_properties.session_id_count_distinct = COUNT_DISTINCT(azure.signinlogs.properties.session_id)` and then aggregated by the count. As reported by Oasis security, not only are multiple TOTP codes used, but multiple sessions which were the original brute force method. This should be higher fidelity as multiple sessions for multiple TOTP are not common unless pentesting or actual brute forcing.

NOTE - < 100 alerts in the last 6 months for this rule, no FP adjustments needed.
<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test
Query can be used in TRADE stack, use `Esql.azure_signinlogs_properties.session_id_count_distinct >= 8`.

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
