### PR TITLE
[Tuning] Agent Spoofing - Mismatched Agent ID

### DIFF
--- a/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
+++ b/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2021/07/14"
 maturity = "production"
-updated_date = "2025/11/10"
+updated_date = "2025/11/13"
 
 [rule]
 author = ["Elastic"]
@@ -29,7 +29,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.agent_id_status:(agent_id_mismatch or mismatch) and not host.name:agentless-*
+event.agent_id_status:agent_id_mismatch and not host.name:agentless-*
 '''
 note = """## Triage and analysis
 


### PR DESCRIPTION
the `event.agent_id_status:mismatch`  is so common/noisy and alone not a sign of agent spoofing (700k+ from 1k+ agents last 7d) impacting both 8.* and 9.* versions.

