### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 8

### DIFF
--- a/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
+++ b/rules/windows/defense_evasion_system_critical_proc_abnormal_file_activity.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/08/19"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -44,6 +44,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -113,6 +114,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_unusual_process_network_connection.toml
+++ b/rules/windows/defense_evasion_unusual_process_network_connection.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -58,6 +59,7 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 

--- a/rules/windows/defense_evasion_via_filter_manager.toml
+++ b/rules/windows/defense_evasion_via_filter_manager.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows", "m365_defender", "system"]
+integration = ["endpoint", "windows", "m365_defender", "system", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -45,6 +45,7 @@ index = [
     "logs-windows.forwarded*",
     "logs-windows.sysmon_operational-*",
     "winlogbeat-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -115,6 +116,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: Windows Security Event Logs",
     "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/defense_evasion_wdac_policy_by_unusual_process.toml
+++ b/rules/windows/defense_evasion_wdac_policy_by_unusual_process.toml
@@ -75,6 +75,7 @@ type = "eql"
 
 query = '''
 file where host.os.type == "windows" and event.action != "deletion" and
+  file.extension : ("p7b", "cip") and
   file.path : (
     "?:\\Windows\\System32\\CodeIntegrity\\*.p7b",
     "?:\\Windows\\System32\\CodeIntegrity\\CiPolicies\\Active\\*.cip",

--- a/rules/windows/defense_evasion_wdac_policy_by_unusual_process.toml
+++ b/rules/windows/defense_evasion_wdac_policy_by_unusual_process.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2025/02/28"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -67,14 +68,23 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 file where host.os.type == "windows" and event.action != "deletion" and
- file.path : ("?:\\Windows\\System32\\CodeIntegrity\\*.p7b", "?:\\Windows\\System32\\CodeIntegrity\\CiPolicies\\Active\\*.cip") and
- not process.executable : "C:\\Windows\\System32\\poqexec.exe"
+  file.path : (
+    "?:\\Windows\\System32\\CodeIntegrity\\*.p7b",
+    "?:\\Windows\\System32\\CodeIntegrity\\CiPolicies\\Active\\*.cip",
+    "\\Device\\HarddiskVolume?\\Windows\\System32\\CodeIntegrity\\*.p7b",
+    "\\Device\\HarddiskVolume?\\Windows\\System32\\CodeIntegrity\\CiPolicies\\Active\\*.cip"
+  ) and
+  not process.executable : (
+    "C:\\Windows\\System32\\poqexec.exe",
+    "\\Device\\HarddiskVolume?\\Windows\\System32\\poqexec.exe"
+  )
 '''
 
 

--- a/rules/windows/defense_evasion_wdac_policy_by_unusual_process.toml
+++ b/rules/windows/defense_evasion_wdac_policy_by_unusual_process.toml
@@ -78,12 +78,12 @@ file where host.os.type == "windows" and event.action != "deletion" and
   file.path : (
     "?:\\Windows\\System32\\CodeIntegrity\\*.p7b",
     "?:\\Windows\\System32\\CodeIntegrity\\CiPolicies\\Active\\*.cip",
-    "\\Device\\HarddiskVolume?\\Windows\\System32\\CodeIntegrity\\*.p7b",
-    "\\Device\\HarddiskVolume?\\Windows\\System32\\CodeIntegrity\\CiPolicies\\Active\\*.cip"
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\CodeIntegrity\\*.p7b",
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\CodeIntegrity\\CiPolicies\\Active\\*.cip"
   ) and
   not process.executable : (
     "C:\\Windows\\System32\\poqexec.exe",
-    "\\Device\\HarddiskVolume?\\Windows\\System32\\poqexec.exe"
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe"
   )
 '''
 

--- a/rules/windows/defense_evasion_wsl_filesystem.toml
+++ b/rules/windows/defense_evasion_wsl_filesystem.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/01/12"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.file-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -67,6 +68,7 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
+    "Data Source: SentinelOne",
 ]
 timestamp_override = "event.ingested"
 type = "eql"


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.