### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 5

### DIFF
--- a/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
+++ b/rules/windows/defense_evasion_misc_lolbin_connecting_to_the_internet.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -43,6 +43,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -111,6 +112,7 @@ tags = [
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
     "Data Source: Sysmon",
 ]
 type = "eql"

--- a/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
+++ b/rules/windows/defense_evasion_ms_office_suspicious_regmod.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2022/01/12"
-integration = ["windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -82,35 +83,25 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type == "change" and registry.value : ("AccessVBOM", "VbaWarnings") and
+registry where host.os.type == "windows" and event.type == "change" and
+    registry.value : ("AccessVBOM", "VbaWarnings") and
     registry.path : (
-        /* Sysmon */
-        "HKU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "HKU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
-        "HKU\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "HKU\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
-        /* MDE */
-        "HKCU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "HKCU\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
-        "HKCU\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "HKCU\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
-        /* Endgame */
-        "\\REGISTRY\\USER\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "\\REGISTRY\\USER\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
-        "\\REGISTRY\\USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "\\REGISTRY\\USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
-        /* SentinelOne */
-        "USER\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "USER\\S-1-5-21-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings",
-        "USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
-        "USER\\S-1-12-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings"
+        "*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM",
+        "*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings"
         ) and
     registry.data.strings : ("0x00000001", "1")
+
+/*
+    Full registry key paths omitted due to data source variations:
+    "HKCU\\S-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\AccessVBOM"
+    "HKCU\\S-1-*\\SOFTWARE\\Microsoft\\Office\\*\\Security\\VbaWarnings"
+*/
 '''
 
 

--- a/rules/windows/defense_evasion_mshta_beacon.toml
+++ b/rules/windows/defense_evasion_mshta_beacon.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/09/02"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ index = [
     "logs-endpoint.events.network-*",
     "winlogbeat-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -65,6 +66,7 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
 ]

--- a/rules/windows/defense_evasion_msxsl_network.toml
+++ b/rules/windows/defense_evasion_msxsl_network.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/03/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -64,6 +65,7 @@ tags = [
     "Use Case: Threat Detection",
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Data Source: SentinelOne",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
 ]

--- a/rules/windows/defense_evasion_ntlm_downgrade.toml
+++ b/rules/windows/defense_evasion_ntlm_downgrade.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2025/04/14"
-integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "windows"]
+integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "windows", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/07/02"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ index = [
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
     "logs-windows.sysmon_operational-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -65,6 +66,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
     "Data Source: Sysmon",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.