### PR TITLE
[Bug] Github Gist API Now Requires Auth

### DIFF
--- a/detection_rules/ghwrap.py
+++ b/detection_rules/ghwrap.py
@@ -109,7 +109,7 @@ def update_gist(  # noqa: PLR0913
 
     if pre_purge:
         # retrieve all existing file names which are not in the file_map and overwrite them to empty to delete files
-        response = requests.get(url, timeout=30)
+        response = requests.get(url, headers=headers, timeout=30)
         response.raise_for_status()
         data = response.json()
         files = list(data["files"])


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/5118

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

Updated Github docs indicate (and error text via curl) that even public gists now require authetication to read. We have the auth handling already. We just need to add the headers to the public read call as well. 

```shell

detection-rules on  5118-bug-github-gist-api-now-requires-auth [?] is  v1.4.1 via  v3.12.11 (detection-rules-build) on  eric.forte
❯ curl --request GET \
      --url "https://api.github.com/gists/0443cfb5016bed103f1940b2f336e45a" \
      --header "accept: application/vnd.github.v3+json"
{
  "message": "Requires authentication",
  "documentation_url": "https://docs.github.com/rest",
  "status": "401"
}⏎
``` 

## How To Test

Run the command `detection_rules dev update-navigator-gists` and no longer see auth failures here. 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
