### PR TITLE
[Rule Tuning] Adjust process.code_signature.trusted condition

### DIFF
--- a/rules/windows/command_and_control_common_llm_endpoint.toml
+++ b/rules/windows/command_and_control_common_llm_endpoint.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/09/01"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/09/01"
+updated_date = "2025/09/05"
 
 
 [rule]
@@ -78,7 +78,10 @@ network where host.os.type == "windows" and dns.question.name != null and
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  (process.executable : ("?:\\Users\\*.exe", "", "?:\\ProgramData\\*.exe") and ?process.code_signature.trusted != true)
+  (
+    process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe") and
+    (?process.code_signature.trusted == false or ?process.code_signature.exist == false)
+  )
  ) and
     dns.question.name : (
     // Major LLM APIs

--- a/rules/windows/command_and_control_common_llm_endpoint.toml
+++ b/rules/windows/command_and_control_common_llm_endpoint.toml
@@ -80,7 +80,7 @@ network where host.os.type == "windows" and dns.question.name != null and
 
   (
     process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe") and
-    (?process.code_signature.trusted == false or ?process.code_signature.exist == false)
+    (?process.code_signature.trusted == false or ?process.code_signature.exists == false)
   )
  ) and
     dns.question.name : (

--- a/rules/windows/command_and_control_dns_susp_tld.toml
+++ b/rules/windows/command_and_control_dns_susp_tld.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/08/20"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/08/20"
+updated_date = "2025/09/05"
 
 [rule]
 author = ["Elastic"]
@@ -77,9 +77,9 @@ network where host.os.type == "windows" and dns.question.name != null and
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
                   "bitsadmin.exe", "InstallUtil.exe", "python.exe", "regsvr32.exe", "dllhost.exe", "node.exe",
                   "java.exe", "javaw.exe", "*.pif", "*.com", "*.scr") or
-  ?process.code_signature.trusted != true or
+  (?process.code_signature.trusted == false or ?process.code_signature.exist == false) or
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
-  process.executable : ("?:\\Users\\*.exe", "", "?:\\ProgramData\\*.exe")
+  process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
  ) and
 dns.question.name regex """.*\.(top|buzz|xyz|rest|ml|cf|gq|ga|onion|monster|cyou|quest|cc|bar|cfd|click|cam|surf|tk|shop|club|icu|pw|ws|online|fun|life|boats|store|hair|skin|motorcycles|christmas|lol|makeup|mom|bond|beauty|biz|live|work|zip|country|accountant|date|party|science|loan|win|men|faith|review|racing|download|host)"""
 '''

--- a/rules/windows/command_and_control_dns_susp_tld.toml
+++ b/rules/windows/command_and_control_dns_susp_tld.toml
@@ -77,7 +77,7 @@ network where host.os.type == "windows" and dns.question.name != null and
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
                   "bitsadmin.exe", "InstallUtil.exe", "python.exe", "regsvr32.exe", "dllhost.exe", "node.exe",
                   "java.exe", "javaw.exe", "*.pif", "*.com", "*.scr") or
-  (?process.code_signature.trusted == false or ?process.code_signature.exist == false) or
+  (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
   process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
  ) and

--- a/rules/windows/discovery_host_public_ip_address_lookup.toml
+++ b/rules/windows/discovery_host_public_ip_address_lookup.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/08/20"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/08/20"
+updated_date = "2025/09/05"
 
 [rule]
 author = ["Elastic"]
@@ -78,11 +78,11 @@ network where host.os.type == "windows" and dns.question.name != null and
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
   "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
 
-  ?process.code_signature.trusted != true or
+  (?process.code_signature.trusted == false or ?process.code_signature.exist == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "", "?:\\ProgramData\\*.exe",  "?\\Device\\HarddiskVolume?\\Users\\*.exe",  "?\\Device\\HarddiskVolume?\\ProgramData\\*.exe")
+  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe", "?\\Device\\HarddiskVolume?\\Users\\*.exe", "?\\Device\\HarddiskVolume?\\ProgramData\\*.exe")
  ) and
  dns.question.name :
          (

--- a/rules/windows/discovery_host_public_ip_address_lookup.toml
+++ b/rules/windows/discovery_host_public_ip_address_lookup.toml
@@ -78,7 +78,7 @@ network where host.os.type == "windows" and dns.question.name != null and
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
   "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
 
-  (?process.code_signature.trusted == false or ?process.code_signature.exist == false) or
+  (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 


### PR DESCRIPTION
## Summary

I suggested using `?process.code_signature.trusted != true` in Samir's PR in order to be compatible with S1 `process.code_signature.trusted` which is only set if true, but it turns out that as the field is optional, this would match any event that doesn't have this field and match the other conditions, causing FPs. This PR address that :awkward-look: