### PR TITLE
[Rule Tuning] `agent.id` --> `host.id` `new_terms` Key Modification

### DIFF
--- a/rules/linux/collection_linux_clipboard_activity.toml
+++ b/rules/linux/collection_linux_clipboard_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/07/27"
 integration = ["endpoint", "auditd_manager", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/12/17"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/collection_potential_audio_recording_activity.toml
+++ b/rules/linux/collection_potential_audio_recording_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/07"
 integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2026/01/12"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/collection_potential_video_recording_or_screenshot_activity.toml
+++ b/rules/linux/collection_potential_video_recording_or_screenshot_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/07"
 integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2026/01/12"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/credential_access_collection_sensitive_files.toml
+++ b/rules/linux/credential_access_collection_sensitive_files.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/22"
 integration = ["endpoint", "auditd_manager", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/12/17"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/defense_evasion_symlink_binary_to_writable_dir.toml
+++ b/rules/linux/defense_evasion_symlink_binary_to_writable_dir.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/04/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/12/18"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/execution_suspicious_mkfifo_execution.toml
+++ b/rules/linux/execution_suspicious_mkfifo_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/04/30"
 integration = ["endpoint", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/12/19"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/impact_process_kill_threshold.toml
+++ b/rules/linux/impact_process_kill_threshold.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/27"
 integration = ["endpoint", "auditd_manager", "crowdstrike"]
 maturity = "production"
-updated_date = "2025/12/19"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
+++ b/rules/linux/lateral_movement_remote_file_creation_world_writeable_dir.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/12/19"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/lateral_movement_unusual_remote_file_creation.toml
+++ b/rules/linux/lateral_movement_unusual_remote_file_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/12/19"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/persistence_ssh_via_backdoored_system_user.toml
+++ b/rules/linux/persistence_ssh_via_backdoored_system_user.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/01/07"
 integration = ["system"]
 maturity = "production"
-updated_date = "2025/12/22"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules/linux/privilege_escalation_ld_preload_shared_object_modif.toml
+++ b/rules/linux/privilege_escalation_ld_preload_shared_object_modif.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/27"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/12/23"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules_building_block/discovery_linux_system_information_discovery.toml
+++ b/rules_building_block/discovery_linux_system_information_discovery.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/07/10"
 integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/12/24"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules_building_block/discovery_linux_system_owner_user_discovery.toml
+++ b/rules_building_block/discovery_linux_system_owner_user_discovery.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/07/10"
 integration = ["endpoint", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2025/12/24"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules_building_block/discovery_of_accounts_or_groups_via_builtin_tools.toml
+++ b/rules_building_block/discovery_of_accounts_or_groups_via_builtin_tools.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/07/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/12/24"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules_building_block/discovery_process_discovery_via_builtin_tools.toml
+++ b/rules_building_block/discovery_process_discovery_via_builtin_tools.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/07/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/12/24"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]

--- a/rules_building_block/discovery_system_network_connections.toml
+++ b/rules_building_block/discovery_system_network_connections.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/07/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/12/24"
+updated_date = "2026/03/02"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
## Summary
Re: https://elasticstack.slack.com/archives/C016E72DWDS/p1772328054787369, a valid point was made. 

> For data from Elastic Defend, the agent.id will be the host of the endpoint, but for Crowdstrike data, the agent.id will be the host of the machine that is running the Crowdstrike integration to get data from FDR, it is not the id of the endpoint.

To address this, this PR updates all agent.id keys to host.id.