### PR TITLE
[Rule Tuning] Update XDR tags for Kubernetes

### DIFF
--- a/rules/integrations/kubernetes/credential_access_azure_arc_proxy_secret_configmap_access.toml
+++ b/rules/integrations/kubernetes/credential_access_azure_arc_proxy_secret_configmap_access.toml
@@ -71,13 +71,13 @@ risk_score = 47
 rule_id = "220d92c6-479d-4a49-9cc0-3a29756dad0c"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Domain: Cloud",
-    "Use Case: Threat Detection",
-    "Tactic: Credential Access",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Collection",
+    "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Tactic: Impact",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/integrations/kubernetes/credential_access_azure_arc_proxy_secret_configmap_access.toml
+++ b/rules/integrations/kubernetes/credential_access_azure_arc_proxy_secret_configmap_access.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/03/10"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/credential_access_get_secrets_access.toml
+++ b/rules/integrations/kubernetes/credential_access_get_secrets_access.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/03/26"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/credential_access_get_secrets_access.toml
+++ b/rules/integrations/kubernetes/credential_access_get_secrets_access.toml
@@ -50,12 +50,12 @@ risk_score = 21
 rule_id = "cbda9a0e-2be4-4eaa-9571-8d6a503e9828"
 severity = "low"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Domain: Containers",
     "Domain: Cloud",
-    "Use Case: Threat Detection",
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Platform: Kubernetes",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/integrations/kubernetes/credential_access_kubernetes_multiple_secret_retrieval_burst.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_multiple_secret_retrieval_burst.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/04/22"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/22"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/credential_access_kubernetes_multiple_secret_retrieval_burst.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_multiple_secret_retrieval_burst.toml
@@ -47,11 +47,11 @@ risk_score = 73
 rule_id = "b4c8e2a1-9f3d-4e7c-a2b1-0d5e6f7a8b9c"
 severity = "high"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Domain: Containers",
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Platform: Kubernetes",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/integrations/kubernetes/credential_access_kubernetes_secret_access_scripting_http_clients.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_secret_access_scripting_http_clients.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/04/22"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/22"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/credential_access_kubernetes_secret_access_scripting_http_clients.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_secret_access_scripting_http_clients.toml
@@ -64,11 +64,11 @@ risk_score = 73
 rule_id = "a4c8e901-2b7f-4d6e-9a3c-8e1f0d5b6c2a"
 severity = "high"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Domain: Containers",
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Platform: Kubernetes",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/kubernetes/credential_access_kubernetes_secret_read_by_node_or_pod_service_account.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_secret_read_by_node_or_pod_service_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/04/22"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/22"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/credential_access_kubernetes_secret_read_by_node_or_pod_service_account.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_secret_read_by_node_or_pod_service_account.toml
@@ -67,11 +67,11 @@ risk_score = 47
 rule_id = "f8a31c62-0d4e-4b9a-b7e1-6c2a9d4e8f10"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Domain: Containers",
     "Tactic: Credential Access",
     "Resources: Investigation Guide",
+    "Platform: Kubernetes",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/kubernetes/credential_access_kubernetes_secrets_list_cluster_and_sensitive_namespaces.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_secrets_list_cluster_and_sensitive_namespaces.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/04/22"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/22"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/credential_access_kubernetes_secrets_list_cluster_and_sensitive_namespaces.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_secrets_list_cluster_and_sensitive_namespaces.toml
@@ -41,12 +41,12 @@ risk_score = 73
 rule_id = "7e3f9a2b-1c4d-5e6f-8a0b-9c8d7e6f5a4b"
 severity = "high"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Domain: Containers",
     "Tactic: Credential Access",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Platform: Kubernetes",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/kubernetes/defense_evasion_events_deleted.toml
+++ b/rules/integrations/kubernetes/defense_evasion_events_deleted.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/27"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/defense_evasion_events_deleted.toml
+++ b/rules/integrations/kubernetes/defense_evasion_events_deleted.toml
@@ -53,12 +53,12 @@ risk_score = 21
 rule_id = "33c27b4e-8ec6-406f-b8e5-345dc024aa97"
 severity = "low"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
-    ]
+]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''

--- a/rules/integrations/kubernetes/discovery_denied_service_account_request.toml
+++ b/rules/integrations/kubernetes/discovery_denied_service_account_request.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/09/13"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/discovery_denied_service_account_request.toml
+++ b/rules/integrations/kubernetes/discovery_denied_service_account_request.toml
@@ -70,11 +70,11 @@ risk_score = 21
 rule_id = "63c056a0-339a-11ed-a261-0242ac120002"
 severity = "low"
 tags = [
-  "Data Source: Kubernetes",
-  "Domain: Kubernetes",
-  "Use Case: Threat Detection",
-  "Tactic: Discovery",
-  "Resources: Investigation Guide",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/integrations/kubernetes/discovery_endpoint_permission_enumeration_by_anonymous_user.toml
+++ b/rules/integrations/kubernetes/discovery_endpoint_permission_enumeration_by_anonymous_user.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/02"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/discovery_endpoint_permission_enumeration_by_anonymous_user.toml
+++ b/rules/integrations/kubernetes/discovery_endpoint_permission_enumeration_by_anonymous_user.toml
@@ -53,11 +53,12 @@ risk_score = 47
 rule_id = "2dd0d4fd-0cc9-4d18-8b46-1a507e28bbc0"
 severity = "medium"
 tags = [
-  "Data Source: Kubernetes",
-  "Domain: Kubernetes",
-  "Use Case: Threat Detection",
-  "Tactic: Discovery",
-  "Resources: Investigation Guide",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
+    "Tactic: Reconnaissance",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/integrations/kubernetes/discovery_endpoint_permission_enumeration_by_user_and_srcip.toml
+++ b/rules/integrations/kubernetes/discovery_endpoint_permission_enumeration_by_user_and_srcip.toml
@@ -51,11 +51,11 @@ risk_score = 47
 rule_id = "a337c3f8-e264-4eb4-9998-22669ca52791"
 severity = "medium"
 tags = [
-  "Data Source: Kubernetes",
-  "Domain: Kubernetes",
-  "Use Case: Threat Detection",
-  "Tactic: Discovery",
-  "Resources: Investigation Guide",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/integrations/kubernetes/discovery_endpoint_permission_enumeration_by_user_and_srcip.toml
+++ b/rules/integrations/kubernetes/discovery_endpoint_permission_enumeration_by_user_and_srcip.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/02"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/03/03"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/discovery_kubernetes_multi_resource_setup_recon.toml
+++ b/rules/integrations/kubernetes/discovery_kubernetes_multi_resource_setup_recon.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/04/22"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/22"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/discovery_kubernetes_multi_resource_setup_recon.toml
+++ b/rules/integrations/kubernetes/discovery_kubernetes_multi_resource_setup_recon.toml
@@ -60,11 +60,11 @@ risk_score = 47
 rule_id = "c2a91e88-4f4b-4e1d-9c7b-8fde112a9403"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Domain: Containers",
     "Tactic: Discovery",
     "Resources: Investigation Guide",
+    "Platform: Kubernetes",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml
+++ b/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml
@@ -70,11 +70,11 @@ risk_score = 21
 rule_id = "12a2f15d-597e-4334-88ff-38a02cb1330b"
 severity = "low"
 tags = [
-  "Data Source: Kubernetes",
-  "Domain: Kubernetes",
-  "Use Case: Threat Detection",
-  "Tactic: Discovery",
-  "Resources: Investigation Guide",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml
+++ b/rules/integrations/kubernetes/discovery_suspicious_self_subject_review.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/06/30"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/execution_anonymous_create_update_patch_pod_request.toml
+++ b/rules/integrations/kubernetes/execution_anonymous_create_update_patch_pod_request.toml
@@ -19,12 +19,11 @@ risk_score = 47
 rule_id = "3a01e5c6-ce01-46d7-ac9f-52dc349695fb"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Execution",
-    "Resources: Investigation Guide"
-    ]
+]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''

--- a/rules/integrations/kubernetes/execution_anonymous_create_update_patch_pod_request.toml
+++ b/rules/integrations/kubernetes/execution_anonymous_create_update_patch_pod_request.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/02"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/execution_forbidden_creation_request.toml
+++ b/rules/integrations/kubernetes/execution_forbidden_creation_request.toml
@@ -58,12 +58,12 @@ risk_score = 47
 rule_id = "ec81962e-4bc8-48e6-bfb0-545fc97d8f6a"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Execution",
-    "Resources: Investigation Guide"
-    ]
+    "Resources: Investigation Guide",
+]
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''

--- a/rules/integrations/kubernetes/execution_forbidden_creation_request.toml
+++ b/rules/integrations/kubernetes/execution_forbidden_creation_request.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/24"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/execution_forbidden_request_from_unsual_user_agent.toml
+++ b/rules/integrations/kubernetes/execution_forbidden_request_from_unsual_user_agent.toml
@@ -56,11 +56,12 @@ risk_score = 47
 rule_id = "4b77d382-b78e-4aae-85a0-8841b80e4fc4"
 severity = "medium"
 tags = [
-  "Data Source: Kubernetes",
-  "Domain: Kubernetes",
-  "Use Case: Threat Detection",
-  "Tactic: Execution",
-  "Resources: Investigation Guide",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Execution",
+    "Resources: Investigation Guide",
+    "Tactic: Discovery",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/integrations/kubernetes/execution_forbidden_request_from_unsual_user_agent.toml
+++ b/rules/integrations/kubernetes/execution_forbidden_request_from_unsual_user_agent.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/17"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/execution_unusual_request_response_by_user_agent.toml
+++ b/rules/integrations/kubernetes/execution_unusual_request_response_by_user_agent.toml
@@ -57,12 +57,13 @@ risk_score = 21
 rule_id = "8a1db198-da6f-4500-b985-7fe2457300af"
 severity = "low"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Domain: Container",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Execution",
     "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Tactic: Initial Access",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/integrations/kubernetes/execution_unusual_request_response_by_user_agent.toml
+++ b/rules/integrations/kubernetes/execution_unusual_request_response_by_user_agent.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/18"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
+++ b/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
@@ -72,9 +72,9 @@ risk_score = 47
 rule_id = "14de811c-d60f-11ec-9fd7-f661ea17fbce"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Execution",
     "Resources: Investigation Guide",
 ]

--- a/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
+++ b/rules/integrations/kubernetes/execution_user_exec_to_pod.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/05/17"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
+++ b/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/09/13"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
+++ b/rules/integrations/kubernetes/initial_access_anonymous_request_authorized.toml
@@ -68,12 +68,11 @@ risk_score = 47
 rule_id = "63c057cc-339a-11ed-a261-0242ac120002"
 severity = "medium"
 tags = [
-  "Data Source: Kubernetes",
-  "Domain: Kubernetes",
-  "Use Case: Threat Detection",
-  "Tactic: Initial Access",
-  "Tactic: Defense Evasion",
-  "Resources: Investigation Guide",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Initial Access",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "new_terms"

--- a/rules/integrations/kubernetes/persistence_cluster_admin_rolebinding_created.toml
+++ b/rules/integrations/kubernetes/persistence_cluster_admin_rolebinding_created.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/04"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/persistence_cluster_admin_rolebinding_created.toml
+++ b/rules/integrations/kubernetes/persistence_cluster_admin_rolebinding_created.toml
@@ -53,9 +53,9 @@ risk_score = 47
 rule_id = "a2951930-dd35-438c-b10e-1bbdc5881cb4"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Persistence",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",

--- a/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml
+++ b/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml
@@ -76,7 +76,14 @@ references = [
 risk_score = 47
 rule_id = "65f9bccd-510b-40df-8263-334f03174fed"
 severity = "medium"
-tags = ["Data Source: Kubernetes", "Tactic: Execution", "Tactic: Persistence", "Resources: Investigation Guide"]
+tags = [
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+    "Tactic: Initial Access",
+]
 timestamp_override = "event.ingested"
 type = "query"
 

--- a/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml
+++ b/rules/integrations/kubernetes/persistence_exposed_service_created_with_type_nodeport.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/persistence_sensitive_role_creation_or_modification.toml
+++ b/rules/integrations/kubernetes/persistence_sensitive_role_creation_or_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/04"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/27"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/persistence_sensitive_role_creation_or_modification.toml
+++ b/rules/integrations/kubernetes/persistence_sensitive_role_creation_or_modification.toml
@@ -52,9 +52,9 @@ risk_score = 47
 rule_id = "0fb25791-d8d4-42ab-8fc7-4954642de85f"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Persistence",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",

--- a/rules/integrations/kubernetes/persistence_service_account_bound_to_clusterrole.toml
+++ b/rules/integrations/kubernetes/persistence_service_account_bound_to_clusterrole.toml
@@ -52,9 +52,9 @@ risk_score = 47
 rule_id = "fd00769d-b18d-450a-a844-7a9f9c71995e"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Persistence",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",

--- a/rules/integrations/kubernetes/persistence_service_account_bound_to_clusterrole.toml
+++ b/rules/integrations/kubernetes/persistence_service_account_bound_to_clusterrole.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/04"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_container_created_with_excessive_linux_capabilities.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_container_created_with_excessive_linux_capabilities.toml
@@ -57,12 +57,13 @@ risk_score = 47
 rule_id = "7164081a-3930-11ed-a261-0242ac120002"
 severity = "medium"
 tags = [
-  "Data Source: Kubernetes",
-  "Domain: Kubernetes",
-  "Use Case: Threat Detection",
-  "Tactic: Execution",
-  "Tactic: Privilege Escalation",
-  "Resources: Investigation Guide",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Execution",
+    "Tactic: Privilege Escalation",
+    "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/kubernetes/privilege_escalation_container_created_with_excessive_linux_capabilities.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_container_created_with_excessive_linux_capabilities.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/09/20"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml
@@ -74,12 +74,12 @@ risk_score = 47
 rule_id = "764c8437-a581-4537-8060-1fdb0e92c92d"
 severity = "medium"
 tags = [
-  "Data Source: Kubernetes",
-  "Domain: Kubernetes",
-  "Use Case: Threat Detection",
-  "Tactic: Execution",
-  "Tactic: Privilege Escalation",
-  "Resources: Investigation Guide",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Tactic: Execution",
+    "Tactic: Privilege Escalation",
+    "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
 type = "query"

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostipc.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostnetwork.toml
@@ -71,9 +71,9 @@ risk_score = 47
 rule_id = "12cbf709-69e8-4055-94f9-24314385c27e"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Execution",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml
@@ -74,9 +74,9 @@ risk_score = 47
 rule_id = "df7fda76-c92b-4943-bc68-04460a5ea5ba"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Execution",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_hostpid.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hostpath_volume.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hostpath_volume.toml
@@ -73,9 +73,9 @@ risk_score = 47
 rule_id = "2abda169-416b-4bb3-9a6b-f8d239fd78ba"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Execution",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",

--- a/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hostpath_volume.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_pod_created_with_sensitive_hostpath_volume.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/11"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml
@@ -71,9 +71,9 @@ risk_score = 47
 rule_id = "c7908cac-337a-4f38-b50d-5eeb78bdb531"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Execution",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",

--- a/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_privileged_pod_created.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/07/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_role_patch_wildcard_verbs_resources_response.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_role_patch_wildcard_verbs_resources_response.toml
@@ -54,11 +54,11 @@ risk_score = 73
 rule_id = "c8f4a2e1-9b3d-4c7e-8f2a-1d0e5b6c7a89"
 severity = "high"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
+    "Data Source: Kubernetes API Server Audit Logs",
+    "Domain: Containers",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
+    "Platform: Kubernetes",
 ]
 timestamp_override = "event.ingested"
 type = "esql"

--- a/rules/integrations/kubernetes/privilege_escalation_role_patch_wildcard_verbs_resources_response.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_role_patch_wildcard_verbs_resources_response.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/04/27"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/27"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_sensitive_rbac_change_followed_by_workload_modification.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_sensitive_rbac_change_followed_by_workload_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/04"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_sensitive_rbac_change_followed_by_workload_modification.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_sensitive_rbac_change_followed_by_workload_modification.toml
@@ -55,11 +55,11 @@ risk_score = 47
 rule_id = "3c82bf84-5941-495b-ac41-0302f28e1a90"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
-    "Tactic: Privilege Escalation",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/integrations/kubernetes/privilege_escalation_sensitive_workload_modification_by_user_agent.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_sensitive_workload_modification_by_user_agent.toml
@@ -54,11 +54,11 @@ risk_score = 21
 rule_id = "78c6559d-47a7-4f30-91fe-7e2e983206c2"
 severity = "low"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
-    "Tactic: Privilege Escalation",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/integrations/kubernetes/privilege_escalation_sensitive_workload_modification_by_user_agent.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_sensitive_workload_modification_by_user_agent.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/03/05"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_service_account_rbac_write_operation.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_service_account_rbac_write_operation.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/02/04"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_service_account_rbac_write_operation.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_service_account_rbac_write_operation.toml
@@ -54,11 +54,11 @@ risk_score = 47
 rule_id = "f2e21713-1eac-4908-a782-1b49c7e9d53b"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
-    "Tactic: Privilege Escalation",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/09/13"
 integration = ["kubernetes"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
+++ b/rules/integrations/kubernetes/privilege_escalation_suspicious_assignment_of_controller_service_account.toml
@@ -70,10 +70,9 @@ risk_score = 47
 rule_id = "63c05204-339a-11ed-a261-0242ac120002"
 severity = "medium"
 tags = [
-    "Data Source: Kubernetes",
-    "Domain: Kubernetes",
-    "Use Case: Threat Detection",
-    "Tactic: Execution",
+    "Domain: Containers",
+    "Platform: Kubernetes",
+    "Data Source: Kubernetes API Server Audit Logs",
     "Tactic: Privilege Escalation",
     "Resources: Investigation Guide",
 ]


### PR DESCRIPTION
# Related
* https://github.com/elastic/ia-trade-team/issues/692

## Summary - What I changed
Adjusts the tags for Kubernetes regarding XDR tag changes for OOTB detection rules. Only tags have been adjusted.

## How To Test
Tests were abstracted to a separate branch (https://github.com/elastic/detection-rules/tree/rule-tag-changes-tests). Asking for a manual review of tags according to approved taxonomy. Please ask for gdoc reference if needed.

## Checklist

- [x] Added a label for the type of pr: `Rule: Tuning`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
