### PR TITLE
[Rule Tuning] SSM Session Started to EC2 Instance

### DIFF
--- a/rules/integrations/aws/lateral_movement_aws_ssm_start_session_to_ec2_instance.toml
+++ b/rules/integrations/aws/lateral_movement_aws_ssm_start_session_to_ec2_instance.toml
@@ -7,9 +7,9 @@ updated_date = "2025/09/05"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies the first occurrence of an AWS user or role establishing a session via SSM to an EC2 instance. Adversaries may use AWS Systems Manager to establish a session to an EC2 instance to execute commands on the instance. This can be used to gain access to the instance and perform actions such as privilege escalation. 
+Identifies the first occurrence of an AWS user or role establishing a session via SSM to an EC2 instance. Adversaries may use AWS Session Manager to establish a session to an EC2 instance to execute commands on the instance. This can be used to gain access to the instance and perform actions such as privilege escalation. 
 """
-false_positives = ["Legitimate use of AWS Systems Manager to establish a session to an EC2 instance."]
+false_positives = ["Legitimate use of AWS Session Manager to establish a session to an EC2 instance."]
 from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/616

## Summary - What I changed

Role/role session noise seen in telemetry due to new fields term using `aws.cloudtrail.user_identity.arn`, which is unique for each role session and does not isolate the role itself.

- new fields term change to `cloud.account.id` and `user.name` combination to account for both IAMUsers and Roles across multiple accounts.
- added AWS to the rule name
- reduced execution window
- small edits to description and IG
- added reference from IG to Reference section
- added highlighted fields

## How To Test

You can test this rule with the following [script](https://github.com/elastic/elastic-aws-ruleset-testing/blob/21330d352069dba5a5bc1c9dfb52a25e2d6e7eb4/SSM/trigger_lateral_movement_aws_ssm_start_session_to_ec2_instance.py) or run `aws ssm start-session --target [instance-id]` against a running EC2 instance with SSM enabled. 

<img width="1441" height="712" alt="Screenshot 2025-09-05 at 2 43 36 PM" src="https://github.com/user-attachments/assets/135cbd04-2d4c-420b-9ee3-3c08d236f131" />

