### PR TITLE
Disabling mutation of the rule body during the serialization process

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -38,7 +38,7 @@ from .integrations import (
     load_integrations_schemas,
 )
 from .mixins import MarshmallowDataclassMixin, StackCompatMixin
-from .rule_formatter import nested_normalize, toml_write
+from .rule_formatter import toml_write
 from .schemas import (
     SCHEMA_DIR,
     definitions,
@@ -1237,7 +1237,7 @@ class BaseRuleContents(ABC):
         """Transform the converted API in place before sending to Kibana."""
 
         # cleanup the whitespace in the rule
-        obj = nested_normalize(obj)
+        # obj = nested_normalize(obj)
 
         # fill in threat.technique so it's never missing
         for threat_entry in obj.get("threat", []):
@@ -1586,7 +1586,8 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         if self.transform:
             data = self.data.process_transforms(self.transform, data)
         dict_obj = {"metadata": metadata, "rule": data}
-        return nested_normalize(dict_obj)
+        # return nested_normalize(dict_obj)
+        return dict_obj
 
     def flattened_dict(self) -> dict[str, Any]:
         flattened: dict[str, Any] = {}


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/detection-rules/issues/5529

## Summary - What I changed

- disabling mutation of the rule body on serialization as it's purpose is not clear, and not documented and counterintuitive

## How To Test

- local and CI/CD tests

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
