### PR TITLE
[New Rule] Potential PowerShell Obfuscated Script via High Entropy

### DIFF
--- a/rules/windows/defense_evasion_posh_high_entropy.toml
+++ b/rules/windows/defense_evasion_posh_high_entropy.toml
@@ -111,6 +111,8 @@ setup = """## Setup
 
 PowerShell Script Block Logging must be enabled to generate the events used by this rule (e.g., 4104).
 Setup instructions: https://ela.st/powershell-logging-setup
+
+This rule uses the following fields that require the Windows Integration v3.3.0 and up: `powershell.file.script_block_entropy_bits`, `powershell.file.script_block_surprisal_stdev`, and `powershell.file.script_block_length`.
 """
 severity = "low"
 tags = [


### PR DESCRIPTION
## Issues

Part of https://github.com/elastic/ia-trade-team/issues/782

## Summary

Identifies PowerShell script blocks with high entropy and non-uniform character distributions. Attackers may obfuscate PowerShell scripts using encoding, encryption, or compression techniques to evade signature-based detections and hinder manual analysis by security analysts.