### PR TITLE
[Rule Tuning] Add Lunixar to RMM rules, fix new_terms condition

### DIFF
--- a/rules/windows/command_and_control_dns_rmm_domains_non_browser.toml
+++ b/rules/windows/command_and_control_dns_rmm_domains_non_browser.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/03/03"
 integration = ["endpoint", "windows"]
 maturity = "production"
-updated_date = "2026/03/23"
+updated_date = "2026/04/27"
 
 [rule]
 author = ["Elastic"]
@@ -125,6 +125,7 @@ FROM logs-endpoint.events.network-*, logs-windows.sysmon_operational-* METADATA 
     "immy.bot",
     "immybot.com",
     "level.io",
+    "lunixar.com",
     "ninjarmm.com",
     "ninjaone.com",
     "centrastage.net",

--- a/rules/windows/command_and_control_multiple_rmm_vendors_same_host.toml
+++ b/rules/windows/command_and_control_multiple_rmm_vendors_same_host.toml
@@ -9,7 +9,7 @@ integration = [
     "crowdstrike",
 ]
 maturity = "production"
-updated_date = "2026/04/07"
+updated_date = "2026/04/27"
 
 [rule]
 author = ["Elastic"]
@@ -117,6 +117,9 @@ from logs-endpoint.events.process-*, endgame-*, logs-crowdstrike.fdr*, logs-m365
     process.name == "LvAgent.exe", "Level",
     process.name == "LMIIgnition.exe", "LogMeIn",
     process.name == "LogMeIn.exe", "LogMeIn",
+    process.name == "Lunixar.exe", "Lunixar",
+    process.name == "LunixarRemote.exe", "Lunixar",
+    process.name == "LunixarUpdater.exe", "Lunixar",
     process.name == "ManageEngine_Remote_Access_Plus.exe", "ManageEngine",
     process.name == "MeshAgent.exe", "MeshCentral",
     process.name == "meshagent.exe", "MeshCentral",

--- a/rules/windows/command_and_control_new_terms_commonly_abused_rmm.toml
+++ b/rules/windows/command_and_control_new_terms_commonly_abused_rmm.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/04/03"
 integration = ["endpoint", "windows", "system"]
 maturity = "production"
-updated_date = "2026/03/30"
+updated_date = "2026/04/27"
 
 [rule]
 author = ["Elastic"]
@@ -76,7 +76,7 @@ timestamp_override = "event.ingested"
 type = "new_terms"
 setup = """## Setup
 
-- **New terms window**: The rule uses `new_terms_fields: host.id` with a 7-day history window. The first time a matching RMM/remote access process is seen on a host within that window will trigger the alert.
+- **New terms window**: The rule uses `new_terms_fields: host.id, process.name` with a 7-day history window. The first time a matching RMM/remote access process name is seen on a host within that window will trigger the alert.
 - **Velociraptor**: If your organization deploys Velociraptor for DFIR or hunting, consider adding a rule exception by host group or excluding `process.name: "Velociraptor.exe"` where appropriate.
 - **Elastic Defend**: For best coverage ensure process events with `process.code_signature` and `process.name` are ingested from Windows endpoints (e.g. logs-endpoint.events.process-*).
 - **Parent matching**: The rule also matches when the started process's parent has an RMM/remote access name or code signer, so first-time child processes (e.g. scripts or binaries spawned by TeamViewer, ScreenConnect, AteraAgent, MeshAgent) are detected. Complement with DNS-based detection (e.g. Sigma rule for remote access software domains from non-browser processes) for full coverage.
@@ -108,6 +108,7 @@ host.os.type: "windows" and
             "Instant Housecall" or
             "ISL Online Ltd." or
             "LogMeIn, Inc." or
+            "LUNIXAR SAS DE CV" or
             "Monitoring Client" or
             "MMSOFT Design Ltd." or
             "Nanosystems S.r.l." or
@@ -172,6 +173,9 @@ host.os.type: "windows" and
             "LvAgent.exe" or
             "LMIIgnition.exe" or
             "LogMeIn.exe" or
+            "Lunixar.exe" or
+            "LunixarRemote.exe" or
+            "LunixarUpdater.exe" or
             "ManageEngine_Remote_Access_Plus.exe" or
             "MeshAgent.exe" or
             "Mikogo-Service.exe" or
@@ -271,6 +275,9 @@ host.os.type: "windows" and
             "LvAgent.exe" or
             "LMIIgnition.exe" or
             "LogMeIn.exe" or
+            "Lunixar.exe" or
+            "LunixarRemote.exe" or
+            "LunixarUpdater.exe" or
             "ManageEngine_Remote_Access_Plus.exe" or
             "MeshAgent.exe" or
             "meshagent.exe" or
@@ -358,6 +365,7 @@ host.os.type: "windows" and
             "Instant Housecall" or
             "ISL Online Ltd." or
             "LogMeIn, Inc." or
+            "LUNIXAR SAS DE CV" or
             "Monitoring Client" or
             "MMSOFT Design Ltd." or
             "Nanosystems S.r.l." or
@@ -421,6 +429,9 @@ host.os.type: "windows" and
             "LvAgent.exe" or
             "LMIIgnition.exe" or
             "LogMeIn.exe" or
+            "Lunixar.exe" or
+            "LunixarRemote.exe" or
+            "LunixarUpdater.exe" or
             "ManageEngine_Remote_Access_Plus.exe" or
             "MeshAgent.exe" or
             "Mikogo-Service.exe" or
@@ -508,9 +519,10 @@ reference = "https://attack.mitre.org/techniques/T1219/002/"
 id = "TA0011"
 name = "Command and Control"
 reference = "https://attack.mitre.org/tactics/TA0011/"
+
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["host.id"]
+value = ["host.id", "process.name"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-7d"


### PR DESCRIPTION
## Summary

Adds Lunixar coverage to the RMM detection rules and updates `First Time Seen Remote Monitoring and Management Tool` to key `new_terms` on both `host.id` and `process.name`. Previously, the rule would alert once for any RMM on a host and miss a different RMM process seen later on that same host.
