### PR TITLE
[Rule Tuning] AWS EC2 Instance Connect SSH Public Key Uploaded

### DIFF
--- a/rules/integrations/aws/lateral_movement_ec2_instance_connect_ssh_public_key_uploaded.toml
+++ b/rules/integrations/aws/lateral_movement_ec2_instance_connect_ssh_public_key_uploaded.toml
@@ -2,20 +2,20 @@
 creation_date = "2024/04/30"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/15"
+updated_date = "2025/09/05"
 
 [rule]
 author = ["Elastic"]
 description = """
 Identifies when a new SSH public key is uploaded to an AWS EC2 instance using the EC2 Instance Connect service. This
-action could indicate an adversary attempting to maintain access to the instance. The rule also detects the
-`SendSerialConsoleSSHPublicKey` or `SendSSHPublicKey` API actions, which are logged when manually uploading an SSH key
+action could indicate an adversary attempting to maintain access to the instance. The rule detects the
+SendSerialConsoleSSHPublicKey or SendSSHPublicKey API actions, which are logged when manually uploading an SSH key
 to an EC2 instance or serial connection. It is important to know that this API call happens automatically by the EC2
 Instance Connect service when a user connects to an EC2 instance using the EC2 Instance Connect service via the CLI or
 AWS Management Console.
 """
 false_positives = ["Administrators may upload SSH public keys to EC2 instances for legitimate purposes."]
-from = "now-9m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
@@ -24,12 +24,12 @@ note = """## Triage and Analysis
 
 ### Investigating AWS EC2 Instance Connect SSH Public Key Uploaded
 
-This rule detects when a new SSH public key is uploaded to an AWS EC2 instance using the EC2 Instance Connect service. Adversaries may upload SSH public keys to EC2 instances to maintain access to the instance or for initial access. This action also occurs automatically in the background when establishing a connection to an instance via the same service.  The rule also covers cases where the `SendSerialConsoleSSHPublicKey` API action is used to upload an SSH public key to a serial connection, which can be exploited for privilege escalation.
+This rule detects when a new SSH public key is uploaded to an AWS EC2 instance using the EC2 Instance Connect service. Adversaries may upload SSH public keys to EC2 instances to maintain access to the instance or for initial access. This action also occurs automatically in the background when establishing a connection to an instance via the same service.  The rule covers cases where the `SendSerialConsoleSSHPublicKey` API action is used to upload an SSH public key to a serial connection, which can be exploited for privilege escalation.
 
 #### Possible Investigation Steps:
 
 - **Identify the Actor**: Review the `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.access_key_id` fields to identify who performed the action. Verify if this actor typically performs such actions and if they have the necessary permissions.
-- **Review the Request Details**: Examine the `aws.cloudtrail.request_parameters` to understand the specific details of the SSH public key upload. Look for any unusual parameters that could suggest unauthorized or malicious modifications.
+- **Review the Request Details**: Examine the `aws.cloudtrail.request_parameters` to understand the specific details of the SSH public key upload. Look for any unusual parameters that could suggest unauthorized or malicious modifications. Use the `target.entity.id` field to determine the targeted EC2 instance.
 - **Analyze the Source of the Request**: Investigate the `source.ip` and `source.geo` fields to determine the geographical origin of the request. An external or unexpected location might indicate compromised credentials or unauthorized access.
 - **Contextualize with Timestamp**: Use the `@timestamp` field to check when the SSH public key was uploaded. Changes during non-business hours or outside regular maintenance windows might require further scrutiny.
 - **Correlate with Other Activities**: Search for related CloudTrail events before and after this action to see if the same actor or IP address engaged in other potentially suspicious activities.
@@ -39,7 +39,7 @@ This rule detects when a new SSH public key is uploaded to an AWS EC2 instance u
 
 - **Legitimate Administrative Actions**: Confirm if the SSH public key upload aligns with scheduled updates, development activities, or legitimate administrative tasks documented in change management systems.
 - **Consistency Check**: Compare the action against historical data of similar actions performed by the user or within the organization. If the action is consistent with past legitimate activities, it might indicate a false alarm.
-- **Verify through Outcomes**: Check the `aws.cloudtrail.response_elements` and the `event.outcome` to confirm if the upload was successful and intended according to policy.
+
 
 ### Response and Remediation:
 
@@ -57,9 +57,10 @@ For further guidance on managing EC2 instances and securing AWS environments, re
 - [AWS EC2 Instance Connect API Reference](https://docs.aws.amazon.com/ec2-instance-connect/latest/APIReference/API_SendSSHPublicKey.html)
 """
 references = [
+    "https://unit42.paloaltonetworks.com/cloud-lateral-movement-techniques",
+    "https://medium.parttimepolymath.net/aws-ec2-instance-connect-a-very-neat-trick-4d2fc0c28010",
     "https://stratus-red-team.cloud/attack-techniques/AWS/aws.lateral-movement.ec2-instance-connect/",
     "https://cloud.hacktricks.xyz/pentesting-cloud/aws-security/aws-privilege-escalation/aws-ec2-privesc",
-    "https://medium.parttimepolymath.net/aws-ec2-instance-connect-a-very-neat-trick-4d2fc0c28010",
     "https://docs.aws.amazon.com/ec2-instance-connect/latest/APIReference/API_SendSSHPublicKey.html",
     "https://docs.aws.amazon.com/ec2-instance-connect/latest/APIReference/API_SendSerialConsoleSSHPublicKey.html",
 ]
@@ -86,6 +87,22 @@ event.dataset: aws.cloudtrail
     and event.outcome: success
 '''
 
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

- https://github.com/elastic/ia-trade-team/issues/616

## Summary - What I changed

This rule is performing as expected and low noise in telemetry so no changes to query
- added investigation fields
- small edits to description and IG
- added a reference from Unit42 showing real world threat case
- reduced execution window

## How To Test

You can test this rule using this [script](https://github.com/elastic/elastic-aws-ruleset-testing/blob/e3efe7e6295354a54e052fbb29756652a6bfef05/EC2/trigger_lateral_movement_ec2_instance_connect_ssh_public_key_uploaded.py). It creates 2 EC2 instances and runs one of the SSH API calls against each instance, creating 2 separate alerts. 

<img width="2882" height="1424" alt="image" src="https://github.com/user-attachments/assets/a6fda24c-d6fd-4113-bd69-e4e2771b657c" />


