### PR TITLE
[Rule Tuning] Misc. Linux Community Tunings

### DIFF
--- a/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
+++ b/rules/linux/defense_evasion_attempt_to_disable_syslog_service.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/04/27"
 integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/09/29"
 
 [rule]
 author = ["Elastic"]
@@ -109,32 +109,32 @@ tags = [
 ]
 timestamp_override = "event.ingested"
 type = "eql"
-
 query = '''
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
  ( (process.name == "service" and process.args == "stop") or
    (process.name == "chkconfig" and process.args == "off") or
    (process.name == "systemctl" and process.args in ("disable", "stop", "kill"))
  ) and process.args in ("syslog", "rsyslog", "syslog-ng", "syslog.service", "rsyslog.service", "syslog-ng.service") and
-not process.parent.name == "rsyslog-rotate"
+not (
+  process.parent.name == "rsyslog-rotate" or
+  process.args == "HUP"
+)
 '''
-
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1562"
 name = "Impair Defenses"
 reference = "https://attack.mitre.org/techniques/T1562/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1562.001"
 name = "Disable or Modify Tools"
 reference = "https://attack.mitre.org/techniques/T1562/001/"
 
-
-
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-

--- a/rules/linux/defense_evasion_dynamic_linker_file_creation.toml
+++ b/rules/linux/defense_evasion_dynamic_linker_file_creation.toml
@@ -2,14 +2,15 @@
 creation_date = "2024/08/08"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/02/04"
+updated_date = "2025/09/29"
 
 [rule]
 author = ["Elastic"]
 description = """
-Detects the creation or modification of files related to the dynamic linker on Linux systems. The dynamic linker is a
-shared library that is used by the Linux kernel to load and execute programs. Attackers may attempt to hijack the
-execution flow of a program by modifying the dynamic linker configuration files.
+Detects the creation or modification of files related to the configuration of the dynamic linker on Linux systems.
+The dynamic linker is a shared library that is used by the Linux kernel to load and execute programs. Attackers may
+attempt to hijack the execution flow of a program by modifying the dynamic linker configuration files. This technique
+is often observed by userland rootkits that leverage shared objects to maintain persistence on a compromised host.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.file*"]
@@ -66,22 +67,27 @@ not (
     "/bin/pacman", "/usr/bin/pacman", "/usr/bin/dpkg-divert", "/bin/dpkg-divert", "/sbin/apk", "/usr/sbin/apk",
     "/usr/local/sbin/apk", "/usr/bin/apt", "/usr/sbin/pacman", "/bin/podman", "/usr/bin/podman", "/usr/bin/puppet",
     "/bin/puppet", "/opt/puppetlabs/puppet/bin/puppet", "/usr/bin/chef-client", "/bin/chef-client",
-    "/bin/autossl_check", "/usr/bin/autossl_check", "/proc/self/exe", "/dev/fd/*",  "/usr/bin/pamac-daemon",
+    "/bin/autossl_check", "/usr/bin/autossl_check", "/proc/self/exe",  "/usr/bin/pamac-daemon",
     "/bin/pamac-daemon", "/usr/lib/snapd/snapd", "/usr/local/bin/dockerd", "/usr/libexec/platform-python",
-    "/usr/lib/snapd/snap-update-ns", "/usr/bin/vmware-config-tools.pl"
+    "/usr/lib/snapd/snap-update-ns", "/usr/bin/vmware-config-tools.pl", "./usr/bin/podman", "/bin/nvidia-cdi-hook",
+    "/usr/lib/dracut/dracut-install", "./usr/bin/nvidia-cdi-hook", "/.envbuilder/bin/envbuilder", "/usr/bin/buildah",
+    "/usr/sbin/dnf", "/usr/bin/pamac", "/sbin/pacman", "/usr/bin/crio", "/usr/sbin/yum-cron"
   ) or
   file.extension in ("swp", "swpx", "swx", "dpkg-remove") or
   file.Ext.original.extension == "dpkg-new" or
   process.executable : (
-    "/nix/store/*", "/var/lib/dpkg/*", "/snap/*", "/dev/fd/*", "/usr/lib/virtualbox/*", "/opt/dynatrace/oneagent/*"
+    "/nix/store/*", "/var/lib/dpkg/*", "/snap/*", "/dev/fd/*", "/usr/lib/virtualbox/*", "/opt/dynatrace/oneagent/*",
+    "/usr/libexec/platform-python*"
   ) or
   process.executable == null or
   process.name in (
     "java", "executor", "ssm-agent-worker", "packagekitd", "crio", "dockerd-entrypoint.sh",
-    "docker-init", "BootTimeChecker"
+    "docker-init", "BootTimeChecker", "dockerd (deleted)", "dockerd"
   ) or
   (process.name == "sed" and file.name : "sed*") or
-  (process.name == "perl" and file.name : "e2scrub_all.tmp*")
+  (process.name == "perl" and file.name : "e2scrub_all.tmp*") or
+  (process.name == "init" and file.name == "ld.wsl.conf") or
+  (process.name == "sshd" and file.extension == "dpkg-new")
 )
 '''
 note = """## Triage and analysis

--- a/rules/linux/defense_evasion_kill_command_executed.toml
+++ b/rules/linux/defense_evasion_kill_command_executed.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/04/07"
+updated_date = "2025/09/29"
 
 [rule]
 author = ["Elastic"]
@@ -90,7 +90,10 @@ timestamp_override = "event.ingested"
 type = "new_terms"
 query = '''
 event.category:process and host.os.type:linux and event.type:start and event.action:exec and
-process.name:(kill or pkill or killall)
+process.name:(kill or pkill or killall) and not (
+  process.args:("-HUP" or "-SIGUSR1" or "-USR2" or "-WINCH" or "-USR1") or
+  process.parent.command_line:"runc init"
+)
 '''
 
 [[rule.threat]]

--- a/rules/linux/defense_evasion_ld_so_creation.toml
+++ b/rules/linux/defense_evasion_ld_so_creation.toml
@@ -2,12 +2,12 @@
 creation_date = "2024/12/16"
 integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/09/29"
 
 [rule]
 author = ["Elastic"]
 description = """
-This rule detects the creation of the dynamic linker (ld.so) file. The dynamic linker is used to load shared libraries
+This rule detects the creation of the dynamic linker (ld.so). The dynamic linker is used to load shared libraries
 needed by an executable. Attackers may attempt to replace the dynamic linker with a malicious version to execute
 arbitrary code.
 """
@@ -52,7 +52,7 @@ The dynamic linker, ld.so, is crucial in Linux environments for loading shared l
 - Review system logs and the process creation history to identify the source of the unauthorized ld.so creation and any associated malicious activity.
 - Escalate the incident to the security operations center (SOC) or incident response team for further investigation and to determine if other systems are affected.
 - Implement additional monitoring and alerting for similar suspicious activities, such as unauthorized file creations in critical system directories, to enhance future detection capabilities."""
-risk_score = 21
+risk_score = 47
 rule_id = "06d555e4-c8ce-4d90-90e1-ec7f66df5a6a"
 setup = """## Setup
 
@@ -79,7 +79,7 @@ For more details on Elastic Agent configuration settings, refer to the [helper g
 - To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
 For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
 """
-severity = "low"
+severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: Linux",
@@ -94,58 +94,68 @@ tags = [
 ]
 timestamp_override = "event.ingested"
 type = "eql"
-
 query = '''
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
 file.path like~ ("/lib/ld-linux*.so*", "/lib64/ld-linux*.so*", "/usr/lib/ld-linux*.so*", "/usr/lib64/ld-linux*.so*") and
-not process.name in ("dockerd", "yum", "dnf", "microdnf", "pacman")
+not process.executable in (
+    "/bin/dpkg", "/usr/bin/dpkg", "/bin/dockerd", "/usr/bin/dockerd", "/usr/sbin/dockerd", "/bin/microdnf",
+    "/usr/bin/microdnf", "/bin/rpm", "/usr/bin/rpm", "/bin/snapd", "/usr/bin/snapd", "/bin/yum", "/usr/bin/yum",
+    "/bin/dnf", "/usr/bin/dnf", "/bin/podman", "/usr/bin/podman", "/bin/dnf-automatic", "/usr/bin/dnf-automatic",
+    "/bin/pacman", "/usr/bin/pacman", "/usr/bin/dpkg-divert", "/bin/dpkg-divert", "/sbin/apk", "/usr/sbin/apk",
+    "/usr/local/sbin/apk", "/usr/bin/apt", "/usr/sbin/pacman", "/bin/podman", "/usr/bin/podman", "/usr/bin/puppet",
+    "/bin/puppet", "/opt/puppetlabs/puppet/bin/puppet", "/usr/bin/chef-client", "/bin/chef-client",
+    "/bin/autossl_check", "/usr/bin/autossl_check", "/proc/self/exe", "/dev/fd/*",  "/usr/bin/pamac-daemon",
+    "/bin/pamac-daemon", "/usr/lib/snapd/snapd", "/usr/local/bin/dockerd", "/usr/libexec/platform-python",
+    "/usr/lib/snapd/snap-update-ns", "./usr/bin/podman", "/usr/bin/crio", "/usr/bin/buildah", "/bin/dnf5",
+    "/usr/bin/dnf5", "/usr/bin/pamac"
+)
 '''
-
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1218"
 name = "System Binary Proxy Execution"
 reference = "https://attack.mitre.org/techniques/T1218/"
 
-
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1059"
 name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1059.004"
 name = "Unix Shell"
 reference = "https://attack.mitre.org/techniques/T1059/004/"
 
-
-
 [rule.threat.tactic]
 id = "TA0002"
 name = "Execution"
 reference = "https://attack.mitre.org/tactics/TA0002/"
+
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1574"
 name = "Hijack Execution Flow"
 reference = "https://attack.mitre.org/techniques/T1574/"
+
 [[rule.threat.technique.subtechnique]]
 id = "T1574.006"
 name = "Dynamic Linker Hijacking"
 reference = "https://attack.mitre.org/techniques/T1574/006/"
 
-
-
 [rule.threat.tactic]
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-

--- a/rules/linux/lateral_movement_unusual_remote_file_creation.toml
+++ b/rules/linux/lateral_movement_unusual_remote_file_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/04/07"
+updated_date = "2025/09/29"
 
 [rule]
 author = ["Elastic"]
@@ -53,7 +53,7 @@ Remote file creation tools like SCP, FTP, and SFTP are essential for transferrin
 - Implement stricter access controls and authentication mechanisms for remote file transfer services to prevent unauthorized use.
 - Escalate the incident to the security operations center (SOC) or incident response team for further investigation and to determine if additional systems have been compromised.
 """
-risk_score = 47
+risk_score = 21
 rule_id = "ed3fedc3-dd10-45a5-a485-34a8b48cea46"
 setup = """## Setup
 
@@ -92,7 +92,7 @@ Auditbeat is a lightweight shipper that you can install on your servers to audit
 - To run Auditbeat on Kubernetes follow the setup instructions in the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/running-on-kubernetes.html).
 - For complete “Setup and Run Auditbeat” information refer to the [helper guide](https://www.elastic.co/guide/en/beats/auditbeat/current/setting-up-and-running.html).
 """
-severity = "medium"
+severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: Linux",
@@ -106,9 +106,16 @@ type = "new_terms"
 query = '''
 event.category:file and host.os.type:linux and event.action:creation and
 process.name:(scp or ftp or sftp or vsftpd or sftp-server or sync) and
-not file.path:(/dev/ptmx or /run/* or /var/run/*)
+not (
+  file.path:(
+    /dev/ptmx or /run/* or /var/run/* or /home/*/.ansible/*AnsiballZ_*.py or /home/*/.ansible/tmp/ansible-tmp* or
+    /root/.ansible/*AnsiballZ_*.py or /tmp/ansible-chief/ansible-tmp*AnsiballZ_*.py or
+    /tmp/newroot/home/*/.ansible/tmp/ansible-tmp*AnsiballZ_*.py or /tmp/.ansible/tmp/ansible-tmp*AnsiballZ_*.py or
+    /tmp/ansible-tmp-*/AnsiballZ_*.py or /tmp/.ansible/ansible-tmp-*AnsiballZ_*.py
+  ) or
+  file.extension:(filepart or yaml or new or rpm or deb)
+)
 '''
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 

--- a/rules/linux/persistence_cron_job_creation.toml
+++ b/rules/linux/persistence_cron_job_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/06/09"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/02/03"
+updated_date = "2025/09/29"
 
 [transform]
 [[transform.osquery]]
@@ -47,7 +47,6 @@ query = "SELECT * FROM users WHERE username = {{user.name}}"
 [[transform.osquery]]
 label = "Osquery - Investigate the Account Authentication Status"
 query = "SELECT * FROM logged_in_users WHERE user = {{user.name}}"
-
 
 [rule]
 author = ["Elastic"]
@@ -194,13 +193,15 @@ event.action in ("rename", "creation") and file.path : (
     "/bin/autossl_check", "/usr/bin/autossl_check", "/proc/self/exe", "/dev/fd/*",  "/usr/bin/pamac-daemon",
     "/bin/pamac-daemon", "/usr/local/bin/dockerd", "/opt/elasticbeanstalk/bin/platform-engine",
     "/opt/puppetlabs/puppet/bin/ruby", "/usr/libexec/platform-python", "/opt/imunify360/venv/bin/python3",
-    "/opt/eset/efs/lib/utild", "/usr/sbin/anacron", "/usr/bin/podman", "/kaniko/kaniko-executor"
+    "/opt/eset/efs/lib/utild", "/usr/sbin/anacron", "/usr/bin/podman", "/kaniko/kaniko-executor",
+    "/usr/bin/pvedaemon", "./usr/bin/podman", "/usr/lib/systemd/systemd"
   ) or
   file.path like ("/var/spool/cron/crontabs/tmp.*", "/etc/cron.d/jumpcloud-updater") or
   file.extension in ("swp", "swpx", "swx", "dpkg-remove") or
   file.Ext.original.extension == "dpkg-new" or
   process.executable : (
-    "/nix/store/*", "/var/lib/dpkg/*", "/tmp/vmis.*", "/snap/*", "/dev/fd/*", "/usr/libexec/platform-python*"
+    "/nix/store/*", "/var/lib/dpkg/*", "/tmp/vmis.*", "/snap/*", "/dev/fd/*", "/usr/libexec/platform-python*",
+    "/var/lib/waagent/Microsoft*"
   ) or
   process.executable == null or
   process.name in (
@@ -208,7 +209,8 @@ event.action in ("rename", "creation") and file.path : (
     "jumpcloud-agent", "crio", "dnf_install", "utild"
   ) or
   (process.name == "sed" and file.name : "sed*") or
-  (process.name == "perl" and file.name : "e2scrub_all.tmp*") 
+  (process.name == "perl" and file.name : "e2scrub_all.tmp*")  or
+  (process.name in ("vi", "vim") and file.name like "*~")
 )
 '''
 

--- a/rules/linux/persistence_extract_initramfs_via_cpio.toml
+++ b/rules/linux/persistence_extract_initramfs_via_cpio.toml
@@ -2,12 +2,12 @@
 creation_date = "2025/01/16"
 integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/09/29"
 
 [rule]
 author = ["Elastic"]
 description = """
-This rule detects the extraction of an initramfs image using the `cpio` command on Linux systems. The `cpio` command is
+This rule detects the extraction of an initramfs image using the "cpio" command on Linux systems. The "cpio" command is
 used to create or extract cpio archives. Attackers may extract the initramfs image to modify the contents or add
 malicious files, which can be leveraged to maintain persistence on the system.
 """
@@ -95,19 +95,27 @@ tags = [
 ]
 timestamp_override = "event.ingested"
 type = "eql"
-
 query = '''
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed") and
-process.name == "cpio" and process.args in ("-H", "--format") and process.args == "newc" and not (
+process.name == "cpio" and process.args in ("-H", "--format") and process.args == "newc" and
+not (
   process.parent.name in ("mkinitramfs", "dracut") or
-  process.parent.executable like~ ("/usr/share/initramfs-tools/*", "/nix/store/*")
+  process.parent.executable like~ ("/usr/share/initramfs-tools/*", "/nix/store/*") or
+  process.parent.args in (
+    "/bin/dracut", "/usr/share/initramfs-tools/hooks/amd64_microcode", "/usr/bin/dracut", "/usr/sbin/mkinitramfs",
+    "/usr/sbin/dracut", "/usr/bin/update-microcode-initrd"
+  ) or
+  process.args like ("/var/tmp/mkinitramfs_*", "/tmp/tmp.*/mkinitramfs_*") or
+  process.working_directory like (
+    "/var/tmp/mkinitramfs-*", "/tmp/microcode-initrd_*", "/var/tmp/mkinitramfs-*", "/var/tmp/dracut.*",
+    "/var/tmp/mkinitramfs_*"
+  )
 )
 '''
-
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
+
 [[rule.threat.technique]]
 id = "T1542"
 name = "Pre-OS Boot"
@@ -123,9 +131,7 @@ id = "T1574"
 name = "Hijack Execution Flow"
 reference = "https://attack.mitre.org/techniques/T1574/"
 
-
 [rule.threat.tactic]
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-


### PR DESCRIPTION
## Summary
This PR tunes several Linux DRs that were flagged by our community as noisy.

### [Rule Tuning] Dynamic Linker (ld.so) Creation
Ref: 	https://github.com/elastic/detection-rules/issues/5104

These two rules detect a similar tactic, but a different technique. The dynamic linker creation/modification file focusses on dynamic linker configuration files, while the dynamic linker ld.so creation focusses on the creation of the linker itself. Both are used in different ways, and therefore it's good to keep them seperated.

However, I did add proper exclusions to both in this PR.

### [Rule Tuning] Cron Job Created or Modified
Ref: https://github.com/elastic/detection-rules/issues/5078

I tuned out the temporary vi/vim files; and a few other common FP patterns. I will avoid tuning out too much here; as it is a DR that our users can exclude themselves easily. 

### [Rule Tuning] Unusual Remote File Creation, exclude files created by Ansible
Ref: https://github.com/elastic/detection-rules/issues/5011

I tuned out the noisy Ansible hits + several hits related to package manager files. Additionally, I bumped down the severity to low; as this is mostly an interesting rule for clusters that generally do not use these utilities on a day-to-day basis. The new_terms rule type does reduce noise; but it is of course still a relatively broad rule.

### [Rule Tuning] Initramfs Extraction via CPIO - kernel upgrades
Ref: https://github.com/elastic/detection-rules/issues/5148

I tuned out hits related to dracut/mkinitramfs args and working directories.

### [Rule Tuning] Unusual File Transfer Utility Launched - sftp
Ref: https://github.com/elastic/detection-rules/issues/5147

This request I will not tune out; as this is a pattern observed by malware such as Outlaw. You can read our blog on this threat here: https://www.elastic.co/security-labs/outlaw-linux-malware.

In a recent PR: https://github.com/elastic/detection-rules/pull/5050, I tuned out the process command_line in the by grouping, which would already result in a decrease in hits. If you want to exclude this; you can do this yourself through an exception, however, this utility being spawned via ssh is a common hit for brute forcer tools like Outlaw.

### [Rule Tuning] Attempt to Disable Syslog Service
Ref: https://github.com/elastic/detection-rules/issues/5146

Logging daemons are configured to use this signal as part of a configuration reload / log file rotation trigger. The `HUP` (SIGHUP) signal is therefore now excluded from the rule. It cut telemetry down for this rule by 90%. 

### [Rule Tuning] Kill Command Execution - SIGHUP, logrotate
Ref: https://github.com/elastic/detection-rules/issues/5145

Tuned out several signals that are not malicious to reduce noise.