### PR TITLE
[DaC] [Bug] Rule Formatter Line Wrapping Breaks Query String Filters

### DIFF
--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -107,14 +107,14 @@ def preserve_formatting_for_fields(data: OrderedDict[str, Any], fields_to_preser
     def preserve_descendant_values(target: Any) -> None:
         """Preserve any string value fields under query DSL nodes."""
         if isinstance(target, dict):
-            for key, value in target.items():
+            for key, value in target.items():  # type: ignore[reportUnknownVariableType]
                 if key == "value" and isinstance(value, str):
                     target[key] = NonformattedField(value)
                 elif isinstance(value, dict | list):
                     preserve_descendant_values(value)
 
         if isinstance(target, list):
-            for value in target:
+            for value in target:  # type: ignore[reportUnknownVariableType]
                 preserve_descendant_values(value)
 
     def apply_preservation(target: OrderedDict[str, Any], keys: list[str]) -> None:

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -101,6 +101,10 @@ class NonformattedField(str):  # noqa: SLOT000
     """Non-formatting class."""
 
 
+class UnwrappedField(str):  # noqa: SLOT000
+    """String field that should not receive artificial line wrapping."""
+
+
 def preserve_formatting_for_fields(data: OrderedDict[str, Any], fields_to_preserve: list[str]) -> OrderedDict[str, Any]:
     """Preserve formatting for specified nested fields in an action."""
 
@@ -126,6 +130,22 @@ def preserve_formatting_for_fields(data: OrderedDict[str, Any], fields_to_preser
     return data
 
 
+def preserve_filter_value_formatting(data: Any) -> Any:
+    """Preserve filter value strings so query DSL literals are not changed."""
+    if isinstance(data, dict):
+        for key, value in data.items():  # type: ignore[reportUnknownVariableType]
+            if key == "value" and isinstance(value, str):
+                data[key] = UnwrappedField(value)  # type: ignore[reportUnknownMemberType]
+            elif isinstance(value, dict | list):
+                preserve_filter_value_formatting(value)
+    elif isinstance(data, list):
+        for value in data:  # type: ignore[reportUnknownVariableType]
+            if isinstance(value, dict | list):
+                preserve_filter_value_formatting(value)
+
+    return data  # type: ignore[reportUnknownVariableType]
+
+
 class RuleTomlEncoder(toml.TomlEncoder):  # type: ignore[reportMissingTypeArgument]
     """Generate a pretty form of toml."""
 
@@ -137,6 +157,7 @@ class RuleTomlEncoder(toml.TomlEncoder):  # type: ignore[reportMissingTypeArgume
         self.dump_funcs[str] = self.dump_str
         self.dump_funcs[list] = self.dump_list
         self.dump_funcs[NonformattedField] = self.dump_str
+        self.dump_funcs[UnwrappedField] = self.dump_unwrapped_str
 
     def dump_str(self, v: str | NonformattedField) -> str:
         """Change the TOML representation to multi-line or single quote when logical."""
@@ -161,6 +182,10 @@ class RuleTomlEncoder(toml.TomlEncoder):  # type: ignore[reportMissingTypeArgume
             return f"'{lines[0]:s}'"
         # In the toml library there is a magic replace for \\\\x -> u00 that we wish to avoid until #4979 is resolved
         # Also addresses an issue where backslashes in certain strings are not properly escaped in self._old_dump_str(v)
+        return json.dumps(v)
+
+    def dump_unwrapped_str(self, v: UnwrappedField) -> str:
+        """Serialize a string without inserting word-wrap newlines."""
         return json.dumps(v)
 
     def _dump_flat_list(self, v: Iterable[Any]) -> str:
@@ -244,8 +269,7 @@ def toml_write(rule_contents: dict[str, Any], out_file_path: Path | None = None)
 
             if k == "filters":
                 # explicitly preserve formatting for value field in filters
-                preserved_fields = ["meta.value"]
-                v = [preserve_formatting_for_fields(meta, preserved_fields) for meta in v] if v is not None else []
+                v = [preserve_filter_value_formatting(filter_) for filter_ in v] if v is not None else []
 
             if k == "note" and isinstance(v, str):
                 # Transform instances of \ to \\ as calling write will convert \\ to \.

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -260,7 +260,7 @@ def toml_write(rule_contents: dict[str, Any], out_file_path: Path | None = None)
                 v = [preserve_formatting_for_fields(action, preserved_fields) for action in v] if v is not None else []
 
             if k == "filters":
-                # explicitly preserve formatting for value field in filters
+                # explicitly preserve formatting for value field and query subfields in filters
                 preserved_fields = ["meta.value", "query"]
                 v = [preserve_formatting_for_fields(meta, preserved_fields) for meta in v] if v is not None else []
 

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -30,6 +30,10 @@ TRIPLE_DQ = DQ * 3
 # - actions[].params.message
 NESTED_PRESERVED_FIELD_NAMES: set[str] = {"message"}
 
+# rule.filters.query (ES DSL): dict keys whose string values skip word-wrap in TOML.
+# NOTE: add keys when a clause type stores long literals under another name.
+FILTER_QUERY_LITERAL_STRING_KEYS: set[str] = {"query", "value"}
+
 
 @cached
 def get_preserved_fmt_fields() -> set[str]:

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -101,12 +101,21 @@ class NonformattedField(str):  # noqa: SLOT000
     """Non-formatting class."""
 
 
-class UnwrappedField(str):  # noqa: SLOT000
-    """String field that should not receive artificial line wrapping."""
-
-
 def preserve_formatting_for_fields(data: OrderedDict[str, Any], fields_to_preserve: list[str]) -> OrderedDict[str, Any]:
     """Preserve formatting for specified nested fields in an action."""
+
+    def preserve_descendant_values(target: Any) -> None:
+        """Preserve any string value fields under query DSL nodes."""
+        if isinstance(target, dict):
+            for key, value in target.items():
+                if key == "value" and isinstance(value, str):
+                    target[key] = NonformattedField(value)
+                elif isinstance(value, dict | list):
+                    preserve_descendant_values(value)
+
+        if isinstance(target, list):
+            for value in target:
+                preserve_descendant_values(value)
 
     def apply_preservation(target: OrderedDict[str, Any], keys: list[str]) -> None:
         """Apply NonformattedField preservation based on keys path."""
@@ -120,6 +129,10 @@ def preserve_formatting_for_fields(data: OrderedDict[str, Any], fields_to_preser
 
         final_key = keys[-1]
         if final_key in target:
+            if final_key == "query":
+                preserve_descendant_values(target[final_key])
+                return
+
             # Apply NonformattedField to the target field if it exists
             target[final_key] = NonformattedField(target[final_key])
 
@@ -128,22 +141,6 @@ def preserve_formatting_for_fields(data: OrderedDict[str, Any], fields_to_preser
         apply_preservation(data, keys)
 
     return data
-
-
-def preserve_filter_value_formatting(data: Any) -> Any:
-    """Preserve filter value strings so query DSL literals are not changed."""
-    if isinstance(data, dict):
-        for key, value in data.items():  # type: ignore[reportUnknownVariableType]
-            if key == "value" and isinstance(value, str):
-                data[key] = UnwrappedField(value)  # type: ignore[reportUnknownMemberType]
-            elif isinstance(value, dict | list):
-                preserve_filter_value_formatting(value)
-    elif isinstance(data, list):
-        for value in data:  # type: ignore[reportUnknownVariableType]
-            if isinstance(value, dict | list):
-                preserve_filter_value_formatting(value)
-
-    return data  # type: ignore[reportUnknownVariableType]
 
 
 class RuleTomlEncoder(toml.TomlEncoder):  # type: ignore[reportMissingTypeArgument]
@@ -157,7 +154,6 @@ class RuleTomlEncoder(toml.TomlEncoder):  # type: ignore[reportMissingTypeArgume
         self.dump_funcs[str] = self.dump_str
         self.dump_funcs[list] = self.dump_list
         self.dump_funcs[NonformattedField] = self.dump_str
-        self.dump_funcs[UnwrappedField] = self.dump_unwrapped_str
 
     def dump_str(self, v: str | NonformattedField) -> str:
         """Change the TOML representation to multi-line or single quote when logical."""
@@ -182,10 +178,6 @@ class RuleTomlEncoder(toml.TomlEncoder):  # type: ignore[reportMissingTypeArgume
             return f"'{lines[0]:s}'"
         # In the toml library there is a magic replace for \\\\x -> u00 that we wish to avoid until #4979 is resolved
         # Also addresses an issue where backslashes in certain strings are not properly escaped in self._old_dump_str(v)
-        return json.dumps(v)
-
-    def dump_unwrapped_str(self, v: UnwrappedField) -> str:
-        """Serialize a string without inserting word-wrap newlines."""
         return json.dumps(v)
 
     def _dump_flat_list(self, v: Iterable[Any]) -> str:
@@ -269,7 +261,8 @@ def toml_write(rule_contents: dict[str, Any], out_file_path: Path | None = None)
 
             if k == "filters":
                 # explicitly preserve formatting for value field in filters
-                v = [preserve_filter_value_formatting(filter_) for filter_ in v] if v is not None else []
+                preserved_fields = ["meta.value", "query"]
+                v = [preserve_formatting_for_fields(meta, preserved_fields) for meta in v] if v is not None else []
 
             if k == "note" and isinstance(v, str):
                 # Transform instances of \ to \\ as calling write will convert \\ to \.

--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -112,7 +112,7 @@ def preserve_formatting_for_fields(data: OrderedDict[str, Any], fields_to_preser
         """Preserve any string value fields under query DSL nodes."""
         if isinstance(target, dict):
             for key, value in target.items():  # type: ignore[reportUnknownVariableType]
-                if key == "value" and isinstance(value, str):
+                if key in FILTER_QUERY_LITERAL_STRING_KEYS and isinstance(value, str):
                     target[key] = NonformattedField(value)
                 elif isinstance(value, dict | list):
                     preserve_descendant_values(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.33"
+version = "1.6.34"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_toml_formatter.py
+++ b/tests/test_toml_formatter.py
@@ -72,3 +72,39 @@ class TestRuleTomlFormatter(unittest.TestCase):
     def test_formatter_deep(self):
         """Test that the data remains unchanged from formatting."""
         self.compare_test_data(self.test_data[1:])
+
+    def test_filter_value_does_not_word_wrap(self):
+        """Test long filter values are not split across TOML lines."""
+        filter_value = (
+            r"C:\Program Files\Microsoft Monitoring Agent\Agent\Health Service State\Monitoring Host Temporary "
+            r"Files*\AvailabilityGroupMonitoring.ps1"
+        )
+        data = {
+            "rule": {
+                "filters": [
+                    {
+                        "meta": {"negate": True},
+                        "query": {
+                            "wildcard": {
+                                "file.path": {
+                                    "case_insensitive": True,
+                                    "value": filter_value,
+                                }
+                            }
+                        },
+                    }
+                ]
+            }
+        }
+        tmp_path = Path(tmp_file)
+
+        try:
+            self.compare_formatted(copy.deepcopy(data))
+            toml_write(copy.deepcopy(data), tmp_path)
+            formatted_data = tmp_path.read_text()
+
+            self.assertIn("Monitoring Host Temporary Files*", formatted_data)
+            self.assertNotIn("Monitoring Host Temporary\nFiles*", formatted_data)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/6045
Resolves https://github.com/elastic/detection-rules/issues/6071
Closes https://github.com/elastic/detection-rules/pull/6074



## Summary - What I changed

This PR updates the logic for handling long KQL Literals that can be incorrectly newline split when writing from ndjson -> TOML through our rule formatter that wraps the text output at 120 characters.

Left is new desired output, and the right is the old output.
<img width="2196" height="589" alt="image" src="https://github.com/user-attachments/assets/7616b4d6-9313-43b6-bd89-2e5dbf3068fc" />


Instead of turning this into a multi-line. We now are preserving the format of any value underneath `query` from the Kibana Filter dataclass.

<img width="780" height="450" alt="image" src="https://github.com/user-attachments/assets/26579ad6-5752-4252-a324-e4525b6b6bf7" />


## How To Test

Import and export the pre-built rule `rules/windows/defense_evasion_posh_assembly_load.toml` and see if the following query path is wrapped or not. 

```
[rule.filters.query.wildcard."file.path"]
case_insensitive = true
value = "C:\\Program Files\\Microsoft Monitoring Agent\\Agent\\Health Service State\\Monitoring Host Temporary Files*\\AvailabilityGroupMonitoring.ps1"

```

To help with this you can use the following ndjson

[test_string_conversion.ndjson.txt](https://github.com/user-attachments/files/27370167/test_string_conversion.ndjson.txt)


```
❯ python -m detection_rules import-rules-to-repo -ac -e test_string_conversion.ndjson --required-only
Loaded config file: /home/forteea1/tmp/tmp/detection-rules/.detection-rules-cfg.json

█▀▀▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄▄▄ ▄   ▄      █▀▀▄ ▄  ▄ ▄   ▄▄▄ ▄▄▄
█  █ █▄▄  █  █▄▄ █    █   █  █ █ █▀▄ █      █▄▄▀ █  █ █   █▄▄ █▄▄
█▄▄▀ █▄▄  █  █▄▄ █▄▄  █  ▄█▄ █▄█ █ ▀▄█      █ ▀▄ █▄▄█ █▄▄ █▄▄ ▄▄█

[+] Building rule for /home/forteea1/tmp/tmp/detection-rules/custom_rules/rules/suspicious_net_reflection_via_powershell.toml
1 results exported
1 rules converted
0 exceptions exported
0 actions connectors exported
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
