### PR TITLE
[Rule Tuning & Deprecation] Tuning & Deprecating Promotion Rule

### DIFF
--- a/rules/_deprecated/container_workload_protection.toml
+++ b/rules/_deprecated/container_workload_protection.toml
@@ -1,10 +1,11 @@
 [metadata]
 creation_date = "2023/04/05"
+deprecation_date = "2026/02/10"
 integration = ["cloud_defend"]
-maturity = "production"
+maturity = "deprecated"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -18,13 +19,13 @@ index = ["logs-cloud_defend.alerts-*"]
 language = "kuery"
 license = "Elastic License v2"
 max_signals = 1000
-name = "Container Workload Protection"
+name = "Deprecated - Container Workload Protection"
 note = """## Triage and analysis
 
 > **Disclaimer**:
 > This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
 
-### Investigating Container Workload Protection
+### Investigating Deprecated - Container Workload Protection
 
 Container Workload Protection is crucial for securing containerized environments by monitoring and defending against threats. Adversaries may exploit vulnerabilities in container orchestration or escape isolation to access host systems. The detection rule leverages alerts from cloud defense modules, focusing on suspicious activities within container domains, enabling timely triage and investigation of potential security incidents.
 
@@ -62,13 +63,11 @@ This rule is configured to generate a maximum of 1000 alerts per run. This is to
 
 For information on troubleshooting the maximum alerts warning please refer to this [guide](https://www.elastic.co/guide/en/security/current/alerts-ui-monitor.html#troubleshoot-max-alerts)."""
 severity = "medium"
-tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
-    "Resources: Investigation Guide",
-]
+tags = ["Data Source: Elastic Defend for Containers", "Domain: Container", "Resources: Investigation Guide"]
 timestamp_override = "event.ingested"
 type = "query"
+
 query = '''
 event.kind:alert and event.module:cloud_defend
 '''
+

--- a/rules/integrations/cloud_defend/command_and_control_curl_socks_proxy_detected_inside_container.toml
+++ b/rules/integrations/cloud_defend/command_and_control_curl_socks_proxy_detected_inside_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/27"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -63,7 +63,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where event.type == "start" and event.action == "exec" and
 process.name == "curl" and process.args like ("--socks5-hostname", "--proxy", "--preproxy", "socks5*", "-x") and
 process.interactive == true and container.id like "?*"
 '''

--- a/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
+++ b/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -77,7 +77,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where event.type == "start" and event.action == "exec" and process.interactive == true and (
   (
     (process.name == "curl" or process.args in ("curl", "/bin/curl", "/usr/bin/curl", "/usr/local/bin/curl")) and
     process.args in ("-o", "-O", "--output", "--remote-name", "--remote-name-all", "--output-dir")

--- a/rules/integrations/cloud_defend/credential_access_cloud_creds_search_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_cloud_creds_search_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -34,7 +34,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name in ("grep", "egrep", "fgrep", "find", "locate", "mlocate", "cat", "sed", "awk") or
   (
     /* Account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -74,7 +74,7 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*" 
+) and process.interactive == true and container.id like "?*" 
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/credential_access_collection_sensitive_files_compression_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_collection_sensitive_files_compression_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -70,7 +70,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name in ("zip", "tar", "gzip", "hdiutil", "7z", "rar", "7zip", "p7zip") or
   (
     /* account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -101,7 +101,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*" 
+) and process.interactive == true and container.id like "?*" 
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/credential_access_sensitive_keys_or_passwords_search_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_sensitive_keys_or_passwords_search_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name in ("grep", "egrep", "fgrep", "find", "locate", "mlocate", "cat", "sed", "awk") or
   (
     /* account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -99,7 +99,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*" 
+) and process.interactive == true and container.id like "?*" 
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/credential_access_service_account_token_or_cert_read.toml
+++ b/rules/integrations/cloud_defend/credential_access_service_account_token_or_cert_read.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where process.interactive == true and container.id like "?*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and
   file.path in (
     "/var/run/secrets/kubernetes.io/serviceaccount/token",

--- a/rules/integrations/cloud_defend/defense_evasion_deletion_of_shell_cmdline_history.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_deletion_of_shell_cmdline_history.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -62,7 +62,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-any where host.os.type == "linux" and event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
+any where event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
   (event.category == "file" and event.type == "deletion" and file.name in (".bash_history", ".sh_history",  ".zsh_history")) or
   (event.category == "process" and event.type == "start" and event.action == "exec" and (
     (

--- a/rules/integrations/cloud_defend/defense_evasion_ld_preload_shared_object_modified_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_ld_preload_shared_object_modified_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -77,9 +77,9 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where host.os.type == "linux" and event.type != "deletion" and
+file where event.type != "deletion" and
 file.path like ("/etc/ld.so.preload", "/etc/ld.so.conf.d/*", "/etc/ld.so.conf") and
-process.interactive == true and container.id like "*" 
+process.interactive == true and container.id like "?*" 
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/defense_evasion_potential_evasion_via_encoded_payload.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_potential_evasion_via_encoded_payload.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -63,7 +63,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where event.type == "start" and event.action == "exec" and process.interactive == true and (
   (process.name in ("base64", "base64plain", "base64url", "base64mime", "base64pem", "base32", "base16") and process.args like~ "*-*d*") or
   (process.name == "xxd" and process.args like~ ("-*r*", "-*p*")) or
   (process.name == "openssl" and process.args == "enc" and process.args in ("-d", "-base64", "-a")) or

--- a/rules/integrations/cloud_defend/discovery_dns_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_dns_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/27"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -70,8 +70,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.interactive == true and container.id like "*" and 
+process where event.type == "start" and event.action == "exec" and
+process.interactive == true and container.id like "?*" and 
 (
   /* getent hosts is often used without a target arg */
   (process.name == "getent" and process.args == "hosts") or

--- a/rules/integrations/cloud_defend/discovery_environment_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_environment_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/27"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -72,7 +72,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name in ("env", "printenv") or
   (
     /* Account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -90,7 +90,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     )
   )
 ) and
-process.interactive == true and container.id like "*"
+process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/discovery_kubelet_certificate_file_access.toml
+++ b/rules/integrations/cloud_defend/discovery_kubelet_certificate_file_access.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/09"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where process.interactive == true and container.id like "?*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and file.path like "/var/lib/kubelet/pki/*") or
   (event.category == "process" and event.type == "start" and event.action == "exec" and
   (

--- a/rules/integrations/cloud_defend/discovery_kubelet_pod_discovery_via_builtin_utilities.toml
+++ b/rules/integrations/cloud_defend/discovery_kubelet_pod_discovery_via_builtin_utilities.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -68,7 +68,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 sequence by container.id, user.id with maxspan=5s
-  [any where host.os.type == "linux" and event.category in ("file", "process") and process.interactive == true and container.id like "*" and (
+  [any where event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
     (event.category == "file" and event.type == "change" and event.action == "open" and file.path like "/var/lib/kubelet/pods/*") or
     (event.category == "process" and event.type == "start" and event.action == "exec" and (
       (process.name in ("du", "nice", "find", "locate", "ls")) or

--- a/rules/integrations/cloud_defend/discovery_potential_cluster_enumeration_via_jq.toml
+++ b/rules/integrations/cloud_defend/discovery_potential_cluster_enumeration_via_jq.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/02"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -41,7 +41,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
+process where event.type == "start" and event.action == "exec" and process.name == "jq" and
 process.interactive == true and container.id like "?*" 
 '''
 

--- a/rules/integrations/cloud_defend/discovery_privilege_boundary_enumeration_from_interactive_process.toml
+++ b/rules/integrations/cloud_defend/discovery_privilege_boundary_enumeration_from_interactive_process.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where event.type == "start" and event.action == "exec" and process.interactive == true and (
   (process.name in ("id", "whoami", "capsh", "getcap", "lsns")) or
   (process.args in (
      "id", "/bin/id", "/usr/bin/id", "/usr/local/bin/id",

--- a/rules/integrations/cloud_defend/discovery_service_account_namespace_read.toml
+++ b/rules/integrations/cloud_defend/discovery_service_account_namespace_read.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -70,7 +70,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where process.interactive == true and container.id like "?*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and
   file.path in (
     "/var/run/secrets/kubernetes.io/serviceaccount/namespace",

--- a/rules/integrations/cloud_defend/discovery_suspicious_network_tool_launched_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/discovery_suspicious_network_tool_launched_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -79,7 +79,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name in (
     "nc.traditional", "nc", "ncat", "netcat", "nmap", "tcpdump", "tshark", "ngrep", "telnet",  "mitmproxy", "socat",
     "zmap", "masscan", "zgrab"
@@ -111,7 +111,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
       "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
     )
   )
-) and process.interactive == true and container.id like "*" and
+) and process.interactive == true and container.id like "?*" and
 not (
   process.name in ("nc.traditional", "nc", "ncat", "netcat") and
   process.args like ("-*z*", "localhost", "127.0.0.1")

--- a/rules/integrations/cloud_defend/discovery_tool_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_tool_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/27"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name == "which" or
   (
     /* Account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -103,7 +103,7 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/execution_container_management_binary_launched_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_container_management_binary_launched_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -78,7 +78,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name in ("dockerd", "kubelet", "kube-proxy", "kubectl", "containerd", "systemd", "crictl") or
   (
     /* Account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -101,7 +101,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     )
   )
 ) and
-process.interactive == true and container.id like "*" and
+process.interactive == true and container.id like "?*" and
 not (
   process.parent.executable in ("/sbin/init", "/usr/bin/dockerd", "/usr/bin/runc", "/usr/bin/containerd-shim-runc-v2") or
   process.working_directory == "/aws" or

--- a/rules/integrations/cloud_defend/execution_direct_interactive_kubernetes_api_request.toml
+++ b/rules/integrations/cloud_defend/execution_direct_interactive_kubernetes_api_request.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/27"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -74,7 +74,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   (
     process.name == "curl" and
     process.args in ("-H", "--header") and
@@ -116,7 +116,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
   (process.name == "ncat" and process.args like "--ssl*") or
   (process.name == "kubectl" and process.args in ("get", "list", "watch", "create", "patch", "update"))
 ) and
-process.interactive == true and container.id like "*"
+process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/execution_interactive_exec_to_container.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_exec_to_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -87,7 +87,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
 process.entry_leader.entry_meta.type == "container" and
 
@@ -95,7 +95,7 @@ process.entry_leader.entry_meta.type == "container" and
 process.entry_leader.same_as_process == true and
 
 /* interactive process */
-process.interactive == true and container.id like "*"
+process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/execution_interactive_file_creation_followed_by_execution.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_file_creation_followed_by_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -64,10 +64,10 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 sequence by container.id, user.id with maxspan=3s
-  [file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and container.id like "?*" and
+  [file where event.type == "creation" and process.interactive == true and container.id like "?*" and
    file.path like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/root/*", "/home/*") and
    not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf", "apk", "pacman", "rpm", "dpkg")] by file.path
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  [process where event.type == "start" and event.action == "exec" and
    process.interactive == true and container.id like "?*"] by process.executable
 '''
 

--- a/rules/integrations/cloud_defend/execution_interactive_file_creation_in_system_binary_locations.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_file_creation_in_system_binary_locations.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -65,7 +65,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and
+file where event.type == "creation" and process.interactive == true and
 file.path like (
   "/etc/*", "/root/*", "/bin/*", "/usr/bin/*", "/usr/local/bin/*", "/entrypoint*"
 ) and (

--- a/rules/integrations/cloud_defend/execution_interactive_shell_spawned_from_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_shell_spawned_from_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -74,9 +74,9 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
-process.entry_leader.same_as_process == false and process.interactive == true and container.id like "*" and
+process.entry_leader.same_as_process == false and process.interactive == true and container.id like "?*" and
 process.args in (
   "sh", "dash", "bash", "zsh", "fish", "busybox",
   "/bin/sh", "/bin/dash", "/bin/bash", "/bin/zsh", "/bin/fish", "/bin/busybox",

--- a/rules/integrations/cloud_defend/execution_kubeletctl_execution.toml
+++ b/rules/integrations/cloud_defend/execution_kubeletctl_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/09"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -77,7 +77,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   (process.name == "kubeletctl" or process.args like "*kubeletctl*") or
   (process.args in ("-s", "--server") and process.args in ("run", "portForward", "scan", "attach", "exec", "pods", "runningpods", "cri", "pid2pod"))
 ) and

--- a/rules/integrations/cloud_defend/execution_netcat_listener_established_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_netcat_listener_established_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -77,7 +77,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name in ("nc","ncat","netcat","netcat.openbsd","netcat.traditional") or
   (
     /* account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -105,7 +105,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/execution_potential_direct_kubelet_access_via_process_args.toml
+++ b/rules/integrations/cloud_defend/execution_potential_direct_kubelet_access_via_process_args.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/09"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process where event.type == "start" and event.action == "exec" and
 process.args like "http*:10250*" and process.interactive == true and container.id like "?*"
 '''
 

--- a/rules/integrations/cloud_defend/execution_suspicious_file_made_executable_via_chmod_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_suspicious_file_made_executable_via_chmod_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where host.os.type == "linux" and event.type in ("change", "creation") and (
+file where event.type in ("change", "creation") and (
   process.name == "chmod" or
   (
     /* account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -87,7 +87,7 @@ file where host.os.type == "linux" and event.type in ("change", "creation") and 
   )
 ) and process.args in ("4755", "755", "777", "0777", "444", "+x", "a+x") and
 process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*", "/mnt/*", "/media/*") and
-process.interactive == true and container.id like "*" and not process.args == "-x"
+process.interactive == true and container.id like "?*" and not process.args == "-x"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/execution_suspicious_interactive_interpreter_command_execution.toml
+++ b/rules/integrations/cloud_defend/execution_suspicious_interactive_interpreter_command_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -63,7 +63,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and process.interactive == true and
 process.parent.executable != null and (
   (
     process.executable like ("/bin/perl*", "/usr/bin/perl*", "/usr/local/bin/perl*") and

--- a/rules/integrations/cloud_defend/execution_tool_installation.toml
+++ b/rules/integrations/cloud_defend/execution_tool_installation.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -70,7 +70,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where event.type == "start" and event.action == "exec" and process.interactive == true and (
   (process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf") and process.args == "install") or
   (process.name == "apk" and process.args == "add") or
   (process.name == "pacman" and process.args like "-*S*") or

--- a/rules/integrations/cloud_defend/persistence_ssh_authorized_keys_modification_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/persistence_ssh_authorized_keys_modification_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -72,9 +72,9 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where host.os.type == "linux" and event.type in ("change", "creation") and
+file where event.type in ("change", "creation") and
 file.name in ("authorized_keys", "authorized_keys2") and
-process.interactive == true and container.id like "*"
+process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/persistence_suspicious_webserver_child_process_execution.toml
+++ b/rules/integrations/cloud_defend/persistence_suspicious_webserver_child_process_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -64,7 +64,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.parent.name in (
       "apache", "nginx", "apache2", "httpd", "lighttpd", "caddy", "mongrel_rails", "gunicorn",
       "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn",

--- a/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -75,7 +75,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name == "debugfs" or
   (
     /* account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -93,7 +93,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
   )
 ) and
 process.args like "/dev/sd*" and not process.args == "-R" and
-container.security_context.privileged == true and process.interactive == true and container.id like "*"
+container.security_context.privileged == true and process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/privilege_escalation_mount_launched_inside_a_privileged_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_mount_launched_inside_a_privileged_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -75,7 +75,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+process where event.type == "start" and event.action == "exec" and (
   process.name == "mount" or
   (
     /* account for tools that execute utilities as a subprocess, in this case the target utility name will appear as a process arg */
@@ -91,7 +91,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
       "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
     )
   )
-) and container.security_context.privileged == true and process.interactive == true and container.id like "*"
+) and container.security_context.privileged == true and process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_notify_on_release_file.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_notify_on_release_file.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -76,8 +76,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
-file.name == "notify_on_release" and process.interactive == true and container.id like "*"
+file where event.type == "change" and event.action == "open" and
+file.name == "notify_on_release" and process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]

--- a/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_release_agent_file.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_release_agent_file.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/02/10"
 
 [rule]
 author = ["Elastic"]
@@ -75,8 +75,8 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
-file.name == "release_agent" and process.interactive == true and container.id like "*"
+file where event.type == "change" and event.action == "open" and
+file.name == "release_agent" and process.interactive == true and container.id like "?*"
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary
Removing `host.os.type == "linux"`, moving from `container.id like "*"` to `container.id like "?*"`, and deprecating the D4C Promotion Rule.