### PR TITLE
[Bug] Add support for quoted string literal

### DIFF
--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -128,6 +128,41 @@ def custom_in_set(self: LarkToEQL, node: KvTree) -> NodeInfo:
     return NodeInfo(term, TypeHint.Boolean, nullable=nullable, source=node)
 
 
+# Matches a quoted-string event type at the start of a (sub)query, e.g.
+#   "ec2.amazonaws.com" where ...
+#   [ "ec2.amazonaws.com" where ... ]
+#   ![ "ec2.amazonaws.com" where ... ]
+# The grammar in `eql==0.9.19` only allows a NAME token here, but Elasticsearch
+# accepts string literals (since event categories may contain characters such
+# as "." that are not valid in an EQL identifier). See
+# https://github.com/elastic/detection-rules/issues/5236.
+_STRING_EVENT_TYPE_RE = re.compile(
+    r'(?P<prefix>\A|(?<=\[)|(?<=!\[))'
+    r'(?P<lead_ws>\s*)'
+    r'"(?P<value>(?:\\.|[^"\\\r\n])*)"'
+    r'(?P<post>\s+where\b)'
+)
+
+
+def _rewrite_string_event_types(query: str) -> str:
+    """Replace string-literal event types with ``any`` while preserving column positions.
+
+    The substitution keeps the overall character count of the rewritten span identical
+    to the original so that any parser error positions remain meaningful to the user.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        original = match.group(0)
+        replacement = match.group("prefix") + match.group("lead_ws") + "any" + match.group("post")
+        if len(replacement) >= len(original):
+            return replacement
+        # Pad after `any` to preserve column positions in error messages.
+        pad = " " * (len(original) - len(replacement))
+        return match.group("prefix") + match.group("lead_ws") + "any" + pad + match.group("post")
+
+    return _STRING_EVENT_TYPE_RE.sub(_replace, query)
+
+
 def custom_base_parse_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
     """Override and address the limitations of the eql in_set method."""
 
@@ -135,8 +170,26 @@ def custom_base_parse_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
     def wrapper(query: str, start: str | None = None, **kwargs: dict[str, Any]) -> Any:
         original_in_set = LarkToEQL.in_set  # type: ignore[reportUnknownMemberType]
         LarkToEQL.in_set = custom_in_set
+        rewritten_query = _rewrite_string_event_types(query)
         try:
-            result = func(query, start=start, **kwargs)
+            try:
+                result = func(rewritten_query, start=start, **kwargs)
+            except eql.EqlParseError as exc:
+                # If we rewrote the query, re-raise using the original source so
+                # the error context shown to the user matches what they wrote.
+                if rewritten_query != query and getattr(exc, "source", None):
+                    original_lines = query.split("\n")
+                    line_idx = getattr(exc, "line", 0) or 0
+                    new_source = "\n".join(original_lines[max(line_idx - 1, 0) : line_idx + 1])
+                    raise type(exc)(
+                        exc.error_msg,
+                        line=exc.line,
+                        column=exc.column,
+                        source=new_source,
+                        width=getattr(exc, "width", 1),
+                        trailer=getattr(exc, "trailer", None),
+                    ) from None
+                raise
         finally:  # Using finally to ensure that the original method is restored
             LarkToEQL.in_set = original_in_set
         return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.27"
+version = "1.6.28"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_python_library.py
+++ b/tests/test_python_library.py
@@ -112,6 +112,34 @@ class TestEQLInSet(BaseRuleTest):
         rc.load_dict(rule_dict)
 
 
+class TestEQLStringEventType(BaseRuleTest):
+    """Tests for EQL queries that use a string-literal event type (e.g. ``"ec2.amazonaws.com" where ...``).
+
+    Elasticsearch accepts these but the bundled ``eql`` package's grammar only allows a NAME token
+    in that position, so detection-rules pre-processes the query before parsing.
+    See https://github.com/elastic/detection-rules/issues/5236.
+    """
+
+    def test_string_event_type_parses(self) -> None:
+        """A leading double-quoted string event type should parse without error."""
+        eql.parse_query('"ec2.amazonaws.com" where event.dataset == "aws.cloudtrail"')
+
+    def test_string_event_type_in_subquery_parses(self) -> None:
+        """A double-quoted string event type inside a sequence subquery should parse."""
+        query = (
+            "sequence by host.id\n"
+            '  ["ec2.amazonaws.com" where event.action == "a"]\n'
+            '  ["foo.bar" where event.action == "b"]'
+        )
+        eql.parse_query(query)
+
+    def test_string_event_type_error_keeps_original_source(self) -> None:
+        """Syntax errors below the rewritten event type should reference the original query text."""
+        with self.assertRaises(eql.EqlParseError) as ctx:
+            eql.parse_query('"ec2.amazonaws.com" where field ==')
+        self.assertIn('"ec2.amazonaws.com"', ctx.exception.source)
+
+
 class TestEQLSequencePerIntegration(BaseRuleTest):
     """Tests for per-subquery EQL validation against the correct integration.package schema."""
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/5236

## Summary - What I changed

This is a draft implementation to use as reference for an issue that belongs in the EQL library. This is just for testing should we decide to resolve this in https://github.com/endgameinc/eql

## How To Test


Run the command view-rule on a modified rule that has a double quoted string as the source for a where clause:

<img width="1188" height="1335" alt="image" src="https://github.com/user-attachments/assets/3118a5c1-9760-42b4-b5ed-b47023f3d497" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
