### PR TITLE
[New Rule] Potential Remote Code Execution via Git Enterprise Server

### DIFF
--- a/rules/cross-platform/execution_cve_2026_3854_rce_via_github_enterprise_server.toml
+++ b/rules/cross-platform/execution_cve_2026_3854_rce_via_github_enterprise_server.toml
@@ -7,7 +7,7 @@ updated_date = "2026/04/29"
 [rule]
 author = ["Elastic"]
 description = """
-Detects potential remote code execution attempts via Git Enterprise Server, as a result of a vulnerability (CVE-2026-3854).
+Detects potential remote code execution attempts via GitHub Enterprise Server, as a result of a vulnerability (CVE-2026-3854).
 Authenticated command injection via git push options in GitHub Enterprise Server allows RCE on backend nodes by abusing
 unsanitized push-option metadata injected into internal headers.
 """
@@ -27,8 +27,38 @@ index = [
 ]
 language = "eql"
 license = "Elastic License v2"
-name = "Potential Remote Code Execution via Git Enterprise Server"
+name = "Potential Remote Code Execution via GitHub Enterprise Server"
 note = """
+## Triage and analysis
+
+> **Disclaimer**:
+> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
+
+### Investigating Potential Remote Code Execution via GitHub Enterprise Server
+
+This rule spots git push activity that includes crafted push options with shell metacharacters, a strong sign that someone is trying to turn repository traffic into command execution on backend GitHub Enterprise Server nodes. An attacker with valid access can issue a push using a malicious option such as `--push-option='x; curl ... | sh'` to inject commands through internal request handling and gain code execution on the server.
+
+### Possible investigation steps
+
+- Validate whether the user, source workstation, and target repository match normal developer behavior and confirm with change records or the user whether the push and any custom push options were expected.
+- Review GitHub Enterprise Server audit, SSH, web, and reverse-proxy logs for the same account and time window to determine whether the push reached the server and whether request handling, hooks, or backend services showed anomalies.
+- Hunt on GitHub Enterprise Server backend nodes for shells, interpreters, download utilities, temporary file creation, or other unexpected child activity spawned shortly after the push to confirm or refute successful code execution.
+- Examine follow-on activity tied to the same account or affected server, including unusual outbound connections, new SSH keys or tokens, repository permission changes, and access to additional systems or repositories.
+- If the activity is unauthorized, preserve volatile data and relevant logs, revoke the user’s credentials and tokens, isolate impacted backend nodes, and expedite remediation or patching for CVE-2026-3854.
+
+### False positive analysis
+
+- A developer or approved script may legitimately use `git push -o/--push-option` to pass custom metadata to repository hooks, and a literal value containing `;` or backticks can match this rule, so verify the option against documented hook usage and confirm the same pattern is routinely used by the same user or repository.
+- A local shell wrapper, alias, or maintenance script can build a `git push` command with quoted semicolons or backtick-based variable expansion that appears suspicious in process telemetry without delivering a malicious payload, so review the parent process and invoked script to confirm it is an expected workflow and that no abnormal activity followed on GitHub Enterprise Server.
+
+### Response and remediation
+
+- Immediately isolate the affected GitHub Enterprise Server backend node or cluster members from the network, pause repository synchronization and background jobs, and block the source workstation, VPN session, or bastion host used for the malicious `git push`.
+- Revoke the involved user’s password, personal access tokens, SSH keys, OAuth tokens, and active sessions, then remove any attacker-added SSH authorized keys, cron entries, system services, scheduled tasks, repository hooks, or webhooks created after the malicious push.
+- Preserve memory, relevant logs, the malicious push command, and any dropped scripts or binaries for forensics, then rebuild or restore compromised GitHub Enterprise Server nodes from a known-good image or backup taken before the exploit and validate repository integrity before returning them to service.
+- Escalate to incident response immediately if you confirm command execution on a backend node, see shells or download tools spawned by Git services, detect outbound connections from the appliance, or find evidence that source code, secrets, tokens, or admin settings were accessed or changed.
+- Patch GitHub Enterprise Server to the fixed release for CVE-2026-3854, restrict or disable push options and custom hooks where not required, rotate secrets stored on the appliance, enforce MFA for administrators, and add detections for `git push` commands carrying shell metacharacters or unusual child processes from Git components.
+
 """
 references = [
     "https://www.wiz.io/blog/github-rce-vulnerability-cve-2026-3854"

--- a/rules/cross-platform/execution_cve_2026_3854_rce_via_github_enterprise_server.toml
+++ b/rules/cross-platform/execution_cve_2026_3854_rce_via_github_enterprise_server.toml
@@ -1,0 +1,99 @@
+[metadata]
+creation_date = "2026/04/29"
+integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike", "auditd_manager"]
+maturity = "production"
+updated_date = "2026/04/29"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects potential remote code execution attempts via Git Enterprise Server, as a result of a vulnerability (CVE-2026-3854).
+Authenticated command injection via git push options in GitHub Enterprise Server allows RCE on backend nodes by abusing
+unsanitized push-option metadata injected into internal headers.
+"""
+from = "now-9m"
+index = [
+    "endgame-*",
+    "logs-crowdstrike.fdr*",
+    "logs-endpoint.events.process-*",
+    "logs-m365_defender.event-*",
+    "logs-sentinel_one_cloud_funnel.*",
+    "logs-system.security*",
+    "logs-windows.forwarded*",
+    "logs-windows.sysmon_operational-*",
+    "winlogbeat-*",
+    "auditbeat-*",
+    "logs-auditd_manager.auditd-*"
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Remote Code Execution via Git Enterprise Server"
+note = """
+"""
+references = [
+    "https://www.wiz.io/blog/github-rce-vulnerability-cve-2026-3854"
+]
+risk_score = 73
+rule_id = "0e35f7da-5cb5-4a28-be8c-998728e26e9a"
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "OS: Windows",
+    "OS: macOS",
+    "Use Case: Threat Detection",
+    "Tactic: Execution",
+    "Tactic: Initial Access",
+    "Data Source: Elastic Endgame",
+    "Data Source: Elastic Defend",
+    "Data Source: Windows Security Event Logs",
+    "Data Source: Microsoft Defender XDR",
+    "Data Source: Sysmon",
+    "Data Source: SentinelOne",
+    "Data Source: Crowdstrike",
+    "Data Source: Auditd Manager",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+process.name like~ ("git", "git.exe") and process.args == "push" and
+process.args like ("-o", "--push-option=*") and process.command_line like ("*;*", "*`*`*")
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+name = "Execution"
+id = "TA0002"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[[rule.threat.technique]]
+id = "T1203"
+name = "Exploitation for Client Execution"
+reference = "https://attack.mitre.org/techniques/T1203/"
+
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1190"
+name = "Exploit Public-Facing Application"
+reference = "https://attack.mitre.org/techniques/T1190/"
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"

--- a/rules/cross-platform/execution_cve_2026_3854_rce_via_github_enterprise_server.toml
+++ b/rules/cross-platform/execution_cve_2026_3854_rce_via_github_enterprise_server.toml
@@ -89,7 +89,7 @@ type = "eql"
 query = '''
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
 process.name like~ ("git", "git.exe") and process.args == "push" and
-process.args like ("-o", "--push-option=*") and process.command_line like ("*;*", "*`*`*")
+process.args like ("-o", "--push-option", "--push-option=*") and process.command_line like ("*;*", "*`*`*")
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary
Detects potential remote code execution attempts via Git Enterprise Server, as a result of a vulnerability (CVE-2026-3854). Authenticated command injection via git push options in GitHub Enterprise Server allows RCE on backend nodes by abusing unsanitized push-option metadata injected into internal headers.

Ref: https://www.wiz.io/blog/github-rce-vulnerability-cve-2026-3854