### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 4

### DIFF
--- a/rules/windows/defense_evasion_lsass_ppl_disabled_registry.toml
+++ b/rules/windows/defense_evasion_lsass_ppl_disabled_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2025/05/27"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/05/27"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -73,13 +74,14 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-  registry.path : ("HKLM\\SYSTEM\\ControlSet*\\Control\\Lsa\\RunAsPPL", "\\REGISTRY\\MACHINE\\SYSTEM\\ControlSet*\\Control\\Lsa\\RunAsPPL") and 
+  registry.value : "RunAsPPL" and registry.path : "*\\SYSTEM\\*ControlSet*\\Control\\Lsa\\RunAsPPL" and
   not registry.data.strings : ("1", "0x00000001", "2", "0x00000002")
 '''
 

--- a/rules/windows/defense_evasion_masquerading_business_apps_installer.toml
+++ b/rules/windows/defense_evasion_masquerading_business_apps_installer.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/09/01"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/05/05"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ developer. Attackers may trick users into downloading malicious executables that
 via malicious ads, forum posts, and tutorials, effectively gaining initial access.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Masquerading as Business App Installer"
@@ -31,6 +31,7 @@ tags = [
     "Tactic: Initial Access",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_masquerading_communication_apps.toml
+++ b/rules/windows/defense_evasion_masquerading_communication_apps.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/05/05"
-integration = ["endpoint"]
+integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/05/05"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,7 @@ Identifies suspicious instances of communications apps, both unsigned and rename
 conceal malicious activity, bypass security features such as allowlists, or trick users into executing malware.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "logs-sentinel_one_cloud_funnel.*", "endgame-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Masquerading as Communication Apps"
@@ -25,6 +25,8 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
+    "Data Source: SentinelOne",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -35,7 +37,7 @@ process where host.os.type == "windows" and
   (
     /* Slack */
     (process.name : "slack.exe" and not
-      (process.code_signature.subject_name in (
+      (process.code_signature.subject_name : (
         "Slack Technologies, Inc.",
         "Slack Technologies, LLC"
        ) and process.code_signature.trusted == true)
@@ -43,32 +45,32 @@ process where host.os.type == "windows" and
 
     /* WebEx */
     (process.name : "WebexHost.exe" and not
-      (process.code_signature.subject_name in ("Cisco WebEx LLC", "Cisco Systems, Inc.") and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : ("Cisco WebEx LLC", "Cisco Systems, Inc.") and process.code_signature.trusted == true)
     ) or
 
     /* Teams */
     (process.name : "Teams.exe" and not
-      (process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true)
     ) or
 
     /* Discord */
     (process.name : "Discord.exe" and not
-      (process.code_signature.subject_name == "Discord Inc." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : "Discord Inc." and process.code_signature.trusted == true)
     ) or
 
     /* RocketChat */
     (process.name : "Rocket.Chat.exe" and not
-      (process.code_signature.subject_name == "Rocket.Chat Technologies Corp." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : "Rocket.Chat Technologies Corp." and process.code_signature.trusted == true)
     ) or
 
     /* Mattermost */
     (process.name : "Mattermost.exe" and not
-      (process.code_signature.subject_name == "Mattermost, Inc." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : "Mattermost, Inc." and process.code_signature.trusted == true)
     ) or
 
     /* WhatsApp */
     (process.name : "WhatsApp.exe" and not
-      (process.code_signature.subject_name in (
+      (process.code_signature.subject_name : (
         "WhatsApp LLC",
         "WhatsApp, Inc",
         "24803D75-212C-471A-BC57-9EF86AB91435"
@@ -77,17 +79,17 @@ process where host.os.type == "windows" and
 
     /* Zoom */
     (process.name : "Zoom.exe" and not
-      (process.code_signature.subject_name == "Zoom Video Communications, Inc." and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : "Zoom Video Communications, Inc." and process.code_signature.trusted == true)
     ) or
 
     /* Outlook */
     (process.name : "outlook.exe" and not
-      (process.code_signature.subject_name == "Microsoft Corporation" and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true)
     ) or
 
     /* Thunderbird */
     (process.name : "thunderbird.exe" and not
-      (process.code_signature.subject_name == "Mozilla Corporation" and process.code_signature.trusted == true)
+      (process.code_signature.subject_name : "Mozilla Corporation" and process.code_signature.trusted == true)
     )
   )
 '''

--- a/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
+++ b/rules/windows/defense_evasion_masquerading_renamed_autoit.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/09/01"
-integration = ["endpoint", "windows", "m365_defender"]
+integration = ["endpoint", "windows", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/05/05"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -43,6 +43,7 @@ index = [
     "logs-windows.sysmon_operational-*",
     "endgame-*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -110,6 +111,7 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_microsoft_defender_tampering.toml
+++ b/rules/windows/defense_evasion_microsoft_defender_tampering.toml
@@ -112,10 +112,10 @@ registry where host.os.type == "windows" and event.type == "change" and process.
     "?:\\Windows\\CCM\\CcmExec.exe", 
     "?:\\Windows\\System32\\DeviceEnroller.exe", 
     "?:\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe",
-    "\\Device\\HarddiskVolume?\\Windows\\system32\\svchost.exe", 
-    "\\Device\\HarddiskVolume?\\Windows\\CCM\\CcmExec.exe", 
-    "\\Device\\HarddiskVolume?\\Windows\\System32\\DeviceEnroller.exe", 
-    "\\Device\\HarddiskVolume?\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe"
+    "\\Device\\HarddiskVolume*\\Windows\\system32\\svchost.exe", 
+    "\\Device\\HarddiskVolume*\\Windows\\CCM\\CcmExec.exe", 
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\DeviceEnroller.exe", 
+    "\\Device\\HarddiskVolume*\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe"
   )
 
 /*

--- a/rules/windows/defense_evasion_microsoft_defender_tampering.toml
+++ b/rules/windows/defense_evasion_microsoft_defender_tampering.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/10/18"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/27"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Austin Songer"]
@@ -19,6 +19,7 @@ index = [
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
     "endgame-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -85,6 +86,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -109,7 +111,11 @@ registry where host.os.type == "windows" and event.type == "change" and process.
     "?:\\Windows\\system32\\svchost.exe", 
     "?:\\Windows\\CCM\\CcmExec.exe", 
     "?:\\Windows\\System32\\DeviceEnroller.exe", 
-    "?:\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe"
+    "?:\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe",
+    "\\Device\\HarddiskVolume?\\Windows\\system32\\svchost.exe", 
+    "\\Device\\HarddiskVolume?\\Windows\\CCM\\CcmExec.exe", 
+    "\\Device\\HarddiskVolume?\\Windows\\System32\\DeviceEnroller.exe", 
+    "\\Device\\HarddiskVolume?\\Program Files (x86)\\Trend Micro\\Security Agent\\tmuninst.exe"
   )
 
 /*


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.