### PR TITLE
[Enhancement] Add test for constant_keyword fields on alerts-only rules

### DIFF
--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -762,7 +762,8 @@ class ESQLValidator(QueryValidator):
             return [field["name"] for field in self.esql_unique_fields]
         return []
 
-    def get_esql_query_indices(self, query: str) -> tuple[str, list[str]]:
+    @staticmethod
+    def get_esql_query_indices(query: str) -> tuple[str, list[str]]:
         """Extract indices from an ES|QL query."""
         match = FROM_SOURCES_REGEX.search(query)
         if not match:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.27"
+version = "1.6.28"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -17,7 +17,7 @@ import kql
 from marshmallow import ValidationError
 from semver import Version
 
-from detection_rules import atlas, attack
+from detection_rules import atlas, attack, ecs
 from detection_rules.config import load_current_package_version
 from detection_rules.integrations import (
     find_latest_compatible_version,
@@ -34,6 +34,7 @@ from detection_rules.rule import (
     TOMLRuleContents,
 )
 from detection_rules.rule_loader import FILE_PATTERN, RULES_CONFIG
+from detection_rules.rule_validators import ESQLValidator
 from detection_rules.schemas import definitions, get_min_supported_stack_version, get_stack_schemas
 from detection_rules.utils import INTEGRATION_RULE_DIR, PatchedTemplate, get_path, load_etc_dump, make_git
 from detection_rules.version_lock import loaded_version_lock
@@ -41,6 +42,20 @@ from detection_rules.version_lock import loaded_version_lock
 from .base import BaseRuleTest
 
 PACKAGE_STACK_VERSION = Version.parse(current_stack_version(), optional_minor_and_patch=True)
+
+
+def _strip_query_literals(query: str) -> str:
+    """Strip string literals and line comments from a query body.
+
+    Used when scanning ES|QL / KQL / EQL queries for field references via regex,
+    so matches inside string literals (e.g. KQL filters embedded as
+    KQL(\"\"\"...\"\"\")) and inside `// comments` don't false-positive.
+    Triple-quoted, double-quoted, and `//` comments cover the patterns used by
+    rules in this repo.
+    """
+    query = re.sub(r'"""[\s\S]*?"""', "", query)
+    query = re.sub(r'"[^"\n]*"', "", query)
+    return re.sub(r"//[^\n]*", "", query)
 
 
 class TestValidRules(BaseRuleTest):
@@ -199,6 +214,57 @@ class TestValidRules(BaseRuleTest):
             The following prebuilt rules do not have either 'index' or 'data_view_id' \n
             """
             self.fail(fail_msg + "\n".join(failures))
+
+    def test_alerts_only_rules_no_constant_keyword_fields(self):
+        """Query rules targeting only .alerts-* indices must not reference constant_keyword ECS fields.
+
+        Kibana's .alerts-ecs-mappings system component template excludes
+        constant_keyword ECS fields by design (a constant_keyword can hold only one
+        value per index, which is incompatible with alerts indices that aggregate
+        signals from many data streams). Querying such a field on alerts-only rules
+        fails at runtime with "Unknown column" / "Unknown field" — use event.dataset
+        instead of data_stream.dataset, and similar substitutions.
+
+        The static AST validators don't catch this: they merge ECS into every
+        validation target's schema (rule_validators.py:202-210), so any field
+        defined in ECS validates as "known" regardless of whether it's actually
+        mapped on .alerts-*. This test fills that gap.
+
+        Multi-index rules (e.g. ".alerts-security.*" + "logs-okta.system-*") are
+        not flagged — the field resolves from the integration mapping side at
+        runtime. Machine-learning rules have no query and are excluded by the
+        QueryRuleData filter.
+        """
+        constant_keyword_fields = sorted(
+            f for f, info in ecs.get_schema().items() if info.get("type") == "constant_keyword"
+        )
+        failures: list[str] = []
+        for rule in self.all_rules:
+            data = rule.contents.data
+            if not isinstance(data, QueryRuleData):
+                continue
+            query = data.get("query") or ""
+            if not query:
+                continue
+            # ES|QL targets indices via the FROM clause; everything else uses the
+            # rule's index field.
+            if data.get("language") == "esql":
+                _, sources = ESQLValidator.get_esql_query_indices(query)
+            else:
+                sources = list(data.index_or_dataview or [])
+            if not sources or not all(s.startswith(".alerts-") for s in sources):
+                continue
+            body = _strip_query_literals(query)
+            offenders = [f for f in constant_keyword_fields if re.search(rf"\b{re.escape(f)}\b", body)]
+            if offenders:
+                failures.append(f"{self.rule_str(rule)} references {offenders} on {sources}")
+
+        if failures:
+            self.fail(
+                "Rules targeting only .alerts-* indices must not reference constant_keyword "
+                "ECS fields (e.g. use event.dataset instead of data_stream.dataset):\n"
+                + "\n".join(failures)
+            )
 
 
 class TestThreatMappings(BaseRuleTest):


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Related
* https://github.com/elastic/detection-rules/pull/5994

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed
Added a CI unit test that fails the build if any KQL/EQL/ES|QL/threshold/new_terms/threat_match rule (a) targets only .alerts-* AND (b) references a constant_keyword ECS field. This closes the validator gap that let #5943 merge: the existing AST validators merge ECS into every target schema, so they treat data_stream.dataset as a known field and never catch this class of bug. The test catches it before runtime regardless of language.

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test
On the fix branch, run:

```bash
python -m unittest tests.test_all_rules.TestValidRules.test_alerts_only_rules_no_constant_keyword_fields -v
```

Expected: PASS.

To confirm the test actually catches the bug, open any of the patched rules (e.g. `rules/cross-platform/newly_observed_elastic_detection_rule.toml`) and change `event.dataset` back to `data_stream.dataset`. Re-run the command, expected: FAIL, with the rule name and offending field in the output. Revert the edit when done.

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
