### PR TITLE
Fix name missing

### DIFF
--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -8,6 +8,7 @@ import datetime
 import functools
 import os
 import typing
+import uuid
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -246,7 +247,9 @@ def rule_prompt(  # noqa: PLR0912, PLR0913, PLR0915
             contents[name] = result
 
     # DEFAULT_PREBUILT_RULES_DIRS[0] is a required directory just as a suggestion
-    suggested_path: Path = Path(DEFAULT_PREBUILT_RULES_DIRS[0]) / contents["name"]
+    suggested_path: Path = Path(DEFAULT_PREBUILT_RULES_DIRS[0]) / contents.get(
+        "name", f"new-rule-{uuid.uuid4().hex[:8]}"
+    )
     path = Path(path or input(f"File path for rule [{suggested_path}]: ") or suggested_path).resolve()
     # Inherit maturity and optionally local dates from the rule if it already exists
     meta = {


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/5157

Related to https://github.com/elastic/detection-rules/pull/5125

## Summary - What I changed

Name is no longer considered a required field, despite being defined as one in BaseRuleData.

It appears this is due to the way marshmallow handles Annotated fields as in BaseRuleData's RequiredFields

```python
    @dataclass
    class RequiredFields:
        name: definitions.NonEmptyStr
        type: definitions.NonEmptyStr
        ecs: bool
....

name: definitions.RuleName
type: definitions.RuleType
```

Name is the only one affected by this error, it also happens to be the only one that is defined as an Annotated Field, as shown below
```
RuleType = Literal["query", "saved_query", "machine_learning", "eql", "esql", "threshold", "threat_match", "new_terms"]

....
RuleName = Annotated[str, fields.String(validate=elastic_rule_name_regexp(NAME_PATTERN))]

```

I expect this is an order of operations change that has the Annotation overwrite the original field information or some similar behavior. 

For additional context and a similar issue with Annotated Fields see: https://github.com/elastic/detection-rules/pull/5125 

## How To Test

Use the create-rule CLI to create a rule and see that name is prompted as a required field. 

```shell
❯ python -m detection_rules create-rule custom_rules/rules/hostname_custom_rule.toml --required-only
Loaded config file: /home/forteea1/bsides_2025/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

Rule type (query, saved_query, machine_learning, eql, esql, threshold, threat_match, new_terms): query
author (required)  (multi, comma separated): Elastic
description (required): Test
language (required): kuery
name (required):
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
