### PR TITLE
[Rule Tuning] Fixes for Unsupported Fields

### DIFF
--- a/rules/linux/initial_access_apache_struts_cve_2023_50164_exploitation_to_webshell.toml
+++ b/rules/linux/initial_access_apache_struts_cve_2023_50164_exploitation_to_webshell.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/11/19"
 integration = ["endpoint", "network_traffic"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/01"
 
 [rule]
 author = ["Elastic"]
@@ -108,8 +108,8 @@ sequence by agent.id with maxspan=10s
       file.extension == "jsp" and
       file.path like "*/webapps/*" and
       not file.path like "*/WEB-INF/*" and
-      not file.path like "*/META-INF/*" and
-      not process.parent.name in ("apk", "apt", "apt-get", "dpkg", "yum", "rpm", "dnf", "systemd", "init")]
+      not file.path like "*/META-INF/*"
+  ]
 '''
 
 [[rule.threat]]

--- a/rules/linux/persistence_web_server_sus_destination_port.toml
+++ b/rules/linux/persistence_web_server_sus_destination_port.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/01"
 
 [rule]
 author = ["Elastic"]
@@ -101,8 +101,7 @@ network where host.os.type == "linux" and event.type == "start" and event.action
     "php-fcgi", "php-cgi.cagefs", "catalina.sh", "hiawatha", "lswsctrl"
   ) or
   user.name in ("apache", "www-data", "httpd", "nginx", "lighttpd", "tomcat", "tomcat8", "tomcat9") or
-  user.id in ("33", "498", "48") or
-  (process.name == "java" and process.working_directory like "/u0?/*")
+  user.id in ("33", "498", "48")
 ) and
 network.direction == "egress" and destination.ip != null and
 not destination.port in (80, 443, 8080, 8443, 8000, 8888, 3128, 3306, 5432, 8220, 8082) and


### PR DESCRIPTION
## Summary
Addressing an issue where unavailable fields were part of the query.

```
7f3e8b9a-2c4d-5e6f-8a1b-9c2d3e4f5a6b — Potential Webshell Deployed via Apache Struts https://github.com/advisories/GHSA-2j39-qcjm-428w Exploitation — process.parent.name inside file where
00546494-5bb0-49d6-9220-5f3b4c12f26a — Uncommon Destination Port Connection by Web Server — process.working_directory inside network where
```