### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 3

### DIFF
--- a/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
+++ b/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/09/03"
-integration = ["endpoint", "windows", "m365_defender"]
+integration = ["endpoint", "windows", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/04/16"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "logs-windows.sysmon_operational-*",
     "endgame-*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -59,14 +60,6 @@ DLL side-loading exploits the DLL search order to load malicious code into trust
 - Escalate the incident to the security operations center (SOC) or incident response team for further analysis and to determine if additional systems or data have been affected."""
 risk_score = 73
 rule_id = "1160dcdb-0a0a-4a79-91d8-9b84616edebd"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "high"
 tags = [
     "Domain: Endpoint",
@@ -79,6 +72,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Resources: Investigation Guide",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -94,7 +88,23 @@ process where host.os.type == "windows" and event.type == "start" and
                             "?:\\Windows\\SysWOW64\\Dism.exe",  
                             "?:\\Program Files (x86)\\Windows Kits\\10\\Assessment and Deployment Kit\\Deployment Tools\\amd64\\DISM\\dism.exe",
                             "?:\\Windows\\System32\\inetsrv\\w3wp.exe", 
-                            "?:\\Windows\\SysWOW64\\inetsrv\\w3wp.exe")
+                            "?:\\Windows\\SysWOW64\\inetsrv\\w3wp.exe") and
+  /* Crowdstrike specific exclusion as it uses NT Object paths */
+  not
+  (
+    data_stream.dataset == "crowdstrike.fdr" and
+    process.executable : (
+        "\\Device\\HarddiskVolume?\\Windows\\explorer.exe", 
+        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\explorer.exe",
+        "\\Device\\HarddiskVolume?\\Program Files\\Microsoft Office\\root\\Office*\\WINWORD.EXE", 
+        "\\Device\\HarddiskVolume?\\Program Files (x86)\\Microsoft Office\\root\\Office*\\WINWORD.EXE", 
+        "\\Device\\HarddiskVolume?\\Windows\\System32\\Dism.exe", 
+        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\Dism.exe",  
+        "\\Device\\HarddiskVolume?\\Program Files (x86)\\Windows Kits\\10\\Assessment and Deployment Kit\\Deployment Tools\\amd64\\DISM\\dism.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\System32\\inetsrv\\w3wp.exe", 
+        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\inetsrv\\w3wp.exe"
+    )
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
+++ b/rules/windows/defense_evasion_execution_suspicious_explorer_winword.toml
@@ -94,15 +94,15 @@ process where host.os.type == "windows" and event.type == "start" and
   (
     data_stream.dataset == "crowdstrike.fdr" and
     process.executable : (
-        "\\Device\\HarddiskVolume?\\Windows\\explorer.exe", 
-        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\explorer.exe",
-        "\\Device\\HarddiskVolume?\\Program Files\\Microsoft Office\\root\\Office*\\WINWORD.EXE", 
-        "\\Device\\HarddiskVolume?\\Program Files (x86)\\Microsoft Office\\root\\Office*\\WINWORD.EXE", 
-        "\\Device\\HarddiskVolume?\\Windows\\System32\\Dism.exe", 
-        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\Dism.exe",  
-        "\\Device\\HarddiskVolume?\\Program Files (x86)\\Windows Kits\\10\\Assessment and Deployment Kit\\Deployment Tools\\amd64\\DISM\\dism.exe",
-        "\\Device\\HarddiskVolume?\\Windows\\System32\\inetsrv\\w3wp.exe", 
-        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\inetsrv\\w3wp.exe"
+        "\\Device\\HarddiskVolume*\\Windows\\explorer.exe", 
+        "\\Device\\HarddiskVolume*\\Windows\\SysWOW64\\explorer.exe",
+        "\\Device\\HarddiskVolume*\\Program Files\\Microsoft Office\\root\\Office*\\WINWORD.EXE", 
+        "\\Device\\HarddiskVolume*\\Program Files (x86)\\Microsoft Office\\root\\Office*\\WINWORD.EXE", 
+        "\\Device\\HarddiskVolume*\\Windows\\System32\\Dism.exe", 
+        "\\Device\\HarddiskVolume*\\Windows\\SysWOW64\\Dism.exe",  
+        "\\Device\\HarddiskVolume*\\Program Files (x86)\\Windows Kits\\10\\Assessment and Deployment Kit\\Deployment Tools\\amd64\\DISM\\dism.exe",
+        "\\Device\\HarddiskVolume*\\Windows\\System32\\inetsrv\\w3wp.exe", 
+        "\\Device\\HarddiskVolume*\\Windows\\SysWOW64\\inetsrv\\w3wp.exe"
     )
   )
 '''

--- a/rules/windows/defense_evasion_execution_windefend_unusual_path.toml
+++ b/rules/windows/defense_evasion_execution_windefend_unusual_path.toml
@@ -93,11 +93,11 @@ process where host.os.type == "windows" and event.type == "start" and
             "?:\\Program Files (x86)\\Microsoft Security Client\\*.exe",
 
             /* Crowdstrike specific exclusion as it uses NT Object paths */
-            "\\Device\\HarddiskVolume?\\ProgramData\\Microsoft\\Windows Defender\\*.exe",
-            "\\Device\\HarddiskVolume?\\Program Files\\Windows Defender\\*.exe",
-            "\\Device\\HarddiskVolume?\\Program Files (x86)\\Windows Defender\\*.exe",
-            "\\Device\\HarddiskVolume?\\Program Files\\Microsoft Security Client\\*.exe",
-            "\\Device\\HarddiskVolume?\\Program Files (x86)\\Microsoft Security Client\\*.exe"
+            "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\*.exe",
+            "\\Device\\HarddiskVolume*\\Program Files\\Windows Defender\\*.exe",
+            "\\Device\\HarddiskVolume*\\Program Files (x86)\\Windows Defender\\*.exe",
+            "\\Device\\HarddiskVolume*\\Program Files\\Microsoft Security Client\\*.exe",
+            "\\Device\\HarddiskVolume*\\Program Files (x86)\\Microsoft Security Client\\*.exe"
     )
   )
 )

--- a/rules/windows/defense_evasion_execution_windefend_unusual_path.toml
+++ b/rules/windows/defense_evasion_execution_windefend_unusual_path.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/07/07"
-integration = ["endpoint", "windows", "m365_defender"]
+integration = ["endpoint", "windows", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic", "Dennis Perto"]
@@ -19,6 +19,7 @@ index = [
     "logs-windows.sysmon_operational-*",
     "endgame-*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -61,14 +62,6 @@ references = [
 ]
 risk_score = 73
 rule_id = "053a0387-f3b5-4ba5-8245-8002cca2bd08"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "high"
 tags = [
     "Domain: Endpoint",
@@ -80,6 +73,7 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -89,12 +83,23 @@ query = '''
 process where host.os.type == "windows" and event.type == "start" and
 (
   (process.pe.original_file_name == "MsMpEng.exe" and not process.name : "MsMpEng.exe") or
-  (process.name : "MsMpEng.exe" and not
-        process.executable : ("?:\\ProgramData\\Microsoft\\Windows Defender\\*.exe",
-                              "?:\\Program Files\\Windows Defender\\*.exe",
-                              "?:\\Program Files (x86)\\Windows Defender\\*.exe",
-                              "?:\\Program Files\\Microsoft Security Client\\*.exe",
-                              "?:\\Program Files (x86)\\Microsoft Security Client\\*.exe"))
+  (
+    process.name : "MsMpEng.exe" and
+    not process.executable : (
+            "?:\\ProgramData\\Microsoft\\Windows Defender\\*.exe",
+            "?:\\Program Files\\Windows Defender\\*.exe",
+            "?:\\Program Files (x86)\\Windows Defender\\*.exe",
+            "?:\\Program Files\\Microsoft Security Client\\*.exe",
+            "?:\\Program Files (x86)\\Microsoft Security Client\\*.exe",
+
+            /* Crowdstrike specific exclusion as it uses NT Object paths */
+            "\\Device\\HarddiskVolume?\\ProgramData\\Microsoft\\Windows Defender\\*.exe",
+            "\\Device\\HarddiskVolume?\\Program Files\\Windows Defender\\*.exe",
+            "\\Device\\HarddiskVolume?\\Program Files (x86)\\Windows Defender\\*.exe",
+            "\\Device\\HarddiskVolume?\\Program Files\\Microsoft Security Client\\*.exe",
+            "\\Device\\HarddiskVolume?\\Program Files (x86)\\Microsoft Security Client\\*.exe"
+    )
+  )
 )
 '''
 

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -82,11 +82,17 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
   file.name regex~ """.*\.(vbs|vbe|bat|js|cmd|wsh|ps1|pdf|docx?|xlsx?|pptx?|txt|rtf|gif|jpg|png|bmp|hta|txt|img|iso)\.exe""" and
   not (
       process.executable : (
-          "*\\Windows\\System32\\msiexec.exe",
-          "*\\Users\\*\\QGIS_SCCM\\Files\\QGIS-OSGeo4W-*-Setup-x86_64.exe"
+          "?:\\Windows\\System32\\msiexec.exe",
+          "\\Device\\HarddiskVolume*\\Windows\\System32\\msiexec.exe",
+          "*\\Users\\*\\QGIS_SCCM\\Files\\QGIS-OSGeo4W-*-Setup-x86_64.exe", 
       ) and
-      file.path : "*\\Program Files\\QGIS *\\apps\\grass\\*.exe"
-  )
+      file.path : "(?:\\Program Files\\QGIS *\\apps\\grass\\*.exe", "\\Device\\HarddiskVolume*\\Program Files\\QGIS *\\apps\\grass\\*.exe")
+  ) and 
+  not process.executable : 
+                             ("C:\\Program Files\\dotnet\\dotnet.exe", 
+                              "C:\\Program Files\\Microsoft Visual Studio\\*.exe",
+                              "\\Device\\HarddiskVolume*\\Program Files\\dotnet\\dotnet.exe", 
+                              "\\Device\\HarddiskVolume*\\Program Files\\Microsoft Visual Studio\\*.exe")
 '''
 
 

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -86,7 +86,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
           "\\Device\\HarddiskVolume*\\Windows\\System32\\msiexec.exe",
           "*\\Users\\*\\QGIS_SCCM\\Files\\QGIS-OSGeo4W-*-Setup-x86_64.exe"
       ) and
-      file.path : "(?:\\Program Files\\QGIS *\\apps\\grass\\*.exe", "\\Device\\HarddiskVolume*\\Program Files\\QGIS *\\apps\\grass\\*.exe")
+      file.path : ("?:\\Program Files\\QGIS *\\apps\\grass\\*.exe", "\\Device\\HarddiskVolume*\\Program Files\\QGIS *\\apps\\grass\\*.exe")
   ) and 
   not process.executable : 
                              ("C:\\Program Files\\dotnet\\dotnet.exe", 

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/01/19"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -71,6 +72,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
     "Resources: Investigation Guide",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -78,8 +80,13 @@ type = "eql"
 query = '''
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "exe" and
   file.name regex~ """.*\.(vbs|vbe|bat|js|cmd|wsh|ps1|pdf|docx?|xlsx?|pptx?|txt|rtf|gif|jpg|png|bmp|hta|txt|img|iso)\.exe""" and
-  not (process.executable : ("?:\\Windows\\System32\\msiexec.exe", "C:\\Users\\*\\QGIS_SCCM\\Files\\QGIS-OSGeo4W-*-Setup-x86_64.exe") and
-       file.path : "?:\\Program Files\\QGIS *\\apps\\grass\\*.exe")
+  not (
+      process.executable : (
+          "*\\Windows\\System32\\msiexec.exe",
+          "*\\Users\\*\\QGIS_SCCM\\Files\\QGIS-OSGeo4W-*-Setup-x86_64.exe"
+      ) and
+      file.path : "*\\Program Files\\QGIS *\\apps\\grass\\*.exe"
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_file_creation_mult_extension.toml
+++ b/rules/windows/defense_evasion_file_creation_mult_extension.toml
@@ -84,7 +84,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
       process.executable : (
           "?:\\Windows\\System32\\msiexec.exe",
           "\\Device\\HarddiskVolume*\\Windows\\System32\\msiexec.exe",
-          "*\\Users\\*\\QGIS_SCCM\\Files\\QGIS-OSGeo4W-*-Setup-x86_64.exe", 
+          "*\\Users\\*\\QGIS_SCCM\\Files\\QGIS-OSGeo4W-*-Setup-x86_64.exe"
       ) and
       file.path : "(?:\\Program Files\\QGIS *\\apps\\grass\\*.exe", "\\Device\\HarddiskVolume*\\Program Files\\QGIS *\\apps\\grass\\*.exe")
   ) and 

--- a/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
+++ b/rules/windows/defense_evasion_hide_encoded_executable_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/25"
-integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "logs-sentinel_one_cloud_funnel.*",
     "winlogbeat-*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -69,6 +70,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: SentinelOne",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/windows/defense_evasion_installutil_beacon.toml
+++ b/rules/windows/defense_evasion_installutil_beacon.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/09/02"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ index = [
     "logs-endpoint.events.network-*",
     "winlogbeat-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -66,6 +67,7 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.