### PR TITLE
[Rule Tunings] AWS DynamoDB new terms Rules

### DIFF
--- a/rules/integrations/aws/exfiltration_dynamodb_scan_by_unusual_user.toml
+++ b/rules/integrations/aws/exfiltration_dynamodb_scan_by_unusual_user.toml
@@ -10,7 +10,7 @@ description = """
 Identifies when an AWS DynamoDB table is scanned by a user who does not typically perform this action. Adversaries may
 use the Scan operation to collect sensitive information or exfiltrate data from DynamoDB tables. This rule detects
 unusual user activity by monitoring for the Scan action in CloudTrail logs. This is a New Terms rule that only flags
-when this behavior is observed by the user.name for the first time.
+when this behavior is observed by a user or role for the first time.
 """
 false_positives = [
     """

--- a/rules/integrations/aws/exfiltration_dynamodb_table_exported_to_s3.toml
+++ b/rules/integrations/aws/exfiltration_dynamodb_table_exported_to_s3.toml
@@ -7,7 +7,7 @@ updated_date = "2025/09/08"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when an AWS DynamoDB table is exported to S3. Adversaries may use the ExportTableToPointInTime operation to collect sensitive information or exfiltrate data from DynamoDB tables. This rule detects unusual user activity by monitoring for the ExportTableToPointInTime action in CloudTrail logs. This is a New Terms rule that only flags when this behavior is observed by the user.name for the first time.
+Identifies when an AWS DynamoDB table is exported to S3. Adversaries may use the ExportTableToPointInTime operation to collect sensitive information or exfiltrate data from DynamoDB tables. This rule detects unusual user activity by monitoring for the ExportTableToPointInTime action in CloudTrail logs. This is a New Terms rule that only flags when this behavior is observed by a user or role for the first time.
 """
 false_positives = [
     """


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/616 

## Summary - What I changed

### AWS DynamoDB Scan by Unusual User
- changed new terms field to use cloud.account.id and user.name combination to account for roles and users
- reduced execution window
- reduced history window
- small edits to description, IG and highlighted fields

### AWS DynamoDB Table Exported to S3
- removed inaccurate setup notes
- reduced history window
- small edits to description and highlighted fields

## How To Test

You can use the following scripts to create a new user + DynamoDB table + execute the intended action: [DynamoDB_Scan](https://github.com/elastic/elastic-aws-ruleset-testing/blob/main/DynamoDB/trigger_exfiltration_dynamodb_scan_by_unusual_user.py)  [DynamoDB_Export_S3](https://github.com/elastic/elastic-aws-ruleset-testing/blob/main/DynamoDB/trigger_exfiltration_dynamodb_table_exported_to_s3.py)

There are test events in our shared stack as well

<img width="1441" height="712" alt="Screenshot 2025-09-08 at 2 06 39 PM" src="https://github.com/user-attachments/assets/6c79b746-0a16-4652-9dff-146e8986e356" />
<img width="1441" height="712" alt="Screenshot 2025-09-08 at 2 04 43 PM" src="https://github.com/user-attachments/assets/d41a11ef-5f3b-4332-acdc-b7de609682fb" />

