### PR TITLE
[Tuning] First Occurrence of STS GetFederationToken Request by User

### DIFF
--- a/rules/integrations/aws/defense_evasion_sts_get_federation_token.toml
+++ b/rules/integrations/aws/defense_evasion_sts_get_federation_token.toml
@@ -2,27 +2,27 @@
 creation_date = "2024/08/19"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/08/25"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the first occurrence of an AWS Security Token Service (STS) `GetFederationToken` request made by a user
-within the last 10 days. The `GetFederationToken` API call allows users to request temporary security credentials to
-access AWS resources. Adversaries may use this API to obtain temporary credentials to access resources they would not
-normally have access to.
+Identifies the first occurrence of an AWS Security Token Service (STS) GetFederationToken request made by a user. The GetFederationToken API call allows users to request temporary security credentials to
+access AWS resources. The maximum expiration period for these tokens is 36 hours and they can be used to create a console signin token even for identities that don't already have one. Adversaries may use this API to obtain temporary credentials for persistence and to bypass IAM API call limitations by gaining console access.
 """
-from = "now-9m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "First Occurrence of STS GetFederationToken Request by User"
+name = "AWS First Occurrence of STS GetFederationToken Request by User"
 references = [
-    "https://hackingthe.cloud/aws/post_exploitation/survive_access_key_deletion_with_sts_getfederationtoken/"
+    "https://hackingthe.cloud/aws/post_exploitation/survive_access_key_deletion_with_sts_getfederationtoken/",
+    "https://www.crowdstrike.com/en-us/blog/how-adversaries-persist-with-aws-user-federation/",
+    "https://medium.com/@adan.alvarez/how-attackers-persist-in-aws-using-getfederationtoken-a-simple-and-effective-technique-used-in-the-987ec1f0bdfe/"
 ]
-risk_score = 21
+risk_score = 47
 rule_id = "7a5cc9a8-5ea3-11ef-beec-f661ea17fbce"
-severity = "low"
+severity = "medium"
 tags = [
     "Domain: Cloud",
     "Data Source: Amazon Web Services",
@@ -30,6 +30,7 @@ tags = [
     "Data Source: AWS STS",
     "Use Case: Threat Detection",
     "Tactic: Defense Evasion",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -37,25 +38,26 @@ type = "new_terms"
 
 query = '''
 event.dataset: "aws.cloudtrail"
-    and event.provider: sts.amazonaws.com
-    and event.action: GetFederationToken
+    and event.provider:sts.amazonaws.com
+    and event.action:GetFederationToken
+    and event.outcome:success
 '''
 note = """## Triage and analysis
 
 > **Disclaimer**:
 > This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
 
-### Investigating First Occurrence of STS GetFederationToken Request by User
+### Investigating AWS First Occurrence of STS GetFederationToken Request by User
 
-AWS Security Token Service (STS) enables users to request temporary credentials for accessing AWS resources. While beneficial for legitimate use, adversaries may exploit this to gain unauthorized access. The detection rule identifies unusual activity by flagging the first instance of a `GetFederationToken` request by a user within a 10-day window, helping to uncover potential misuse aimed at evading defenses.
+AWS Security Token Service (STS) enables users to request temporary credentials for accessing AWS resources. While beneficial for legitimate use, adversaries may exploit this to gain unauthorized access. These credentials will remain active for the duration specified (maximum 36 hours), even if the initial compromised identity is deleted. They can also be used to request a console signin token which allows the adversary to make sensitive IAM API calls which would otherwise be denied with the federation token alone. The detection rule identifies unusual activity by flagging the first instance of a `GetFederationToken` request by a user helping to uncover potential misuse aimed at evading defenses and gaining persistence.
 
 ### Possible investigation steps
 
-- Review the specific user account associated with the GetFederationToken request to determine if the activity aligns with their typical behavior and role within the organization.
-- Examine the AWS CloudTrail logs for additional context around the time of the GetFederationToken request, looking for any other unusual or suspicious activities by the same user or related accounts.
-- Check the source IP address and geolocation of the GetFederationToken request to identify if it originates from an expected or unexpected location.
-- Investigate the resources accessed using the temporary credentials obtained from the GetFederationToken request to assess if there was any unauthorized or suspicious access.
-- Consult with the user or their manager to verify if the GetFederationToken request was legitimate and necessary for their work tasks.
+- Review the specific user account associated with the `GetFederationToken` request to determine if the activity aligns with their typical behavior and role within the organization.
+- Examine the AWS CloudTrail logs for additional context around the time of the `GetFederationToken` request, looking for any other unusual or suspicious activities by the same user or related accounts.
+- Check the `source.ip` and `source.geo` fields of the request to identify if it originates from an expected or unexpected location.
+- View the `aws.cloudtrail.response_elements` to find the created `federatedUser.arn`. Investigate the resources accessed by this Federated User to assess if there was any suspicious activity.
+- Consult with the requesting user `aws.cloudtrail.user_identity.arn` to verify if the `GetFederationToken` request was legitimate and necessary for their work tasks.
 
 ### False positive analysis
 
@@ -66,13 +68,28 @@ AWS Security Token Service (STS) enables users to request temporary credentials 
 
 ### Response and remediation
 
-- Immediately revoke the temporary credentials associated with the `GetFederationToken` request to prevent unauthorized access to AWS resources.
-- Review CloudTrail logs to identify any suspicious activities performed using the temporary credentials and assess the potential impact on AWS resources.
-- Isolate the affected user account by disabling it temporarily to prevent further unauthorized actions until a thorough investigation is completed.
+- If compromise is verified, attach a policy that denies all actions, effectively preventing any further activity, even from temporary credentials. You can use the AWS-managed policy [AWSDenyAll](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSDenyAll.html). This ensures that any temporary credentials generated by the compromised user are also blocked, stopping the attacker’s activities.
 - Notify the security team and relevant stakeholders about the incident for awareness and further investigation.
 - Conduct a root cause analysis to determine how the `GetFederationToken` request was initiated and identify any potential security gaps or misconfigurations.
 - Implement additional monitoring and alerting for `GetFederationToken` requests to detect and respond to similar activities promptly in the future.
 - Review and update IAM policies and permissions to ensure that only authorized users have the ability to request temporary credentials, reducing the risk of misuse."""
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
@@ -90,6 +107,22 @@ reference = "https://attack.mitre.org/techniques/T1550/001/"
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+[[rule.threat.technique.subtechnique]]
+id = "T1098.001"
+name = "Additional Cloud Credentials"
+reference = "https://attack.mitre.org/techniques/T1098/001/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
 
 [rule.new_terms]
 field = "new_terms_fields"


### PR DESCRIPTION

# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/616
<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

Rule is executing as expected, however it is alerting on failed requests. Low alert telemetry.

This tuning:
- removed markdown and edited description to be more specific
- reduced execution window for 1 min lookback
- name change to add `AWS` consistent with all other rules
- added references that reflect in the wild threats and persistence usage
- increased risk_score and severity to medium accounting for usage as persistence mechanism in the wild
- added Persistence tag and Mitre tactic, technique, subtechnique
- added `event.outcome: success` criteria to query
- edited investigation guide to be more accurate reflection of steps required for investigating alert, including appropriate response action
- added highlighted fields 

_**Note: only IAMUser and Root user identities can call this actions so we can use `aws.cloudtrail.user_identity.arn` as the new terms field without worrying about Role vs Role + Session issue seen with other new_terms rules**_

## How To Test

To test you can use this [script](https://github.com/elastic/elastic-aws-ruleset-testing/blob/4e44890d11477a0db61a3051a78f73f5440b581f/STS/trigger_defense_evasion_sts_get_federation_token.py) which will create a new user, long term credentials, authenticate and run `GetFederationToken` API. To test manually, use an existing user identity with long term credentials and run the following or similar command (you must attach a policy):
```
aws sts get-federation-token --name UnauthorizedUser --policy-arns arn=arn:aws:iam::aws:policy/AdministratorAccess --duration-seconds 43200 
```
<img width="1474" height="749" alt="Screenshot 2025-08-25 at 4 47 30 PM" src="https://github.com/user-attachments/assets/3eebb621-fc7d-4b4a-8606-99e653775f7c" />


