### PR TITLE
[Rule Tuning] Fixes FPs related to a process.args_count bug

### DIFF
--- a/rules/windows/defense_evasion_masquerading_werfault.toml
+++ b/rules/windows/defense_evasion_masquerading_werfault.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/24"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2025/05/05"
+updated_date = "2025/08/12"
 
 [transform]
 [[transform.osquery]]
@@ -120,7 +120,10 @@ type = "eql"
 
 query = '''
 sequence by host.id, process.entity_id with maxspan = 5s
-  [process where host.os.type == "windows" and event.type:"start" and process.name : ("wermgr.exe", "WerFault.exe") and process.args_count == 1]
+  [process where host.os.type == "windows" and event.type:"start" and process.name : ("wermgr.exe", "WerFault.exe") and
+    (process.args_count == 1 and
+      /* Excludes bug where a missing closing quote sets args_count to 1 despite extra args */
+      not process.command_line regex~ """\".*\.exe[^\"].*""")]
   [network where host.os.type == "windows" and process.name : ("wermgr.exe", "WerFault.exe") and network.protocol != "dns" and
     network.direction : ("outgoing", "egress") and destination.ip !="::1" and destination.ip !="127.0.0.1"
   ]

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/09/02"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/12"
 
 [transform]
 [[transform.osquery]]
@@ -116,7 +116,9 @@ query = '''
 sequence with maxspan=1h
   [process where host.os.type == "windows" and event.type == "start" and
      (process.name : "rundll32.exe" or process.pe.original_file_name == "RUNDLL32.EXE") and
-      process.args_count == 1
+      (process.args_count == 1 and
+        /* Excludes bug where a missing closing quote sets args_count to 1 despite extra args */
+        not process.command_line regex~ """\".*\.exe[^\"].*""")
   ] by process.entity_id
   [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "rundll32.exe"
   ] by process.parent.entity_id

--- a/rules/windows/defense_evasion_unusual_dir_ads.toml
+++ b/rules/windows/defense_evasion_unusual_dir_ads.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/04"
 integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/12"
 
 [rule]
 author = ["Elastic"]
@@ -79,7 +79,13 @@ type = "eql"
 
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
-  process.args : "?:\\*:*" and process.args_count == 1
+  process.args : "?:\\*:*" and
+  (
+    process.args_count == 1 and
+
+    /* Excludes bug where a missing closing quote sets args_count to 1 despite extra args */
+    not process.command_line regex~ """\".*\.exe[^\"].*"""
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/defense_evasion_unusual_network_connection_via_rundll32.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/12"
 
 [rule]
 author = ["Elastic"]
@@ -73,7 +73,13 @@ type = "eql"
 
 query = '''
 sequence by host.id, process.entity_id with maxspan=1m
-  [process where host.os.type == "windows" and event.type == "start" and process.name : "rundll32.exe" and process.args_count == 1]
+  [process where host.os.type == "windows" and event.type == "start" and process.name : "rundll32.exe" and
+  (
+    process.args_count == 1 and
+
+    /* Excludes bug where a missing closing quote sets args_count to 1 despite extra args */
+    not process.command_line regex~ """\".*\.exe[^\"].*"""
+  )]
   [network where host.os.type == "windows" and process.name : "rundll32.exe" and
    not cidrmatch(destination.ip, "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24",
        "192.0.0.0/29", "192.0.0.8/32", "192.0.0.9/32", "192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32",


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/detection-rules/issues/4944
Endpoint dev issue: 16786
sdh-endpoint issue: 630
Community user on slack: https://elasticstack.slack.com/archives/CRGSUQC20/p1753795588123129

## Summary

There’s a hard-to-reproduce bug in process events where a missing closing double quote in the command line causes it to be counted as a single argument. For more technical details, see Gabe’s explanation in the SDH.

This PR adds a regex pattern to exclude matches from this bug. The most affected rule is `Unusual Process Execution Path - Alternate Data Stream`, which has been triggering on commonly used software (e.g., browsers) and causing 130k+ false positives in the last 30 days.