### PR TITLE
[Tuning] Multiple Cloud Secrets Accessed by Source Address

### DIFF
--- a/rules/cross-platform/credential_access_multi_could_secrets_via_api.toml
+++ b/rules/cross-platform/credential_access_multi_could_secrets_via_api.toml
@@ -164,7 +164,6 @@ FROM logs-* METADATA _id, _version, _index
     Esql_priv.user_values = VALUES(Esql_priv.user_id),
     Esql_priv.client_user_id_values = VALUES(client.user.id),
     Esql_priv.aws_user_identity_arn_values = VALUES(aws.cloudtrail.user_identity.arn),
-    Esql_priv.azure_upn_values = VALUES(azure.platformlogs.identity.claim.upn),
     // Namespace values
     Esql.data_stream_namespace_values = VALUES(data_stream.namespace)
   BY source.ip


### PR DESCRIPTION
Rule fails to execute if one of the three indexes is missing. switched to generic index pattern `logs-*`. Removed `event.dataset == "azure.activitylogs" AND azure.activitylogs.operation_name` from rule scope as it require specific integration field names which causes the rule to fail. 

The new query still matches on TRADE stack dataset : 

<img width="1386" height="1062" alt="image" src="https://github.com/user-attachments/assets/6c228ee1-34a2-4865-add4-7fb5523aafd3" />
