### PR TITLE
[Rule Tuning] Credential Access via TruffleHog Execution

### DIFF
--- a/rules/cross-platform/credential_access_trufflehog_execution.toml
+++ b/rules/cross-platform/credential_access_trufflehog_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/09/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/10/06"
+updated_date = "2025/11/25"
 
 [rule]
 author = ["Elastic"]
@@ -54,7 +54,10 @@ This rule flags TruffleHog executed to scan the local filesystem with verified J
 - Escalate to full incident response if trufflehog ran under a service account, on a build server/CI runner, or if any discovered secret was used to authenticate to external git remotes (e.g., github.com), cloud APIs, or private registries in the same session.
 - Harden by blocking unapproved trufflehog execution via application control, moving approved secret scanning to a locked-down pipeline, enforcing short-lived PATs and key rotation, enabling egress filtering from developer hosts/runners, and deploying fleet-wide detections for "trufflehog --results=verified --json filesystem".
 """
-references = ["https://www.elastic.co/blog/shai-hulud-worm-npm-supply-chain-compromise"]
+references = [
+    "https://www.elastic.co/blog/shai-hulud-worm-npm-supply-chain-compromise",
+    "https://socket.dev/blog/shai-hulud-strikes-again-v2",
+]
 risk_score = 21
 rule_id = "47595dea-452b-4d37-b82d-6dd691325139"
 severity = "low"
@@ -72,7 +75,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
-process.args == "--results=verified" and process.args == "--json" and process.args == "filesystem"
+process.args == "--json" and process.args == "filesystem"
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary
Tuning to add FN for https://socket.dev/blog/shai-hulud-strikes-again-v2.