### PR TITLE
[Bug] Omit ES|QL engine columns from required_fields

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -683,7 +683,7 @@ class QueryValidator:
         required: list[dict[str, Any]] = []
         unique_fields: list[str] = self.unique_fields or []
         if isinstance(self, ESQLValidator):
-            unique_fields = [f for f in unique_fields if not f.startswith(("Esql_priv.", "Esql."))]
+            unique_fields = [f for f in unique_fields if not f.startswith(definitions.ESQL_DYNAMIC_FIELD_PREFIXES)]
 
         for fld in unique_fields:
             field_type = ecs_schema.get(fld, {}).get("type")

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -682,6 +682,8 @@ class QueryValidator:
 
         required: list[dict[str, Any]] = []
         unique_fields: list[str] = self.unique_fields or []
+        if isinstance(self, ESQLValidator):
+            unique_fields = [f for f in unique_fields if not f.startswith(("Esql_priv.", "Esql."))]
 
         for fld in unique_fields:
             field_type = ecs_schema.get(fld, {}).get("type")

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -47,7 +47,7 @@ from .integrations import (
 )
 from .rule import EQLRuleData, QueryRuleData, QueryValidator, RuleMeta, TOMLRuleContents, set_eql_config
 from .schemas import get_latest_stack_version, get_stack_schemas, get_stack_versions
-from .schemas.definitions import FROM_SOURCES_REGEX
+from .schemas.definitions import ESQL_DYNAMIC_FIELD_PREFIXES, FROM_SOURCES_REGEX
 
 EQL_ERROR_TYPES = (
     eql.EqlCompileError
@@ -792,7 +792,7 @@ class ESQLValidator(QueryValidator):
         for column in query_columns:
             column_name = column["name"]
             # Skip Dynamic fields
-            if column_name.startswith(("Esql.", "Esql_priv.")):
+            if column_name.startswith(ESQL_DYNAMIC_FIELD_PREFIXES):
                 continue
             # Skip internal fields
             if column_name in ("_id", "_version", "_index"):

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -79,6 +79,7 @@ MINOR_SEMVER = re.compile(r"^\d+\.\d+$")
 FROM_SOURCES_REGEX = re.compile(
     r"^\s*FROM\s+(?P<sources>(?:.+?(?:,\s*)?\n?)+?)\s*(?:\||\bmetadata\b|//|$)", re.IGNORECASE | re.MULTILINE
 )
+ESQL_DYNAMIC_FIELD_PREFIXES = ("Esql.", "Esql_priv.")
 BRANCH_PATTERN = f"{VERSION_PATTERN}|^master$"
 ELASTICSEARCH_EQL_FEATURES = {
     "allow_negation": (Version.parse("8.9.0"), None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.29"
+version = "1.6.30"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -19,6 +19,7 @@ from detection_rules.misc import (
     get_default_config,
     getdefault,
 )
+from detection_rules.rule import ESQLRuleData
 from detection_rules.rule_loader import RuleCollection
 from detection_rules.utils import get_path, load_rule_contents
 
@@ -245,9 +246,13 @@ class TestRemoteRules(BaseRuleTest):
         _ = RuleCollection().load_dict(production_rule)
 
     def test_esql_required_fields_omit_engine_columns(self):
-        """required_fields must not list Esql.* / Esql_priv.* (not index mappings)."""
+        """ESQL required_fields must not list Esql.* / Esql_priv.* (not index mappings)."""
         for rule in self.all_rules:
-            for rf in rule.contents.to_api_format().get("required_fields") or []:
+            data = rule.contents.data
+            if not isinstance(data, ESQLRuleData):
+                continue
+            index = data.get("index") or []
+            for rf in data.get_required_fields(index) or []:
                 name = rf["name"]
                 assert not name.startswith(("Esql_priv.", "Esql.")), (
                     f"{rule.id} - {rule.name}: required_fields must not include ES|QL engine columns "

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -242,7 +242,12 @@ class TestRemoteRules(BaseRuleTest):
         | stats Esql.host_id_count_distinct = count_distinct(host.id) by rule.name, event.code
         | where Esql.host_id_count_distinct >= 3
         """
-        _ = RuleCollection().load_dict(production_rule)
+        rule = RuleCollection().load_dict(production_rule)
+        for rf in rule.contents.to_api_format().get("required_fields") or []:
+            name = rf["name"]
+            assert not name.startswith(("Esql_priv.", "Esql.")), (
+                f"required_fields must not include ES|QL engine columns (not index mappings): {name!r}"
+            )
 
     def test_esql_endpoint_unknown_index(self):
         """Test an ESQL rule's index validation. This is expected to error on an unknown index."""

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -245,23 +245,14 @@ class TestRemoteRules(BaseRuleTest):
         _ = RuleCollection().load_dict(production_rule)
 
     def test_esql_required_fields_omit_engine_columns(self):
-        """required_fields must not list Esql.* / Esql_priv.* (not index mappings). Same query shape as test_esql_endpoint_alerts_index."""
-        file_path = get_path(["tests", "data", "command_control_dummy_production_rule.toml"])
-        original_production_rule = load_rule_contents(file_path)
-        production_rule = deepcopy(original_production_rule)[0]
-        production_rule["rule"]["query"] = """
-        from logs-endpoint.alerts-* METADATA _id, _version, _index
-        | where event.code in ("malicious_file", "memory_signature", "shellcode_thread") and rule.name is not null
-        | keep host.id, rule.name, event.code, _id, _version, _index
-        | stats Esql.host_id_count_distinct = count_distinct(host.id) by rule.name, event.code
-        | where Esql.host_id_count_distinct >= 3
-        """
-        rule = RuleCollection().load_dict(production_rule)
-        for rf in rule.contents.to_api_format().get("required_fields") or []:
-            name = rf["name"]
-            assert not name.startswith(("Esql_priv.", "Esql.")), (
-                f"required_fields must not include ES|QL engine columns (not index mappings): {name!r}"
-            )
+        """required_fields must not list Esql.* / Esql_priv.* (not index mappings)."""
+        for rule in self.all_rules:
+            for rf in rule.contents.to_api_format().get("required_fields") or []:
+                name = rf["name"]
+                assert not name.startswith(("Esql_priv.", "Esql.")), (
+                    f"{rule.id} - {rule.name}: required_fields must not include ES|QL engine columns "
+                    f"(not index mappings): {name!r}"
+                )
 
     def test_esql_endpoint_unknown_index(self):
         """Test an ESQL rule's index validation. This is expected to error on an unknown index."""

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -21,6 +21,7 @@ from detection_rules.misc import (
 )
 from detection_rules.rule import ESQLRuleData
 from detection_rules.rule_loader import RuleCollection
+from detection_rules.schemas.definitions import ESQL_DYNAMIC_FIELD_PREFIXES
 from detection_rules.utils import get_path, load_rule_contents
 
 from .base import BaseRuleTest
@@ -254,7 +255,7 @@ class TestRemoteRules(BaseRuleTest):
             index = data.get("index") or []
             for rf in data.get_required_fields(index) or []:
                 name = rf["name"]
-                assert not name.startswith(("Esql_priv.", "Esql.")), (
+                assert not name.startswith(ESQL_DYNAMIC_FIELD_PREFIXES), (
                     f"{rule.id} - {rule.name}: required_fields must not include ES|QL engine columns "
                     f"(not index mappings): {name!r}"
                 )

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -242,6 +242,20 @@ class TestRemoteRules(BaseRuleTest):
         | stats Esql.host_id_count_distinct = count_distinct(host.id) by rule.name, event.code
         | where Esql.host_id_count_distinct >= 3
         """
+        _ = RuleCollection().load_dict(production_rule)
+
+    def test_esql_required_fields_omit_engine_columns(self):
+        """required_fields must not list Esql.* / Esql_priv.* (not index mappings). Same query shape as test_esql_endpoint_alerts_index."""
+        file_path = get_path(["tests", "data", "command_control_dummy_production_rule.toml"])
+        original_production_rule = load_rule_contents(file_path)
+        production_rule = deepcopy(original_production_rule)[0]
+        production_rule["rule"]["query"] = """
+        from logs-endpoint.alerts-* METADATA _id, _version, _index
+        | where event.code in ("malicious_file", "memory_signature", "shellcode_thread") and rule.name is not null
+        | keep host.id, rule.name, event.code, _id, _version, _index
+        | stats Esql.host_id_count_distinct = count_distinct(host.id) by rule.name, event.code
+        | where Esql.host_id_count_distinct >= 3
+        """
         rule = RuleCollection().load_dict(production_rule)
         for rf in rule.contents.to_api_format().get("required_fields") or []:
             name = rf["name"]


### PR DESCRIPTION
Fixes #6026.

## Summary

`required_fields` for ES|QL rules was built from every column Kibana returns from the query, including `Esql.*` and `Esql_priv.*` names from stats and similar operators. Those are not fields on the source indices, so the rule editor showed warnings that the fields were missing from the rule index patterns.

We now drop those prefixes when assembling `required_fields` for ES|QL only. KQL and EQL are unchanged.

There is also an assertion in `test_esql_endpoint_alerts_index` that runs when remote ES|QL validation is enabled (same skip conditions as the rest of `TestRemoteRules`).

## How to test

- CI Should pass with the new unit test (test [triggered manually](https://github.com/elastic/detection-rules/actions/runs/25223971672/job/73962829014?pr=6027))
- Building an ESQL artifact (e.g. `view-rule` should show required_fields without dynamic fields)

<details><summary>View-Rule Test</summary>
<p>
```bash
python -m detection_rules view-rule mikas_folder/rules/multiple_alerts_same_tactic_by_host.toml --esql-remote-validation

  response = elastic_client.esql.query(query=query)
{
  "author": [
    "Elastic"
  ],
  "description": "This rule correlates multiple security alerts associated with the same ATT&CK tactic on a single host within a defined time window. By requiring alerts from multiple distinct detection rules, this detection helps identify hosts exhibiting concentrated malicious behavior, which may indicate an active intrusion or post-compromise activity. The rule is intended to assist analysts in prioritizing triage toward hosts with higher likelihood of compromise rather than signaling a single discrete event.",
  "from": "now-60m",
  "interval": "30m",
  "language": "esql",
  "license": "Elastic License v2",
  "name": "Multiple Alerts in Same ATT&CK Tactic by Host",
  "note": "## Triage and analysis\n\n> **Disclaimer**:\n> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.\n\n### Investigating Multiple Alerts in Same ATT&CK Tactic by Host\n\nThe detection rule identifies hosts with alerts from the same ATT&CK tactic, indicating potential compromise. Adversaries exploit system vulnerabilities, moving through different tactics like execution, defense evasion, and credential access. This rule prioritizes hosts with high-risk.\n\n### Possible investigation steps\n\n- Review the alert details to identify the specific host involved and the different techniques that triggered the alerts.\n- Examine the timeline of the alerts to understand the sequence of events and determine if there is a pattern or progression in the tactics used.\n- Correlate the alert data with other logs and telemetry from the host, such as process creation, network connections, and file modifications, to gather additional context.\n- Investigate any known vulnerabilities or misconfigurations on the host that could have been exploited by the adversary.\n- Check for any indicators of compromise (IOCs) associated with the alerts, such as suspicious IP addresses, domains, or file hashes, and search for these across the network.\n- Assess the impact and scope of the potential compromise by determining if other hosts or systems have similar alerts or related activity.\n\n### False positive analysis\n\n- Alerts from routine administrative tasks may trigger multiple rules. Review and exclude known benign activities such as scheduled software updates or system maintenance.\n- Security tools running on the host might generate multiple alerts. Identify and exclude alerts from trusted security applications to reduce noise.\n- Automated scripts or batch processes can mimic adversarial behavior. Analyze and whitelist these processes if they are verified as non-threatening.\n- Frequent alerts from development or testing environments can be misleading. Consider excluding these environments from the rule or applying a different risk score.\n- User behavior anomalies, such as accessing multiple systems or applications, might trigger alerts. Implement user behavior baselines to differentiate between normal and suspicious activities.\n\n### Response and remediation\n\n- Isolate the affected host from the network immediately to prevent further lateral movement by the adversary.\n- Conduct a thorough forensic analysis of the host to identify the specific vulnerabilities exploited and gather evidence of the attack phases involved.\n- Remove any identified malicious software or unauthorized access tools from the host, ensuring all persistence mechanisms are eradicated.\n- Apply security patches and updates to the host to address any exploited vulnerabilities and prevent similar attacks.\n- Restore the host from a known good backup if necessary, ensuring that the backup is free from compromise.\n- Monitor the host and network for any signs of re-infection or further suspicious activity, using enhanced logging and alerting based on the identified attack patterns.\n- Escalate the incident to the appropriate internal or external cybersecurity teams for further investigation and potential legal action if the attack is part of a larger campaign.",
  "query": "from .alerts-security.*  metadata _id\n\n| where kibana.alert.risk_score > 21 and\n        kibana.alert.rule.name IS NOT NULL and\n        host.id is not null and event.dataset is not null and\n\n        // excluding ML and Threat Match rules as they tend to be noisy\n        not kibana.alert.rule.type in (\"threat_match\", \"machine_learning\") and\n\n        // excluding noisy tactics like Discovery, Persistence and Lateral Movement\n        kibana.alert.rule.threat.tactic.name in (\"Credential Access\", \"Defense Evasion\", \"Execution\", \"Command and Control\") and\n\n        // excluding some noisy rules\n        not kibana.alert.rule.name in (\"Agent Spoofing - Mismatched Agent ID\", \"Process Termination followed by Deletion\") and\n        not KQL(\"\"\"kibana.alert.rule.tags : \"Rule Type: Higher-Order Rule\" \"\"\")\n\n// extract unique counts and values by host.id and tactic name\n| stats Esql.alerts_count = COUNT(*),\n        Esql.kibana_alert_rule_name_distinct_count = COUNT_DISTINCT(kibana.alert.rule.name),\n        Esql.event_module_distinct_count = COUNT_DISTINCT(event.module),\n        Esql.event_module_values = VALUES(event.module),\n        Esql.kibana_alert_rule_name_values = VALUES(kibana.alert.rule.name),\n        Esql.threat_technique_id_distinct_count = COUNT_DISTINCT(kibana.alert.rule.threat.technique.id),\n        Esql.threat_technique_name_values = VALUES(kibana.alert.rule.threat.technique.name),\n        Esql.process_executable_values = VALUES(process.executable),\n        Esql.process_parent_executable_values = VALUES(process.parent.executable),\n        Esql.process_command_line_values = VALUES(process.command_line),\n        Esql.process_entity_id_distinct_count = COUNT_DISTINCT(process.entity_id) by host.id, kibana.alert.rule.threat.tactic.name\n\n// filter for at least 3 unique rules and exclude noisy patterns like high count of alerts or processes often associated with noisy FPs\n| where Esql.kibana_alert_rule_name_distinct_count >= 3 and Esql.process_entity_id_distinct_count <= 10 and Esql.alerts_count <= 20\n\n// fields populated in the resulting alerts\n| Keep host.id, kibana.alert.rule.threat.tactic.name, Esql.*\n",
  "required_fields": [
    {
      "ecs": true,
      "name": "host.id",
      "type": "keyword"
    },
    {
      "ecs": false,
      "name": "kibana.alert.rule.threat.tactic.name",
      "type": "keyword"
    }
  ],
  "risk_score": 73,
  "rule_id": "6e92a21a-58e7-449a-9cfd-9f563f59ac88",
  "severity": "high",
  "tags": [
    "Use Case: Threat Detection",
    "Rule Type: Higher-Order Rule",
    "Resources: Investigation Guide"
  ],
  "timestamp_override": "event.ingested",
  "type": "esql",
  "version": 1
}
(detection_dev) ➜  detection-rules git:(fix-esql-required-fields-no-dynamic-columns) ✗ 
```



</p>
</details> 