### PR TITLE
[Rule Tuning] Remove `host.os.type` Unit Test Forwarded Events Exception

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.5.9"
+version = "1.5.10"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rules/windows/credential_access_bruteforce_admin_account.toml
+++ b/rules/windows/credential_access_bruteforce_admin_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [transform]
 [[transform.osquery]]
@@ -107,7 +107,8 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name, source.ip with maxspan=10s
-  [authentication where event.action == "logon-failed" and winlog.logon.type : "Network" and
+  [authentication where host.os.type == "windows" and
+    event.action == "logon-failed" and winlog.logon.type : "Network" and
     source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1" and user.name : "*admin*" and
 
     /* noisy failure status codes often associated to authentication misconfiguration */

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_followed_by_success.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [transform]
 [[transform.osquery]]
@@ -111,7 +111,7 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name, source.ip with maxspan=5s
-  [authentication where event.action == "logon-failed" and
+  [authentication where host.os.type == "windows" and event.action == "logon-failed" and
     /* event 4625 need to be logged */
     winlog.logon.type : "Network" and user.id != null and 
     source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1" and 
@@ -120,7 +120,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
     /* noisy failure status codes often associated to authentication misconfiguration */
     not winlog.event_data.Status : ("0xC000015B", "0XC000005E", "0XC0000133", "0XC0000192")] with runs=5
-  [authentication where event.action == "logged-in" and
+  [authentication where host.os.type == "windows" and event.action == "logged-in" and
     /* event 4624 need to be logged */
     winlog.logon.type : "Network" and
     source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1" and

--- a/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
+++ b/rules/windows/credential_access_bruteforce_multiple_logon_failure_same_srcip.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [transform]
 [[transform.osquery]]
@@ -121,7 +121,7 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name, source.ip with maxspan=10s
-  [authentication where event.action == "logon-failed" and
+  [authentication where host.os.type == "windows" and event.action == "logon-failed" and
     /* event 4625 need to be logged */
     winlog.logon.type : "Network" and
     source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1" and

--- a/rules/windows/credential_access_dcsync_newterm_subjectuser.toml
+++ b/rules/windows/credential_access_dcsync_newterm_subjectuser.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/12/19"
 integration = ["windows", "system"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -95,11 +95,12 @@ timestamp_override = "event.ingested"
 type = "new_terms"
 
 query = '''
-event.code:"4662" and winlog.event_data.Properties:(
-                               *DS-Replication-Get-Changes* or *DS-Replication-Get-Changes-All* or
-                               *DS-Replication-Get-Changes-In-Filtered-Set* or *1131f6ad-9c07-11d1-f79f-00c04fc2dcd2* or
-                               *1131f6aa-9c07-11d1-f79f-00c04fc2dcd2* or *89e95b76-444d-4c62-991a-0facbeda640c*) and
- not winlog.event_data.SubjectUserName:(*$ or MSOL_*)
+event.code:"4662" and host.os.type:"windows" and 
+  winlog.event_data.Properties:(
+    *DS-Replication-Get-Changes* or *DS-Replication-Get-Changes-All* or
+    *DS-Replication-Get-Changes-In-Filtered-Set* or *1131f6ad-9c07-11d1-f79f-00c04fc2dcd2* or
+    *1131f6aa-9c07-11d1-f79f-00c04fc2dcd2* or *89e95b76-444d-4c62-991a-0facbeda640c*) and
+  not winlog.event_data.SubjectUserName:(*$ or MSOL_*)
 '''
 
 

--- a/rules/windows/credential_access_dcsync_user_backdoor.toml
+++ b/rules/windows/credential_access_dcsync_user_backdoor.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/10"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -92,7 +92,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code:"5136" and
+event.code:"5136" and host.os.type:"windows" and
   winlog.event_data.AttributeLDAPDisplayName:"nTSecurityDescriptor" and
   winlog.event_data.AttributeValue : (
     (

--- a/rules/windows/credential_access_kerberos_coerce.toml
+++ b/rules/windows/credential_access_kerberos_coerce.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/14"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/06/14"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -93,8 +93,11 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-(event.code:4662 and winlog.event_data.AdditionalInfo: *UWhRC*BAAAA*MicrosoftDNS*) or 
-(event.code:5137 and winlog.event_data.ObjectDN: *UWhRC*BAAAA*MicrosoftDNS*)
+host.os.type:"windows" and
+(
+  (event.code:4662 and winlog.event_data.AdditionalInfo: *UWhRC*BAAAA*MicrosoftDNS*) or 
+  (event.code:5137 and winlog.event_data.ObjectDN: *UWhRC*BAAAA*MicrosoftDNS*)
+)
 '''
 
 

--- a/rules/windows/credential_access_ldap_attributes.toml
+++ b/rules/windows/credential_access_ldap_attributes.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/11/09"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -89,7 +89,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where event.code == "4662" and
+any where host.os.type == "windows" and event.code == "4662" and
 
   not winlog.event_data.SubjectUserSid : "S-1-5-18" and
 

--- a/rules/windows/credential_access_machine_account_smb_relay.toml
+++ b/rules/windows/credential_access_machine_account_smb_relay.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/16"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/06/16"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -69,7 +69,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-file where event.code == "5145" and endswith(user.name, "$") and
+file where host.os.type == "windows" and event.code == "5145" and endswith(user.name, "$") and
 
  /* compare computername with user.name and make sure they match */
  startswith~(winlog.computer_name, substring(user.name, 0, -1)) and

--- a/rules/windows/credential_access_saved_creds_vault_winlog.toml
+++ b/rules/windows/credential_access_saved_creds_vault_winlog.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/30"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -73,12 +73,12 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
  /* 2 consecutive vault reads from same pid for web creds */
 
- [any where event.code : "5382" and
+ [any where host.os.type == "windows" and event.code == "5382" and
   (winlog.event_data.SchemaFriendlyName : "Windows Web Password Credential" and winlog.event_data.Resource : "http*") and
   not winlog.event_data.SubjectLogonId : "0x3e7" and
   not winlog.event_data.Resource : "http://localhost/"]
 
- [any where event.code : "5382" and
+ [any where host.os.type == "windows" and event.code == "5382" and
   (winlog.event_data.SchemaFriendlyName : "Windows Web Password Credential" and winlog.event_data.Resource : "http*") and
   not winlog.event_data.SubjectLogonId : "0x3e7" and
   not winlog.event_data.Resource : "http://localhost/"]

--- a/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
+++ b/rules/windows/credential_access_seenabledelegationprivilege_assigned_to_user.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/01/27"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -90,7 +90,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code:4704 and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
+event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
 '''
 
 

--- a/rules/windows/credential_access_shadow_credentials.toml
+++ b/rules/windows/credential_access_shadow_credentials.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/01/26"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -99,7 +99,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code:"5136" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
+event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
   winlog.event_data.AttributeValue :B\:828* and
   not winlog.event_data.SubjectUserName: MSOL_*
 '''

--- a/rules/windows/credential_access_spn_attribute_modified.toml
+++ b/rules/windows/credential_access_spn_attribute_modified.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/22"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/09/11"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -98,7 +98,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code:5136 and winlog.event_data.OperationType:"%%14674" and
+event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
   winlog.event_data.ObjectClass:"user" and
   winlog.event_data.AttributeLDAPDisplayName:"servicePrincipalName"
 '''

--- a/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
+++ b/rules/windows/credential_access_suspicious_winreg_access_via_sebackup_priv.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/16"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -97,12 +97,12 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
- [iam where event.action == "logged-in-special"  and
+ [iam where host.os.type == "windows" and event.action == "logged-in-special" and
   winlog.event_data.PrivilegeList : "SeBackupPrivilege" and
 
   /* excluding accounts with existing privileged access */
   not winlog.event_data.PrivilegeList : "SeDebugPrivilege"]
- [any where event.code == "5145" and winlog.event_data.RelativeTargetName : "winreg"]
+ [any where host.os.type == "windows" and event.code == "5145" and winlog.event_data.RelativeTargetName : "winreg"]
 '''
 
 

--- a/rules/windows/discovery_high_number_ad_properties.toml
+++ b/rules/windows/discovery_high_number_ad_properties.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/29"
 integration = ["windows", "system"]
 maturity = "production"
-updated_date = "2025/09/11"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -78,7 +78,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where event.code == "4662" and not winlog.event_data.SubjectUserSid : "S-1-5-18" and
+any where host.os.type == "windows" and event.code == "4662" and not winlog.event_data.SubjectUserSid : "S-1-5-18" and
  winlog.event_data.AccessMaskDescription == "Read Property" and length(winlog.event_data.Properties) >= 2000
 '''
 

--- a/rules/windows/lateral_movement_remote_service_installed_winlog.toml
+++ b/rules/windows/lateral_movement_remote_service_installed_winlog.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/30"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -66,9 +66,9 @@ type = "eql"
 
 query = '''
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
-[authentication where event.action == "logged-in" and winlog.logon.type : "Network" and
-event.outcome=="success" and source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1"]
-[iam where event.action == "service-installed" and
+[authentication where host.os.type == "windows" and event.action == "logged-in" and winlog.logon.type : "Network" and
+ event.outcome == "success" and source.ip != null and source.ip != "127.0.0.1" and source.ip != "::1"]
+[iam where host.os.type == "windows" and event.action == "service-installed" and
  not winlog.event_data.SubjectLogonId : "0x3e7" and
  not winlog.event_data.ServiceFileName :
                ("?:\\Windows\\ADCR_Agent\\adcrsvc.exe",

--- a/rules/windows/lateral_movement_remote_task_creation_winlog.toml
+++ b/rules/windows/lateral_movement_remote_task_creation_winlog.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -56,7 +56,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-iam where event.action == "scheduled-task-created" and
+iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
  winlog.event_data.RpcCallClientLocality : "0" and winlog.event_data.ClientProcessId : "0"
 '''
 

--- a/rules/windows/persistence_ad_adminsdholder.toml
+++ b/rules/windows/persistence_ad_adminsdholder.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/01/31"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -74,7 +74,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code:5136 and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
+event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
 '''
 
 

--- a/rules/windows/persistence_msds_alloweddelegateto_krbtgt.toml
+++ b/rules/windows/persistence_msds_alloweddelegateto_krbtgt.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/01/27"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -86,7 +86,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-iam where event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
+iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
 '''
 
 

--- a/rules/windows/persistence_remote_password_reset.toml
+++ b/rules/windows/persistence_remote_password_reset.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/10/18"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -76,13 +76,13 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name with maxspan=1m
-  [authentication where event.action == "logged-in" and
+  [authentication where host.os.type == "windows" and event.action == "logged-in" and
     /* event 4624 need to be logged */
     winlog.logon.type : "Network" and event.outcome == "success" and source.ip != null and
     source.ip != "127.0.0.1" and source.ip != "::1" and
     not winlog.event_data.TargetUserName : ("svc*", "PIM_*", "_*_", "*-*-*", "*$")] by winlog.event_data.TargetLogonId
    /* event 4724 need to be logged */
-  [iam where event.action == "reset-password" and
+  [iam where host.os.type == "windows" and event.action == "reset-password" and
    (
     /*
        This rule is very noisy if not scoped to privileged accounts, duplicate the

--- a/rules/windows/persistence_scheduled_task_creation_winlog.toml
+++ b/rules/windows/persistence_scheduled_task_creation_winlog.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -65,7 +65,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-iam where event.action == "scheduled-task-created" and
+iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
 
  /* excluding tasks created by the computer account */
  not user.name : "*$" and

--- a/rules/windows/persistence_scheduled_task_updated.toml
+++ b/rules/windows/persistence_scheduled_task_updated.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/07/07"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -65,7 +65,7 @@ timestamp_override = "event.ingested"
 type = "new_terms"
 
 query = '''
-event.category: "iam" and event.code: "4702" and
+event.category: "iam" and host.os.type:"windows" and event.code: "4702" and
   not winlog.event_data.SubjectUserSid: ("S-1-5-18" or "S-1-5-19" or "S-1-5-20") and
   not user.name : *$
 '''

--- a/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
+++ b/rules/windows/persistence_sdprop_exclusion_dsheuristics.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/24"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -93,7 +93,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where event.code == "5136" and
+any where host.os.type == "windows" and event.code == "5136" and
   winlog.event_data.AttributeLDAPDisplayName : "dSHeuristics" and
   length(winlog.event_data.AttributeValue) > 15 and
   winlog.event_data.AttributeValue regex~ "[0-9]{15}([1-9a-f]).*"

--- a/rules/windows/persistence_service_windows_service_winlog.toml
+++ b/rules/windows/persistence_service_windows_service_winlog.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/30"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [transform]
 [[transform.osquery]]
@@ -110,7 +110,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where
+any where host.os.type == "windows" and
   (event.code : "4697" and
    (winlog.event_data.ServiceFileName : 
            ("*COMSPEC*", "*\\127.0.0.1*", "*Admin$*", "*powershell*", "*rundll32*", "*cmd.exe*", "*PSEXESVC*", 

--- a/rules/windows/persistence_sysmon_wmi_event_subscription.toml
+++ b/rules/windows/persistence_sysmon_wmi_event_subscription.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/02/02"
 integration = ["windows", "endpoint"]
 maturity = "production"
-updated_date = "2025/07/02"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -69,7 +69,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-any where
+any where host.os.type == "windows" and
  (
    (event.dataset == "windows.sysmon_operational" and event.code == "21" and
     ?winlog.event_data.Operation : "Created" and ?winlog.event_data.Consumer : ("*subscription:CommandLineEventConsumer*", "*subscription:ActiveScriptEventConsumer*")) or

--- a/rules/windows/persistence_temp_scheduled_task.toml
+++ b/rules/windows/persistence_temp_scheduled_task.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -67,8 +67,8 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
-   [iam where event.action == "scheduled-task-created" and not user.name : "*$"]
-   [iam where event.action == "scheduled-task-deleted" and not user.name : "*$"]
+   [iam where host.os.type == "windows" and event.action == "scheduled-task-created" and not user.name : "*$"]
+   [iam where host.os.type == "windows" and event.action == "scheduled-task-deleted" and not user.name : "*$"]
 '''
 
 

--- a/rules/windows/privilege_escalation_badsuccessor_dmsa_abuse.toml
+++ b/rules/windows/privilege_escalation_badsuccessor_dmsa_abuse.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/05/23"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/05/23"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -56,7 +56,7 @@ timestamp_override = "event.ingested"
 type = "new_terms"
 
 query = '''
-event.code:5136 and winlog.event_data.AttributeLDAPDisplayName:"msDS-ManagedAccountPrecededByLink"
+event.code:5136 and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-ManagedAccountPrecededByLink"
 '''
 
 

--- a/rules/windows/privilege_escalation_create_process_as_different_user.toml
+++ b/rules/windows/privilege_escalation_create_process_as_different_user.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/30"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -70,14 +70,14 @@ type = "eql"
 query = '''
 sequence by winlog.computer_name with maxspan=1m
 
-[authentication where event.action:"logged-in" and
+[authentication where host.os.type == "windows" and event.action:"logged-in" and
  event.outcome == "success" and user.id : ("S-1-5-21-*", "S-1-12-1-*") and
 
  /* seclogon service */
  process.name == "svchost.exe" and
  winlog.event_data.LogonProcessName : "seclogo*" and source.ip == "::1" ] by winlog.event_data.TargetLogonId
 
-[process where event.type == "start"] by winlog.event_data.TargetLogonId
+[process where host.os.type == "windows" and event.type == "start"] by winlog.event_data.TargetLogonId
 '''
 
 

--- a/rules/windows/privilege_escalation_credroaming_ldap.toml
+++ b/rules/windows/privilege_escalation_credroaming_ldap.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/11/09"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -90,7 +90,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.code:"5136" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
+event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
   winlog.event_data.OperationType:"%%14674" and
   not winlog.event_data.SubjectUserSid : "S-1-5-18"
 '''

--- a/rules/windows/privilege_escalation_dmsa_creation_by_unusual_user.toml
+++ b/rules/windows/privilege_escalation_dmsa_creation_by_unusual_user.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/05/23"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/05/23"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -55,7 +55,7 @@ timestamp_override = "event.ingested"
 type = "new_terms"
 
 query = '''
-event.code:5137 and winlog.event_data.ObjectClass:"msDS-DelegatedManagedServiceAccount"
+event.code:5137 and host.os.type:"windows" and winlog.event_data.ObjectClass:"msDS-DelegatedManagedServiceAccount"
 '''
 
 

--- a/rules/windows/privilege_escalation_krbrelayup_service_creation.toml
+++ b/rules/windows/privilege_escalation_krbrelayup_service_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/04/27"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/06/19"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -73,7 +73,7 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name with maxspan=5m
- [authentication where
+ [authentication where host.os.type == "windows" and
 
   /* event 4624 need to be logged */
   event.action == "logged-in" and event.outcome == "success" and winlog.event_data.ElevatedToken == "%%1843" and process.pid == 0 and 
@@ -81,7 +81,7 @@ sequence by winlog.computer_name with maxspan=5m
   /* authenticate locally using relayed kerberos Ticket */
   winlog.event_data.AuthenticationPackageName :"Kerberos" and winlog.logon.type == "Network" and cidrmatch(source.ip, "127.0.0.0/8", "::1")] by winlog.event_data.TargetLogonId
 
-  [any where
+  [any where host.os.type == "windows" and
    /* event 4697 need to be logged */
    event.action : "service-installed"] by winlog.event_data.SubjectLogonId
 '''

--- a/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
+++ b/rules/windows/privilege_escalation_samaccountname_spoofing_attack.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/12/12"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -76,7 +76,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-iam where event.action == "renamed-user-account" and
+iam where host.os.type == "windows" and event.action == "renamed-user-account" and
   /* machine account name renamed to user like account name */
   winlog.event_data.OldTargetUserName : "*$" and not winlog.event_data.NewTargetUserName : "*$"
 '''

--- a/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
+++ b/rules/windows/privilege_escalation_suspicious_dnshostname_update.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/05/11"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/03/20"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -74,7 +74,8 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-iam where event.action == "changed-computer-account" and user.id : ("S-1-5-21-*", "S-1-12-1-*") and
+iam where host.os.type == "windows" and event.action == "changed-computer-account" and
+    user.id : ("S-1-5-21-*", "S-1-12-1-*") and
 
     /* if DnsHostName value equal a DC DNS hostname then it's highly suspicious */
     winlog.event_data.DnsHostName : "??*" and

--- a/rules/windows/privilege_escalation_thread_cpu_priority_hijack.toml
+++ b/rules/windows/privilege_escalation_thread_cpu_priority_hijack.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/09/25"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2025/09/25"
+updated_date = "2025/11/14"
 
 [rule]
 author = ["Elastic"]
@@ -73,7 +73,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-event.category:iam and event.code:"4674" and
+event.category:iam and host.os.type:"windows" and event.code:"4674" and
 winlog.event_data.PrivilegeList:"SeIncreaseBasePriorityPrivilege" and event.outcome:"success" and
 winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-1-5-18" or "S-1-5-19" or "S-1-5-20")
 '''

--- a/tests/test_specific_rules.py
+++ b/tests/test_specific_rules.py
@@ -49,12 +49,7 @@ class TestEndpointQuery(BaseRuleTest):
 
             err_msg = f"{self.rule_str(rule)} missing required field for endpoint rule"
             if "host.os.type" not in fields:
-                # Exception for Forwarded Events which contain Windows-only fields.
-                if rule.path.parent.name == "windows":
-                    if not any(field.startswith("winlog.") for field in fields):
-                        self.assertIn("host.os.type", fields, err_msg)
-                else:
-                    self.assertIn("host.os.type", fields, err_msg)
+                self.assertIn("host.os.type", fields, err_msg)
 
 
 class TestNewTerms(BaseRuleTest):


### PR DESCRIPTION
## Issues

Resolves https://github.com/elastic/detection-rules/issues/5045

## Summary

As we no longer have the limitation of the Forwarded Logs not populating the `host.os.type` field, this PR removes the exception from the unit tests and adjust the rules.