### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 14

### DIFF
--- a/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
+++ b/rules/windows/persistence_suspicious_scheduled_task_runtime.toml
@@ -1,15 +1,15 @@
 [metadata]
 creation_date = "2020/11/19"
-integration = ["endpoint"]
+integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2025/04/07"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
 description = "Identifies execution of a suspicious program via scheduled tasks by looking at process lineage and command line usage."
 false_positives = ["Legitimate scheduled tasks running third party software."]
 from = "now-9m"
-index = ["logs-endpoint.events.process-*"]
+index = ["logs-endpoint.events.process-*", "logs-windows.sysmon_operational-*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Execution via Scheduled Task"
@@ -62,6 +62,7 @@ tags = [
     "Tactic: Execution",
     "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
+    "Data Source: Sysmon",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/windows/persistence_suspicious_service_created_registry.toml
+++ b/rules/windows/persistence_suspicious_service_created_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/23"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "winlogbeat-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -71,6 +72,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -79,10 +81,7 @@ type = "eql"
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
   registry.value : "ImagePath" and
-  registry.path : (
-    "HKLM\\SYSTEM\\ControlSet*\\Services\\*\\ImagePath",
-    "\\REGISTRY\\MACHINE\\SYSTEM\\ControlSet*\\Services\\*\\ImagePath"
-    ) and
+  registry.path : "*\\SYSTEM\\ControlSet*\\Services\\*\\ImagePath" and
   /* add suspicious registry ImagePath values here */
   registry.data.strings : ("%COMSPEC%*", "*\\.\\pipe\\*")
 '''

--- a/rules/windows/persistence_time_provider_mod.toml
+++ b/rules/windows/persistence_time_provider_mod.toml
@@ -128,7 +128,7 @@ registry where host.os.type == "windows" and event.type == "change" and
   registry.data.strings:"*.dll" and
   not
   (
-    process.name : "msiexec.exe" and
+    process.executable : ("?:\\Windows\\System32\\msiexec.exe", "\\Device\\HarddiskVolume*\\Windows\\System32\\msiexec.exe") and
     registry.data.strings : "?:\\Program Files\\VMware\\VMware Tools\\vmwTimeProvider\\vmwTimeProvider.dll"
   ) and
   not registry.data.strings : "C:\\Windows\\SYSTEM32\\w32time.DLL"

--- a/rules/windows/persistence_time_provider_mod.toml
+++ b/rules/windows/persistence_time_provider_mod.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/01/19"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [transform]
 [[transform.osquery]]
@@ -46,6 +46,7 @@ index = [
     "winlogbeat-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -115,6 +116,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -122,15 +124,11 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-  registry.path: (
-    "HKLM\\SYSTEM\\*ControlSet*\\Services\\W32Time\\TimeProviders\\*",
-    "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Services\\W32Time\\TimeProviders\\*",
-    "MACHINE\\SYSTEM\\*ControlSet*\\Services\\W32Time\\TimeProviders\\*"
-  ) and
+  registry.path: "*\\SYSTEM\\*ControlSet*\\Services\\W32Time\\TimeProviders\\*" and
   registry.data.strings:"*.dll" and
   not
   (
-    process.executable : "?:\\Windows\\System32\\msiexec.exe" and
+    process.name : "msiexec.exe" and
     registry.data.strings : "?:\\Program Files\\VMware\\VMware Tools\\vmwTimeProvider\\vmwTimeProvider.dll"
   ) and
   not registry.data.strings : "C:\\Windows\\SYSTEM32\\w32time.DLL"

--- a/rules/windows/persistence_via_hidden_run_key_valuename.toml
+++ b/rules/windows/persistence_via_hidden_run_key_valuename.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/15"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "crowdstrike", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -11,7 +11,15 @@ Identifies a persistence mechanism that utilizes the NtSetValueKey native API to
 registry key. An adversary may use this method to hide from system utilities such as the Registry Editor (regedit).
 """
 from = "now-9m"
-index = ["logs-endpoint.events.registry-*", "winlogbeat-*", "logs-windows.sysmon_operational-*", "endgame-*"]
+index = [
+    "logs-endpoint.events.registry-*",
+    "winlogbeat-*",
+    "logs-windows.sysmon_operational-*",
+    "endgame-*",
+    "logs-crowdstrike.fdr*",
+    "logs-sentinel_one_cloud_funnel.*",
+    "logs-m365_defender.event-*",
+]
 language = "eql"
 license = "Elastic License v2"
 name = "Persistence via Hidden Run Key Detected"
@@ -56,14 +64,6 @@ references = [
 ]
 risk_score = 73
 rule_id = "a9b05c3b-b304-4bf9-970d-acdfaef2944c"
-setup = """## Setup
-
-If enabling an EQL rule on a non-elastic-agent index (such as beats) for versions <8.2,
-events will not define `event.ingested` and default fallback for EQL rules was not added until version 8.2.
-Hence for this rule to work effectively, users will need to add a custom ingest pipeline to populate
-`event.ingested` to @timestamp.
-For more details on adding a custom ingest pipeline refer - https://www.elastic.co/guide/en/fleet/current/data-streams-pipeline-tutorial.html
-"""
 severity = "high"
 tags = [
     "Domain: Endpoint",
@@ -72,10 +72,13 @@ tags = [
     "Tactic: Persistence",
     "Tactic: Defense Evasion",
     "Tactic: Execution",
+    "Resources: Investigation Guide",
     "Data Source: Elastic Endgame",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
-    "Resources: Investigation Guide",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Data Source: Microsoft Defender for Endpoint",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -83,18 +86,12 @@ type = "eql"
 query = '''
 /* Registry Path ends with backslash */
 registry where host.os.type == "windows" and event.type == "change" and length(registry.data.strings) > 0 and
- registry.path : ("HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
-                  "HKU\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
-                  "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
-                  "HKLM\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run\\",
-                  "HKEY_USERS\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\",
-                  "HKU\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\",
-                  "\\REGISTRY\\MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\",
-                  "\\REGISTRY\\USER\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
-                  "\\REGISTRY\\MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
-                  "\\REGISTRY\\MACHINE\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run\\",
-                  "\\REGISTRY\\USER\\*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\",
-                  "\\REGISTRY\\MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\")
+  registry.path : "*\\Run\\" and
+  registry.path : (
+    "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\",
+    "*\\Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run\\",
+    "*\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run\\"
+  )
 '''
 
 

--- a/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
+++ b/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
@@ -89,8 +89,8 @@ registry where host.os.type == "windows" and event.type == "change" and
         "C:\\Windows\\System32\\msiexec.exe",
         "C:\\Windows\\SysWOW64\\msiexec.exe",
         /* Crowdstrike specific exclusion as it uses NT Object paths */
-        "\\Device\\HarddiskVolume?\\Windows\\System32\\msiexec.exe",
-        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\msiexec.exe"
+        "\\Device\\HarddiskVolume*\\Windows\\System32\\msiexec.exe",
+        "\\Device\\HarddiskVolume*\\Windows\\SysWOW64\\msiexec.exe"
   )
 '''
 

--- a/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
+++ b/rules/windows/persistence_via_lsa_security_support_provider_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/18"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -71,6 +72,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -78,15 +80,18 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-   registry.path : (
-      "HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\Security Packages*",
-      "HKLM\\SYSTEM\\*ControlSet*\\Control\\Lsa\\OSConfig\\Security Packages*",
-      "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Control\\Lsa\\Security Packages*",
-      "\\REGISTRY\\MACHINE\\SYSTEM\\*ControlSet*\\Control\\Lsa\\OSConfig\\Security Packages*",
-      "MACHINE\\SYSTEM\\*ControlSet*\\Control\\Lsa\\Security Packages*",
-      "MACHINE\\SYSTEM\\*ControlSet*\\Control\\Lsa\\OSConfig\\Security Packages*"
-   ) and
-   not process.executable : ("C:\\Windows\\System32\\msiexec.exe", "C:\\Windows\\SysWOW64\\msiexec.exe")
+  registry.value : "Security Packages" and
+  registry.path : (
+      "*\\SYSTEM\\*ControlSet*\\Control\\Lsa\\Security Packages",
+      "*\\SYSTEM\\*ControlSet*\\Control\\Lsa\\OSConfig\\Security Packages"
+  ) and
+  not process.executable : (
+        "C:\\Windows\\System32\\msiexec.exe",
+        "C:\\Windows\\SysWOW64\\msiexec.exe",
+        /* Crowdstrike specific exclusion as it uses NT Object paths */
+        "\\Device\\HarddiskVolume?\\Windows\\System32\\msiexec.exe",
+        "\\Device\\HarddiskVolume?\\Windows\\SysWOW64\\msiexec.exe"
+  )
 '''
 
 


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.