### PR TITLE
[Rule Tuning] Windows 3rd Party EDR Compatibility - Part 16

### DIFF
--- a/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
+++ b/rules/windows/defense_evasion_disable_posh_scriptblocklogging.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2022/01/31"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/08/27"
+updated_date = "2025/08/28"
 
 [rule]
 author = ["Elastic"]
@@ -18,6 +18,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -79,22 +80,26 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-    registry.path : (
-        "HKLM\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\\EnableScriptBlockLogging",
-        "\\REGISTRY\\MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\\EnableScriptBlockLogging",
-        "MACHINE\\SOFTWARE\\Policies\\Microsoft\\Windows\\PowerShell\\ScriptBlockLogging\\EnableScriptBlockLogging"
-    ) and registry.data.strings : ("0", "0x00000000") and
+    registry.value : "EnableScriptBlockLogging" and
+    registry.data.strings : ("0", "0x00000000") and
     not process.executable : (
           "?:\\Windows\\System32\\svchost.exe",
           "?:\\Windows\\System32\\DeviceEnroller.exe",
           "?:\\Windows\\system32\\omadmclient.exe",
-          "?:\\Program Files (x86)\\N-able Technologies\\AutomationManagerAgent\\AutomationManager.AgentService.exe"
+          "?:\\Program Files (x86)\\N-able Technologies\\AutomationManagerAgent\\AutomationManager.AgentService.exe",
+          
+          /* Crowdstrike specific exclusion as it uses NT Object paths */
+          "\\Device\\HarddiskVolume*\\Windows\\System32\\svchost.exe",
+          "\\Device\\HarddiskVolume*\\Windows\\System32\\DeviceEnroller.exe",
+          "\\Device\\HarddiskVolume*\\Windows\\system32\\omadmclient.exe",
+          "\\Device\\HarddiskVolume*\\Program Files (x86)\\N-able Technologies\\AutomationManagerAgent\\AutomationManager.AgentService.exe"
     )
 '''
 

--- a/rules/windows/defense_evasion_unusual_network_connection_via_dllhost.toml
+++ b/rules/windows/defense_evasion_unusual_network_connection_via_dllhost.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/05/28"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/28"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -69,6 +70,7 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 

--- a/rules/windows/defense_evasion_unusual_network_connection_via_rundll32.toml
+++ b/rules/windows/defense_evasion_unusual_network_connection_via_rundll32.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/02/18"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/08/12"
+updated_date = "2025/08/28"
 
 [rule]
 author = ["Elastic"]
@@ -16,6 +16,7 @@ index = [
     "logs-endpoint.events.process-*",
     "logs-endpoint.events.network-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -68,6 +69,7 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 

--- a/rules/windows/lateral_movement_scheduled_task_target.toml
+++ b/rules/windows/lateral_movement_scheduled_task_target.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/20"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/28"
 
 [rule]
 author = ["Elastic"]
@@ -13,6 +13,7 @@ index = [
     "logs-endpoint.events.network-*",
     "winlogbeat-*",
     "logs-windows.sysmon_operational-*",
+    "logs-sentinel_one_cloud_funnel.*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -57,6 +58,7 @@ tags = [
     "Resources: Investigation Guide",
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
+    "Data Source: SentinelOne",
 ]
 type = "eql"
 
@@ -69,7 +71,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
    source.ip != "127.0.0.1" and source.ip != "::1"
    ]
    [registry where host.os.type == "windows" and event.type == "change" and registry.value : "Actions" and
-    registry.path : "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions"]
+    registry.path : "*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Schedule\\TaskCache\\Tasks\\*\\Actions"]
 '''
 
 

--- a/rules/windows/persistence_appinitdlls_registry.toml
+++ b/rules/windows/persistence_appinitdlls_registry.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/18"
-integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
+integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/28"
 
 [transform]
 [[transform.osquery]]
@@ -55,6 +55,7 @@ index = [
     "endgame-*",
     "logs-m365_defender.event-*",
     "logs-sentinel_one_cloud_funnel.*",
+    "logs-crowdstrike.fdr*",
 ]
 language = "eql"
 license = "Elastic License v2"
@@ -127,20 +128,14 @@ tags = [
     "Data Source: Sysmon",
     "Data Source: Microsoft Defender for Endpoint",
     "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-  registry.path : (
-     "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
-     "HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
-     "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
-     "\\REGISTRY\\MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
-     "MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls",
-     "MACHINE\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls"
-  ) and
+  registry.value : "AppInit_Dlls" and
   not process.executable : (
      "?:\\Windows\\System32\\DriverStore\\FileRepository\\*\\Display.NvContainer\\NVDisplay.Container.exe",
      "?:\\Windows\\System32\\msiexec.exe",
@@ -149,8 +144,23 @@ registry where host.os.type == "windows" and event.type == "change" and
      "?:\\Program Files\\Commvault\\ContentStore*\\Base\\cvd.exe",
      "?:\\Program Files (x86)\\Commvault\\Base\\cvd.exe",
      "?:\\Program Files (x86)\\Commvault\\ContentStore*\\Base\\cvd.exe",
-     "?:\\Program Files\\NVIDIA Corporation\\Display.NvContainer\\NVDisplay.Container.exe"
+     "?:\\Program Files\\NVIDIA Corporation\\Display.NvContainer\\NVDisplay.Container.exe",
+
+     /* Crowdstrike specific condition as it uses NT Object paths */
+     "\\Device\\HarddiskVolume*\\Windows\\System32\\DriverStore\\FileRepository\\*\\Display.NvContainer\\NVDisplay.Container.exe",
+     "\\Device\\HarddiskVolume*\\Windows\\System32\\msiexec.exe",
+     "\\Device\\HarddiskVolume*\\Windows\\SysWOW64\\msiexec.exe",
+     "\\Device\\HarddiskVolume*\\Program Files\\Commvault\\Base\\cvd.exe",
+     "\\Device\\HarddiskVolume*\\Program Files\\Commvault\\ContentStore*\\Base\\cvd.exe",
+     "\\Device\\HarddiskVolume*\\Program Files (x86)\\Commvault\\Base\\cvd.exe",
+     "\\Device\\HarddiskVolume*\\Program Files (x86)\\Commvault\\ContentStore*\\Base\\cvd.exe",
+     "\\Device\\HarddiskVolume*\\Program Files\\NVIDIA Corporation\\Display.NvContainer\\NVDisplay.Container.exe"
   )
+  /*
+    Full registry key path omitted due to data source variations:
+    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls"
+    "HKLM\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows NT\\CurrentVersion\\Windows\\AppInit_Dlls"
+  */
 '''
 
 

--- a/rules/windows/privilege_escalation_printspooler_registry_copyfiles.toml
+++ b/rules/windows/privilege_escalation_printspooler_registry_copyfiles.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2020/11/26"
-integration = ["endpoint", "windows"]
+integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/28"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,14 @@ Exploitation involves chaining multiple primitives to load an arbitrary DLL into
 SYSTEM.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.registry-*", "endgame-*", "logs-windows.sysmon_operational-*", "winlogbeat-*"]
+index = [
+    "logs-endpoint.events.registry-*",
+    "endgame-*",
+    "logs-windows.sysmon_operational-*",
+    "winlogbeat-*",
+    "logs-sentinel_one_cloud_funnel.*",
+    "logs-m365_defender.event-*",
+]
 language = "eql"
 license = "Elastic License v2"
 name = "Suspicious Print Spooler Point and Print DLL"
@@ -68,23 +75,21 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Sysmon",
     "Resources: Investigation Guide",
+    "Data Source: SentinelOne",
+    "Data Source: Microsoft Defender for Endpoint",
 ]
 type = "eql"
 
 query = '''
 sequence by host.id with maxspan=30s
 [registry where host.os.type == "windows" and
- registry.path : (
-    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Print\\Printers\\*\\SpoolDirectory",
-    "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Print\\Printers\\*\\SpoolDirectory"
-    ) and
- registry.data.strings : "C:\\Windows\\System32\\spool\\drivers\\x64\\4"]
+   registry.value : "SpoolDirectory" and
+   registry.path : "*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Print\\Printers\\*\\SpoolDirectory" and
+   registry.data.strings : "C:\\Windows\\System32\\spool\\drivers\\x64\\4"]
 [registry where host.os.type == "windows" and
- registry.path : (
-    "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Print\\Printers\\*\\CopyFiles\\Payload\\Module",
-    "\\REGISTRY\\MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Print\\Printers\\*\\CopyFiles\\Payload\\Module"
-    ) and
- registry.data.strings : "C:\\Windows\\System32\\spool\\drivers\\x64\\4\\*"]
+   registry.value : "Module" and
+   registry.path : "*\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Print\\Printers\\*\\CopyFiles\\Payload\\Module" and
+   registry.data.strings : "C:\\Windows\\System32\\spool\\drivers\\x64\\4\\*"]
 '''
 
 

--- a/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
+++ b/rules/windows/privilege_escalation_unusual_printspooler_childprocess.toml
@@ -1,8 +1,8 @@
 [metadata]
 creation_date = "2021/07/06"
-integration = ["endpoint", "windows", "system"]
+integration = ["endpoint", "windows", "system", "crowdstrike", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/08/28"
 
 [rule]
 author = ["Elastic"]
@@ -17,7 +17,17 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["logs-endpoint.events.process-*", "logs-system.security*", "logs-windows.forwarded*", "winlogbeat-*"]
+index = [
+    "logs-endpoint.events.process-*",
+    "logs-system.security*",
+    "logs-windows.forwarded*",
+    "winlogbeat-*",
+    "logs-crowdstrike.fdr*",
+    "logs-sentinel_one_cloud_funnel.*",
+    "logs-m365_defender.event-*",
+    "endgame-*",
+    "logs-windows.sysmon_operational-*",
+]
 language = "eql"
 license = "Elastic License v2"
 name = "Unusual Print Spooler Child Process"
@@ -71,6 +81,11 @@ tags = [
     "Data Source: Elastic Defend",
     "Data Source: Windows Security Event Logs",
     "Resources: Investigation Guide",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Data Source: Microsoft Defender for Endpoint",
+    "Data Source: Elastic Endgame",
+    "Data Source: Sysmon",
 ]
 timestamp_override = "event.ingested"
 type = "eql"
@@ -89,7 +104,11 @@ process where host.os.type == "windows" and event.type == "start" and
  not (process.name : "regsvr32.exe" and process.command_line : "*PrintConfig.dll*") and
  not process.executable : (
     "?:\\Program Files (x86)\\CutePDF Writer\\CPWriter2.exe",
-    "?:\\Program Files (x86)\\GPLGS\\gswin32c.exe"
+    "?:\\Program Files (x86)\\GPLGS\\gswin32c.exe",
+
+    /* Crowdstrike specific condition as it uses NT Object paths */
+    "\\Device\\HarddiskVolume*\\Program Files (x86)\\CutePDF Writer\\CPWriter2.exe",
+    "\\Device\\HarddiskVolume*\\Program Files (x86)\\GPLGS\\gswin32c.exe"
  )
 '''
 


### PR DESCRIPTION
## Issue

Related (but not limited) to https://github.com/elastic/ia-trade-team/issues/498

## Summary

This PR is part of a series that adds compatibility for additional data sources, including CrowdStrike, SentinelOne, Microsoft Defender for Endpoint, Endgame, and Sysmon.

To review this PR, you can use the [EDR Field Compatibility Matrix](https://docs.google.com/spreadsheets/d/1ZaRmSXIVYLO9AGXeZge3u0W938aGxbfd6Vha52Rs1_I/edit?usp=sharing), which details field compatibility for each event.category across EDR data sources.

Some changes go beyond metadata and include logic updates to optimize, simplify, or account for differences between data sources (For example, CrowdStrike uses NT Object paths for Windows paths instead of drive letters.). Please review these cases with extra attention, and don’t hesitate to ask questions.