### PR TITLE
[New] Potential Credential Discovery via Recursive Grep

### DIFF
--- a/rules/cross-platform/credential_access_grep_recursive_credential_discovery.toml
+++ b/rules/cross-platform/credential_access_grep_recursive_credential_discovery.toml
@@ -70,7 +70,7 @@ from logs-endpoint.events.process-* metadata _id, _version, _index
 | where host.os.type in ("linux", "macos")
   and event.category == "process"
   and process.name in ("grep", "egrep")
-  and (to_lower(process.command_line) like "* -r*" or to_lower(process.command_line like "*--recursive*"))
+  and (to_lower(process.command_line) like "* -r*" or to_lower(process.command_line) like "*--recursive*")
   and (
     process.command_line like "*password*"
     or process.command_line like "*passwd*"


### PR DESCRIPTION
Identifies recursive grep activity on Linux or macOS where the command line suggests hunting for secrets, credentials, keys, tokens, or sensitive paths (for example .env, .git, .aws). Events are aggregated per host, user, parent process, and one-minute window, the rule surfaces activity only when at least three distinct grep command lines match in the same bucket, to reduce noise from one-off searches.

