### PR TITLE
Fix rule name regex to improve validation

### DIFF
--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -64,7 +64,7 @@ DATE_PATTERN = re.compile(r"^\d{4}/\d{2}/\d{2}$")
 MATURITY_LEVELS = ["development", "experimental", "beta", "production", "deprecated"]
 OS_OPTIONS = ["windows", "linux", "macos"]
 
-NAME_PATTERN = re.compile(r"^[a-zA-Z0-9].+?[a-zA-Z0-9\[\]()]$")
+NAME_PATTERN = re.compile(r"^[a-zA-Z0-9\[\(].+?[a-zA-Z0-9\[\]()]$")
 PR_PATTERN = re.compile(r"^$|\d+$")
 SHA256_PATTERN = re.compile(r"^[a-fA-F0-9]{64}$")
 # NOTE this additional bad UUID pattern is a stop gap until the rule has been deprecated


### PR DESCRIPTION

## Summary - What I changed

Updated the NAME_PATTERN regex to ensure it correctly matches rule names that start with alphanumeric characters or brackets. This change fixes a bug where rule names that begin with a non-alpha character such as `[` or `(` would cause the validate-rules module to crash.

Updated the `NAME_PATTERN` regex in `detection-rules/detection_rules/schemas/definitions.py`

## How To Test
Create a detection rule where the name starts with a non alpha character such as `[Okta] New admin` and validate that rule.

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
