### PR TITLE
WIP - Add batch processing to Kibana import-rules

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -28,6 +28,7 @@ Currently supported arguments:
 * es_user 
 * es_password
 * api_key
+* kibana_import_batch_size (positive integer; default `50`)
 
 Authenticating to Kibana is only available using api_key.
 
@@ -52,6 +53,8 @@ For instance, some users may want to increase the default value in cases where h
 Using the environment variable `DR_REMOTE_ESQL_VALIDATION` will enable remote ESQL validation for rules that use ESQL queries. This validation will be performed whenever the rule is loaded including for example the view-rule command. This requires the appropriate kibana_url or cloud_id, api_key, and es_url to be set in the config file or as environment variables.
 
 Using the environment variable `DR_SKIP_EMPTY_INDEX_CLEANUP` will disable the cleanup of remote testing indexes that are created as part of the remote ESQL validation. By default, these indexes are deleted after the validation is complete, or upon validation error.
+
+Using the environment variable `DR_KIBANA_IMPORT_BATCH_SIZE` (or the `kibana_import_batch_size` config value) will control how many rules are sent per HTTP request by `kibana import-rules`. The default is `50`. Increase it to reduce the number of round-trips when Kibana is fast; decrease it if large imports time out (Kibana has an internal ~2 minute request budget). The value must be a positive integer. See [Batching and shared exceptions / action connectors](#batching-and-shared-exceptions--action-connectors) for how this interacts with grouped rules.
 
 ## Importing rules into the repo
 
@@ -262,6 +265,39 @@ Options:
                                   Overwrite action connectors in existing rules
   -h, --help                      Show this message and exit.
 ```
+
+#### Batching and shared exceptions / action connectors
+
+`kibana import-rules` splits the rule set into batches before calling Kibana's `/_import`
+endpoint, so large imports do not exceed Kibana's internal request budget. Batch size is
+resolved in the following order (highest precedence first):
+
+1. `DR_KIBANA_IMPORT_BATCH_SIZE` environment variable
+2. `kibana_import_batch_size` in the user config file
+3. Built-in default of `50`
+
+Rules linked through shared TOML exceptions or action connectors cannot be split across
+batches. Each TOML exception and action connector declares the rules it applies to via
+`metadata.rule_ids`; `import-rules` keeps every rule listed on an exception/connector in
+the same batch as that exception/connector so a single `/_import` payload always
+contains both the rule and the shared item it depends on. Only the rules and items
+being imported are considered when grouping — existing Kibana state is not consulted.
+
+As a consequence, a single batch may exceed the configured `batch_size` when a group of
+linked rules is larger than it. The batch is sent intact in that case, because splitting
+it would separate a rule from the exception/connector it depends on. If you hit Kibana
+timeouts on such a group, split the underlying exception/connector TOML files so fewer
+rules are linked together.
+
+Each batch prints a progress line such as:
+
+```
+Importing batch 3/12: 50 rule(s), 2 exception list(s), 1 action connector(s)
+```
+
+The final summary aggregates success counts, errors, exceptions, and action connectors
+across all batches, so the command's exit output is equivalent to a single-request
+import.
 
 Example usage of a successful upload:
 

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -28,7 +28,7 @@ from .main import root
 from .misc import add_params, get_kibana_client, kibana_options, nested_set, raise_client_error
 from .rule import TOMLRule, TOMLRuleContents, downgrade_contents_from_rule
 from .rule_loader import RawRuleCollection, RuleCollection, update_metadata_from_file
-from .schemas import definitions  # noqa: TC001
+from .schemas import definitions
 from .utils import CUSTOM_RULES_KQL, format_command_options, rulename_to_filename
 
 RULES_CONFIG = parse_rules_config()

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -111,7 +111,7 @@ def kibana_import_rules(  # noqa: PLR0915
 ) -> tuple[dict[str, Any], list[RuleResource]]:
     """Import rules into Kibana."""
 
-    def _handle_response_errors(response: dict[str, Any]) -> None:
+    def _handle_response_errors(response: dict[str, Any], imported_exception_dicts: list[list[dict[str, Any]]]) -> None:
         """Handle errors from the import response."""
 
         def _parse_list_id(s: str) -> str | None:
@@ -123,7 +123,7 @@ def kibana_import_rules(  # noqa: PLR0915
         workaround_errors: list[str] = []
         workaround_error_types: set[str] = set()
 
-        flattened_exceptions: list[dict[str, Any]] = [e for sublist in exception_dicts for e in sublist]
+        flattened_exceptions: list[dict[str, Any]] = [e for sublist in imported_exception_dicts for e in sublist]
         all_exception_list_ids: set[str] = {exception["list_id"] for exception in flattened_exceptions}
 
         click.echo(f"{len(response['errors'])} rule(s) failed to import!")
@@ -173,36 +173,57 @@ def kibana_import_rules(  # noqa: PLR0915
             click.echo(f" - {ids_str}")
 
     kibana = ctx.obj["kibana"]
-    rule_dicts = [r.contents.to_api_format() for r in rules]
-    rule_ids = {rule["rule_id"] for rule in rule_dicts}
+    batch_size = definitions.KIBANA_IMPORT_BATCH_SIZE
+    rules_list = list(rules)
+    imported_exception_dicts: list[list[dict[str, Any]]] = []
+    imported_action_connectors_dicts: list[list[dict[str, Any]]] = []
+    successful_rule_ids: list[str] = []
+    all_errors: list[dict[str, Any]] = []
+    results: list[RuleResource] = []
+
     with kibana:
         cl = GenericCollection.default()
-        exception_dicts: list[list[dict[str, Any]]] = [
-            d.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
-            for d in cl.items_matching(TOMLExceptionContents, rule_ids)
-        ]
-        action_connectors_dicts: list[list[dict[str, Any]]] = [
-            d.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
-            for d in cl.items_matching(TOMLActionConnectorContents, rule_ids)
-        ]
-        response, successful_rule_ids, results = RuleResource.import_rules(  # type: ignore[reportUnknownMemberType]
-            rule_dicts,
-            exception_dicts,
-            action_connectors_dicts,
-            overwrite=overwrite,
-            overwrite_exceptions=overwrite_exceptions,
-            overwrite_action_connectors=overwrite_action_connectors,
-        )
+        for i in range(0, len(rules_list), batch_size):
+            batched_rules = rules_list[i : i + batch_size]
+            rule_dicts = [r.contents.to_api_format() for r in batched_rules]
+            rule_ids = {rule["rule_id"] for rule in rule_dicts}
+
+            exception_dicts: list[list[dict[str, Any]]] = [
+                d.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+                for d in cl.items_matching(TOMLExceptionContents, rule_ids)
+            ]
+            action_connectors_dicts: list[list[dict[str, Any]]] = [
+                d.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+                for d in cl.items_matching(TOMLActionConnectorContents, rule_ids)
+            ]
+
+            response, batch_successful_rule_ids, batch_results = RuleResource.import_rules(  # type: ignore[reportUnknownMemberType]
+                rule_dicts,
+                exception_dicts,
+                action_connectors_dicts,
+                overwrite=overwrite,
+                overwrite_exceptions=overwrite_exceptions,
+                overwrite_action_connectors=overwrite_action_connectors,
+            )
+            response = cast("dict[str, Any]", response)
+
+            imported_exception_dicts.extend(exception_dicts)
+            imported_action_connectors_dicts.extend(action_connectors_dicts)
+            successful_rule_ids.extend(cast("list[str]", batch_successful_rule_ids))
+            all_errors.extend(cast("list[dict[str, Any]]", response.get("errors", [])))
+            results.extend(cast("list[RuleResource]", batch_results))
+
+    response: dict[str, Any] = {"errors": all_errors}
 
     if successful_rule_ids:
         click.echo(f"{len(successful_rule_ids)} rule(s) successfully imported")  # type: ignore[reportUnknownArgumentType]
         rule_str = "\n - ".join(successful_rule_ids)  # type: ignore[reportUnknownArgumentType]
         click.echo(f" - {rule_str}")
     if response["errors"]:
-        _handle_response_errors(response)  # type: ignore[reportUnknownArgumentType]
+        _handle_response_errors(response, imported_exception_dicts)  # type: ignore[reportUnknownArgumentType]
     else:
-        _process_imported_items(exception_dicts, "exception list(s)", "list_id")  # type: ignore[reportUnknownArgumentType]
-        _process_imported_items(action_connectors_dicts, "action connector(s)", "id")  # type: ignore[reportUnknownArgumentType]
+        _process_imported_items(imported_exception_dicts, "exception list(s)", "list_id")  # type: ignore[reportUnknownArgumentType]
+        _process_imported_items(imported_action_connectors_dicts, "action connector(s)", "id")  # type: ignore[reportUnknownArgumentType]
 
     return response, results  # type: ignore[reportUnknownVariableType]
 

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -25,7 +25,7 @@ from .config import parse_rules_config
 from .exception import TOMLException, TOMLExceptionContents, build_exception_objects, parse_exceptions_results_from_api
 from .generic_loader import GenericCollection
 from .main import root
-from .misc import add_params, get_kibana_client, kibana_options, nested_set, raise_client_error
+from .misc import add_params, get_kibana_client, getdefault, kibana_options, nested_set, raise_client_error
 from .rule import TOMLRule, TOMLRuleContents, downgrade_contents_from_rule
 from .rule_loader import RawRuleCollection, RuleCollection, update_metadata_from_file
 from .schemas import definitions
@@ -91,6 +91,147 @@ def upload_rule(ctx: click.Context, rules: RuleCollection, replace_id: bool) -> 
     return results
 
 
+def _resolve_import_batch_size() -> int:
+    """Resolve the Kibana import batch size.""""
+
+    """
+    Order of precedence (highest first):
+    * ``DR_KIBANA_IMPORT_BATCH_SIZE`` environment variable
+    * ``kibana_import_batch_size`` in the user config file (``.detection-rules-cfg.*``)
+    * ``definitions.KIBANA_IMPORT_BATCH_SIZE`` default
+    """
+    raw = getdefault("kibana_import_batch_size")()
+    if raw is None or raw == "":
+        return definitions.KIBANA_IMPORT_BATCH_SIZE
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise_client_error(
+            "Invalid kibana_import_batch_size / DR_KIBANA_IMPORT_BATCH_SIZE value "
+            f"{raw!r}; expected a positive integer."
+        )
+    if value <= 0:
+        raise_client_error(
+            "Invalid kibana_import_batch_size / DR_KIBANA_IMPORT_BATCH_SIZE value "
+            f"{value}; expected a positive integer."
+        )
+    return value
+
+
+def _build_import_batches(
+    rules_list: list[TOMLRule],
+    exceptions: list[Any],
+    action_connectors: list[Any],
+    batch_size: int,
+) -> list[tuple[list[TOMLRule], list[Any], list[Any]]]:
+    """Group rules that share an exception or action connector, then chunk up to ``batch_size``."""
+
+    """
+    Only the rules and items being imported are considered; Kibana state is not consulted.
+    A linked group larger than ``batch_size`` is emitted intact as one oversized batch so a
+    rule is never separated from the exception/connector it depends on.
+    """
+    rule_by_id: dict[str, TOMLRule] = {r.id: r for r in rules_list}
+    import_ids: set[str] = set(rule_by_id)
+
+    # One group per rule; each group is (rules, exceptions, connectors).
+    # group_of[rule_id] points at the rule's current group key.
+    group_of: dict[str, str] = {rid: rid for rid in import_ids}
+    groups: dict[str, tuple[list[TOMLRule], list[Any], list[Any]]] = {
+        rid: ([rule_by_id[rid]], [], []) for rid in import_ids
+    }
+
+    def attach(item: Any, slot: int) -> None:
+        linked = [rid for rid in getattr(item.contents.metadata, "rule_ids", []) if rid in import_ids]
+        if not linked:
+            return
+        target = group_of[linked[0]]
+        for rid in linked[1:]:
+            src = group_of[rid]
+            if src == target:
+                continue
+            src_rules, src_exc, src_conn = groups.pop(src)
+            for moved in src_rules:
+                group_of[moved.id] = target
+            groups[target][0].extend(src_rules)
+            groups[target][1].extend(src_exc)
+            groups[target][2].extend(src_conn)
+        groups[target][slot].append(item)
+
+    for e in exceptions:
+        attach(e, 1)
+    for a in action_connectors:
+        attach(a, 2)
+
+    batches: list[tuple[list[TOMLRule], list[Any], list[Any]]] = []
+    cur: tuple[list[TOMLRule], list[Any], list[Any]] = ([], [], [])
+    for group_rules, group_exc, group_conn in groups.values():
+        if cur[0] and len(cur[0]) + len(group_rules) > batch_size:
+            batches.append(cur)
+            cur = ([], [], [])
+        cur[0].extend(group_rules)
+        cur[1].extend(group_exc)
+        cur[2].extend(group_conn)
+    if cur[0]:
+        batches.append(cur)
+
+    return batches
+
+
+_MERGE_BOOL_KEYS: tuple[str, ...] = (
+    "success",
+    "exceptions_success",
+    "action_connectors_success",
+)
+_MERGE_COUNT_KEYS: tuple[str, ...] = (
+    "success_count",
+    "rules_count",
+    "exceptions_success_count",
+    "action_connectors_success_count",
+)
+_MERGE_LIST_KEYS: tuple[str, ...] = (
+    "errors",
+    "exceptions_errors",
+    "action_connectors_errors",
+    "action_connectors_warnings",
+)
+
+
+def _merge_import_responses(responses: list[dict[str, Any]]) -> dict[str, Any]:
+    """Merge per-batch Kibana ``/_import`` responses into a single aggregate response.
+
+    Boolean success flags are AND-ed, count fields are summed, and error/warning lists are
+    concatenated. Unknown keys from the first response are preserved so callers that inspect
+    additional fields are not silently stripped.
+    """
+    merged: dict[str, Any] = {key: True for key in _MERGE_BOOL_KEYS}
+    merged.update({key: 0 for key in _MERGE_COUNT_KEYS})
+    merged.update({key: [] for key in _MERGE_LIST_KEYS})
+
+    for resp in responses:
+        if not resp:
+            continue
+        for key in _MERGE_BOOL_KEYS:
+            if key in resp:
+                merged[key] = bool(merged[key]) and bool(resp[key])
+        for key in _MERGE_COUNT_KEYS:
+            if key in resp:
+                try:
+                    merged[key] = int(merged[key]) + int(resp[key])
+                except (TypeError, ValueError):
+                    continue
+        for key in _MERGE_LIST_KEYS:
+            value = resp.get(key)
+            if isinstance(value, list):
+                merged[key].extend(value)  # type: ignore[reportUnknownArgumentType]
+        for key, value in resp.items():
+            if key in _MERGE_BOOL_KEYS or key in _MERGE_COUNT_KEYS or key in _MERGE_LIST_KEYS:
+                continue
+            merged.setdefault(key, value)
+
+    return merged
+
+
 @kibana_group.command("import-rules")
 @multi_collection
 @click.option("--overwrite", "-o", is_flag=True, help="Overwrite existing rules")
@@ -109,7 +250,14 @@ def kibana_import_rules(  # noqa: PLR0915
     overwrite_exceptions: bool = False,
     overwrite_action_connectors: bool = False,
 ) -> tuple[dict[str, Any], list[RuleResource]]:
-    """Import rules into Kibana."""
+    """Import rules into Kibana.
+
+    Rules are sent to Kibana's ``/_import`` endpoint in batches to avoid request timeouts
+    on large rule sets. Batch size is resolved from the ``DR_KIBANA_IMPORT_BATCH_SIZE``
+    environment variable or the ``kibana_import_batch_size`` config setting (default: 50).
+    Rules that share a TOML exception or action connector are always kept together in the
+    same batch, so a batch may exceed the configured size when a linked group is larger.
+    """
 
     def _handle_response_errors(response: dict[str, Any], imported_exception_dicts: list[list[dict[str, Any]]]) -> None:
         """Handle errors from the import response."""
@@ -173,29 +321,38 @@ def kibana_import_rules(  # noqa: PLR0915
             click.echo(f" - {ids_str}")
 
     kibana = ctx.obj["kibana"]
-    batch_size = definitions.KIBANA_IMPORT_BATCH_SIZE
+    batch_size = _resolve_import_batch_size()
     rules_list = list(rules)
     imported_exception_dicts: list[list[dict[str, Any]]] = []
     imported_action_connectors_dicts: list[list[dict[str, Any]]] = []
     successful_rule_ids: list[str] = []
-    all_errors: list[dict[str, Any]] = []
+    batch_responses: list[dict[str, Any]] = []
     results: list[RuleResource] = []
 
     with kibana:
         cl = GenericCollection.default()
-        for i in range(0, len(rules_list), batch_size):
-            batched_rules = rules_list[i : i + batch_size]
-            rule_dicts = [r.contents.to_api_format() for r in batched_rules]
-            rule_ids = {rule["rule_id"] for rule in rule_dicts}
+        import_rule_ids = {r.id for r in rules_list}
+        all_exceptions = list(cl.items_matching(TOMLExceptionContents, import_rule_ids))
+        all_action_connectors = list(cl.items_matching(TOMLActionConnectorContents, import_rule_ids))
 
+        batches = _build_import_batches(rules_list, all_exceptions, all_action_connectors, batch_size)
+        total_batches = len(batches)
+
+        for batch_index, (batched_rules, batched_exceptions, batched_connectors) in enumerate(batches, start=1):
+            rule_dicts = [r.contents.to_api_format() for r in batched_rules]
             exception_dicts: list[list[dict[str, Any]]] = [
-                d.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
-                for d in cl.items_matching(TOMLExceptionContents, rule_ids)
+                e.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+                for e in batched_exceptions
             ]
             action_connectors_dicts: list[list[dict[str, Any]]] = [
-                d.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
-                for d in cl.items_matching(TOMLActionConnectorContents, rule_ids)
+                a.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+                for a in batched_connectors
             ]
+
+            click.echo(
+                f"Importing batch {batch_index}/{total_batches}: {len(rule_dicts)} rule(s), "
+                f"{len(exception_dicts)} exception list(s), {len(action_connectors_dicts)} action connector(s)"
+            )
 
             response, batch_successful_rule_ids, batch_results = RuleResource.import_rules(  # type: ignore[reportUnknownMemberType]
                 rule_dicts,
@@ -210,22 +367,22 @@ def kibana_import_rules(  # noqa: PLR0915
             imported_exception_dicts.extend(exception_dicts)
             imported_action_connectors_dicts.extend(action_connectors_dicts)
             successful_rule_ids.extend(cast("list[str]", batch_successful_rule_ids))
-            all_errors.extend(cast("list[dict[str, Any]]", response.get("errors", [])))
+            batch_responses.append(response)
             results.extend(cast("list[RuleResource]", batch_results))
 
-    response: dict[str, Any] = {"errors": all_errors}
+    merged_response: dict[str, Any] = _merge_import_responses(batch_responses)
 
     if successful_rule_ids:
-        click.echo(f"{len(successful_rule_ids)} rule(s) successfully imported")  # type: ignore[reportUnknownArgumentType]
-        rule_str = "\n - ".join(successful_rule_ids)  # type: ignore[reportUnknownArgumentType]
+        click.echo(f"{len(successful_rule_ids)} rule(s) successfully imported")
+        rule_str = "\n - ".join(successful_rule_ids)
         click.echo(f" - {rule_str}")
-    if response["errors"]:
-        _handle_response_errors(response, imported_exception_dicts)  # type: ignore[reportUnknownArgumentType]
+    if merged_response["errors"]:
+        _handle_response_errors(merged_response, imported_exception_dicts)
     else:
-        _process_imported_items(imported_exception_dicts, "exception list(s)", "list_id")  # type: ignore[reportUnknownArgumentType]
-        _process_imported_items(imported_action_connectors_dicts, "action connector(s)", "id")  # type: ignore[reportUnknownArgumentType]
+        _process_imported_items(imported_exception_dicts, "exception list(s)", "list_id")
+        _process_imported_items(imported_action_connectors_dicts, "action connector(s)", "id")
 
-    return response, results  # type: ignore[reportUnknownVariableType]
+    return merged_response, results
 
 
 @kibana_group.command("export-rules")

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -59,6 +59,7 @@ def elastic_rule_name_regexp(pattern: Pattern[str]) -> Callable[[Any], Any]:
 HTTP_STATUS_BAD_REQUEST = 400
 ASSET_TYPE = "security_rule"
 SAVED_OBJECT_TYPE = "security-rule"
+KIBANA_IMPORT_BATCH_SIZE = 50
 
 DATE_PATTERN = re.compile(r"^\d{4}/\d{2}/\d{2}$")
 MATURITY_LEVELS = ["development", "experimental", "beta", "production", "deprecated"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.1"
+version = "1.6.2"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves: https://github.com/elastic/detection-rules/issues/5829


<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

> [!IMPORTANT]
> The primary concern with doing this is avoiding a case where actions/exceptions are imported separately from their connected rules leading to a rule not yet existing on the stack, but an exception being pushed first. The implementation in this PR addresses this,but this is an area reviewers should have increased scrutiny.

Added batch processing to Kibana requests. This impacts the kibana import/export rule commands to provide a means to avoid Kibana timeouts and overly long processing times. 

### Alternatives

If this PR adds too much overhead or maintenance burden, we can alternatively add an info or warning message if the number of rules moved is beyond 1k to suggest increasing the Kibana timeout window if timeout errors occur.  

## How To Test

Test various DaC commands via:
```
make test-remote-cli
```

```
====================================================================== test session starts ======================================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /tmp/detection-rules
configfile: pyproject.toml
plugins: typeguard-4.5.1
collected 17 items                                                                                                                                              

tests/test_rules_remote.py .................                                                                                                              [100%]

======================================================================= warnings summary ========================================================================
tests/test_rules_remote.py: 20 warnings
  /tmp/detection-rules/env/detection-rules-build/lib/python3.12/site-packages/elasticsearch/_sync/client/__init__.py:399: SecurityWarning: Connecting to 'https://127.0.0.1:9200' using TLS with verify_certs=False is insecure
    _transport = transport_class(

tests/test_rules_remote.py: 14 warnings
  /tmp/detection-rules/detection_rules/index_mappings.py:366: ElasticsearchWarning: No limit defined, adding default limit of [1000]
    response = elastic_client.esql.query(query=query)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 17 passed, 34 warnings in 26.46s ================================================================
Removing generated files...
Detection-rules Remote CLI tests completed!
```

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
