### PR TITLE
[Rule Deprecation] Agent Spoofing - Mismatched Agent ID

### DIFF
--- a/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
+++ b/rules/cross-platform/defense_evasion_agent_spoofing_mismatched_id.toml
@@ -36,7 +36,7 @@ note = """## Triage and analysis
 > **Disclaimer**:
 > This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
 
-### Investigating Agent Spoofing - Mismatched Agent ID
+### Investigating Deprecated - Agent Spoofing - Mismatched Agent ID
 
 In security environments, agent IDs uniquely identify software agents that report events. Adversaries may spoof these IDs to disguise unauthorized activities, evading detection systems. The detection rule identifies discrepancies between expected and actual agent IDs, flagging potential spoofing attempts. By monitoring for mismatches, it helps uncover efforts to masquerade malicious actions as legitimate.
 


### PR DESCRIPTION
## Issues

Related to the SDH # 655

## Summary

Marks the rule for deprecation as the current query is looking for an undocumented value that is likely invalid. The previous logic was noisy and the FPs couldn't be solved at the rule level.