### PR TITLE
[Tuning] Simple HTTP Web Server Connection

### DIFF
--- a/rules/linux/persistence_simple_web_server_connection_accepted.toml
+++ b/rules/linux/persistence_simple_web_server_connection_accepted.toml
@@ -13,7 +13,7 @@ payload to the server web root, allowing them to regain remote access to the sys
 an attacker requests the server to execute a command or script via a potential backdoor.
 """
 from = "now-9m"
-index = ["logs-endpoint.events.network*"]
+index = ["logs-endpoint.events.process*", "logs-endpoint.events.network*"]
 language = "eql"
 license = "Elastic License v2"
 name = "Simple HTTP Web Server Connection"


### PR DESCRIPTION
https://github.com/elastic/sdh-protections/issues/631

This tuning fixes rule logic assuming network events capture process.command_line by converting it to a sequence/correlation of process start event followed by network event.