### PR TITLE
[New Rule] Multiple High-Severity Alerts for Privileged AD User

### DIFF
--- a/rules/windows/multiple_alerts_domain_admin_user.toml
+++ b/rules/windows/multiple_alerts_domain_admin_user.toml
@@ -9,8 +9,9 @@ min_stack_version = "9.3.0"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies AD privileged users that generate multiple high severity alerts within 4 hours by correlating alert and
-Active Directory Entity Analytics data.
+Correlates high-severity alerts with Active Directory Entity Analytics to identify privileged users (e.g., domain admins)
+triggering multiple alerts within a 4-hour window. Compromised privileged accounts pose critical risk due to their
+elevated permissions, making them high-priority targets for investigation.
 """
 from = "now-4h"
 interval = "1h"


### PR DESCRIPTION
## Issues

Part of https://github.com/elastic/ia-trade-team/issues/720

## Summary

Correlates high-severity alerts with Active Directory Entity Analytics to identify privileged users (e.g., domain admins)
triggering multiple alerts within a 4-hour window. Compromised privileged accounts pose critical risk due to their
elevated permissions, making them high-priority targets for investigation.

Blocked until the 9.3 release as we need to wait until `INLINE STATS` go GA.