### PR TITLE
[Rule Tuning] Update XDR tags for macOS

### DIFF
--- a/rules/macos/collection_discovery_output_written_to_suspicious_file.toml
+++ b/rules/macos/collection_discovery_output_written_to_suspicious_file.toml
@@ -53,10 +53,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Collection",
     "Tactic: Discovery",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/macos/collection_discovery_output_written_to_suspicious_file.toml
+++ b/rules/macos/collection_discovery_output_written_to_suspicious_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/collection_pbpaste_execution_via_unusual_parent.toml
+++ b/rules/macos/collection_pbpaste_execution_via_unusual_parent.toml
@@ -25,10 +25,9 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Collection",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Collection",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/collection_pbpaste_execution_via_unusual_parent.toml
+++ b/rules/macos/collection_pbpaste_execution_via_unusual_parent.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/02/03"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/collection_sensitive_file_access_followed_by_compression.toml
+++ b/rules/macos/collection_sensitive_file_access_followed_by_compression.toml
@@ -22,10 +22,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Collection",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Collection",
+    "Resources: Investigation Guide",
+    "Tactic: Exfiltration",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/collection_sensitive_file_access_followed_by_compression.toml
+++ b/rules/macos/collection_sensitive_file_access_followed_by_compression.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_aws_s3_connection_via_script.toml
+++ b/rules/macos/command_and_control_aws_s3_connection_via_script.toml
@@ -53,10 +53,11 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
+    "Tactic: Command and Control",
     "Resources: Investigation Guide",
+    "Tactic: Execution",
+    "Tactic: Exfiltration",
 ]
 type = "esql"
 query = '''

--- a/rules/macos/command_and_control_aws_s3_connection_via_script.toml
+++ b/rules/macos/command_and_control_aws_s3_connection_via_script.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_executable_download_via_wget.toml
+++ b/rules/macos/command_and_control_executable_download_via_wget.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/02/09"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_executable_download_via_wget.toml
+++ b/rules/macos/command_and_control_executable_download_via_wget.toml
@@ -55,10 +55,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
+    "Tactic: Command and Control",
     "Resources: Investigation Guide",
+    "Tactic: Execution",
 ]
 type = "eql"
 query = '''

--- a/rules/macos/command_and_control_google_calendar_c2_via_script.toml
+++ b/rules/macos/command_and_control_google_calendar_c2_via_script.toml
@@ -27,11 +27,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Command and Control",
     "Tactic: Execution",
-    "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Resources: Investigation Guide",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/command_and_control_google_calendar_c2_via_script.toml
+++ b/rules/macos/command_and_control_google_calendar_c2_via_script.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_network_connection_to_oast_domain.toml
+++ b/rules/macos/command_and_control_network_connection_to_oast_domain.toml
@@ -25,10 +25,12 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Command and Control",
+    "Resources: Investigation Guide",
+    "Tactic: Execution",
+    "Tactic: Exfiltration",
+    "Tactic: Initial Access",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/command_and_control_network_connection_to_oast_domain.toml
+++ b/rules/macos/command_and_control_network_connection_to_oast_domain.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_perl_outbound_network_connection.toml
+++ b/rules/macos/command_and_control_perl_outbound_network_connection.toml
@@ -53,10 +53,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Command and Control",
     "Tactic: Execution",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/macos/command_and_control_perl_outbound_network_connection.toml
+++ b/rules/macos/command_and_control_perl_outbound_network_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_potential_etherhiding_c2.toml
+++ b/rules/macos/command_and_control_potential_etherhiding_c2.toml
@@ -25,11 +25,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Command and Control",
     "Tactic: Execution",
-    "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Resources: Investigation Guide",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/command_and_control_potential_etherhiding_c2.toml
+++ b/rules/macos/command_and_control_potential_etherhiding_c2.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_script_interpreter_connection_to_non_standard_port.toml
+++ b/rules/macos/command_and_control_script_interpreter_connection_to_non_standard_port.toml
@@ -56,10 +56,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Command and Control",
     "Tactic: Execution",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/macos/command_and_control_script_interpreter_connection_to_non_standard_port.toml
+++ b/rules/macos/command_and_control_script_interpreter_connection_to_non_standard_port.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_suspicious_curl_from_macos_application.toml
+++ b/rules/macos/command_and_control_suspicious_curl_from_macos_application.toml
@@ -26,10 +26,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Command and Control",
+    "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/command_and_control_suspicious_curl_from_macos_application.toml
+++ b/rules/macos/command_and_control_suspicious_curl_from_macos_application.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_suspicious_curl_to_google_app_script.toml
+++ b/rules/macos/command_and_control_suspicious_curl_to_google_app_script.toml
@@ -26,10 +26,9 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Command and Control",
+    "Resources: Investigation Guide",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/command_and_control_suspicious_curl_to_google_app_script.toml
+++ b/rules/macos/command_and_control_suspicious_curl_to_google_app_script.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_suspicious_outbound_network_via_unsigned_binary.toml
+++ b/rules/macos/command_and_control_suspicious_outbound_network_via_unsigned_binary.toml
@@ -22,10 +22,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Command and Control",
+    "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/command_and_control_suspicious_outbound_network_via_unsigned_binary.toml
+++ b/rules/macos/command_and_control_suspicious_outbound_network_via_unsigned_binary.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_unusual_connection_to_suspicious_top_level_domain.toml
+++ b/rules/macos/command_and_control_unusual_connection_to_suspicious_top_level_domain.toml
@@ -56,9 +56,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
+    "Tactic: Command and Control",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/command_and_control_unusual_connection_to_suspicious_top_level_domain.toml
+++ b/rules/macos/command_and_control_unusual_connection_to_suspicious_top_level_domain.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/25"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/04/07"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_unusual_network_connection_to_suspicious_web_service.toml
+++ b/rules/macos/command_and_control_unusual_network_connection_to_suspicious_web_service.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/26"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/command_and_control_unusual_network_connection_to_suspicious_web_service.toml
+++ b/rules/macos/command_and_control_unusual_network_connection_to_suspicious_web_service.toml
@@ -59,10 +59,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
+    "Tactic: Command and Control",
     "Resources: Investigation Guide",
+    "Tactic: Exfiltration",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/macos/credential_access_credentials_keychains.toml
+++ b/rules/macos/credential_access_credentials_keychains.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/04/21"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_credentials_keychains.toml
+++ b/rules/macos/credential_access_credentials_keychains.toml
@@ -51,9 +51,8 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/credential_access_dumping_hashes_bi_cmds.toml
+++ b/rules/macos/credential_access_dumping_hashes_bi_cmds.toml
@@ -51,9 +51,8 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/credential_access_dumping_hashes_bi_cmds.toml
+++ b/rules/macos/credential_access_dumping_hashes_bi_cmds.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/25"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_dumping_keychain_security.toml
+++ b/rules/macos/credential_access_dumping_keychain_security.toml
@@ -48,9 +48,8 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/credential_access_dumping_keychain_security.toml
+++ b/rules/macos/credential_access_dumping_keychain_security.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_high_volume_of_pbpaste.toml
+++ b/rules/macos/credential_access_high_volume_of_pbpaste.toml
@@ -91,11 +91,11 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
-    "Data Source: Jamf Protect",
     "Data Source: Elastic Defend",
+    "Data Source: Jamf Protect Event Logs",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/credential_access_high_volume_of_pbpaste.toml
+++ b/rules/macos/credential_access_high_volume_of_pbpaste.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/09/12"
 integration = ["endpoint", "jamf_protect"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [transform]
 [[transform.investigate]]

--- a/rules/macos/credential_access_kerberosdump_kcc.toml
+++ b/rules/macos/credential_access_kerberosdump_kcc.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_kerberosdump_kcc.toml
+++ b/rules/macos/credential_access_kerberosdump_kcc.toml
@@ -50,9 +50,8 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/credential_access_keychain_pwd_retrieval_security_cmd.toml
+++ b/rules/macos/credential_access_keychain_pwd_retrieval_security_cmd.toml
@@ -54,9 +54,8 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/credential_access_keychain_pwd_retrieval_security_cmd.toml
+++ b/rules/macos/credential_access_keychain_pwd_retrieval_security_cmd.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/06"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_mitm_localhost_webproxy.toml
+++ b/rules/macos/credential_access_mitm_localhost_webproxy.toml
@@ -51,10 +51,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/credential_access_mitm_localhost_webproxy.toml
+++ b/rules/macos/credential_access_mitm_localhost_webproxy.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_potential_macos_ssh_bruteforce.toml
+++ b/rules/macos/credential_access_potential_macos_ssh_bruteforce.toml
@@ -47,10 +47,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Initial Access",
 ]
 timestamp_override = "event.ingested"
 type = "threshold"

--- a/rules/macos/credential_access_potential_macos_ssh_bruteforce.toml
+++ b/rules/macos/credential_access_potential_macos_ssh_bruteforce.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/16"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
+++ b/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
@@ -50,10 +50,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Execution",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
+++ b/rules/macos/credential_access_promt_for_pwd_via_osascript.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/16"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_python_sensitive_file_access_first_occurrence.toml
+++ b/rules/macos/credential_access_python_sensitive_file_access_first_occurrence.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_python_sensitive_file_access_first_occurrence.toml
+++ b/rules/macos/credential_access_python_sensitive_file_access_first_occurrence.toml
@@ -57,12 +57,11 @@ rule_id = "03b150d9-9280-4eb8-9906-38cfb6184666"
 severity = "medium"
 tags = [
     "Domain: Endpoint",
+    "Domain: GenAI",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
-    "Domain: LLM",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/macos/credential_access_suspicious_web_browser_sensitive_file_access.toml
+++ b/rules/macos/credential_access_suspicious_web_browser_sensitive_file_access.toml
@@ -47,10 +47,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/credential_access_suspicious_web_browser_sensitive_file_access.toml
+++ b/rules/macos/credential_access_suspicious_web_browser_sensitive_file_access.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/credential_access_systemkey_dumping.toml
+++ b/rules/macos/credential_access_systemkey_dumping.toml
@@ -48,10 +48,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/credential_access_systemkey_dumping.toml
+++ b/rules/macos/credential_access_systemkey_dumping.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_apple_softupdates_modification.toml
+++ b/rules/macos/defense_evasion_apple_softupdates_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/15"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_apple_softupdates_modification.toml
+++ b/rules/macos/defense_evasion_apple_softupdates_modification.toml
@@ -48,9 +48,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
+++ b/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/14"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
+++ b/rules/macos/defense_evasion_attempt_del_quarantine_attrib.toml
@@ -51,9 +51,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/defense_evasion_attempt_to_disable_gatekeeper.toml
+++ b/rules/macos/defense_evasion_attempt_to_disable_gatekeeper.toml
@@ -50,9 +50,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/defense_evasion_attempt_to_disable_gatekeeper.toml
+++ b/rules/macos/defense_evasion_attempt_to_disable_gatekeeper.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_dylib_injection_via_env_vars.toml
+++ b/rules/macos/defense_evasion_dylib_injection_via_env_vars.toml
@@ -27,11 +27,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Defense Evasion",
     "Tactic: Persistence",
-    "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Resources: Investigation Guide",
+    "Tactic: Privilege Escalation",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/defense_evasion_dylib_injection_via_env_vars.toml
+++ b/rules/macos/defense_evasion_dylib_injection_via_env_vars.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_gatekeeper_override_and_execution.toml
+++ b/rules/macos/defense_evasion_gatekeeper_override_and_execution.toml
@@ -22,10 +22,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Defense Evasion",
+    "Resources: Investigation Guide",
+    "Tactic: Execution",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/defense_evasion_gatekeeper_override_and_execution.toml
+++ b/rules/macos/defense_evasion_gatekeeper_override_and_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_install_root_certificate.toml
+++ b/rules/macos/defense_evasion_install_root_certificate.toml
@@ -50,9 +50,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/defense_evasion_install_root_certificate.toml
+++ b/rules/macos/defense_evasion_install_root_certificate.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/13"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_modify_environment_launchctl.toml
+++ b/rules/macos/defense_evasion_modify_environment_launchctl.toml
@@ -50,9 +50,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/defense_evasion_modify_environment_launchctl.toml
+++ b/rules/macos/defense_evasion_modify_environment_launchctl.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/14"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_privacy_controls_tcc_database_modification.toml
+++ b/rules/macos/defense_evasion_privacy_controls_tcc_database_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_privacy_controls_tcc_database_modification.toml
+++ b/rules/macos/defense_evasion_privacy_controls_tcc_database_modification.toml
@@ -52,10 +52,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
+    "Vuln: CVE-2020-9934",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/defense_evasion_privilege_escalation_privacy_pref_sshd_fulldiskaccess.toml
+++ b/rules/macos/defense_evasion_privilege_escalation_privacy_pref_sshd_fulldiskaccess.toml
@@ -50,11 +50,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Privilege Escalation",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
+    "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/defense_evasion_privilege_escalation_privacy_pref_sshd_fulldiskaccess.toml
+++ b/rules/macos/defense_evasion_privilege_escalation_privacy_pref_sshd_fulldiskaccess.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_safari_config_change.toml
+++ b/rules/macos/defense_evasion_safari_config_change.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/14"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_safari_config_change.toml
+++ b/rules/macos/defense_evasion_safari_config_change.toml
@@ -48,9 +48,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/defense_evasion_sandboxed_office_app_suspicious_zip_file.toml
+++ b/rules/macos/defense_evasion_sandboxed_office_app_suspicious_zip_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_sandboxed_office_app_suspicious_zip_file.toml
+++ b/rules/macos/defense_evasion_sandboxed_office_app_suspicious_zip_file.toml
@@ -52,9 +52,8 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/defense_evasion_suspicious_tcc_access_granted.toml
+++ b/rules/macos/defense_evasion_suspicious_tcc_access_granted.toml
@@ -21,11 +21,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
-    "Tactic: Collection",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Collection",
+    "Tactic: Defense Evasion",
+    "Resources: Investigation Guide",
+    "Tactic: Privilege Escalation",
 ]
 type = "esql"
 note = """## Triage and analysis

--- a/rules/macos/defense_evasion_suspicious_tcc_access_granted.toml
+++ b/rules/macos/defense_evasion_suspicious_tcc_access_granted.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_tcc_bypass_mounted_apfs_access.toml
+++ b/rules/macos/defense_evasion_tcc_bypass_mounted_apfs_access.toml
@@ -48,11 +48,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
-    "Use Case: Vulnerability",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
+    "Vuln: CVE-2020-9771",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/defense_evasion_tcc_bypass_mounted_apfs_access.toml
+++ b/rules/macos/defense_evasion_tcc_bypass_mounted_apfs_access.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/defense_evasion_unload_endpointsecurity_kext.toml
+++ b/rules/macos/defense_evasion_unload_endpointsecurity_kext.toml
@@ -43,10 +43,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
+    "Tactic: Persistence",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/defense_evasion_unload_endpointsecurity_kext.toml
+++ b/rules/macos/defense_evasion_unload_endpointsecurity_kext.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/02/02"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/discovery_dns_request_for_ip_lookup_service.toml
+++ b/rules/macos/discovery_dns_request_for_ip_lookup_service.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/02/09"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/discovery_dns_request_for_ip_lookup_service.toml
+++ b/rules/macos/discovery_dns_request_for_ip_lookup_service.toml
@@ -53,9 +53,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Discovery",
     "Data Source: Elastic Defend",
+    "Tactic: Discovery",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/discovery_external_ip_address_discovery_via_curl.toml
+++ b/rules/macos/discovery_external_ip_address_discovery_via_curl.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/02/09"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/discovery_external_ip_address_discovery_via_curl.toml
+++ b/rules/macos/discovery_external_ip_address_discovery_via_curl.toml
@@ -53,9 +53,8 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Discovery",
     "Data Source: Elastic Defend",
+    "Tactic: Discovery",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/discovery_full_disk_access_check.toml
+++ b/rules/macos/discovery_full_disk_access_check.toml
@@ -53,10 +53,11 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Discovery",
     "Data Source: Elastic Defend",
+    "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Tactic: Privilege Escalation",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/discovery_full_disk_access_check.toml
+++ b/rules/macos/discovery_full_disk_access_check.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/discovery_suspicious_sip_check.toml
+++ b/rules/macos/discovery_suspicious_sip_check.toml
@@ -53,10 +53,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Discovery",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
+    "Tactic: Discovery",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/discovery_suspicious_sip_check.toml
+++ b/rules/macos/discovery_suspicious_sip_check.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/discovery_system_and_network_configuration_check.toml
+++ b/rules/macos/discovery_system_and_network_configuration_check.toml
@@ -53,9 +53,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Discovery",
     "Data Source: Elastic Defend",
+    "Tactic: Discovery",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/discovery_system_and_network_configuration_check.toml
+++ b/rules/macos/discovery_system_and_network_configuration_check.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/discovery_users_domain_built_in_commands.toml
+++ b/rules/macos/discovery_users_domain_built_in_commands.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/12"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/discovery_users_domain_built_in_commands.toml
+++ b/rules/macos/discovery_users_domain_built_in_commands.toml
@@ -46,9 +46,8 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Discovery",
     "Data Source: Elastic Defend",
+    "Tactic: Discovery",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/execution_defense_evasion_electron_app_childproc_node_js.toml
+++ b/rules/macos/execution_defense_evasion_electron_app_childproc_node_js.toml
@@ -51,10 +51,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Defense Evasion",
     "Tactic: Execution",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/execution_defense_evasion_electron_app_childproc_node_js.toml
+++ b/rules/macos/execution_defense_evasion_electron_app_childproc_node_js.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/execution_initial_access_suspicious_browser_childproc.toml
+++ b/rules/macos/execution_initial_access_suspicious_browser_childproc.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/execution_initial_access_suspicious_browser_childproc.toml
+++ b/rules/macos/execution_initial_access_suspicious_browser_childproc.toml
@@ -51,11 +51,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Initial Access",
-    "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Tactic: Execution",
+    "Tactic: Initial Access",
     "Resources: Investigation Guide",
+    "Tactic: Command and Control",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/execution_installer_package_spawned_network_event.toml
+++ b/rules/macos/execution_installer_package_spawned_network_event.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/02/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/execution_installer_package_spawned_network_event.toml
+++ b/rules/macos/execution_installer_package_spawned_network_event.toml
@@ -60,10 +60,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
+    "Tactic: Command and Control",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/macos/execution_python_shell_spawn_first_occurrence.toml
+++ b/rules/macos/execution_python_shell_spawn_first_occurrence.toml
@@ -58,12 +58,11 @@ rule_id = "92a36c98-b24a-4bf7-aac7-1eac71fa39cf"
 severity = "medium"
 tags = [
     "Domain: Endpoint",
+    "Domain: GenAI",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
-    "Domain: LLM",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/macos/execution_python_shell_spawn_first_occurrence.toml
+++ b/rules/macos/execution_python_shell_spawn_first_occurrence.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/execution_script_via_automator_workflows.toml
+++ b/rules/macos/execution_script_via_automator_workflows.toml
@@ -48,9 +48,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/macos/execution_script_via_automator_workflows.toml
+++ b/rules/macos/execution_script_via_automator_workflows.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/execution_scripting_osascript_exec_followed_by_netcon.toml
+++ b/rules/macos/execution_scripting_osascript_exec_followed_by_netcon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/execution_scripting_osascript_exec_followed_by_netcon.toml
+++ b/rules/macos/execution_scripting_osascript_exec_followed_by_netcon.toml
@@ -50,10 +50,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Command and Control",
     "Tactic: Execution",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/macos/execution_shell_execution_via_apple_scripting.toml
+++ b/rules/macos/execution_shell_execution_via_apple_scripting.toml
@@ -50,9 +50,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
 ]
 type = "eql"

--- a/rules/macos/execution_shell_execution_via_apple_scripting.toml
+++ b/rules/macos/execution_shell_execution_via_apple_scripting.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/execution_unusual_library_load_via_python.toml
+++ b/rules/macos/execution_unusual_library_load_via_python.toml
@@ -26,10 +26,9 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Execution",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/execution_unusual_library_load_via_python.toml
+++ b/rules/macos/execution_unusual_library_load_via_python.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -48,10 +48,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Initial Access",
     "Data Source: Elastic Defend",
+    "Tactic: Initial Access",
     "Resources: Investigation Guide",
+    "Tactic: Execution",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/lateral_movement_credential_access_kerberos_bifrostconsole.toml
+++ b/rules/macos/lateral_movement_credential_access_kerberos_bifrostconsole.toml
@@ -47,11 +47,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Credential Access",
     "Tactic: Lateral Movement",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/lateral_movement_credential_access_kerberos_bifrostconsole.toml
+++ b/rules/macos/lateral_movement_credential_access_kerberos_bifrostconsole.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/12"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/lateral_movement_mounting_smb_share.toml
+++ b/rules/macos/lateral_movement_mounting_smb_share.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/25"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/lateral_movement_mounting_smb_share.toml
+++ b/rules/macos/lateral_movement_mounting_smb_share.toml
@@ -47,9 +47,8 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Lateral Movement",
     "Data Source: Elastic Defend",
+    "Tactic: Lateral Movement",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
+++ b/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
@@ -48,10 +48,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Lateral Movement",
     "Data Source: Elastic Defend",
+    "Tactic: Lateral Movement",
     "Resources: Investigation Guide",
+    "Tactic: Persistence",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
+++ b/rules/macos/lateral_movement_remote_ssh_login_enabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/08/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/lateral_movement_suspicious_curl_to_jamf_endpoint.toml
+++ b/rules/macos/lateral_movement_suspicious_curl_to_jamf_endpoint.toml
@@ -22,11 +22,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Lateral Movement",
-    "Tactic: Execution",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Execution",
+    "Tactic: Lateral Movement",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/lateral_movement_suspicious_curl_to_jamf_endpoint.toml
+++ b/rules/macos/lateral_movement_suspicious_curl_to_jamf_endpoint.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/lateral_movement_vpn_connection_attempt.toml
+++ b/rules/macos/lateral_movement_vpn_connection_attempt.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/25"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/lateral_movement_vpn_connection_attempt.toml
+++ b/rules/macos/lateral_movement_vpn_connection_attempt.toml
@@ -51,10 +51,10 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Lateral Movement",
     "Data Source: Elastic Defend",
+    "Tactic: Lateral Movement",
     "Resources: Investigation Guide",
+    "Tactic: Initial Access",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_account_creation_hide_at_logon.toml
+++ b/rules/macos/persistence_account_creation_hide_at_logon.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_account_creation_hide_at_logon.toml
+++ b/rules/macos/persistence_account_creation_hide_at_logon.toml
@@ -47,10 +47,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_apple_mail_rule_modification.toml
+++ b/rules/macos/persistence_apple_mail_rule_modification.toml
@@ -56,10 +56,11 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Tactic: Execution",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_apple_mail_rule_modification.toml
+++ b/rules/macos/persistence_apple_mail_rule_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_creation_change_launch_agents_file.toml
+++ b/rules/macos/persistence_creation_change_launch_agents_file.toml
@@ -50,10 +50,10 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Execution",
 ]
 type = "eql"
 

--- a/rules/macos/persistence_creation_change_launch_agents_file.toml
+++ b/rules/macos/persistence_creation_change_launch_agents_file.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_creation_hidden_login_item_osascript.toml
+++ b/rules/macos/persistence_creation_hidden_login_item_osascript.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_creation_hidden_login_item_osascript.toml
+++ b/rules/macos/persistence_creation_hidden_login_item_osascript.toml
@@ -46,11 +46,11 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
-    "Tactic: Execution",
     "Data Source: Elastic Defend",
+    "Tactic: Execution",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_credential_access_authorization_plugin_creation.toml
+++ b/rules/macos/persistence_credential_access_authorization_plugin_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/13"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_credential_access_authorization_plugin_creation.toml
+++ b/rules/macos/persistence_credential_access_authorization_plugin_creation.toml
@@ -51,10 +51,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Credential Access",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_crontab_creation.toml
+++ b/rules/macos/persistence_crontab_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/04/25"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_crontab_creation.toml
+++ b/rules/macos/persistence_crontab_creation.toml
@@ -50,10 +50,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Execution",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_curl_execution_via_shell_profile.toml
+++ b/rules/macos/persistence_curl_execution_via_shell_profile.toml
@@ -22,11 +22,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
-    "Tactic: Command and Control",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Command and Control",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+    "Tactic: Execution",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/persistence_curl_execution_via_shell_profile.toml
+++ b/rules/macos/persistence_curl_execution_via_shell_profile.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_defense_evasion_hidden_launch_agent_deamon_logonitem_process.toml
+++ b/rules/macos/persistence_defense_evasion_hidden_launch_agent_deamon_logonitem_process.toml
@@ -51,10 +51,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_defense_evasion_hidden_launch_agent_deamon_logonitem_process.toml
+++ b/rules/macos/persistence_defense_evasion_hidden_launch_agent_deamon_logonitem_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_directory_services_plugins_modification.toml
+++ b/rules/macos/persistence_directory_services_plugins_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/13"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_directory_services_plugins_modification.toml
+++ b/rules/macos/persistence_directory_services_plugins_modification.toml
@@ -48,9 +48,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_docker_shortcuts_plist_modification.toml
+++ b/rules/macos/persistence_docker_shortcuts_plist_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_docker_shortcuts_plist_modification.toml
+++ b/rules/macos/persistence_docker_shortcuts_plist_modification.toml
@@ -49,9 +49,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_emond_rules_file_creation.toml
+++ b/rules/macos/persistence_emond_rules_file_creation.toml
@@ -50,10 +50,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Privilege Escalation",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_emond_rules_file_creation.toml
+++ b/rules/macos/persistence_emond_rules_file_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_emond_rules_process_execution.toml
+++ b/rules/macos/persistence_emond_rules_process_execution.toml
@@ -51,10 +51,11 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Execution",
+    "Tactic: Privilege Escalation",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_emond_rules_process_execution.toml
+++ b/rules/macos/persistence_emond_rules_process_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_enable_root_account.toml
+++ b/rules/macos/persistence_enable_root_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_enable_root_account.toml
+++ b/rules/macos/persistence_enable_root_account.toml
@@ -47,10 +47,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Privilege Escalation",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_evasion_hidden_launch_agent_deamon_creation.toml
+++ b/rules/macos/persistence_evasion_hidden_launch_agent_deamon_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_evasion_hidden_launch_agent_deamon_creation.toml
+++ b/rules/macos/persistence_evasion_hidden_launch_agent_deamon_creation.toml
@@ -49,10 +49,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
+    "Tactic: Defense Evasion",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_finder_sync_plugin_pluginkit.toml
+++ b/rules/macos/persistence_finder_sync_plugin_pluginkit.toml
@@ -50,9 +50,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_finder_sync_plugin_pluginkit.toml
+++ b/rules/macos/persistence_finder_sync_plugin_pluginkit.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_folder_action_scripts_runtime.toml
+++ b/rules/macos/persistence_folder_action_scripts_runtime.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_folder_action_scripts_runtime.toml
+++ b/rules/macos/persistence_folder_action_scripts_runtime.toml
@@ -48,10 +48,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Execution",
     "Tactic: Persistence",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_hidden_plist_filename.toml
+++ b/rules/macos/persistence_hidden_plist_filename.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/01/30"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_hidden_plist_filename.toml
+++ b/rules/macos/persistence_hidden_plist_filename.toml
@@ -26,11 +26,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
-    "Tactic: Defense Evasion",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Defense Evasion",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_login_logout_hooks_defaults.toml
+++ b/rules/macos/persistence_login_logout_hooks_defaults.toml
@@ -50,9 +50,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_login_logout_hooks_defaults.toml
+++ b/rules/macos/persistence_login_logout_hooks_defaults.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_loginwindow_plist_modification.toml
+++ b/rules/macos/persistence_loginwindow_plist_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_loginwindow_plist_modification.toml
+++ b/rules/macos/persistence_loginwindow_plist_modification.toml
@@ -50,10 +50,10 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/macos/persistence_manual_chromium_extension_loading.toml
+++ b/rules/macos/persistence_manual_chromium_extension_loading.toml
@@ -26,11 +26,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
-    "Tactic: Credential Access",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Credential Access",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+    "Tactic: Collection",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_manual_chromium_extension_loading.toml
+++ b/rules/macos/persistence_manual_chromium_extension_loading.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_modification_sublime_app_plugin_or_script.toml
+++ b/rules/macos/persistence_modification_sublime_app_plugin_or_script.toml
@@ -47,9 +47,8 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_modification_sublime_app_plugin_or_script.toml
+++ b/rules/macos/persistence_modification_sublime_app_plugin_or_script.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_periodic_tasks_file_mdofiy.toml
+++ b/rules/macos/persistence_periodic_tasks_file_mdofiy.toml
@@ -51,9 +51,8 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_periodic_tasks_file_mdofiy.toml
+++ b/rules/macos/persistence_periodic_tasks_file_mdofiy.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_python_launch_agent_or_daemon_creation_first_occurrence.toml
+++ b/rules/macos/persistence_python_launch_agent_or_daemon_creation_first_occurrence.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/23"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/08"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_python_launch_agent_or_daemon_creation_first_occurrence.toml
+++ b/rules/macos/persistence_python_launch_agent_or_daemon_creation_first_occurrence.toml
@@ -57,12 +57,11 @@ rule_id = "25368123-b7b8-4344-9fd4-df28051b4c6e"
 severity = "medium"
 tags = [
     "Domain: Endpoint",
+    "Domain: GenAI",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
-    "Domain: LLM",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/macos/persistence_screensaver_engine_unexpected_child_process.toml
+++ b/rules/macos/persistence_screensaver_engine_unexpected_child_process.toml
@@ -59,9 +59,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_screensaver_engine_unexpected_child_process.toml
+++ b/rules/macos/persistence_screensaver_engine_unexpected_child_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/10/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/02/04"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_screensaver_plist_file_modification.toml
+++ b/rules/macos/persistence_screensaver_plist_file_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/10/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_screensaver_plist_file_modification.toml
+++ b/rules/macos/persistence_screensaver_plist_file_modification.toml
@@ -57,9 +57,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_startup_item_plist_creation.toml
+++ b/rules/macos/persistence_startup_item_plist_creation.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/01/30"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_startup_item_plist_creation.toml
+++ b/rules/macos/persistence_startup_item_plist_creation.toml
@@ -26,10 +26,9 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_suspicious_calendar_modification.toml
+++ b/rules/macos/persistence_suspicious_calendar_modification.toml
@@ -52,9 +52,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_suspicious_calendar_modification.toml
+++ b/rules/macos/persistence_suspicious_calendar_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/19"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_suspicious_file_creation_via_pkg_install_script.toml
+++ b/rules/macos/persistence_suspicious_file_creation_via_pkg_install_script.toml
@@ -25,10 +25,10 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+    "Tactic: Execution",
 ]
 type = "eql"
 note = """## Triage and analysis

--- a/rules/macos/persistence_suspicious_file_creation_via_pkg_install_script.toml
+++ b/rules/macos/persistence_suspicious_file_creation_via_pkg_install_script.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_suspicious_launch_agent_or_launch_daemon.toml
+++ b/rules/macos/persistence_suspicious_launch_agent_or_launch_daemon.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/01/30"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/persistence_suspicious_launch_agent_or_launch_daemon.toml
+++ b/rules/macos/persistence_suspicious_launch_agent_or_launch_daemon.toml
@@ -28,10 +28,9 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
-    "Resources: Investigation Guide"
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/macos/persistence_via_atom_init_file_modification.toml
+++ b/rules/macos/persistence_via_atom_init_file_modification.toml
@@ -50,9 +50,8 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
     "Data Source: Elastic Defend",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/persistence_via_atom_init_file_modification.toml
+++ b/rules/macos/persistence_via_atom_init_file_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/privilege_escalation_applescript_with_admin_privs.toml
+++ b/rules/macos/privilege_escalation_applescript_with_admin_privs.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/27"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/privilege_escalation_applescript_with_admin_privs.toml
+++ b/rules/macos/privilege_escalation_applescript_with_admin_privs.toml
@@ -47,10 +47,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Execution",
     "Tactic: Privilege Escalation",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/privilege_escalation_explicit_creds_via_scripting.toml
+++ b/rules/macos/privilege_escalation_explicit_creds_via_scripting.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/07"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/privilege_escalation_explicit_creds_via_scripting.toml
+++ b/rules/macos/privilege_escalation_explicit_creds_via_scripting.toml
@@ -51,10 +51,9 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Elastic Defend",
     "Tactic: Execution",
     "Tactic: Privilege Escalation",
-    "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/privilege_escalation_exploit_adobe_acrobat_updater.toml
+++ b/rules/macos/privilege_escalation_exploit_adobe_acrobat_updater.toml
@@ -51,10 +51,11 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Privilege Escalation",
-    "Use Case: Vulnerability",
     "Data Source: Elastic Defend",
+    "Tactic: Privilege Escalation",
+    "Vuln: CVE-2020-9613",
+    "Vuln: CVE-2020-9614",
+    "Vuln: CVE-2020-9615",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/privilege_escalation_exploit_adobe_acrobat_updater.toml
+++ b/rules/macos/privilege_escalation_exploit_adobe_acrobat_updater.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/19"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/privilege_escalation_local_user_added_to_admin.toml
+++ b/rules/macos/privilege_escalation_local_user_added_to_admin.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/01/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/privilege_escalation_local_user_added_to_admin.toml
+++ b/rules/macos/privilege_escalation_local_user_added_to_admin.toml
@@ -47,9 +47,8 @@ severity = "medium"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Privilege Escalation",
     "Data Source: Elastic Defend",
+    "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/privilege_escalation_root_crontab_filemod.toml
+++ b/rules/macos/privilege_escalation_root_crontab_filemod.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/27"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2025/03/18"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/macos/privilege_escalation_root_crontab_filemod.toml
+++ b/rules/macos/privilege_escalation_root_crontab_filemod.toml
@@ -50,9 +50,8 @@ severity = "high"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
-    "Tactic: Privilege Escalation",
     "Data Source: Elastic Defend",
+    "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/privilege_escalation_user_added_to_admin_group.toml
+++ b/rules/macos/privilege_escalation_user_added_to_admin_group.toml
@@ -87,9 +87,8 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: macOS",
-    "Use Case: Threat Detection",
+    "Data Source: Jamf Protect Event Logs",
     "Tactic: Privilege Escalation",
-    "Data Source: Jamf Protect",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/macos/privilege_escalation_user_added_to_admin_group.toml
+++ b/rules/macos/privilege_escalation_user_added_to_admin_group.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/09/12"
 integration = ["jamf_protect"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [transform]
 [[transform.investigate]]


### PR DESCRIPTION
# Related
* https://github.com/elastic/ia-trade-team/issues/692

## Summary - What I changed
Adjusts the tags for macOS regarding XDR tag changes for OOTB detection rules. Only tags have been adjusted.

## How To Test
Tests were abstracted to a separate branch (https://github.com/elastic/detection-rules/tree/rule-tag-changes-tests). Asking for a manual review of tags according to approved taxonomy. Please ask for gdoc reference if needed.

## Checklist

- [x] Added a label for the type of pr: `Rule: Tuning`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
