### PR TITLE
[Rule Tuning] Update XDR tags for FIM

### DIFF
--- a/rules/integrations/fim/persistence_suspicious_file_modifications.toml
+++ b/rules/integrations/fim/persistence_suspicious_file_modifications.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/06/03"
 integration = ["fim"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/fim/persistence_suspicious_file_modifications.toml
+++ b/rules/integrations/fim/persistence_suspicious_file_modifications.toml
@@ -50,12 +50,11 @@ severity = "low"
 tags = [
     "Domain: Endpoint",
     "OS: Linux",
-    "Use Case: Threat Detection",
-    "Tactic: Persistence",
-    "Tactic: Credential Access",
-    "Tactic: Privilege Escalation",
-    "Tactic: Defense Evasion",
     "Data Source: File Integrity Monitoring",
+    "Tactic: Credential Access",
+    "Tactic: Defense Evasion",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"


### PR DESCRIPTION
# Related
* https://github.com/elastic/ia-trade-team/issues/692

## Summary - What I changed
Adjusts the tags for FIM regarding XDR tag changes for OOTB detection rules. Only tags have been adjusted.

## How To Test
Tests were abstracted to a separate branch (https://github.com/elastic/detection-rules/tree/rule-tag-changes-tests). Asking for a manual review of tags according to approved taxonomy. Please ask for gdoc reference if needed.

## Checklist

- [x] Added a label for the type of pr: `Rule: Tuning`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
