### PR TITLE
[New Rule] Web Server Unusual Spike in Error Response Codes

### DIFF
--- a/rules/cross-platform/reconnaissance_web_server_unusual_spike_in_error_response_codes.toml
+++ b/rules/cross-platform/reconnaissance_web_server_unusual_spike_in_error_response_codes.toml
@@ -34,16 +34,10 @@ tags = [
 timestamp_override = "event.ingested"
 type = "esql"
 query = '''
-from
-  logs-network_traffic.http-*,
-  logs-network_traffic.tls-*,
-  logs-nginx.access-*,
-  logs-apache.access-*,
-  logs-apache_tomcat.access-*,
-  logs-iis.access-*
+from logs-network_traffic.http-*, logs-network_traffic.tls-*, logs-nginx.access-*, logs-apache.access-*, logs-apache_tomcat.access-*, logs-iis.access-*
 | where
     (url.original is not null or url.full is not null) and
-    http.request.method == "GET" and 
+    http.request.method == "GET" and
     http.response.status_code in (
       500, // Internal Server Error
       502, // Bad Gateway


### PR DESCRIPTION
## Summary
This rule detects unusual spikes in error response codes (500, 502, 503, 504) from web servers, which may indicate reconnaissance activities such as vulnerability scanning or fuzzing attempts by adversaries. These activities often generate a high volume of error responses as they probe for weaknesses in web applications. Error response codes may potentially indicate server-side issues that could be exploited.

## Telemetry
<img width="1892" height="502" alt="{19F922BA-58B0-4109-B293-0835A7E58301}" src="https://github.com/user-attachments/assets/def3bc19-9511-4111-a61e-4c19c96b3617" />
