### PR TITLE
feat: ESQL query validation against Elastic cluster

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1432,15 +1432,14 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         # if both exist, rule tags are only used if defined in definitions for non-dataset packages
         # of machine learning analytic packages
 
-        rule_integrations = meta.get("integration", [])
-        if rule_integrations:
-            for integration in rule_integrations:
-                ineligible_integrations = [
-                    *definitions.NON_DATASET_PACKAGES,
-                    *map(str.lower, definitions.MACHINE_LEARNING_PACKAGES),
-                ]
-                if integration in ineligible_integrations or isinstance(data, MachineLearningRuleData):
-                    packaged_integrations.append({"package": integration, "integration": None})
+        rule_integrations = meta.get("integration") or []
+        for integration in rule_integrations:
+            ineligible_integrations = [
+                *definitions.NON_DATASET_PACKAGES,
+                *map(str.lower, definitions.MACHINE_LEARNING_PACKAGES),
+            ]
+            if integration in ineligible_integrations or isinstance(data, MachineLearningRuleData):
+                packaged_integrations.append({"package": integration, "integration": None})
 
         packaged_integrations.extend(parse_datasets(list(datasets), package_manifest))
 
@@ -1754,7 +1753,7 @@ def parse_datasets(datasets: list[str], package_manifest: dict[str, Any]) -> lis
         else:
             package = value
 
-        if package in list(package_manifest):
+        if package in package_manifest:
             packaged_integrations.append({"package": package, "integration": integration})
     return packaged_integrations
 

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -527,3 +527,16 @@ class PatchedTemplate(Template):
                 # another group we're not expecting
                 raise ValueError("Unrecognized named group in pattern", self.pattern)
         return ids
+
+
+FROM_SOURCES_REGEX = re.compile(r"^\s*FROM\s+(?P<sources>.+?)\s*(?:\||\bmetadata\b|//|$)", re.IGNORECASE | re.MULTILINE)
+
+
+def get_esql_query_indices(query: str) -> tuple[str, list[str]]:
+    match = FROM_SOURCES_REGEX.search(query)
+
+    if not match:
+        return "", []
+
+    sources_str = match.group("sources")
+    return sources_str, [source.strip() for source in sources_str.split(",")]

--- a/hunting/definitions.py
+++ b/hunting/definitions.py
@@ -59,5 +59,5 @@ class Hunt:
             # Check if either "stats by" or "| keep" exists in the query
             if not stats_by_pattern.search(query) and not keep_pattern.search(query):
                 raise ValueError(
-                    f"Hunt: {self.name} contains an ES|QL query that mustcontain either 'stats by' or 'keep' functions."
+                    f"Hunt: {self.name} contains an ES|QL query that must contain either 'stats by' or 'keep' functions"
                 )


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

- related to https://github.com/elastic/detection-rules/pull/4912

## Summary - What I changed

- new unit test added that validates ESQL rules
- the validation function collects all mappings necessary for the query, creates a temporary index and validates the query against that index

## How To Test

- the unit tests expect to read cluster details either from a config file (for example `.detection-rules-cfg.yml`) or from the environment variables
- the code here was tested against [a containerized Elastic cluster](https://github.com/peasead/elastic-container) running locally, with a dedicated API key

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
