### PR TITLE
[Rule Tunings] AWS remove target.entity.id and actor.entity.id fields

### DIFF
--- a/rules/integrations/aws/credential_access_new_terms_secretsmanager_getsecretvalue.toml
+++ b/rules/integrations/aws/credential_access_new_terms_secretsmanager_getsecretvalue.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/06"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/15"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Nick Jones", "Elastic"]

--- a/rules/integrations/aws/credential_access_retrieve_secure_string_parameters_via_ssm.toml
+++ b/rules/integrations/aws/credential_access_retrieve_secure_string_parameters_via_ssm.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/12"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/15"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_deleted.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/26"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_evasion.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_evasion.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/10"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/15"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
+++ b/rules/integrations/aws/defense_evasion_cloudtrail_logging_suspended.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/06/10"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_cloudwatch_alarm_deletion.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/06/15"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_configuration_recorder_stopped.toml
+++ b/rules/integrations/aws/defense_evasion_configuration_recorder_stopped.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/06/16"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_guardduty_detector_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_guardduty_detector_deletion.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/28"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_rds_instance_restored.toml
+++ b/rules/integrations/aws/defense_evasion_rds_instance_restored.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/06/29"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Austin Songer", "Elastic"]

--- a/rules/integrations/aws/defense_evasion_route53_dns_query_resolver_config_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_route53_dns_query_resolver_config_deletion.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/12"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_waf_acl_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_waf_acl_deletion.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
+++ b/rules/integrations/aws/defense_evasion_waf_rule_or_rule_group_deletion.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/06/09"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/exfiltration_ec2_ebs_snapshot_shared_with_another_account.toml
+++ b/rules/integrations/aws/exfiltration_ec2_ebs_snapshot_shared_with_another_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/16"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/exfiltration_ec2_full_network_packet_capture_detected.toml
+++ b/rules/integrations/aws/exfiltration_ec2_full_network_packet_capture_detected.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/05/05"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/exfiltration_rds_snapshot_shared_with_another_account.toml
+++ b/rules/integrations/aws/exfiltration_rds_snapshot_shared_with_another_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/25"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/exfiltration_s3_bucket_replicated_to_external_account.toml
+++ b/rules/integrations/aws/exfiltration_s3_bucket_replicated_to_external_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/12"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/15"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/exfiltration_sns_rare_protocol_subscription_by_user.toml
+++ b/rules/integrations/aws/exfiltration_sns_rare_protocol_subscription_by_user.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/11/01"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/15"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_group_deletion.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/18"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
+++ b/rules/integrations/aws/impact_cloudwatch_log_stream_deletion.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/20"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_ec2_ebs_snapshot_access_removed.toml
+++ b/rules/integrations/aws/impact_ec2_ebs_snapshot_access_removed.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/02"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_efs_filesystem_deleted.toml
+++ b/rules/integrations/aws/impact_efs_filesystem_deleted.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/08/27"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Austin Songer", "Elastic"]

--- a/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
+++ b/rules/integrations/aws/impact_iam_deactivate_mfa_device.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/26"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_deletion.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/05/21"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/impact_rds_instance_cluster_deletion_protection_disabled.toml
+++ b/rules/integrations/aws/impact_rds_instance_cluster_deletion_protection_disabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/28"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/lateral_movement_ec2_instance_connect_ssh_public_key_uploaded.toml
+++ b/rules/integrations/aws/lateral_movement_ec2_instance_connect_ssh_public_key_uploaded.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/30"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/15"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_iam_roles_anywhere_trusted_anchor_created_with_external_ca.toml
+++ b/rules/integrations/aws/persistence_iam_roles_anywhere_trusted_anchor_created_with_external_ca.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/20"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_lambda_backdoor_invoke_function_for_any_principal.toml
+++ b/rules/integrations/aws/persistence_lambda_backdoor_invoke_function_for_any_principal.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/30"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_rds_db_instance_password_modified.toml
+++ b/rules/integrations/aws/persistence_rds_db_instance_password_modified.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/27"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_rds_instance_made_public.toml
+++ b/rules/integrations/aws/persistence_rds_instance_made_public.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/29"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/persistence_route_53_domain_transferred_to_another_account.toml
+++ b/rules/integrations/aws/persistence_route_53_domain_transferred_to_another_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/05/10"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/16"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic", "Austin Songer"]

--- a/rules/integrations/aws/privilege_escalation_iam_customer_managed_policy_attached_to_role.toml
+++ b/rules/integrations/aws/privilege_escalation_iam_customer_managed_policy_attached_to_role.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/11/04"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/15"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/aws/privilege_escalation_iam_update_assume_role_policy.toml
+++ b/rules/integrations/aws/privilege_escalation_iam_update_assume_role_policy.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/06"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/01/15"
+updated_date = "2026/01/21"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
### Issue Link
- https://github.com/elastic/ia-trade-team/issues/781

## Summary - What I changed

`target.entity.id` and `actor.entity.id` fields will soon be fully removed from the AWS Integration. This rule tuning replaces rule queries that relied on `target.entity.id` with the equivalent field `entity.target.id` which was introduced with AWS version 4.7.0 along with several new entity classification fields. This tuning also removes references to these fields in highlighted fields and investigation guides for several rules.

<img width="1622" height="1488" alt="image" src="https://github.com/user-attachments/assets/024fbdb2-c0e4-4785-9735-5285218e4fa9" />

## Rules with Query Changes

**AWS IAM Customer-Managed Policy Attached to Role by Rare User
AWS IAM Assume Role Policy Update**

Both of these rules relied on `target.entity.id` as a new terms field, this field has been replaced with `entity.target.id` field which is populating the same value for the event.actions these rules trigger on, as shown in the screenshot below.

<img width="1600" height="445" alt="Screenshot 2026-01-15 at 12 13 17 PM" src="https://github.com/user-attachments/assets/27e482fe-2a09-4dfb-8337-2e5070422183" />

## How To Test
- recent test data is in our stack for the 2 rules that have changes to their new terms values. 
- test scripts for each: 
  - [trigger_privilege_escalation_iam_customer_managed_policy_attached_to_role.py](https://github.com/elastic/elastic-aws-ruleset-testing/blob/main/IAM/trigger_privilege_escalation_iam_customer_managed_policy_attached_to_role.py)
  - [trigger_privilege_escalation_update_assume_role_policy.py](https://github.com/elastic/elastic-aws-ruleset-testing/blob/main/IAM/trigger_privilege_escalation_update_assume_role_policy.py) 
