### PR TITLE
[Tuning] LSASS Process Access via Windows API

### DIFF
--- a/rules/windows/credential_access_lsass_openprocess_api.toml
+++ b/rules/windows/credential_access_lsass_openprocess_api.toml
@@ -139,6 +139,7 @@ from logs-endpoint.events.api-*, logs-m365_defender.event-* metadata _id, _versi
         Esql.count_distinct_hosts = count_distinct(host.id),
         Esql.host_id_values = VALUES(host.id),
         Esql.host_name_values = VALUES(host.name),
+        Esql.user_name_values = VALUES(user.name),
         Esql.process_pid_values = VALUES(process.entity_id),
         Esql.process_executable_values = VALUES(process.executable),
         Esql.data_stream_namespace.values = VALUES(data_stream.namespace),
@@ -150,10 +151,11 @@ from logs-endpoint.events.api-*, logs-m365_defender.event-* metadata _id, _versi
 // Extract the single host ID and process into their corresponding ECS fields for alerts exclusion
 | eval host.id = mv_min(Esql.host_id_values),
        host.name = mv_min(Esql.host_name_values),
-       process.executable = mv_min(Esql.process_executable_values)
+       process.executable = mv_min(Esql.process_executable_values), 
+       user.name = mv_min(Esql.user_name_values)
 
 // Add the new field to the keep statement
-| keep Esql.*, host.id, host.name, process.executable
+| keep Esql.*, host.id, host.name, user.name, process.executable
 '''
 
 


### PR DESCRIPTION
adds host.name to the alert and move the original values of process.executable.

https://github.com/elastic/sdh-protections/issues/659#issuecomment-3985459310