### PR TITLE
[New Rule] Credential Access via TruffleHog Execution

### DIFF
--- a/rules/cross-platform/credential_access_trufflehog_execution.toml
+++ b/rules/cross-platform/credential_access_trufflehog_execution.toml
@@ -1,0 +1,61 @@
+[metadata]
+creation_date = "2025/09/18"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/09/18"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects the execution of TruffleHog, a tool used to search for high-entropy strings and secrets
+in code repositories, which may indicate an attempt to access credentials. This tool was abused by the Shai-Hulud
+worm to search for credentials in code repositories.
+"""
+false_positives = [
+    """
+    Trufflehog is a legitimate open-source tool used by security professionals and developers to search for sensitive
+    information, such as passwords, API keys, and other secrets, within code repositories. It is commonly employed
+    during security assessments and code reviews to identify potential vulnerabilities.
+    """,
+]
+from = "now-9m"
+index = ["logs-endpoint.events.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Credential Access via TruffleHog Execution"
+references = ["https://www.elastic.co/blog/shai-hulud-worm-npm-supply-chain-compromise"]
+risk_score = 21
+rule_id = "47595dea-452b-4d37-b82d-6dd691325139"
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "OS: Windows",
+    "OS: macOS",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Data Source: Elastic Defend"
+]
+type = "eql"
+query = '''
+process where event.type == "start" and process.name in ("trufflehog.exe", "trufflehog") and
+process.args == "--results=verified" and process.args == "--json" and process.args == "filesystem"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1003"
+name = "OS Credential Dumping"
+reference = "https://attack.mitre.org/techniques/T1003/"
+
+[[rule.threat.technique]]
+id = "T1555"
+name = "Credentials from Password Stores"
+reference = "https://attack.mitre.org/techniques/T1555/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"


### PR DESCRIPTION
## Summary
This rule detects the execution of TruffleHog, a tool used to search for high-entropy strings and secrets in code repositories, which may indicate an attempt to access credentials. This tool was abused by the Shai-Hulud worm to search for credentials in code repositories.

## Telemetry
<img width="1684" height="801" alt="{17633C37-2A66-4462-96FB-284EE2BC958F}" src="https://github.com/user-attachments/assets/d6ec64d3-45e9-4b31-9b08-88ded7f41cfa" />
