### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 15

### DIFF
--- a/rules/windows/persistence_werfault_reflectdebugger.toml
+++ b/rules/windows/persistence_werfault_reflectdebugger.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/08/29"
-integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "windows"]
+integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "windows", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -17,6 +17,7 @@ index = [
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
     "logs-windows.sysmon_operational-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -69,6 +70,7 @@ tags = [
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
     "Data Source: Sysmon",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -76,11 +78,8 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-  registry.path : (
-    "HKLM\\Software\\Microsoft\\Windows\\Windows Error Reporting\\Hangs\\ReflectDebugger",
-    "\\REGISTRY\\MACHINE\\Software\\Microsoft\\Windows\\Windows Error Reporting\\Hangs\\ReflectDebugger",
-    "MACHINE\\Software\\Microsoft\\Windows\\Windows Error Reporting\\Hangs\\ReflectDebugger"
-  )
+  registry.value : "ReflectDebugger" and
+  registry.path : "*\\Software\\Microsoft\\Windows\\Windows Error Reporting\\Hangs\\ReflectDebugger"
 '''
 
 

--- a/rules/windows/privilege_escalation_disable_uac_registry.toml
+++ b/rules/windows/privilege_escalation_disable_uac_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/01/20"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -20,6 +20,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -91,23 +92,19 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
+  registry.value : ("EnableLUA", "ConsentPromptBehaviorAdmin", "PromptOnSecureDesktop") and
   registry.path :
     (
-      "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA",
-      "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\ConsentPromptBehaviorAdmin",
-      "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\PromptOnSecureDesktop",
-      "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA",
-      "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\ConsentPromptBehaviorAdmin",
-      "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\PromptOnSecureDesktop",
-      "MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA",
-      "MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\ConsentPromptBehaviorAdmin",
-      "MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\PromptOnSecureDesktop"
+      "*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA",
+      "*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\ConsentPromptBehaviorAdmin",
+      "*\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\PromptOnSecureDesktop"
     ) and
   registry.data.strings : ("0", "0x00000000")
 '''

--- a/rules/windows/privilege_escalation_exploit_cve_202238028.toml
+++ b/rules/windows/privilege_escalation_exploit_cve_202238028.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2024/04/23"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -15,6 +15,7 @@ index = [
     "winlogbeat-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -71,6 +72,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -80,8 +82,8 @@ query = '''
 file where host.os.type == "windows" and event.type != "deletion" and
     file.name : "MPDW-constraints.js" and
     file.path : (
-        "?:\\*\\Windows\\system32\\DriVerStoRe\\FiLeRePoSiToRy\\*\\MPDW-constraints.js",
-        "?:\\*\\Windows\\WinSxS\\amd64_microsoft-windows-printing-printtopdf_*\\MPDW-constraints.js"
+        "*\\Windows\\system32\\DriverStore\\FileRepository\\*\\MPDW-constraints.js",
+        "*\\Windows\\WinSxS\\amd64_microsoft-windows-printing-printtopdf_*\\MPDW-constraints.js"
     )
 '''
 

--- a/rules/windows/privilege_escalation_reg_service_imagepath_mod.toml
+++ b/rules/windows/privilege_escalation_reg_service_imagepath_mod.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2024/06/05"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "crowdstrike", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,15 @@ privileges from groups like Server Operators may change the ImagePath of service
 to execute commands.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.registry-*", "logs-windows.sysmon_operational-*", "winlogbeat-*"]
+index = [
+    "logs-endpoint.events.registry-*",
+    "logs-windows.sysmon_operational-*",
+    "winlogbeat-*",
+    "logs-crowdstrike.fdr*",
+    "logs-sentinel_one_cloud_funnel.*",
+    "logs-m365_defender.event-*",
+    "endgame-*",
+]
 language = "eql"
 license = "Elastic License v2"
 name = "Potential Privilege Escalation via Service ImagePath Modification"
@@ -63,14 +71,18 @@ tags = [
     "Tactic: Privilege Escalation",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
+    "Data Source: SentinelOne",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Elastic Endgame",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
-  event.action == "modification" and registry.value == "ImagePath" and
+  registry.value == "ImagePath" and
   registry.key : (
     "*\\ADWS", "*\\AppHostSvc", "*\\AppReadiness", "*\\AudioEndpointBuilder", "*\\AxInstSV", "*\\camsvc", "*\\CertSvc",
     "*\\COMSysApp", "*\\CscService", "*\\defragsvc", "*\\DeviceAssociationService", "*\\DeviceInstall", "*\\DevQueryBroker",

--- a/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
+++ b/rules/windows/privilege_escalation_rogue_windir_environment_var.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/26"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "winlogbeat-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -72,6 +73,7 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
@@ -81,16 +83,8 @@ query = '''
 registry where host.os.type == "windows" and event.type == "change" and
 registry.value : ("windir", "systemroot") and
 registry.path : (
-    "HKEY_USERS\\*\\Environment\\windir",
-    "HKEY_USERS\\*\\Environment\\systemroot",
-    "HKU\\*\\Environment\\windir",
-    "HKU\\*\\Environment\\systemroot",
-    "HKCU\\*\\Environment\\windir",
-    "HKCU\\*\\Environment\\systemroot",
-    "\\REGISTRY\\USER\\*\\Environment\\windir",
-    "\\REGISTRY\\USER\\*\\Environment\\systemroot",
-    "USER\\*\\Environment\\windir",
-    "USER\\*\\Environment\\systemroot"
+    "*\\Environment\\windir",
+    "*\\Environment\\systemroot"
     ) and
  not registry.data.strings : ("C:\\windows", "%SystemRoot%")
 '''

--- a/rules/windows/privilege_escalation_unquoted_service_path.toml
+++ b/rules/windows/privilege_escalation_unquoted_service_path.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2023/07/13"
-integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "windows", "system"]
+integration = ["endpoint", "m365_defender", "sentinel_one_cloud_funnel", "windows", "system", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/26"
 
 [rule]
 author = ["Elastic"]
@@ -19,6 +19,7 @@ index = [
     "logs-sentinel_one_cloud_funnel.*",
     "logs-system.security*",
     "logs-windows.sysmon_operational-*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -72,6 +73,7 @@ tags = [
     "Data Source: Elastic Endgame",
     "Data Source: Sysmon",
     "Data Source: Windows Security Event Logs",
+    "Data Source: Crowdstrike",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.