### PR TITLE
[Tuning] SDH - Investigating MFA Deactivation with no Re-Activation for Okta User Account

### DIFF
--- a/rules/integrations/okta/persistence_mfa_deactivation_with_no_reactivation.toml
+++ b/rules/integrations/okta/persistence_mfa_deactivation_with_no_reactivation.toml
@@ -33,9 +33,9 @@ This rule fires when an Okta user account has MFA deactivated and no subsequent 
 
 #### Possible investigation steps:
 
-- Identify the entity related to the alert by reviewing `okta.target.alternate_id` or `user.target.full_name` fields. This should give the username of the account being targeted. Verify if MFA is deactivated for the target entity.
+- Identify the entity related to the alert by reviewing `okta.target.alternate_id`, `okta.target.id` or `user.target.full_name` fields. This should give the username of the account being targeted. Verify if MFA is deactivated for the target entity.
 - Using the `okta.target.alternate_id` field, search for MFA re-activation events where `okta.event_type` is `user.mfa.factor.activate`. Note if MFA re-activation attempts were made against the target.
-- Identify the actor performing the deactivation by reviewing `okta.actor.alternate_id` or `user.full_name` fields. This should give the username of the account performing the action. Determine if deactivation was performed by a separate user. 
+- Identify the actor performing the deactivation by reviewing `okta.actor.alternate_id`, `okta.actor.id` or `user.full_name` fields. This should give the username of the account performing the action. Determine if deactivation was performed by a separate user. 
 - Review events where `okta.event_type` is `user.authenticate*` to determine if the actor or target accounts had suspicious login activity.
     - Geolocation details found in `client.geo*` related fields may be useful in determining if the login activity was suspicious for this user.
 - Examine related administrative activity by the actor for privilege misuse or suspicious changes.


### PR DESCRIPTION
*Issue link(s)*:
- https://github.com/elastic/sdh-protections/issues/606

## Summary - What I changed

This tuning addresses SDH ticket by:
- replacing sequence by `okta.actor.id` with `okta.target.id` in query. This will ensure the deactivation and activation attempts are measured against the target entity. To account for instances where separate users (okta.actor.id) perform deactivation and activation actions against the same target account (okta.target.id)
- Adjusts the investigation guide to use correct target vs. actor fields

The rule query looks for a sequence of 
1. MFA deactivation event that is 
2. NOT followed by an MFA activation event within a 12 hour window against the same target account.  
<img width="1297" height="486" alt="Screenshot 2025-08-15 at 5 27 47 PM" src="https://github.com/user-attachments/assets/122b325d-6b64-4c56-b280-60d152157049" />


Below is data for a sequence of 
1.  MFA deactivation event that is 
2. followed by an MFA activation event within a 12 hour window against the same target account. 

This shows that this sequence does exist in our test stack but was not picked up by the rule. This is the expected outcome so the rule query is working properly. This data also shows that the change to `okta.target.id` will account for instances where different entities `okta.actor.id` perform each action against the same target.

<img width="1297" height="486" alt="Screenshot 2025-08-15 at 5 26 29 PM" src="https://github.com/user-attachments/assets/03900693-7158-40c6-86bd-5bc844ee1147" />



