### PR TITLE
[Bug] Rule Toml Write Formatting Wrongly Formats \\\\x

### DIFF
--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -151,6 +151,8 @@ class RuleTomlEncoder(toml.TomlEncoder):  # type: ignore[reportMissingTypeArgume
             return "\n".join([TRIPLE_SQ] + [self._old_dump_str(line)[1:-1] for line in lines] + [TRIPLE_SQ])
         if raw:
             return f"'{lines[0]:s}'"
+        if "\\\\x" in v:
+            return f'"{v!s}"'
         return self._old_dump_str(v)
 
     def _dump_flat_list(self, v: Iterable[Any]) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.3.23"
+version = "1.3.24"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
+++ b/rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/13"
 
 [rule]
 author = ["Elastic"]
@@ -106,14 +106,14 @@ value = "?:\\\\Windows\\\\Sys?????\\\\PrintConfig.dll"
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
-value = "?:\\Windows\\Sys?????\\u005lrs.dll"
+value = "?:\\Windows\\Sys?????\\x5lrs.dll"
 [[rule.filters]]
 
 [rule.filters.meta]
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
-value = "?:\\Windows\\system32\\spool\\DRIVERS\\u0064\\\\*.dll"
+value = "?:\\Windows\\system32\\spool\\DRIVERS\\x64\\*.dll"
 [[rule.filters]]
 
 [rule.filters.meta]
@@ -127,7 +127,7 @@ value = "?:\\\\Windows\\\\system32\\\\spool\\\\DRIVERS\\\\W32X86\\\\*.dll"
 negate = true
 [rule.filters.query.wildcard."file.path"]
 case_insensitive = true
-value = "?:\\Windows\\system32\\spool\\PRTPROCS\\u0064\\\\*.dll"
+value = "?:\\Windows\\system32\\spool\\PRTPROCS\\x64\\*.dll"
 [[rule.filters]]
 
 [rule.filters.meta]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

Resolves https://github.com/elastic/detection-rules/issues/4977

## Summary - What I changed

**Note: Please review this fairly carefully as we need to check for unintended consequences and whether or not this is the true root cause of the issue that broke the rule in https://github.com/elastic/detection-rules/issues/4977**

I added a hardcoded check to mitigate an unwated behavior of Python's toml library string dump formatting (see Additional Context from https://github.com/elastic/detection-rules/issues/4977).

This checks for the presence of `\\\\x` which would trigger an unwanted replacement to `\\u00` and calls python's string formatting directly instead of toml's string dump.  


## How To Test

1. Use the version lock file from commit `2d2c5b4` 
2. Pull the rule contents for `rules/windows/privilege_escalation_printspooler_service_suspicious_file.toml` from this commit as well.
3. Run a command such as `python -m detection_rules dev trim-version-lock 8.14.0` that would same_toml on a rule with `\\\\x` 
4. See that the `[rule.filters.query.wildcard."file.path"]` values are do not have `\\\\x` replaced with `\\u00` whereas they did in  https://github.com/elastic/detection-rules/pull/4555

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
