### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 9

### DIFF
--- a/rules/windows/defense_evasion_wsl_registry_modification.toml
+++ b/rules/windows/defense_evasion_wsl_registry_modification.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/01/12"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -73,6 +74,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timeline_id = "3e47ef71-ebfc-4520-975c-cb27fc090799"

--- a/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
+++ b/rules/windows/execution_command_prompt_connecting_to_the_internet.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -48,6 +48,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -118,6 +119,7 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 

--- a/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
+++ b/rules/windows/execution_html_help_executable_program_connecting_to_the_internet.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -43,6 +43,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -120,6 +121,7 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 

--- a/rules/windows/execution_powershell_susp_args_via_winscript.toml
+++ b/rules/windows/execution_powershell_susp_args_via_winscript.toml
@@ -1,12 +1,12 @@
 [metadata]
 creation_date = "2024/09/09"
-integration = ["windows", "system", "sentinel_one_cloud_funnel", "m365_defender"]
+integration = ["windows", "system", "sentinel_one_cloud_funnel", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
-description = "Identifies PowerShell.exe or Cmd.exe execution spawning from Windows Script Host processes Wscript.exe.\n"
+description = "Identifies PowerShell.exe or Cmd.exe execution spawning from Windows Script Host processes Wscript.exe."
 from = "now-9m"
 index = [
     "logs-m365_defender.event-*",
@@ -15,6 +15,8 @@ index = [
     "logs-windows.forwarded*",
     "logs-windows.sysmon_operational-*",
     "winlogbeat-*",
+    "endgame-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -61,19 +63,21 @@ tags = [
     "OS: Windows",
     "Use Case: Threat Detection",
     "Tactic: Execution",
+    "Resources: Investigation Guide",
     "Data Source: Windows Security Event Logs",
     "Data Source: Sysmon",
     "Data Source: SentinelOne",
     "Data Source: Microsoft Defender for Endpoint",
-    "Resources: Investigation Guide",
+    "Data Source: Elastic Endgame",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-process where host.os.type == "windows" and event.action == "start" and
+process where host.os.type == "windows" and event.type == "start" and
   process.name : ("powershell.exe", "pwsh.exe", "cmd.exe") and
-  process.parent.name : ("wscript.exe", "mshta.exe") and ?process.parent.args : "?:\\Users\\*"
+  process.parent.name : ("wscript.exe", "mshta.exe")
 '''
 
 

--- a/rules/windows/execution_psexec_lateral_movement_command.toml
+++ b/rules/windows/execution_psexec_lateral_movement_command.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -70,6 +71,7 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.