### PR TITLE
[Bug] Small bugfix to address update navigator edge case

### DIFF
--- a/detection_rules/ghwrap.py
+++ b/detection_rules/ghwrap.py
@@ -113,7 +113,8 @@ def update_gist(  # noqa: PLR0913
         response.raise_for_status()
         data = response.json()
         files = list(data["files"])
-        body["files"] = {file: {} for file in files if file not in file_map}
+        keep_names = {path.name for path in file_map}
+        body["files"] = {name: {} for name in files if name not in keep_names}
         response = requests.patch(url, headers=headers, json=body, timeout=30)
         response.raise_for_status()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.15"
+version = "1.6.16"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

Related to Unit Test failures after merging https://github.com/elastic/detection-rules/pull/5937 ([ref](https://github.com/elastic/detection-rules/actions/runs/24201923539/job/70674764224)). 


**TLDR: this is apparently the first time we have run into a case where we wanted to run `update_gist` with `pre_purge = True` and in a case where the code logic is telling Github to pre_purge all of the files before re-uploading/updating them.**

![bulk_delete_request](https://github.com/user-attachments/assets/8f58c9b0-c1fd-40e6-a023-2949ed1ba7f9)

This comparison does not have the intended effect, while the request going to Github is to pre_purge the files, we do not need/want to do this.

The function `update_gist(..., pre_purge=True)` built the “files to remove” map with `file not in file_map`, but `file` from the GitHub API is a **string** while `file_map` keys are **`pathlib.Path`** objects. 

This mismatch would result in every existing gist file was marked for deletion (`{filename: {}}`) in the first `PATCH`. GitHub rejected that request with **`422 Unprocessable Entity`**, which broke CI on `python -m detection_rules dev update-navigator-gists` (e.g. the “Update navigator gist files” step on pushes to `main`).

> [!NOTE]
> This only changes the pre-purge behavior which this error attempts to delete every file before re-upload. Since re-upload would occur this would not necessarily change overall outcome since the gist would be updated / re-uploaded to mach.  

This error has been occurring intermittently for some time. In the most recent ~400 completed runs (2025-11-24 → 2026-04-09), there were 15 failures total. 12 of those failures failed on the step Update navigator gist files. It is not entirely clear if it is the identical issue, but the initial evidence would suggest that it is. 

## Change

Compare using basenames only:

```python
keep_names = {path.name for path in file_map}
body["files"] = {name: {} for name in files if name not in keep_names}
```

Only files that are actually absent from the new upload set are purged.


<img width="1885" height="1354" alt="Screenshot from 2026-04-09 17-27-22" src="https://github.com/user-attachments/assets/939c8ba4-2fb3-478b-8400-72eb92fabd66" />


## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
