### PR TITLE
fix: Allow different order of the metadata fields in ESQL queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.3.18"
+version = "1.3.19"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

This request is a continuation of https://github.com/elastic/detection-rules/pull/4579


## Summary - What I changed

- implemented logic adjustment from https://github.com/elastic/detection-rules/pull/4579
- added a unit test

## How To Test

```bash
$ pytest tests/test_schemas.py
============================ test session starts =============================
platform darwin -- Python 3.12.11, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/traut/Work/detection-rules
configfile: pyproject.toml
plugins: anyio-4.9.0, typeguard-3.0.2
collected 11 items

tests/test_schemas.py ...........                                      [100%]

============================= 11 passed in 0.79s =============================
$
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
