### PR TITLE
[New Rule] GitHub Authentication Token Access via Node.js

### DIFF
--- a/rules/linux/credential_access_gh_auth_via_nodejs.toml
+++ b/rules/linux/credential_access_gh_auth_via_nodejs.toml
@@ -1,0 +1,96 @@
+[metadata]
+creation_date = "2025/09/18"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2025/09/18"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects when the Node.js runtime spawns a shell to execute the GitHub CLI (gh) command to retrieve
+a GitHub authentication token. The GitHub CLI is a command-line tool that allows users to interact with
+GitHub from the terminal. The "gh auth token" command is used to retrieve an authentication token for
+GitHub, which can be used to authenticate API requests and perform actions on behalf of the user. Adversaries
+may use this technique to access GitHub repositories and potentially exfiltrate sensitive information or
+perform malicious actions. This activity was observed in the wild as part of the Shai-Hulud worm.
+"""
+from = "now-9m"
+index = ["logs-endpoint.events.process*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Authentication Token Access via Node.js"
+references = ["https://www.elastic.co/blog/shai-hulud-worm-npm-supply-chain-compromise"]
+risk_score = 47
+rule_id = "e5d69377-f8cf-4e8f-8328-690822cd012a"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Tactic: Discovery",
+    "Data Source: Elastic Defend",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.parent.name == "node" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and process.args == "gh auth token"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique]]
+id = "T1528"
+name = "Steal Application Access Token"
+reference = "https://attack.mitre.org/techniques/T1528/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1613"
+name = "Container and Resource Discovery"
+reference = "https://attack.mitre.org/techniques/T1613/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"


### PR DESCRIPTION
## Summary
This rule detects when the Node.js runtime spawns a shell to execute the GitHub CLI (gh) command to retrieve a GitHub authentication token. The GitHub CLI is a command-line tool that allows users to interact with GitHub from the terminal. The "gh auth token" command is used to retrieve an authentication token for GitHub, which can be used to authenticate API requests and perform actions on behalf of the user. Adversaries may use this technique to access GitHub repositories and potentially exfiltrate sensitive information or perform malicious actions. This activity was observed in the wild as part of the Shai-Hulud worm.

## Additional guidance
- [Navigating the Shai-Hulud Worm: Elastic's proactive defense against npm supply chain compromise](https://www.elastic.co/blog/shai-hulud-worm-npm-supply-chain-compromise)

## Telemetry
<img width="1190" height="400" alt="{90AFD0D0-F8D6-41D9-AF77-7C5C7E6D5706}" src="https://github.com/user-attachments/assets/dcc5d405-91f8-423d-834b-aad73a88a4ba" />
