### PR TITLE
[Rule Tuning] Check if registry.data.strings is null on exclusion-based logic

### DIFF
--- a/rules/windows/defense_evasion_lsass_ppl_disabled_registry.toml
+++ b/rules/windows/defense_evasion_lsass_ppl_disabled_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/05/27"
 integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/08/26"
+updated_date = "2025/10/07"
 
 [rule]
 author = ["Elastic"]
@@ -81,7 +81,8 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-  registry.value : "RunAsPPL" and registry.path : "*\\SYSTEM\\*ControlSet*\\Control\\Lsa\\RunAsPPL" and
+  registry.data.strings != null and registry.value : "RunAsPPL" and
+  registry.path : "*\\SYSTEM\\*ControlSet*\\Control\\Lsa\\RunAsPPL" and
   not registry.data.strings : ("1", "0x00000001", "2", "0x00000002")
 '''
 

--- a/rules/windows/defense_evasion_reg_disable_enableglobalqueryblocklist.toml
+++ b/rules/windows/defense_evasion_reg_disable_enableglobalqueryblocklist.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/05/31"
 integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/08/26"
+updated_date = "2025/10/07"
 
 [rule]
 author = ["Elastic"]
@@ -84,7 +84,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
 (
   (registry.value : "EnableGlobalQueryBlockList" and registry.data.strings : ("0", "0x00000000")) or
   (registry.value : "GlobalQueryBlockList" and not registry.data.strings : "wpad")

--- a/rules/windows/persistence_services_registry.toml
+++ b/rules/windows/persistence_services_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/18"
 integration = ["endpoint", "windows", "m365_defender", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/08/18"
+updated_date = "2025/10/07"
 
 [rule]
 author = ["Elastic"]
@@ -79,7 +79,7 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and
-  registry.value : ("ServiceDLL", "ImagePath") and
+  registry.data.strings != null and registry.value : ("ServiceDLL", "ImagePath") and
   registry.path : (
       "HKLM\\SYSTEM\\ControlSet*\\Services\\*\\ServiceDLL",
       "HKLM\\SYSTEM\\ControlSet*\\Services\\*\\ImagePath",

--- a/rules/windows/privilege_escalation_reg_service_imagepath_mod.toml
+++ b/rules/windows/privilege_escalation_reg_service_imagepath_mod.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/05"
 integration = ["endpoint", "windows", "crowdstrike", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
-updated_date = "2025/08/26"
+updated_date = "2025/10/07"
 
 [rule]
 author = ["Elastic"]
@@ -82,7 +82,7 @@ type = "eql"
 
 query = '''
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
-  registry.value == "ImagePath" and
+  registry.data.strings != null and registry.value == "ImagePath" and
   registry.key : (
     "*\\ADWS", "*\\AppHostSvc", "*\\AppReadiness", "*\\AudioEndpointBuilder", "*\\AxInstSV", "*\\camsvc", "*\\CertSvc",
     "*\\COMSysApp", "*\\CscService", "*\\defragsvc", "*\\DeviceAssociationService", "*\\DeviceInstall", "*\\DevQueryBroker",


### PR DESCRIPTION
## Issues

SDH 629

## Summary

A few rules that use `not registry.data.strings` conditions may cause FPs with the 3rd party EDRs where registry.data.strings is null, I've reviewed all usage of `registry.data.strings` and included a `registry.data.strings != null` check on them.