### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 11

### DIFF
--- a/rules/windows/lateral_movement_defense_evasion_lanman_nullsessionpipe_modification.toml
+++ b/rules/windows/lateral_movement_defense_evasion_lanman_nullsessionpipe_modification.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/03/22"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "winlogbeat-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -74,6 +75,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -81,12 +83,10 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-registry.path : (
-    "HKLM\\SYSTEM\\*ControlSet*\\services\\LanmanServer\\Parameters\\NullSessionPipes",
-    "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\services\\LanmanServer\\Parameters\\NullSessionPipes",
-    "MACHINE\\SYSTEM\\*ControlSet*\\services\\LanmanServer\\Parameters\\NullSessionPipes"
-) and length(registry.data.strings) > 0 and
-not registry.data.strings : "(empty)"
+  registry.value : "NullSessionPipes" and
+  registry.path : "*\\SYSTEM\\*ControlSet*\\services\\LanmanServer\\Parameters\\NullSessionPipes" and
+  length(registry.data.strings) > 0 and
+  not registry.data.strings : "(empty)"
 '''
 
 

--- a/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
+++ b/rules/windows/lateral_movement_incoming_winrm_shell_execution.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/24"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/05/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -72,6 +73,7 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 

--- a/rules/windows/lateral_movement_powershell_remoting_target.toml
+++ b/rules/windows/lateral_movement_powershell_remoting_target.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/24"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/05/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -22,6 +22,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -75,6 +76,7 @@ tags = [
     "Tactic: Execution",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: SentinelOne",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/windows/lateral_movement_rdp_enabled_registry.toml
+++ b/rules/windows/lateral_movement_rdp_enabled_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/25"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -73,24 +74,30 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-  registry.path : (
-    "HKLM\\SYSTEM\\*ControlSet*\\Control\\Terminal Server\\fDenyTSConnections",
-    "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Control\\Terminal Server\\fDenyTSConnections",
-    "MACHINE\\*ControlSet*\\Control\\Terminal Server\\fDenyTSConnections"
-  ) and
+  registry.value : "fDenyTSConnections" and
+  registry.path : "*\\SYSTEM\\*ControlSet*\\Control\\Terminal Server\\fDenyTSConnections" and
   registry.data.strings : ("0", "0x00000000") and
-  not process.executable : ("?:\\Windows\\System32\\SystemPropertiesRemote.exe", 
-                            "?:\\Windows\\System32\\SystemPropertiesComputerName.exe", 
-                            "?:\\Windows\\System32\\SystemPropertiesAdvanced.exe", 
-                            "?:\\Windows\\System32\\SystemSettingsAdminFlows.exe", 
-                            "?:\\Windows\\WinSxS\\*\\TiWorker.exe", 
-                            "?:\\Windows\\system32\\svchost.exe")
+  not process.executable : (
+        "?:\\Windows\\System32\\SystemPropertiesRemote.exe",
+        "?:\\Windows\\System32\\SystemPropertiesComputerName.exe",
+        "?:\\Windows\\System32\\SystemPropertiesAdvanced.exe",
+        "?:\\Windows\\System32\\SystemSettingsAdminFlows.exe",
+        "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+        "?:\\Windows\\system32\\svchost.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\System32\\SystemPropertiesRemote.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\System32\\SystemPropertiesComputerName.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\System32\\SystemPropertiesAdvanced.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\System32\\SystemSettingsAdminFlows.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\WinSxS\\*\\TiWorker.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\system32\\svchost.exe"
+  )
 '''
 
 

--- a/rules/windows/persistence_adobe_hijack_persistence.toml
+++ b/rules/windows/persistence_adobe_hijack_persistence.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -41,6 +41,7 @@ index = [
     "endgame-*",
     "logs-sentinel_one_cloud_funnel.*",
     "logs-m365_defender.event-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -97,14 +98,6 @@ Attackers can replace the `RdrCEF.exe` executable with their own to maintain the
 references = ["https://twitter.com/pabraeken/status/997997818362155008"]
 risk_score = 21
 rule_id = "2bf78aa2-9c56-48de-b139-f169bf99cf86"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "low"
 tags = [
     "Domain: Endpoint",
@@ -117,14 +110,21 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: SentinelOne",
     "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 file where host.os.type == "windows" and event.type == "creation" and
-  file.path : ("?:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-               "?:\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe") and
+  file.path : (
+    "?:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
+    "?:\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
+
+    /* Crowdstrike specific condition as it uses NT Object paths */
+    "\\Device\\HarddiskVolume?\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
+    "\\Device\\HarddiskVolume?\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe"
+  ) and
   not process.name : "msiexec.exe"
 '''
 


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.