### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 13

### DIFF
--- a/rules/windows/persistence_ms_office_addins_file.toml
+++ b/rules/windows/persistence_ms_office_addins_file.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/10/16"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -68,6 +69,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -76,12 +78,16 @@ type = "eql"
 query = '''
 file where host.os.type == "windows" and event.type != "deletion" and
  file.extension : ("wll","xll","ppa","ppam","xla","xlam") and
- file.path :
-    (
+ file.path : (
     "C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
     "C:\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
-    "C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
-    )
+    "C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*",
+
+    /* Crowdstrike specific condition as it uses NT Object paths */
+    "\\Device\\HarddiskVolume?\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
+    "\\Device\\HarddiskVolume?\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
+    "\\Device\\HarddiskVolume?\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
+ )
 '''
 
 

--- a/rules/windows/persistence_ms_office_addins_file.toml
+++ b/rules/windows/persistence_ms_office_addins_file.toml
@@ -84,9 +84,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
     "C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*",
 
     /* Crowdstrike specific condition as it uses NT Object paths */
-    "\\Device\\HarddiskVolume?\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
-    "\\Device\\HarddiskVolume?\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
-    "\\Device\\HarddiskVolume?\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
+    "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
+    "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
+    "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
  )
 '''
 

--- a/rules/windows/persistence_ms_outlook_vba_template.toml
+++ b/rules/windows/persistence_ms_outlook_vba_template.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/23"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -73,6 +74,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -80,7 +82,8 @@ type = "eql"
 
 query = '''
 file where host.os.type == "windows" and event.type != "deletion" and
- file.path : "C:\\Users\\*\\AppData\\Roaming\\Microsoft\\Outlook\\VbaProject.OTM"
+  file.name : "VbaProject.OTM" and
+  file.path : "*\\AppData\\Roaming\\Microsoft\\Outlook\\VbaProject.OTM"
 '''
 
 

--- a/rules/windows/persistence_ms_outlook_vba_template.toml
+++ b/rules/windows/persistence_ms_outlook_vba_template.toml
@@ -83,7 +83,7 @@ type = "eql"
 query = '''
 file where host.os.type == "windows" and event.type != "deletion" and
   file.name : "VbaProject.OTM" and
-  file.path : "*\\AppData\\Roaming\\Microsoft\\Outlook\\VbaProject.OTM"
+  file.path : ("?:\\Users\\*\\AppData\\Roaming\\Microsoft\\Outlook\\VbaProject.OTM", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Outlook\\VbaProject.OTM")
 '''
 
 

--- a/rules/windows/persistence_msoffice_startup_registry.toml
+++ b/rules/windows/persistence_msoffice_startup_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/08/22"
-integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,8 @@ index = [
     "logs-m365_defender.event-*",
     "endgame-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
+    "logs-windows.sysmon_operational-*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -71,6 +73,8 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
+    "Data Source: Sysmon",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/windows/persistence_netsh_helper_dll.toml
+++ b/rules/windows/persistence_netsh_helper_dll.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/08/29"
-integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "windows"]
+integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "windows", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
     "logs-windows.sysmon_operational-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -68,6 +69,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
     "Data Source: Sysmon",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/windows/persistence_powershell_profiles.toml
+++ b/rules/windows/persistence_powershell_profiles.toml
@@ -130,9 +130,12 @@ type = "eql"
 query = '''
 file where host.os.type == "windows" and event.type != "deletion" and
   file.name : ("profile.ps1", "Microsoft.Powershell_profile.ps1") and
-  file.path : ("*\\Documents\\WindowsPowerShell\\*",
-               "*\\Documents\\PowerShell\\*",
-               "*\\Windows\\System32\\WindowsPowerShell\\*")
+  file.path : ("?:\\Users\\*\\Documents\\WindowsPowerShell\\*.ps1", 
+                    "?:\\Users\\*\\Documents\\PowerShell\\*.ps1", 
+                    "?:\\Windows\\System32\\WindowsPowerShell\\*.ps1", 
+                    "\\Device\\HarddiskVolume*\\Users\\*\\Documents\\WindowsPowerShell\\*.ps1", 
+                    "\\Device\\HarddiskVolume*\\Users\\*\\Documents\\PowerShell\\*.ps1", 
+                    "\\Device\\HarddiskVolume*\\Windows\\System32\\WindowsPowerShell\\*.ps1")
 '''
 
 

--- a/rules/windows/persistence_powershell_profiles.toml
+++ b/rules/windows/persistence_powershell_profiles.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2022/10/13"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -45,6 +45,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -120,6 +121,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -127,10 +129,10 @@ type = "eql"
 
 query = '''
 file where host.os.type == "windows" and event.type != "deletion" and
-  file.path : ("?:\\Users\\*\\Documents\\WindowsPowerShell\\*",
-               "?:\\Users\\*\\Documents\\PowerShell\\*",
-               "?:\\Windows\\System32\\WindowsPowerShell\\*") and
-  file.name : ("profile.ps1", "Microsoft.Powershell_profile.ps1")
+  file.name : ("profile.ps1", "Microsoft.Powershell_profile.ps1") and
+  file.path : ("*\\Documents\\WindowsPowerShell\\*",
+               "*\\Documents\\PowerShell\\*",
+               "*\\Windows\\System32\\WindowsPowerShell\\*")
 '''
 
 


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.