### PR TITLE
[Rule Tuning] AWS suspicious user agents (TruffleHog, Kali CLI/Boto3)

### DIFF
--- a/rules/integrations/aws/initial_access_suspicious_user_agent_detected_in_cloudtrail.toml
+++ b/rules/integrations/aws/initial_access_suspicious_user_agent_detected_in_cloudtrail.toml
@@ -120,11 +120,15 @@ query = '''
 any where event.dataset == "aws.cloudtrail"
   and event.outcome == "success"
   and (
-      (
-        user_agent.name: ("aws-cli", "Boto3")
-        and stringContains(user_agent.original, "distrib#kali")
-      )
-      or stringContains(user_agent.original, "TruffleHog")
+    (
+      stringContains(user_agent.original, "distrib#kali")
+      or stringContains(user_agent.original, "+kali")
+      or stringContains(user_agent.original, "kali-amd64")
+      or stringContains(user_agent.original, "kali-arm64")
+    ) or (
+      stringContains(user_agent.original, "TruffleHog")
+      or stringContains(user_agent.original, "trufflehog")
+    )
   )
 '''
 


### PR DESCRIPTION
## Summary
- Renames `initial_access_kali_user_agent_detected_with_aws_cli.toml` to `initial_access_suspicious_user_agent_detected_in_cloudtrail.toml` and sets the rule name to **AWS Suspicious User Agent Fingerprint**.
- **Kali:** Keeps detection for `aws-cli` / `Boto3` when `user_agent.original` contains `distrib#kali`.
- **TruffleHog:** Matches successful CloudTrail API calls where `user_agent.original` contains `TruffleHog` (secret scanners validating live AWS credentials without requiring `aws-cli` / `Boto3` as `user_agent.name`).
- Refreshes description, investigation notes, and references, including [Kudelski Security: Investigating Two Variants of the Trivy Supply-Chain Compromise](https://kudelskisecurity.com/research/investigating-two-variants-of-the-trivy-supply-chain-compromise).

## Threat coverage
Post-access abuse of **valid cloud accounts** (MITRE **T1078.004 – Cloud Accounts**): tooling that validates stolen keys (**TruffleHog** in CloudTrail) or runs AWS API clients from an **offensive Linux distribution** (**Kali** fingerprint), consistent with supply-chain theft of credentials and follow-on cloud reconnaissance.
