### PR TITLE
[Rule Tuning] Suspicious PrintSpooler Service Executable File Creation

### DIFF
--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/13"
 
 [rule]
 author = ["Elastic"]
@@ -87,54 +87,55 @@ event.category : "file" and host.os.type : "windows" and event.type : "creation"
 
 
 [[rule.filters]]
-
 [rule.filters.meta]
 negate = false
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
 value = "?:\\\\Windows\\\\Sys?????\\\\*"
-[[rule.filters]]
 
+[[rule.filters]]
 [rule.filters.meta]
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
 value = "?:\\\\Windows\\\\Sys?????\\\\PrintConfig.dll"
-[[rule.filters]]
 
+[[rule.filters]]
 [rule.filters.meta]
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
-value = "?:\\Windows\\Sys?????\\u005lrs.dll"
-[[rule.filters]]
+value = "?:\\\\Windows\\\\Sys?????\\\\x5lrs.dll"
 
+[[rule.filters]]
 [rule.filters.meta]
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
-value = "?:\\Windows\\system32\\spool\\DRIVERS\\u0064\\\\*.dll"
-[[rule.filters]]
+value = "?:\\\\Windows\\\\system32\\\\spool\\\\DRIVERS\\\\x64\\\\*.dll"
 
+[[rule.filters]]
 [rule.filters.meta]
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
 value = "?:\\\\Windows\\\\system32\\\\spool\\\\DRIVERS\\\\W32X86\\\\*.dll"
-[[rule.filters]]
 
+[[rule.filters]]
 [rule.filters.meta]
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
-value = "?:\\Windows\\system32\\spool\\PRTPROCS\\u0064\\\\*.dll"
-[[rule.filters]]
+value = "?:\\\\Windows\\\\system32\\\\spool\\\\PRTPROCS\\\\x64\\\\*.dll"
 
+[[rule.filters]]
 [rule.filters.meta]
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
 value = "?:\\\\Windows\\\\system32\\\\spool\\\\{????????-????-????-????-????????????}\\\\*.dll"
+
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]


### PR DESCRIPTION
## Issue

Resolves https://github.com/elastic/detection-rules/issues/4968

## Summary

Revert the changes made to the exceptions in https://github.com/elastic/detection-rules/pull/4555. A fix for the Python tooling bug that caused this will be handled in a separate PR.