### PR TITLE
[Rule Tuning] Update XDR tags for Microsoft Exchange Online Message Trace

### DIFF
--- a/rules/integrations/microsoft_exchange_online_message_trace/initial_access_azure_monitor_callback_phishing_email.toml
+++ b/rules/integrations/microsoft_exchange_online_message_trace/initial_access_azure_monitor_callback_phishing_email.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/03/23"
 integration = ["microsoft_exchange_online_message_trace"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/04"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/microsoft_exchange_online_message_trace/initial_access_azure_monitor_callback_phishing_email.toml
+++ b/rules/integrations/microsoft_exchange_online_message_trace/initial_access_azure_monitor_callback_phishing_email.toml
@@ -63,11 +63,11 @@ severity = "low"
 tags = [
     "Domain: Cloud",
     "Domain: Email",
-    "Data Source: Microsoft 365",
-    "Data Source: Microsoft Exchange Online Message Trace",
-    "Use Case: Threat Detection",
+    "Data Source: M365 Audit Logs",
+    "Data Source: Microsoft Exchange Online Logs",
     "Tactic: Initial Access",
     "Resources: Investigation Guide",
+    "Platform: Microsoft 365",
 ]
 timestamp_override = "event.ingested"
 type = "esql"


### PR DESCRIPTION
# Related
* https://github.com/elastic/ia-trade-team/issues/692

## Summary - What I changed
Adjusts the tags for Microsoft Exchange Online Message Trace regarding XDR tag changes for OOTB detection rules. Only tags have been adjusted.

## How To Test
Tests were abstracted to a separate branch (https://github.com/elastic/detection-rules/tree/rule-tag-changes-tests). Asking for a manual review of tags according to approved taxonomy. Please ask for gdoc reference if needed.

## Checklist

- [x] Added a label for the type of pr: `Rule: Tuning`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
