### PR TITLE
[New] Elastic Defend Alert from Package Manager Install Ancestry

### DIFF
--- a/rules/cross-platform/initial_access_elastic_defend_alert_package_manager_ancestor.toml
+++ b/rules/cross-platform/initial_access_elastic_defend_alert_package_manager_ancestor.toml
@@ -14,7 +14,6 @@ spawn chains are a common path for supply-chain and postinstall abuse; this High
 whose process tree includes such activity for prioritization.
 """
 from = "now-9m"
-interval = "5m"
 language = "esql"
 license = "Elastic License v2"
 name = "Elastic Defend Alert from Package Manager Install Ancestry"


### PR DESCRIPTION
Detects Elastic Defend alerts (behavior, malicious file, memory signature, shellcode) where the alerted process has a package-manager install context in its ancestry: npm (Node.js), PyPI (pip / Python / uv), or Rust (cargo). Install-time spawn chains are a common path for supply-chain and postinstall abuse; this Higher-Order rule surfaces Defend alerts whose process tree includes such activity for prioritization.

