### PR TITLE
[New Rule] PowerShell Script Block Entropy Outlier via MAD Z-Score

### DIFF
--- a/rules/windows/defense_evasion_posh_entropy_z_score.toml
+++ b/rules/windows/defense_evasion_posh_entropy_z_score.toml
@@ -19,7 +19,7 @@ false_positives = [
   entropy or uneven character distributions.
   """,
   """
-  Low-volume environments can yield more instable baselines, which can increase alert noise.
+  Low-volume environments can yield more unstable baselines, which can increase alert noise.
   """
 ]
 from = "now-4h"


### PR DESCRIPTION
## Issues

Part of https://github.com/elastic/ia-trade-team/issues/720 and https://github.com/elastic/ia-trade-team/issues/782

## Summary

Identifies PowerShell scripts with unusually high entropy relative to host and global baselines via MAD-based z-scores with host/global shrinkage. This detection requires enough data to build stable baselines, so it may not alert in low-volume environments.

~~Blocked until the 9.3 release as we need to wait until `INLINE STATS` go GA.~~