### PR TITLE
[New Rule] Potential Service Masquerading

### DIFF
--- a/rules/linux/defense_evasion_service_masquerading.toml
+++ b/rules/linux/defense_evasion_service_masquerading.toml
@@ -33,7 +33,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "esql"
 query = '''
-from logs-endpoint.events.file-*, logs-endgame.events.file-*, logs-crowdstrike.fdr-*, logs-sentinel_one_cloud_funnel.* metadata _id, _version, _index
+from logs-endpoint.events.file-*, endgame-*, logs-crowdstrike.fdr-*, logs-sentinel_one_cloud_funnel.* metadata _id, _version, _index
 | where event.type == "creation" and file.extension == "service" and (
   match(file.name, "cron.service", { "fuzziness": 1, "max_expansions": 10 }) or
   match(file.name, "crond.service", { "fuzziness": 1, "max_expansions": 10 }) or


### PR DESCRIPTION
## Summary
Identifies attempts to masquerade as a commonly seen Linux system service to evade detection and blend in with normal system activity. By leveraging the fuzziness parameter, the rule is able to match similar service names to the ones seen in the query.

<img width="1897" height="528" alt="{CFB18372-C645-424E-BF5D-692BDAC7652D}" src="https://github.com/user-attachments/assets/0164129b-1a8e-48e2-8995-5f4e7d855947" />
