### PR TITLE
[Rule Tunings] AWS SNS New Terms Rules

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -166,7 +166,8 @@
     "aws.cloudtrail.flattened.request_parameters.reason": "keyword",
     "aws.cloudtrail.flattened.request_parameters.omitted": "keyword",
     "aws.cloudtrail.flattened.response_elements.documentDescription.documentType": "keyword",
-    "aws.cloudtrail.flattened.request_parameters.groupSet.items.groupId": "keyword"
+    "aws.cloudtrail.flattened.request_parameters.groupSet.items.groupId": "keyword",
+    "aws.cloudtrail.flattened.request_parameters.protocol": "keyword"
   },
   "logs-azure.signinlogs-*": {
     "azure.signinlogs.properties.conditional_access_audiences.application_id": "keyword",

--- a/rules/integrations/aws/exfiltration_sns_rare_protocol_subscription_by_user.toml
+++ b/rules/integrations/aws/exfiltration_sns_rare_protocol_subscription_by_user.toml
@@ -2,44 +2,40 @@
 creation_date = "2024/11/01"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/02/12"
+updated_date = "2025/09/09"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies when an SNS topic is subscribed to by an email address of a user who does not typically perform this action.
-Adversaries may subscribe to an SNS topic to collect sensitive information or exfiltrate data via an external email
-address.
+Identifies when a use subscribes to an SNS topic using a new protocol type (ie. email, http, lambda, etc.). SNS allows users to subscribe to recieve topic messages across a broad range of protocols like email, sms, lambda functions, http endpoints, and applications. Adversaries may subscribe to an SNS topic to collect sensitive information or exfiltrate data via an external email address, cross-account AWS service or other means. This rule identifies a new protocol subscription method for a particular user. 
 """
 false_positives = [
     """
-    Legitimate users may subscribe to SNS topics for legitimate purposes. Ensure that the subscription is authorized and
-    the subscription email address is known before taking action.
+    Legitimate users may subscribe to SNS topics for legitimate purposes. Ensure that the subscription is authorized before taking action.
     """,
 ]
-from = "now-9m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "AWS SNS Email Subscription by Rare User"
+name = "AWS SNS Rare Protocol Subscription by User"
 note = """## Triage and analysis
 
-### Investigating AWS SNS Email Subscription by Rare User
+### Investigating AWS SNS Rare Protocol Subscription by User
 
-This rule identifies when an SNS topic is subscribed to by an email address of a user who does not typically perform this action. While subscribing to SNS topics is a common practice, adversaries may exploit this feature to collect sensitive information or exfiltrate data via an external email address.
+This rule identifies when an SNS topic is subscribed to by a rare protocol for a particular user. While subscribing to SNS topics is a common practice, adversaries may exploit this feature to collect sensitive information or exfiltrate data via an external email address, mobile number, or cross-account AWS service like Lambda.
 
-This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that only flags when this behavior is observed for the first time on a host in the last 14 days.
+This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that only flags when this behavior is observed using a protocol for the first time.
 
 #### Possible Investigation Steps
 
 - **Identify the Actor**: Review the `aws.cloudtrail.user_identity.arn` field to identify the user who requested the subscription. Verify if this actor typically performs such actions and has the necessary permissions. It may be unusual for this activity to originate from certain user types, such as an assumed role or federated user.
 - **Review the SNS Subscription Event**: Analyze the specifics of the `Subscribe` action in CloudTrail logs:
-  - **Topic**: Look at the `aws.cloudtrail.request_parameters.topicArn` field to identify the SNS topic involved in the subscription.
-  - **Protocol and Endpoint**: Review the `aws.cloudtrail.request_parameters.protocol` and `aws.cloudtrail.request_parameters.endpoint` fields to confirm the subscription's protocol and email address. Confirm if this endpoint is associated with a known or trusted entity.
-  - **Subscription Status**: Check the `aws.cloudtrail.response_elements.subscriptionArn` field for the subscription's current status, noting if it requires confirmation.
+  - **Topic**: Look at the `aws.cloudtrail.request_parameters` or `target.entity.id` field to identify the SNS topic involved in the subscription.
+  - **Protocol and Endpoint**: Review the `aws.cloudtrail.request_parameters` field to confirm the subscription's protocol and endpoint, if available. Confirm if this endpoint is associated with a known or trusted entity.
+  - **Subscription Status**: Check the `aws.cloudtrail.response_elements` field for the subscription's current status, noting if it requires confirmation.
 - **Verify Authorization**: Evaluate whether the user typically engages in SNS subscription actions and if they are authorized to do so for the specified topic.
 - **Contextualize with Related Events**: Review related CloudTrail logs around the event time for other actions by the same user or IP address. Look for activities involving other AWS services, such as S3 or IAM, that may indicate further suspicious behavior.
-- **Evaluate the Subscription Endpoint**: Determine whether the email endpoint is legitimate or associated with any known entity. This may require checking internal documentation or reaching out to relevant AWS account administrators.
 - **Check for Publish Actions**: Investigate for any subsequent `Publish` actions on the same SNS topic that may indicate exfiltration attempts or data leakage. If Publish actions are detected, further investigate the contents of the messages.
 - **Review IAM Policies**: Examine the user or role's IAM policies to ensure that the subscription action is within the scope of their permissions or should be.
 
@@ -60,7 +56,11 @@ This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-
 For further guidance on managing and securing SNS topics in AWS environments, refer to the [AWS SNS documentation](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) and AWS best practices for security.
 
 """
-references = ["https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html"]
+references = [
+        "https://docs.aws.amazon.com/sns/latest/api/API_Subscribe.html",
+        "https://permiso.io/blog/s/smishing-attack-on-aws-sms-new-phone-who-dis/",
+        "https://www.sentinelone.com/labs/sns-sender-active-campaigns-unleash-messaging-spam-through-the-cloud/",
+]
 risk_score = 21
 rule_id = "3df49ff6-985d-11ef-88a1-f661ea17fbcd"
 severity = "low"
@@ -72,6 +72,8 @@ tags = [
     "Resources: Investigation Guide",
     "Use Case: Threat Detection",
     "Tactic: Exfiltration",
+    "Tactic: Collection",
+    "Tactic: Impact",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"
@@ -80,7 +82,7 @@ query = '''
 event.dataset: "aws.cloudtrail"
     and event.provider: "sns.amazonaws.com"
     and event.action: "Subscribe"
-    and aws.cloudtrail.request_parameters: *protocol=email*
+    and event.outcome: "success"
 '''
 
 
@@ -108,27 +110,44 @@ reference = "https://attack.mitre.org/techniques/T1530/"
 id = "TA0009"
 name = "Collection"
 reference = "https://attack.mitre.org/tactics/TA0009/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1496"
+name = "Resource Hijacking"
+reference = "https://attack.mitre.org/techniques/T1496/"
+[[rule.threat.technique.subtechnique]]
+id = "T1496.004"
+name = "Cloud Service Hijacking"
+reference = "https://attack.mitre.org/techniques/T1496/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
 
 [rule.investigation_fields]
 field_names = [
     "@timestamp",
     "user.name",
-    "source.address",
+    "user_agent.original",
+    "source.ip",
     "aws.cloudtrail.user_identity.arn",
     "aws.cloudtrail.user_identity.type",
-    "user_agent.original",
+    "aws.cloudtrail.user_identity.access_key_id",
     "event.action",
     "event.outcome",
+    "cloud.account.id",
     "cloud.region",
-    "aws.cloudtrail.flattened.request_parameters.protocol",
-    "aws.cloudtrail.flattened.request_parameters.topicArn",
-    "aws.cloudtrail.flattened.response_elements.subscriptionArn",
     "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
 ]
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["aws.cloudtrail.user_identity.arn"]
+value = ["cloud.account.id", "user.name", "aws.cloudtrail.flattened.request_parameters.protocol"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-14d"

--- a/rules/integrations/aws/lateral_movement_sns_topic_message_publish_by_rare_user.toml
+++ b/rules/integrations/aws/lateral_movement_sns_topic_message_publish_by_rare_user.toml
@@ -2,17 +2,16 @@
 creation_date = "2025/01/07"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/01/07"
+updated_date = "2025/09/09"
 
 [rule]
 author = ["Elastic"]
 description = """
 Identifies when an SNS topic message is published by a rare user in AWS. Adversaries may publish messages to SNS topics
 for phishing campaigns, data exfiltration, or lateral movement within the AWS environment. SNS topics are used to send
-notifications and messages to subscribed endpoints such as applications, devices or email addresses, making them a
-valuable target for adversaries to distribute malicious content or exfiltrate sensitive data. This is a [New
-Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that only flags
-when this behavior is observed for the first time on a user in the last 14 days.
+notifications and messages to subscribed endpoints such as applications, mobile devices or email addresses, making them a
+valuable target for adversaries to distribute malicious content or exfiltrate sensitive data. This is a New Terms rule that only flags
+when this behavior is observed for the first time by a user or role.
 """
 false_positives = [
     """
@@ -20,22 +19,24 @@ false_positives = [
     is authorized before taking action.
     """,
 ]
-from = "now-9m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "SNS Topic Message Publish by Rare User"
+name = "AWS SNS Topic Message Publish by Rare User"
 note = """## Triage and Analysis
 
-### Investigating SNS Topic Message Publish by Rare User
+### Investigating AWS SNS Topic Message Publish by Rare User
 
 This rule identifies when a message is published to an SNS topic by a user who has rarely or never published messages before. This activity could indicate adversarial actions, such as using SNS topics for phishing campaigns, data exfiltration, or lateral movement within an AWS environment.
+
+This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that only flags when this behavior is observed for the first time by a user or role.
 
 #### Possible Investigation Steps
 
 - **Identify the Actor and Resource**:
-  - **User Identity and Role**: Examine the `aws.cloudtrail.user_identity.arn` to identify the user or role responsible for publishing the SNS message. Verify whether this actor is authorized to publish messages to SNS topics. This user is considered "rare" since they have not published messages to SNS topics in the last 14 days.
-  - **Access Key Details**: Review the `aws.cloudtrail.user_identity.access_key_id` to determine if the access key used is valid or compromised.
+  - **User Identity and Role**: Examine the `aws.cloudtrail.user_identity.arn` to identify the user or role responsible for publishing the SNS message. Verify whether this actor is authorized to publish messages to SNS topics.
+  - **Access Key Details**: Review the `aws.cloudtrail.user_identity.access_key_id` to determine the access key used.
   - **SNS Topic ARN**: Analyze `aws.cloudtrail.resources.arn` to confirm whether the SNS topic is critical, sensitive, or used for authorized purposes.
 
 - **Evaluate the Context of the SNS Message**:
@@ -90,9 +91,12 @@ For more information on SNS topic management and securing AWS resources, refer t
 references = [
     "https://docs.aws.amazon.com/sns/latest/api/API_Publish.html",
     "https://hackingthe.cloud/aws/exploitation/Misconfigured_Resource-Based_Policies/exploting_public_resources_attack_playbook/",
+    "https://permiso.io/blog/s/smishing-attack-on-aws-sms-new-phone-who-dis/",
+    "https://www.sentinelone.com/labs/sns-sender-active-campaigns-unleash-messaging-spam-through-the-cloud/",
 ]
 risk_score = 47
 rule_id = "2112ecce-cd34-11ef-873f-f661ea17fbcd"
+setup = "AWS SNS topic data event types need to be enabled in the CloudTrail trail configuration to capture the Publish action. Ensure that the AWS CloudTrail service is [configured](https://docs.aws.amazon.com/sns/latest/dg/logging-using-cloudtrail.html#cloudtrail-data-events) to log data events for SNS."
 severity = "medium"
 tags = [
     "Domain: Cloud",
@@ -103,6 +107,7 @@ tags = [
     "Resources: Investigation Guide",
     "Tactic: Lateral Movement",
     "Tactic: Exfiltration",
+    "Tactic: Impact",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"
@@ -116,24 +121,21 @@ event.dataset:"aws.cloudtrail"
 
 [rule.investigation_fields]
 field_names = [
-   "@timestamp",
-   "user.name",
-   "aws.cloudtrail.user_identity.arn",
-   "aws.cloudtrail.user_identity.type",
-   "aws.cloudtrail.user_identity.access_key_id",
-   "user_agent.original",
-   "aws.cloudtrail.flattened.request_parameters.topicArn",
-   "event.action",
-   "event.outcome",
-   "cloud.region",
-   "source.ip",
-   "source.geo.city_name",
-   "source.geo.region_name",
-   "source.geo.country_name",
-   "aws.cloudtrail.request_id",
-   "aws.cloudtrail.resources.arn",
-   "aws.cloudtrail.event_category",
-   "aws.cloudtrail.response_elements.messageId"
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "aws.cloudtrail.resources.arn",     
+    "aws.cloudtrail.resources.type",   
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
 ]
 
 [[rule.threat]]
@@ -160,12 +162,29 @@ reference = "https://attack.mitre.org/techniques/T1567/"
 id = "TA0010"
 name = "Exfiltration"
 reference = "https://attack.mitre.org/tactics/TA0010/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1496"
+name = "Resource Hijacking"
+reference = "https://attack.mitre.org/techniques/T1496/"
+[[rule.threat.technique.subtechnique]]
+id = "T1496.004"
+name = "Cloud Service Hijacking"
+reference = "https://attack.mitre.org/techniques/T1496/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["aws.cloudtrail.user_identity.arn"]
+value = ["cloud.account.id", "user.name", "aws.cloudtrail.resources.arn"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
-value = "now-14d"
+value = "now-10d"
 
 

--- a/rules/integrations/aws/resource_development_sns_topic_created_by_rare_user.toml
+++ b/rules/integrations/aws/resource_development_sns_topic_created_by_rare_user.toml
@@ -2,13 +2,14 @@
 creation_date = "2025/02/11"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2025/02/11"
+updated_date = "2025/09/09"
 
 [rule]
 author = ["Elastic"]
 description = """
 Identifies when an SNS topic is created by a user who does not typically perform this action. Adversaries may create SNS
-topics to stage capabilities for data exfiltration or other malicious activities.
+topics to stage capabilities for data exfiltration or other malicious activities. This is a New Terms rule that only flags
+when this behavior is observed for the first time by a user or role.
 """
 false_positives = [
     """
@@ -16,7 +17,7 @@ false_positives = [
     action.
     """,
 ]
-from = "now-9m"
+from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
@@ -27,23 +28,23 @@ note = """## Triage and Analysis
 
 This rule detects the creation of an AWS Simple Notification Service (SNS) topic by a user who does not typically perform this action. Adversaries may create SNS topics to facilitate data exfiltration or other malicious activities.
 
-This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that only flags when this behavior is observed for the first time on a host in the last 10 days.
+This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that only flags when this behavior is observed for the first time by a user or role.
 
 #### Possible Investigation Steps
 
-### 1. Identify the Actor and Context
+### Identify the Actor and Context
 - **User Identity and Role**:
   - Examine `aws.cloudtrail.user_identity.arn` to determine **who** created the SNS topic.
-  - Identify whether the actor assumed a **privileged IAM role** (`aws.cloudtrail.user_identity.type: "AssumedRole"`).
+  - Identify whether the actor assumed a **privileged IAM role** (`aws.cloudtrail.user_identity.type: "AssumedRole"`) or used a long term access keys (`aws.cloudtrail.user_identity.access_key_id`).
 - **User Agent and Tooling**:
-  - Check `user_agent.name` to determine if this action was performed via the AWS CLI, SDK, or Console.
+  - Check `user_agent.original` to determine if this action was performed via the AWS CLI, SDK, or Console.
   - If `aws-cli` was used, review whether it aligns with typical automation or administrative behavior.
 - **Source IP and Geographic Location**:
   - Review `source.ip` and `source.geo` fields to confirm if the request originated from a **trusted** or **unexpected** location.
 
-### 2. Evaluate the SNS Topic Creation
+### Evaluate the SNS Topic Creation
 - **Topic Name and Purpose**:
-  - Check `aws.cloudtrail.flattened.request_parameters.name` for the **SNS topic name** and determine whether it appears suspicious (e.g., random strings, unusual keywords).
+  - Check `aws.cloudtrail.request_parameters` for the **SNS topic name** and determine whether it appears suspicious (e.g., random strings, unusual keywords).
 - **Target Region and Account**:
   - Verify `cloud.region` and `cloud.account.id` to **ensure the SNS topic was created in an expected environment**.
 - **Associated API Calls**:
@@ -53,7 +54,7 @@ This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-
     - `SetTopicAttributes`
   - These may indicate follow-up steps taken to misuse the SNS topic.
 
-### 3. Analyze Potential Malicious Intent
+### Analyze Potential Malicious Intent
 - **Is This an Isolated Action or a Pattern?**
   - Check if this **user has previously created SNS topics** using historical CloudTrail logs.
   - Look for **multiple topic creations in a short period**, which may suggest an automation script or malicious behavior.
@@ -84,7 +85,11 @@ This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-
 - **Investigate for Persistence**:
   - Check whether the SNS topic is **being used as a notification channel for Lambda, S3, or other AWS services**.
 """
-references = ["https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html"]
+references = [
+      "https://docs.aws.amazon.com/sns/latest/api/API_CreateTopic.html",
+      "https://permiso.io/blog/s/smishing-attack-on-aws-sms-new-phone-who-dis/",
+      "https://www.sentinelone.com/labs/sns-sender-active-campaigns-unleash-messaging-spam-through-the-cloud/",
+]
 risk_score = 21
 rule_id = "3c3f65b8-e8b4-11ef-9511-f661ea17fbce"
 severity = "low"
@@ -96,6 +101,7 @@ tags = [
     "Resources: Investigation Guide",
     "Use Case: Threat Detection",
     "Tactic: Resource Development",
+    "Tactic: Impact",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"
@@ -105,8 +111,6 @@ event.dataset: "aws.cloudtrail"
     and event.provider: "sns.amazonaws.com"
     and event.action: "CreateTopic"
     and event.outcome: "success"
-    and aws.cloudtrail.user_identity.type: "AssumedRole"
-    and aws.cloudtrail.user_identity.arn: *i-*
 '''
 
 
@@ -122,26 +126,42 @@ reference = "https://attack.mitre.org/techniques/T1608/"
 id = "TA0042"
 name = "Resource Development"
 reference = "https://attack.mitre.org/tactics/TA0042/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1496"
+name = "Resource Hijacking"
+reference = "https://attack.mitre.org/techniques/T1496/"
+[[rule.threat.technique.subtechnique]]
+id = "T1496.004"
+name = "Cloud Service Hijacking"
+reference = "https://attack.mitre.org/techniques/T1496/004/"
+
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
 
 [rule.investigation_fields]
 field_names = [
     "@timestamp",
     "user.name",
-    "source.address",
+    "user_agent.original",
+    "source.ip",
     "aws.cloudtrail.user_identity.arn",
     "aws.cloudtrail.user_identity.type",
-    "user_agent.original",
+    "aws.cloudtrail.user_identity.access_key_id",
     "event.action",
     "event.outcome",
+    "cloud.account.id",
     "cloud.region",
-    "aws.cloudtrail.flattened.request_parameters.protocol",
-    "aws.cloudtrail.flattened.request_parameters.topicArn",
     "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements"
 ]
-
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["aws.cloudtrail.user_identity.arn"]
+value = ["cloud.account.id", "user.name"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-10d"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

- https://github.com/elastic/ia-trade-team/issues/616

## Summary - What I changed

AWS SNS is a pub/sub style service where users can subscribe to a topic and receive messages published to that topic. Below is a screenshot of the different protocols a user could subscribe with and the various endpoints that could be associated with those protocols.

<img width="859" height="793" alt="Screenshot 2025-09-09 at 4 30 49 PM" src="https://github.com/user-attachments/assets/0f2067d1-8599-40a0-b640-1ddd59f1b263" />


AWS SNS Email Subscription by Rare User -->  AWS SNS Rare Protocol Subscription by User (not a new rule)
- changed the scope of the rule to capture the first time a user/role subscribes to a topic via a particular protocol (ie. email, http, lambda, mobile). Subscribing to an SNS topic via email is a rather normal behavior and it would be normal for each user to subscribe this way "for the first time" making this rule not as valuable as it was intended to be.
- reduced execution window
- added real-world threat references
- added additional MITRE technique and Impact tag
- small edits to IG and Description
- edited highlighted fields
**note: I had to use the flattened field added to non-ecs file as there is no other way of capturing the subscription protocol**

AWS SNS Topic Message Publish by Rare User
- added AWS to name for consistency -changed new terms fields to use a combination of cloud.account.id and user.name against the topic itself `aws.cloudtrail.resources.arn`. So that instead of simply evaluating the first time a user/role publishes a message to ANY topic, this rule now looks for the first time a user/role publishes a message to a particular topic. We want to make this distinction to capture the case where an identity responsible for publishing to a particular topic A suddenly starts publishing to another topic B, which indicates behavior that should be verified.
- reduced new terms window
- added setup notes as Data events are necessary for capturing the `Publish` API call
- reduced execution window
- added real-world threat references
- added additional MITRE technique and Impact tag
- small edits to IG and Description
- edited highlighted fields

AWS SNS Topic Created by Rare User
- removed the `AssumedRole` and `*-i*` parameters from the query as this narrowed the query to only alert on behavior from EC2 instance roles. We ideally want to evaluate this behavior for all users and roles.
- reduced execution window
- added real-world threat references
- added additional MITRE technique and Impact tag
- small edits to IG and Description
- edited highlighted fields

## How To Test

Each query can be run in our shared stack against existing test data. You can use one of these scripts to trigger the rules, this [one](https://github.com/elastic/elastic-aws-ruleset-testing/blob/44568305476de122fb9a4ef5dc79cad7512c44c3/SNS/trigger_lateral_movement_sns_topic_message_publish_by_rare_user%20copy.py) triggers all 3 rules using an email protocol subscription , this [one](https://github.com/elastic/elastic-aws-ruleset-testing/blob/44568305476de122fb9a4ef5dc79cad7512c44c3/SNS/trigger_exfiltration_sns_rare_protocol_subscription_by_user.py) does not publish a message but uses a lambda protocol subscription method
