### PR TITLE
[New Rule] Kubernetes Anonymous User Bound to ClusterRole

### DIFF
--- a/rules/integrations/kubernetes/persistence_anonymous_user_bound_to_clusterrole.toml
+++ b/rules/integrations/kubernetes/persistence_anonymous_user_bound_to_clusterrole.toml
@@ -1,0 +1,76 @@
+[metadata]
+creation_date = "2026/02/04"
+integration = ["kubernetes"]
+maturity = "production"
+updated_date = "2026/02/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects creation of a ClusterRoleBinding that assigns permissions to "system:anonymous" or "system:unauthenticated",
+effectively allowing unauthenticated access to Kubernetes resources and potentially enabling cluster compromise.
+"""
+index = ["logs-kubernetes.audit_logs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Kubernetes Anonymous User Bound to ClusterRole"
+references = [
+    "https://heilancoos.github.io/research/2025/12/16/kubernetes.html#overly-permissive-role-based-access-control",
+]
+risk_score = 47
+rule_id = "620e720f-7beb-4c3d-acbd-d304b70a7f71"
+severity = "medium"
+tags = [
+    "Data Source: Kubernetes",
+    "Domain: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+]
+timestamp_override = "event.ingested"
+type = "query"
+query = '''
+event.dataset:"kubernetes.audit_logs" and
+kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" and
+kubernetes.audit.objectRef.resource:"clusterrolebindings" and
+kubernetes.audit.verb:"create" and (
+  kubernetes.audit.responseObject.subjects.name:("system:anonymous" or "system:unauthenticated") or
+  kubernetes.audit.requestObject.subjects.name:("system:anonymous" or "system:unauthenticated")
+)
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1133/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.006"
+name = "Additional Container Cluster Roles"
+reference = "https://attack.mitre.org/techniques/T1098/006/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1133/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.006"
+name = "Additional Container Cluster Roles"
+reference = "https://attack.mitre.org/techniques/T1098/006/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"


### PR DESCRIPTION
## Summary
The fields used in this rule (`kubernetes.audit.responseObject.subjects.name` and `kubernetes.audit.requestObject.subjects.name`) are not yet mapped. I will need to create an issue for the integrations team and get these fixed. For now, I will push this rule as a draft. 