### PR TITLE
[Rule Tuning] Python Startup Hook Rules

### DIFF
--- a/rules/linux/persistence_pth_file_creation.toml
+++ b/rules/linux/persistence_pth_file_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/26"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/04/07"
+updated_date = "2025/12/03"
 
 [rule]
 author = ["Elastic"]
@@ -127,6 +127,11 @@ framework = "MITRE ATT&CK"
 id = "T1546"
 name = "Event Triggered Execution"
 reference = "https://attack.mitre.org/techniques/T1546/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1546.018"
+name = "Python Startup Hooks"
+reference = "https://attack.mitre.org/techniques/T1546/018/"
 
 [[rule.threat.technique]]
 id = "T1574"

--- a/rules/linux/persistence_site_and_user_customize_file_creation.toml
+++ b/rules/linux/persistence_site_and_user_customize_file_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/26"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/04/07"
+updated_date = "2025/12/03"
 
 [rule]
 author = ["Elastic"]
@@ -122,6 +122,11 @@ framework = "MITRE ATT&CK"
 id = "T1546"
 name = "Event Triggered Execution"
 reference = "https://attack.mitre.org/techniques/T1546/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1546.018"
+name = "Python Startup Hooks"
+reference = "https://attack.mitre.org/techniques/T1546/018/"
 
 [[rule.threat.technique]]
 id = "T1574"


### PR DESCRIPTION
## Summary
In the latest MITRE Release, my contribution for Python Startup Hooks was added to the framework:

- https://attack.mitre.org/techniques/T1546/018/

To properly reflect the rules I created for this technique, I have now added the new mappings.