### PR TITLE
[Feature] Add base_version field to rule metadata

### DIFF
--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -355,6 +355,7 @@ def rule_prompt(  # noqa: PLR0912, PLR0913, PLR0915
         "creation_date": kwargs.get("creation_date") or creation_date,
         "updated_date": kwargs.get("updated_date") or creation_date,
         "maturity": "development",
+        "base_version": kwargs.get("base_version"),
     }
 
     try:

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -278,6 +278,9 @@ def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
             )
         )
 
+        if contents.get("version") is not None:
+            contents["base_version"] = contents["version"]
+
         output = rule_prompt(
             rule_path,
             required_only=required_only,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -115,6 +115,7 @@ class RuleMeta(MarshmallowDataclassMixin):
     deprecation_date: definitions.Date | None = None
 
     # Optional fields
+    base_version: int | None = None
     bypass_bbr_timing: bool | None = None
     comments: str | None = None
     integration: str | list[str] | None = None
@@ -1648,7 +1649,9 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         if include_metadata:
             converted["meta"] = rule_dict["metadata"]
 
-        if include_version:
+        if self.metadata.base_version is not None:
+            converted["version"] = self.metadata.base_version
+        elif include_version:
             converted["version"] = self.autobumped_version
 
         return converted


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

## Summary - What I changed

When working with modified prebuilt rules in a custom folder the prebuilt rules will have a base_version that the UI requires when showing the differences between a modified custom rule and any updates published by the Elastic team. This PR adds the code to extract and add the `base_version` field to the metadata section of the rule as an integer. 
 
```
[metadata]
base_version = 107
```

## How To Test

- Modify a prebuilt rule and export it from the cluster to a toml file. Verify that the new file has a base_version field
- Import the rule with the base_version from the repo back to the cluster and verify that it was successfully added.

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
