### PR TITLE
[Bug] ESQL validation support fix

### DIFF
--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -17,6 +17,7 @@ from elasticsearch.exceptions import BadRequestError
 from semver import Version
 
 from . import ecs, integrations, misc, utils
+from .config import load_current_package_version
 from .esql import EventDataset
 from .esql_errors import (
     EsqlKibanaBaseError,
@@ -510,7 +511,7 @@ def prepare_mappings(  # noqa: PLR0913
         custom_mapping.update({index: index_mapping})
 
     # Load ECS in an index mapping format (nested schema)
-    current_version = Version.parse(stack_version, optional_minor_and_patch=True)
+    current_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
     ecs_schema = get_ecs_schema_mappings(current_version)
 
     # Filter combined mappings based on the provided indices

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.22"
+version = "1.6.23"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to https://github.com/elastic/detection-rules/pull/5918

## Summary - What I changed


An ES|QL validation PR: https://github.com/elastic/detection-rules/pull/5925 introduced an optimization to catch field validation issues on stack version prior to backporting. 

However, this update did not take into account that we also run ES|QL validation on the old stack branches during the release process. Outside of the release process this is not done, so it appeared that we could make this optimization. 

The lock versions job is run from main, so the validation occurs, but the context/checkout of the repo is on older branches e.g. 8.19 ([failed run](https://github.com/elastic/detection-rules/actions/runs/24797621287/job/72571495870))

This PR reverts the optimization to address lock version errors. Re-introduces the risk needing to be careful with ES|QL PRs like https://github.com/elastic/detection-rules/pull/5923, but this is unavoidable given the required release process.


## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
