### PR TITLE
[Rule Tuning] Update XDR tags for Cloud Defend

### DIFF
--- a/rules/integrations/cloud_defend/command_and_control_curl_socks_proxy_detected_inside_container.toml
+++ b/rules/integrations/cloud_defend/command_and_control_curl_socks_proxy_detected_inside_container.toml
@@ -53,12 +53,13 @@ risk_score = 47
 rule_id = "eb958cb3-dead-42b6-94ff-b9de6721fab2"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/command_and_control_curl_socks_proxy_detected_inside_container.toml
+++ b/rules/integrations/cloud_defend/command_and_control_curl_socks_proxy_detected_inside_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
+++ b/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
@@ -66,13 +66,14 @@ risk_score = 47
 rule_id = "a8b08d2d-6dfe-453f-87d1-11d5fc3ec746"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
+++ b/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/command_and_control_tunneling_and_port_forwarding.toml
+++ b/rules/integrations/cloud_defend/command_and_control_tunneling_and_port_forwarding.toml
@@ -56,12 +56,13 @@ risk_score = 47
 rule_id = "9d94d61b-9476-41ff-a8d3-3d24b4bb8158"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/command_and_control_tunneling_and_port_forwarding.toml
+++ b/rules/integrations/cloud_defend/command_and_control_tunneling_and_port_forwarding.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/container_workload_protection.toml
+++ b/rules/integrations/cloud_defend/container_workload_protection.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/container_workload_protection.toml
+++ b/rules/integrations/cloud_defend/container_workload_protection.toml
@@ -63,9 +63,11 @@ This rule is configured to generate a maximum of 1000 alerts per run. This is to
 For information on troubleshooting the maximum alerts warning please refer to this [guide](https://www.elastic.co/guide/en/security/current/alerts-ui-monitor.html#troubleshoot-max-alerts)."""
 severity = "medium"
 tags = [
+    "Domain: Containers",
+    "Platform: Kubernetes",
     "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/cloud_defend/credential_access_cloud_creds_search_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_cloud_creds_search_inside_a_container.toml
@@ -24,12 +24,13 @@ risk_score = 47
 rule_id = "d0b0f3ed-0b37-44bf-adee-e8cb7de92767"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Credential Access",
-    "Resources: Investigation Guide",
+    "Tactic: Discovery",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/credential_access_cloud_creds_search_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_cloud_creds_search_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/credential_access_collection_sensitive_files_compression_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_collection_sensitive_files_compression_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/credential_access_collection_sensitive_files_compression_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_collection_sensitive_files_compression_inside_a_container.toml
@@ -59,13 +59,14 @@ risk_score = 47
 rule_id = "475b42f0-61fb-4ef0-8a85-597458bfb0a1"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Collection",
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/credential_access_sensitive_keys_or_passwords_search_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_sensitive_keys_or_passwords_search_inside_a_container.toml
@@ -61,12 +61,16 @@ risk_score = 47
 rule_id = "9661ed8b-001c-40dc-a777-0983b7b0c91a"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
+    "Tactic: Discovery",
+    "Vuln: CVE-2021-25741",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/credential_access_sensitive_keys_or_passwords_search_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/credential_access_sensitive_keys_or_passwords_search_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/credential_access_service_account_token_or_cert_read.toml
+++ b/rules/integrations/cloud_defend/credential_access_service_account_token_or_cert_read.toml
@@ -61,12 +61,14 @@ risk_score = 47
 rule_id = "66229f32-c460-410d-bc37-4b32322cd4bb"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/credential_access_service_account_token_or_cert_read.toml
+++ b/rules/integrations/cloud_defend/credential_access_service_account_token_or_cert_read.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/defense_evasion_decoded_payload_piped_to_interpreter.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_decoded_payload_piped_to_interpreter.toml
@@ -56,13 +56,14 @@ risk_score = 73
 rule_id = "0fb83aa0-3d17-41e9-b09c-56397bf7a7d9"
 severity = "high"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Defense Evasion",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/defense_evasion_decoded_payload_piped_to_interpreter.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_decoded_payload_piped_to_interpreter.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/defense_evasion_deletion_of_shell_cmdline_history.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_deletion_of_shell_cmdline_history.toml
@@ -52,12 +52,13 @@ risk_score = 73
 rule_id = "cebabc1e-1145-4e39-b04b-34d621ee1e2c"
 severity = "high"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/defense_evasion_deletion_of_shell_cmdline_history.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_deletion_of_shell_cmdline_history.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/defense_evasion_file_creation_execution_deletion_cradle.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_file_creation_execution_deletion_cradle.toml
@@ -56,13 +56,15 @@ risk_score = 73
 rule_id = "1dc56174-5d02-4ca4-af92-e391f096fb21"
 severity = "high"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Defense Evasion",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Command and Control",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/defense_evasion_file_creation_execution_deletion_cradle.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_file_creation_execution_deletion_cradle.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/defense_evasion_interactive_process_execution_from_suspicious_directory.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_interactive_process_execution_from_suspicious_directory.toml
@@ -52,13 +52,15 @@ risk_score = 73
 rule_id = "279e272a-91d9-4780-878c-bfcac76e6e31"
 severity = "high"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Defense Evasion",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Command and Control",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/defense_evasion_interactive_process_execution_from_suspicious_directory.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_interactive_process_execution_from_suspicious_directory.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/defense_evasion_ld_preload_shared_object_modified_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_ld_preload_shared_object_modified_inside_a_container.toml
@@ -67,12 +67,15 @@ risk_score = 73
 rule_id = "342f834b-21a6-41bf-878c-87d116eba3ee"
 severity = "high"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/defense_evasion_ld_preload_shared_object_modified_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_ld_preload_shared_object_modified_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/defense_evasion_potential_evasion_via_encoded_payload.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_potential_evasion_via_encoded_payload.toml
@@ -55,13 +55,14 @@ risk_score = 47
 rule_id = "227cf26a-88d1-4bcb-bf4c-925e5875abcf"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Defense Evasion",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/defense_evasion_potential_evasion_via_encoded_payload.toml
+++ b/rules/integrations/cloud_defend/defense_evasion_potential_evasion_via_encoded_payload.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_dns_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_dns_enumeration.toml
@@ -60,12 +60,13 @@ risk_score = 21
 rule_id = "74ee9a2d-5ed3-40c8-9e6c-523d2e6a17ef"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_dns_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_dns_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_environment_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_environment_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_environment_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_environment_enumeration.toml
@@ -62,12 +62,13 @@ risk_score = 21
 rule_id = "f66a6869-d4c7-4d20-ab13-beefd03b63b4"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_kubelet_certificate_file_access.toml
+++ b/rules/integrations/cloud_defend/discovery_kubelet_certificate_file_access.toml
@@ -61,12 +61,14 @@ risk_score = 21
 rule_id = "42de0740-8ed8-4b8b-995c-635b56a8bbf4"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Tactic: Credential Access",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_kubelet_certificate_file_access.toml
+++ b/rules/integrations/cloud_defend/discovery_kubelet_certificate_file_access.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_kubelet_pod_discovery_via_builtin_utilities.toml
+++ b/rules/integrations/cloud_defend/discovery_kubelet_pod_discovery_via_builtin_utilities.toml
@@ -57,12 +57,13 @@ risk_score = 21
 rule_id = "f596175f-b8fd-43ac-b9e9-ea2a96bb55d8"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_kubelet_pod_discovery_via_builtin_utilities.toml
+++ b/rules/integrations/cloud_defend/discovery_kubelet_pod_discovery_via_builtin_utilities.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_potential_cluster_enumeration_via_jq.toml
+++ b/rules/integrations/cloud_defend/discovery_potential_cluster_enumeration_via_jq.toml
@@ -31,12 +31,12 @@ risk_score = 21
 rule_id = "33ff31e9-3872-4944-8394-81dae76c12d9"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
-    "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_potential_cluster_enumeration_via_jq.toml
+++ b/rules/integrations/cloud_defend/discovery_potential_cluster_enumeration_via_jq.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/02"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_privilege_boundary_enumeration_from_interactive_process.toml
+++ b/rules/integrations/cloud_defend/discovery_privilege_boundary_enumeration_from_interactive_process.toml
@@ -61,12 +61,13 @@ risk_score = 21
 rule_id = "737626a2-4dca-4195-8ecd-68ef96fd1bad"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_privilege_boundary_enumeration_from_interactive_process.toml
+++ b/rules/integrations/cloud_defend/discovery_privilege_boundary_enumeration_from_interactive_process.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_service_account_namespace_read.toml
+++ b/rules/integrations/cloud_defend/discovery_service_account_namespace_read.toml
@@ -60,12 +60,14 @@ risk_score = 21
 rule_id = "f7c64a1b-9d00-4b92-9042-d3bb4196899a"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Tactic: Collection",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_service_account_namespace_read.toml
+++ b/rules/integrations/cloud_defend/discovery_service_account_namespace_read.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_suspicious_network_tool_launched_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/discovery_suspicious_network_tool_launched_inside_a_container.toml
@@ -67,14 +67,16 @@ risk_score = 21
 rule_id = "1a289854-5b78-49fe-9440-8a8096b1ab50"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Discovery",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
+    "Tactic: Discovery",
     "Tactic: Reconnaissance",
     "Resources: Investigation Guide",
+    "Tactic: Credential Access",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_suspicious_network_tool_launched_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/discovery_suspicious_network_tool_launched_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/discovery_tool_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_tool_enumeration.toml
@@ -61,12 +61,13 @@ risk_score = 21
 rule_id = "b84264aa-37a3-49f8-8bbc-60acbe9d4f86"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/discovery_tool_enumeration.toml
+++ b/rules/integrations/cloud_defend/discovery_tool_enumeration.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/27"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_container_management_binary_launched_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_container_management_binary_launched_inside_a_container.toml
@@ -68,12 +68,14 @@ risk_score = 21
 rule_id = "6c6bb7ea-0636-44ca-b541-201478ef6b50"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Discovery",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_container_management_binary_launched_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_container_management_binary_launched_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_direct_interactive_kubernetes_api_request.toml
+++ b/rules/integrations/cloud_defend/execution_direct_interactive_kubernetes_api_request.toml
@@ -63,13 +63,15 @@ risk_score = 21
 rule_id = "26a989d2-010e-4dae-b46b-689d03cc22b3"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Lateral Movement",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_direct_interactive_kubernetes_api_request.toml
+++ b/rules/integrations/cloud_defend/execution_direct_interactive_kubernetes_api_request.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_interactive_exec_to_container.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_exec_to_container.toml
@@ -77,12 +77,13 @@ risk_score = 21
 rule_id = "420e5bb4-93bf-40a3-8f4a-4cc1af90eca1"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_interactive_exec_to_container.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_exec_to_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_interactive_file_creation_followed_by_execution.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_file_creation_followed_by_execution.toml
@@ -52,13 +52,14 @@ risk_score = 47
 rule_id = "b799720e-40d0-4dd6-9c9c-4f193a6ed643"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_interactive_file_creation_followed_by_execution.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_file_creation_followed_by_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/02/06"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_interactive_file_creation_in_system_binary_locations.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_file_creation_in_system_binary_locations.toml
@@ -53,14 +53,15 @@ risk_score = 47
 rule_id = "05a50000-9886-4695-ad33-3f990dc142e2"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
     "Tactic: Defense Evasion",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_interactive_file_creation_in_system_binary_locations.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_file_creation_in_system_binary_locations.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_interactive_shell_spawned_from_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_shell_spawned_from_inside_a_container.toml
@@ -64,12 +64,13 @@ risk_score = 21
 rule_id = "8d3d0794-c776-476b-8674-ee2e685f6470"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_interactive_shell_spawned_from_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_interactive_shell_spawned_from_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_kubeletctl_execution.toml
+++ b/rules/integrations/cloud_defend/execution_kubeletctl_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_kubeletctl_execution.toml
+++ b/rules/integrations/cloud_defend/execution_kubeletctl_execution.toml
@@ -66,13 +66,14 @@ risk_score = 21
 rule_id = "2572f7e0-7647-4c68-a42b-d3b1973deaae"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_netcat_listener_established_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_netcat_listener_established_inside_a_container.toml
@@ -67,12 +67,15 @@ risk_score = 47
 rule_id = "a52a9439-d52c-401c-be37-2785235c6547"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Command and Control",
+    "Tactic: Exfiltration",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_netcat_listener_established_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_netcat_listener_established_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_payload_downloaded_and_piped_to_shell.toml
+++ b/rules/integrations/cloud_defend/execution_payload_downloaded_and_piped_to_shell.toml
@@ -55,14 +55,15 @@ risk_score = 47
 rule_id = "a750bbcc-863f-41ef-9924-fd8224e23694"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
     "Tactic: Defense Evasion",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_payload_downloaded_and_piped_to_shell.toml
+++ b/rules/integrations/cloud_defend/execution_payload_downloaded_and_piped_to_shell.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_potential_direct_kubelet_access_via_process_args.toml
+++ b/rules/integrations/cloud_defend/execution_potential_direct_kubelet_access_via_process_args.toml
@@ -60,13 +60,15 @@ risk_score = 47
 rule_id = "b4bd186b-69c6-45ad-8bef-5c35bbadeaef"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Discovery",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Lateral Movement",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_potential_direct_kubelet_access_via_process_args.toml
+++ b/rules/integrations/cloud_defend/execution_potential_direct_kubelet_access_via_process_args.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_suspicious_file_made_executable_via_chmod_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_suspicious_file_made_executable_via_chmod_inside_a_container.toml
@@ -63,13 +63,15 @@ risk_score = 21
 rule_id = "ec604672-bed9-43e1-8871-cf591c052550"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Defense Evasion",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Privilege Escalation",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_suspicious_file_made_executable_via_chmod_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/execution_suspicious_file_made_executable_via_chmod_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/30"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_suspicious_interactive_interpreter_command_execution.toml
+++ b/rules/integrations/cloud_defend/execution_suspicious_interactive_interpreter_command_execution.toml
@@ -55,13 +55,15 @@ risk_score = 47
 rule_id = "cd24c340-b778-44bd-ab69-2f739bd70ce1"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
+    "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_suspicious_interactive_interpreter_command_execution.toml
+++ b/rules/integrations/cloud_defend/execution_suspicious_interactive_interpreter_command_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/execution_tool_installation.toml
+++ b/rules/integrations/cloud_defend/execution_tool_installation.toml
@@ -63,12 +63,14 @@ risk_score = 21
 rule_id = "527d23e6-8b67-4a8e-a6bd-5169b90ab2a8"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Command and Control",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/execution_tool_installation.toml
+++ b/rules/integrations/cloud_defend/execution_tool_installation.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/impact_process_killing.toml
+++ b/rules/integrations/cloud_defend/impact_process_killing.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/05"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/impact_process_killing.toml
+++ b/rules/integrations/cloud_defend/impact_process_killing.toml
@@ -64,12 +64,13 @@ risk_score = 21
 rule_id = "85d9c573-ad77-461b-8315-9a02a280b20b"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Impact",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/persistence_modification_of_persistence_relevant_files.toml
+++ b/rules/integrations/cloud_defend/persistence_modification_of_persistence_relevant_files.toml
@@ -59,14 +59,15 @@ risk_score = 21
 rule_id = "f246e70e-5e20-4006-8460-d72b023d6adf"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Execution",
+    "Tactic: Persistence",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/persistence_modification_of_persistence_relevant_files.toml
+++ b/rules/integrations/cloud_defend/persistence_modification_of_persistence_relevant_files.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/persistence_ssh_authorized_keys_modification_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/persistence_ssh_authorized_keys_modification_inside_a_container.toml
@@ -61,13 +61,15 @@ risk_score = 47
 rule_id = "f7769104-e8f9-4931-94a2-68fc04eadec3"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Lateral Movement",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Privilege Escalation",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/persistence_ssh_authorized_keys_modification_inside_a_container.toml
+++ b/rules/integrations/cloud_defend/persistence_ssh_authorized_keys_modification_inside_a_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/persistence_suspicious_echo_or_printf_execution.toml
+++ b/rules/integrations/cloud_defend/persistence_suspicious_echo_or_printf_execution.toml
@@ -57,14 +57,16 @@ risk_score = 73
 rule_id = "d9bfa475-270d-4b07-93cb-b1f49abe13da"
 severity = "high"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Execution",
+    "Tactic: Persistence",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/persistence_suspicious_echo_or_printf_execution.toml
+++ b/rules/integrations/cloud_defend/persistence_suspicious_echo_or_printf_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/persistence_suspicious_webserver_child_process_execution.toml
+++ b/rules/integrations/cloud_defend/persistence_suspicious_webserver_child_process_execution.toml
@@ -52,14 +52,17 @@ risk_score = 73
 rule_id = "497a7091-0ebd-44d7-88c4-367ab4d4d852"
 severity = "high"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
-    "Tactic: Execution",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Command and Control",
+    "Tactic: Execution",
+    "Tactic: Persistence",
     "Resources: Investigation Guide",
+    "Tactic: Credential Access",
+    "Tactic: Initial Access",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/persistence_suspicious_webserver_child_process_execution.toml
+++ b/rules/integrations/cloud_defend/persistence_suspicious_webserver_child_process_execution.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/privilege_escalation_chroot_execution_detected_inside_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_chroot_execution_detected_inside_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/04/06"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/privilege_escalation_chroot_execution_detected_inside_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_chroot_execution_detected_inside_container.toml
@@ -56,11 +56,11 @@ rule_id = "47661529-15ed-4848-93da-9fbded7a3a0e"
 severity = "low"
 tags = [
     "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
@@ -65,12 +65,14 @@ risk_score = 47
 rule_id = "97697a52-4a76-4f0a-aa4f-25c178aae6eb"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_debugfs_launched_inside_a_privileged_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/privilege_escalation_mount_launched_inside_a_privileged_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_mount_launched_inside_a_privileged_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/privilege_escalation_mount_launched_inside_a_privileged_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_mount_launched_inside_a_privileged_container.toml
@@ -65,12 +65,13 @@ risk_score = 21
 rule_id = "41f7da9e-4e9f-4a81-9b58-40d725d83bc0"
 severity = "low"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/privilege_escalation_nsenter_execution_inside_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_nsenter_execution_inside_container.toml
@@ -61,11 +61,11 @@ rule_id = "39029450-8e2d-4034-81b0-15af8e4e3a4e"
 severity = "high"
 tags = [
     "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/privilege_escalation_nsenter_execution_inside_container.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_nsenter_execution_inside_container.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/31"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_notify_on_release_file.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_notify_on_release_file.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/01/15"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_notify_on_release_file.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_notify_on_release_file.toml
@@ -66,12 +66,14 @@ risk_score = 47
 rule_id = "ef65e82c-d8b4-4895-9824-5f6bc6166804"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Vuln: CVE-2022-0492",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_release_agent_file.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_release_agent_file.toml
@@ -65,12 +65,15 @@ risk_score = 47
 rule_id = "160896de-b66f-42cb-8fef-20f53a9006ea"
 severity = "medium"
 tags = [
-    "Data Source: Elastic Defend for Containers",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
+    "Platform: Kubernetes",
+    "Data Source: Elastic Defend for Containers",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Tactic: Persistence",
+    "Vuln: CVE-2022-0492",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_release_agent_file.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_potential_container_escape_via_modified_release_agent_file.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/privilege_escalation_unshare_namespace_manip.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_unshare_namespace_manip.toml
@@ -57,12 +57,12 @@ rule_id = "9e5dbd3b-5e19-4648-a1cf-c2649c91b015"
 severity = "medium"
 tags = [
     "Domain: Endpoint",
-    "Domain: Container",
+    "Domain: Containers",
     "OS: Linux",
-    "Use Case: Threat Detection",
     "Tactic: Privilege Escalation",
     "Data Source: Elastic Defend for Containers",
-    "Resources: Investigation Guide"
+    "Resources: Investigation Guide",
+    "Platform: Elastic",
 ]
 timestamp_override = "event.ingested"
 type = "eql"

--- a/rules/integrations/cloud_defend/privilege_escalation_unshare_namespace_manip.toml
+++ b/rules/integrations/cloud_defend/privilege_escalation_unshare_namespace_manip.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/05/01"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]


### PR DESCRIPTION
# Related
* https://github.com/elastic/ia-trade-team/issues/692

## Summary - What I changed
Adjusts the tags for Cloud Defend regarding XDR tag changes for OOTB detection rules. Only tags have been adjusted.

## How To Test
Tests were abstracted to a separate branch (https://github.com/elastic/detection-rules/tree/rule-tag-changes-tests). Asking for a manual review of tags according to approved taxonomy. Please ask for gdoc reference if needed.

## Checklist

- [x] Added a label for the type of pr: `Rule: Tuning`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
