### PR TITLE
[Rule Tuning] Update XDR tags for CyberArk PAS

### DIFF
--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
@@ -3,7 +3,7 @@ creation_date = "2021/06/23"
 integration = ["cyberarkpas"]
 maturity = "production"
 promotion = true
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_error_audit_event_promotion.toml
@@ -34,11 +34,12 @@ rule_id = "3f0e5410-a4bf-4e8c-bcfc-79d67a285c54"
 rule_name_override = "event.action"
 severity = "high"
 tags = [
-    "Data Source: CyberArk PAS",
-    "Use Case: Log Auditing",
-    "Use Case: Threat Detection",
+    "Domain: Identity",
+    "Platform: CyberArk",
+    "Data Source: CyberArk PAS Logs",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Tactic: Initial Access",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
@@ -3,7 +3,7 @@ creation_date = "2021/06/23"
 integration = ["cyberarkpas"]
 maturity = "production"
 promotion = true
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
+++ b/rules/integrations/cyberarkpas/privilege_escalation_cyberarkpas_recommended_events_to_monitor_promotion.toml
@@ -34,11 +34,14 @@ rule_id = "c5f81243-56e0-47f9-b5bb-55a5ed89ba57"
 rule_name_override = "event.action"
 severity = "high"
 tags = [
-    "Data Source: CyberArk PAS",
-    "Use Case: Log Auditing",
-    "Use Case: Threat Detection",
+    "Domain: Identity",
+    "Platform: CyberArk",
+    "Data Source: CyberArk PAS Logs",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Tactic: Credential Access",
+    "Tactic: Initial Access",
+    "Tactic: Persistence",
 ]
 timestamp_override = "event.ingested"
 type = "query"


### PR DESCRIPTION
# Related
* https://github.com/elastic/ia-trade-team/issues/692

## Summary - What I changed
Adjusts the tags for CyberArk PAS regarding XDR tag changes for OOTB detection rules. Only tags have been adjusted.

## How To Test
Tests were abstracted to a separate branch (https://github.com/elastic/detection-rules/tree/rule-tag-changes-tests). Asking for a manual review of tags according to approved taxonomy. Please ask for gdoc reference if needed.

## Checklist

- [x] Added a label for the type of pr: `Rule: Tuning`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
