### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 6

### DIFF
--- a/rules/windows/defense_evasion_persistence_account_tokenfilterpolicy.toml
+++ b/rules/windows/defense_evasion_persistence_account_tokenfilterpolicy.toml
@@ -97,8 +97,8 @@ registry where host.os.type == "windows" and event.type == "change" and
     "C:\\Windows\\system32\\omadmclient.exe",
 
     /* Crowdstrike specific exclusion as it uses NT Object paths */
-    "\\Device\\HarddiskVolume?\\system32\\deviceenroller.exe",
-    "\\Device\\HarddiskVolume?\\system32\\omadmclient.exe"
+    "\\Device\\HarddiskVolume*\\system32\\deviceenroller.exe",
+    "\\Device\\HarddiskVolume*\\system32\\omadmclient.exe"
   )
 '''
 

--- a/rules/windows/defense_evasion_persistence_account_tokenfilterpolicy.toml
+++ b/rules/windows/defense_evasion_persistence_account_tokenfilterpolicy.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2022/11/01"
-integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/07/03"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ index = [
     "endgame-*",
     "logs-sentinel_one_cloud_funnel.*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -76,6 +77,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: SentinelOne",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -92,7 +94,11 @@ registry where host.os.type == "windows" and event.type == "change" and
   not process.executable : (
     /* Intune */
     "C:\\Windows\\system32\\deviceenroller.exe",
-    "C:\\Windows\\system32\\omadmclient.exe"
+    "C:\\Windows\\system32\\omadmclient.exe",
+
+    /* Crowdstrike specific exclusion as it uses NT Object paths */
+    "\\Device\\HarddiskVolume?\\system32\\deviceenroller.exe",
+    "\\Device\\HarddiskVolume?\\system32\\omadmclient.exe"
   )
 '''
 

--- a/rules/windows/defense_evasion_proxy_execution_via_msdt.toml
+++ b/rules/windows/defense_evasion_proxy_execution_via_msdt.toml
@@ -81,7 +81,7 @@ type = "eql"
 
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
-  (process.pe.original_file_name == "msdt.exe" or process.name : "msdt.exe") and
+  (?process.pe.original_file_name == "msdt.exe" or process.name : "msdt.exe") and
   (
     process.args : ("IT_RebrowseForFile=*", "ms-msdt:/id", "ms-msdt:-id", "*FromBase64*") or
 
@@ -94,13 +94,13 @@ process where host.os.type == "windows" and event.type == "start" and
     (process.pe.original_file_name == "msdt.exe" and not process.name : "msdt.exe" and process.name != null) or
 
     (
-      process.pe.original_file_name == "msdt.exe" and
+      ?process.pe.original_file_name == "msdt.exe" and
       not process.executable : (
         "?:\\Windows\\system32\\msdt.exe",
         "?:\\Windows\\SysWOW64\\msdt.exe",
         /* Crowdstrike specific exclusion as it uses NT Object paths */
-        "\\Device\\HarddiskVolume?\\Windows\\system32\\msdt.exe",
-        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\msdt.exe"
+        "\\Device\\HarddiskVolume*\\Windows\\system32\\msdt.exe",
+        "\\Device\\HarddiskVolume*\\Windows\\SysWOW64\\msdt.exe"
       )
     )
   )

--- a/rules/windows/defense_evasion_proxy_execution_via_msdt.toml
+++ b/rules/windows/defense_evasion_proxy_execution_via_msdt.toml
@@ -1,6 +1,6 @@
 [metadata]
 creation_date = "2022/05/31"
-integration = ["endpoint", "windows", "m365_defender", "crowdstrike"]
+integration = ["endpoint", "windows", "m365_defender", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
 updated_date = "2025/08/26"
 
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-crowdstrike.fdr*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -74,6 +75,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: Sysmon",
     "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/windows/defense_evasion_proxy_execution_via_msdt.toml
+++ b/rules/windows/defense_evasion_proxy_execution_via_msdt.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2022/05/31"
-integration = ["endpoint", "windows", "m365_defender"]
+integration = ["endpoint", "windows", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ index = [
     "logs-windows.sysmon_operational-*",
     "endgame-*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -72,6 +73,7 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: Sysmon",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -79,18 +81,29 @@ type = "eql"
 
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
-   (process.pe.original_file_name == "msdt.exe" or process.name : "msdt.exe") and
-   (
+  (process.pe.original_file_name == "msdt.exe" or process.name : "msdt.exe") and
+  (
     process.args : ("IT_RebrowseForFile=*", "ms-msdt:/id", "ms-msdt:-id", "*FromBase64*") or
 
-    (process.args : "-af" and process.args : "/skip" and
-     process.parent.name : ("explorer.exe", "cmd.exe", "powershell.exe", "cscript.exe", "wscript.exe", "mshta.exe", "rundll32.exe", "regsvr32.exe") and
-     process.args : ("?:\\WINDOWS\\diagnostics\\index\\PCWDiagnostic.xml", "PCWDiagnostic.xml", "?:\\Users\\Public\\*", "?:\\Windows\\Temp\\*")) or
+    (
+      process.args : "-af" and process.args : "/skip" and
+      process.parent.name : ("explorer.exe", "cmd.exe", "powershell.exe", "cscript.exe", "wscript.exe", "mshta.exe", "rundll32.exe", "regsvr32.exe") and
+      process.args : ("?:\\WINDOWS\\diagnostics\\index\\PCWDiagnostic.xml", "PCWDiagnostic.xml", "?:\\Users\\Public\\*", "?:\\Windows\\Temp\\*")
+    ) or
 
     (process.pe.original_file_name == "msdt.exe" and not process.name : "msdt.exe" and process.name != null) or
 
-    (process.pe.original_file_name == "msdt.exe" and not process.executable : ("?:\\Windows\\system32\\msdt.exe", "?:\\Windows\\SysWOW64\\msdt.exe"))
+    (
+      process.pe.original_file_name == "msdt.exe" and
+      not process.executable : (
+        "?:\\Windows\\system32\\msdt.exe",
+        "?:\\Windows\\SysWOW64\\msdt.exe",
+        /* Crowdstrike specific exclusion as it uses NT Object paths */
+        "\\Device\\HarddiskVolume?\\Windows\\system32\\msdt.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\msdt.exe"
+      )
     )
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_reg_disable_enableglobalqueryblocklist.toml
+++ b/rules/windows/defense_evasion_reg_disable_enableglobalqueryblocklist.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2024/05/31"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ index = [
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
     "endgame-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -76,6 +77,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
     "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/windows/defense_evasion_rundll32_no_arguments.toml
+++ b/rules/windows/defense_evasion_rundll32_no_arguments.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/09/02"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/08/12"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -37,7 +37,7 @@ Identifies child processes of unusual instances of RunDLL32 where the command li
 RunDLL32 could indicate malicious activity.
 """
 from = "now-60m"
-index = ["logs-endpoint.events.process-*", "winlogbeat-*", "logs-windows.sysmon_operational-*"]
+index = ["logs-endpoint.events.process-*", "winlogbeat-*", "logs-windows.sysmon_operational-*", "logs-crowdstrike.fdr*"]
 interval = "30m"
 language = "eql"
 license = "Elastic License v2"
@@ -108,6 +108,7 @@ tags = [
     "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
+++ b/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
@@ -82,7 +82,6 @@ type = "eql"
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
   registry.value : "EnableAt" and
-  registry.path : "*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt" and
   registry.data.strings : ("1", "0x00000001")
 '''
 

--- a/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
+++ b/rules/windows/defense_evasion_scheduledjobs_at_protocol_enabled.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/23"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -72,6 +73,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -79,11 +81,9 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-  registry.path : (
-    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt",
-    "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt",
-    "MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt"
-  ) and registry.data.strings : ("1", "0x00000001")
+  registry.value : "EnableAt" and
+  registry.path : "*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\Configuration\\EnableAt" and
+  registry.data.strings : ("1", "0x00000001")
 '''
 
 


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.