### PR TITLE
[New Rule] Web Server Unusual Spike in Error Logs

### DIFF
--- a/rules/cross-platform/reconnaissance_web_server_unusual_spike_in_error_logs.toml
+++ b/rules/cross-platform/reconnaissance_web_server_unusual_spike_in_error_logs.toml
@@ -33,10 +33,6 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-network_traffic.http-*, logs-network_traffic.tls-*, logs-nginx.access-*, logs-apache.access-*, logs-apache_tomcat.access-*, logs-iis.access-*
-  logs-nginx.error-*,
-  logs-apache_tomcat.error-*,
-  logs-apache.error-*,
-  logs-iis.error-*
 | keep
     @timestamp,
     event.type,


### PR DESCRIPTION
## Summary
This rule detects unusual spikes in error logs from web servers, which may indicate reconnaissance activities such as vulnerability scanning or fuzzing attempts by adversaries. These activities often generate a high volume of error responses as they probe for weaknesses in web applications. Error response codes may potentially indicate server-side issues that could be exploited.

