### PR TITLE
[Rule Tuning] Suspicious React Server Child Process

### DIFF
--- a/rules/cross-platform/initial_access_execution_susp_react_serv_child.toml
+++ b/rules/cross-platform/initial_access_execution_susp_react_serv_child.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/12/04"
 integration = ["endpoint", "windows", "auditd_manager", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/12/05"
+updated_date = "2025/12/08"
 
 [rule]
 author = ["Elastic"]
@@ -77,7 +77,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where event.type == "start" and event.action != "fork" and (
+process where event.type == "start" and event.action in ("exec", "executed", "start", "process_started") and (
     process.name in (
       "sh", "bash", "zsh", "curl", "wget", "id", "whoami", "uname", "cmd.exe", "cat", "powershell.exe", "java", "rundll32.exe", "wget.exe", "certutil.exe",
       "nc", "ncat", "netcat", "nc.openbsd", "nc.traditional", "socat", "busybox", "mkfifo", "nohup", "setsid", "xterm"


### PR DESCRIPTION
## Summary
I proposed to add `event.action != fork` to the rule; but this got me thinking. When event aggregation is used, e.g. an event that gets 
`event.type ["start", "end"]` and `event.action ["exec", "fork", "end"]`, setting `event.action != fork` will exclude it. This will introduce FNs.

This tuning should fix this. My bad for the recommendation. 