### PR TITLE
[Rule Tuning] Potential Disabling of AppArmor - Restore AppArmor serv…

### DIFF
--- a/rules/linux/defense_evasion_disable_apparmor_attempt.toml
+++ b/rules/linux/defense_evasion_disable_apparmor_attempt.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/08/28"
 integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/12/17"
+updated_date = "2026/01/18"
 
 [rule]
 author = ["Elastic"]
@@ -104,10 +104,10 @@ query = '''
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
 (
-  (process.name == "service" and process.args == "stop") or
-  (process.name == "chkconfig" and process.args == "off") or
-  (process.name == "update-rc.d" and process.args in ("remove", "disable")) or
-  (process.name == "systemctl" and process.args in ("disable", "stop", "kill", "mask")) or
+  (process.name == "systemctl" and process.args in ("disable", "stop", "kill", "mask") and process.args in ("apparmor", "apparmor.service")) or
+  (process.name == "service" and process.args == "apparmor" and process.args == "stop") or
+  (process.name == "chkconfig" and process.args == "apparmor" and process.args == "off") or
+  (process.name == "update-rc.d" and process.args == "apparmor" and process.args in ("remove", "disable")) or
   (process.name == "ln" and process.args : "/etc/apparmor.d/*" and process.args == "/etc/apparmor.d/disable/")
 ) and
 not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"


### PR DESCRIPTION
*Issue link*: https://github.com/elastic/detection-rules/issues/5573

## Summary - What I changed

The 2025/12/17 update to the "Potential Disabling of AppArmor" rule (`fac52c69-2646-4e79-89c0-fd7653461010`) inadvertently removed the AppArmor service name filters from the `systemctl`, `service`, and `chkconfig` conditions. The newly added `update-rc.d` condition was also written without an AppArmor filter.

This caused the rule to trigger on **all** service management operations regardless of which service was targeted, despite the rule being specifically designed to detect AppArmor tampering.

### Query Diff

```diff
-(process.name == "systemctl" and process.args in ("disable", "stop", "kill", "mask")) or
-(process.name == "service" and process.args == "stop") or
-(process.name == "chkconfig" and process.args == "off") or
-(process.name == "update-rc.d" and process.args in ("remove", "disable")) or
+(process.name == "systemctl" and process.args in ("disable", "stop", "kill", "mask") and process.args in ("apparmor", "apparmor.service")) or
+(process.name == "service" and process.args == "apparmor" and process.args == "stop") or
+(process.name == "chkconfig" and process.args == "apparmor" and process.args == "off") or
+(process.name == "update-rc.d" and process.args == "apparmor" and process.args in ("remove", "disable")) or
```

### Changes Made

- Restored `process.args in ("apparmor", "apparmor.service")` to the `systemctl` condition
- Restored `process.args == "apparmor"` to the `service` condition
- Restored `process.args == "apparmor"` to the `chkconfig` condition
- Added `process.args == "apparmor"` to the `update-rc.d` condition (was missing in original update)
- Updated `updated_date` to reflect this change

## How To Test

### Before Fix (False Positive)

The following command triggers an alert:

```bash
sudo systemctl stop elasticsearch
```

**Alert generated:** "process event with process systemctl, parent process sudo, by root on nsm created high alert Potential Disabling of AppArmor."

**Expected:** No alert (Elasticsearch is not AppArmor)

### After Fix

The same command should no longer trigger an alert. Only commands explicitly targeting `apparmor` or `apparmor.service` should trigger:

```bash
# Should trigger alert
sudo systemctl stop apparmor
sudo systemctl disable apparmor.service
sudo service apparmor stop

# Should NOT trigger alert
sudo systemctl stop elasticsearch
sudo systemctl stop nginx
sudo service apache2 stop
```

### Test Query

```sql
process where host.os.type == "linux" and event.type == "start" and
event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
(
  (process.name == "systemctl" and process.args in ("disable", "stop", "kill", "mask") and process.args in ("apparmor", "apparmor.service")) or
  (process.name == "service" and process.args == "apparmor" and process.args == "stop") or
  (process.name == "chkconfig" and process.args == "apparmor" and process.args == "off") or
  (process.name == "update-rc.d" and process.args == "apparmor" and process.args in ("remove", "disable")) or
  (process.name == "ln" and process.args : "/etc/apparmor.d/*" and process.args == "/etc/apparmor.d/disable/")
) and
not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated