### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 1

### DIFF
--- a/rules/windows/command_and_control_outlook_home_page.toml
+++ b/rules/windows/command_and_control_outlook_home_page.toml
@@ -61,9 +61,9 @@ references = [
     "https://cloud.google.com/blog/topics/threat-intelligence/breaking-the-rules-tough-outlook-for-home-page-attacks/",
     "https://github.com/trustedsec/specula",
 ]
-risk_score = 47
+risk_score = 73
 rule_id = "ac5a2759-5c34-440a-b0c4-51fe674611d6"
-severity = "medium"
+severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: Windows",

--- a/rules/windows/command_and_control_outlook_home_page.toml
+++ b/rules/windows/command_and_control_outlook_home_page.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2024/08/01"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/06/12"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -75,6 +76,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
     "Resources: Investigation Guide",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/command_and_control_outlook_home_page.toml
+++ b/rules/windows/command_and_control_outlook_home_page.toml
@@ -86,7 +86,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
     registry.path : (
         "*\\SOFTWARE\\Microsoft\\Office\\*\\Outlook\\Webview\\*",
         "*\\SOFTWARE\\Microsoft\\Office\\*\\Outlook\\Today\\*"
-    ) and registry.data.strings : "*://*"
+    ) and registry.data.strings : ("*://*", "*http*")
 '''
 
 

--- a/rules/windows/command_and_control_port_forwarding_added_registry.toml
+++ b/rules/windows/command_and_control_port_forwarding_added_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/25"
-integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-sentinel_one_cloud_funnel.*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -81,16 +82,14 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: SentinelOne",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and registry.path : (
-  "HKLM\\SYSTEM\\*ControlSet*\\Services\\PortProxy\\v4tov4\\*",
-  "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Services\\PortProxy\\v4tov4\\*",
-  "MACHINE\\SYSTEM\\*ControlSet*\\Services\\PortProxy\\v4tov4\\*"
-)
+registry where host.os.type == "windows" and
+  registry.path : "*\\SYSTEM\\*ControlSet*\\Services\\PortProxy\\v4tov4\\*"
 '''
 
 

--- a/rules/windows/command_and_control_port_forwarding_added_registry.toml
+++ b/rules/windows/command_and_control_port_forwarding_added_registry.toml
@@ -88,8 +88,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and
-  registry.path : "*\\SYSTEM\\*ControlSet*\\Services\\PortProxy\\v4tov4\\*"
+registry where host.os.type == "windows" and event.type == "change" and 
+  registry.path : "*\\SYSTEM\\*ControlSet*\\Services\\PortProxy\\v4tov4\\*" and registry.data.strings != null
 '''
 
 

--- a/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
+++ b/rules/windows/credential_access_mimikatz_memssp_default_logs.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/08/31"
-integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ index = [
     "endgame-*",
     "logs-sentinel_one_cloud_funnel.*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -83,6 +84,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: SentinelOne",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
@@ -119,63 +119,31 @@ type = "eql"
 
 query = '''
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
-  file.name : ("amsi.dll", "amsi") and
+  file.name : ("amsi.dll", "amsi") and 
+  event.action != "A process changed a file creation time" and 
   not file.path : (
-    "?:\\$SysReset\\CloudImage\\Package_for_RollupFix*",
+    "?:\\$SysReset\\CloudImage\\Package_for_RollupFix*\\amsi.dll",
     "?:\\Windows\\system32\\amsi.dll",
     "?:\\Windows\\Syswow64\\amsi.dll",
-    "?:\\$WINDOWS.~BT\\DUImageSandbox\\*",
-    "?:\\$WINDOWS.~BT\\NewOS\\Windows\\WinSXS\\*",
-    "?:\\$WINDOWS.~BT\\NewOS\\Windows\\servicing\\LCU\\*",
-    "?:\\$WINDOWS.~BT\\Work\\*\\*",
-    "?:\\$WINDOWS.~BT\\Store\\Offline\\File\\C$\\Windows\\SoftwareDistribution\\Download.bak\\*",
-    "?:\\Windows\\CbsTemp\\*\\f\\amsi.dll",
+    "?:\\$WINDOWS.~BT\\*\\amsi.dll",
+    "?:\\Windows\\CbsTemp\\*\\amsi.dll",
     "?:\\Windows\\SoftwareDistribution\\Download\\*",
-    "?:\\Windows\\WinSxS\\amd64_microsoft-antimalware-scan-interface_*\\amsi.dll"
-  ) and
-  not
-  (
-    process.executable : "C:\\Windows\\System32\\wbengine.exe" and
-    file.path : (
-      "\\Device\\HarddiskVolume??\\Windows\\system32\\amsi.dll",
-      "\\Device\\HarddiskVolume??\\Windows\\syswow64\\amsi.dll",
-      "\\Device\\HarddiskVolume??\\Windows\\WinSxS\\*\\amsi.dll",
-      "\\\\?\\Volume{*}\\Windows\\WinSxS\\*\\amsi.dll",
-      "\\\\?\\Volume{*}\\Windows\\system32\\amsi.dll",
-      "\\\\?\\Volume{*}\\Windows\\syswow64\\amsi.dll"
-    )
-  ) and
-  /* Crowdstrike specific exclusion as it uses NT Object paths */
-  not
-  (
-    data_stream.dataset == "crowdstrike.fdr" and
-    (
-      file.path : (
-          "\\Device\\HarddiskVolume?\\$SysReset\\CloudImage\\Package_for_RollupFix*",
-          "\\Device\\HarddiskVolume?\\Windows\\system32\\amsi.dll",
-          "\\Device\\HarddiskVolume?\\Windows\\Syswow64\\amsi.dll",
-          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\DUImageSandbox\\*",
-          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\NewOS\\Windows\\WinSXS\\*",
-          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\NewOS\\Windows\\servicing\\LCU\\*",
-          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\Work\\*\\*",
-          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\Store\\Offline\\File\\C$\\Windows\\SoftwareDistribution\\Download.bak\\*",
-          "\\Device\\HarddiskVolume?\\Windows\\CbsTemp\\*\\f\\amsi.dll",
-          "\\Device\\HarddiskVolume?\\Windows\\SoftwareDistribution\\Download\\*",
-          "\\Device\\HarddiskVolume?\\Windows\\WinSxS\\amd64_microsoft-antimalware-scan-interface_*\\amsi.dll"
-      ) or
-      (
-        process.name : "wbengine.exe" and
-        file.path : (
-          "\\Device\\HarddiskVolume??\\Windows\\system32\\amsi.dll",
-          "\\Device\\HarddiskVolume??\\Windows\\syswow64\\amsi.dll",
-          "\\Device\\HarddiskVolume??\\Windows\\WinSxS\\*\\amsi.dll",
-          "\\\\?\\Volume{*}\\Windows\\WinSxS\\*\\amsi.dll",
-          "\\\\?\\Volume{*}\\Windows\\system32\\amsi.dll",
-          "\\\\?\\Volume{*}\\Windows\\syswow64\\amsi.dll"
-        )
-      )
-    )
-  )
+    "?:\\Windows\\WinSxS\\*\\amsi.dll", 
+    "?:\\Windows\\servicing\\*\\amsi.dll",
+    "\\\\?\\Volume{*}\\Windows\\WinSxS\\*\\amsi.dll", 
+    "\\\\?\\Volume{*}\\Windows\\system32\\amsi.dll", 
+    "\\\\?\\Volume{*}\\Windows\\syswow64\\amsi.dll",
+
+    /* Crowdstrike specific exclusion as it uses NT Object paths */
+    "\\Device\\HarddiskVolume*\\Windows\\system32\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\syswow64\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\WinSxS\\*\\amsi.dll",
+    "\\Device\\HarddiskVolume*\\$SysReset\\CloudImage\\Package_for_RollupFix*\\amsi.dll",
+    "\\Device\\HarddiskVolume*\\$WINDOWS.~BT\\*\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download\\*\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\servicing\\*\\amsi.dll"
+  ) 
 '''
 
 

--- a/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/01/17"
-integration = ["windows", "endpoint", "sentinel_one_cloud_funnel", "m365_defender"]
+integration = ["windows", "endpoint", "sentinel_one_cloud_funnel", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/05/05"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -44,6 +44,7 @@ index = [
     "endgame-*",
     "logs-sentinel_one_cloud_funnel.*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -111,6 +112,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: SentinelOne",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -141,6 +143,36 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
       "\\\\?\\Volume{*}\\Windows\\WinSxS\\*\\amsi.dll",
       "\\\\?\\Volume{*}\\Windows\\system32\\amsi.dll",
       "\\\\?\\Volume{*}\\Windows\\syswow64\\amsi.dll"
+    )
+  ) and
+  /* Crowdstrike specific exclusion as it uses NT Object paths */
+  not
+  (
+    data_stream.dataset == "crowdstrike.fdr" and
+    (
+      file.path : (
+          "\\Device\\HarddiskVolume?\\$SysReset\\CloudImage\\Package_for_RollupFix*",
+          "\\Device\\HarddiskVolume?\\Windows\\system32\\amsi.dll",
+          "\\Device\\HarddiskVolume?\\Windows\\Syswow64\\amsi.dll",
+          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\DUImageSandbox\\*",
+          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\NewOS\\Windows\\WinSXS\\*",
+          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\NewOS\\Windows\\servicing\\LCU\\*",
+          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\Work\\*\\*",
+          "\\Device\\HarddiskVolume?\\$WINDOWS.~BT\\Store\\Offline\\File\\C$\\Windows\\SoftwareDistribution\\Download.bak\\*",
+          "\\Device\\HarddiskVolume?\\Windows\\CbsTemp\\*\\f\\amsi.dll",
+          "\\Device\\HarddiskVolume?\\Windows\\SoftwareDistribution\\Download\\*",
+          "\\Device\\HarddiskVolume?\\Windows\\WinSxS\\amd64_microsoft-antimalware-scan-interface_*\\amsi.dll"
+      ) or
+      (
+        process.name : "wbengine.exe" and
+        file.path : (
+          "\\Device\\HarddiskVolume??\\Windows\\system32\\amsi.dll",
+          "\\Device\\HarddiskVolume??\\Windows\\syswow64\\amsi.dll",
+          "\\Device\\HarddiskVolume??\\Windows\\WinSxS\\*\\amsi.dll",
+          "\\\\?\\Volume{*}\\Windows\\WinSxS\\*\\amsi.dll",
+          "\\\\?\\Volume{*}\\Windows\\system32\\amsi.dll",
+          "\\\\?\\Volume{*}\\Windows\\syswow64\\amsi.dll"
+      )
     )
   )
 '''

--- a/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
+++ b/rules/windows/defense_evasion_amsi_bypass_dllhijack.toml
@@ -172,6 +172,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
           "\\\\?\\Volume{*}\\Windows\\WinSxS\\*\\amsi.dll",
           "\\\\?\\Volume{*}\\Windows\\system32\\amsi.dll",
           "\\\\?\\Volume{*}\\Windows\\syswow64\\amsi.dll"
+        )
       )
     )
   )

--- a/rules/windows/defense_evasion_amsienable_key_mod.toml
+++ b/rules/windows/defense_evasion_amsienable_key_mod.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/06/01"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -90,6 +91,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.