### PR TITLE
add json.dumps to fix multiline escape issue

### DIFF
--- a/detection_rules/rule_formatter.py
+++ b/detection_rules/rule_formatter.py
@@ -155,7 +155,7 @@ class RuleTomlEncoder(toml.TomlEncoder):  # type: ignore[reportMissingTypeArgume
 
         if multiline:
             if raw:
-                return "".join([TRIPLE_DQ, *initial_newline, *lines, TRIPLE_DQ])
+                return "".join([TRIPLE_DQ] + initial_newline + [json.dumps(line.strip("\n"))[1:-1] + "\n" for line in lines] + [TRIPLE_DQ])
             return "\n".join([TRIPLE_SQ] + [json.dumps(line)[1:-1] for line in lines] + [TRIPLE_SQ])
         if raw:
             return f"'{lines[0]:s}'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.31"
+version = "1.6.32"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: Related #6071 

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

I changed the return value to be also json dumped for "multiline Triple Double Quoted" stuff.
Because it is also done for Triple Single Quoted things and usual single lines which don't have this issue.

Issue before fix:
Backslashes will not be escaped here and therefore will get lost when saved as toml file:
<img width="1841" height="921" alt="grafik" src="https://github.com/user-attachments/assets/00e19904-6bea-4920-a746-74578fa41e62" />

Single line string for example will be escaped:
<img width="1803" height="957" alt="grafik" src="https://github.com/user-attachments/assets/2a74e8f6-0850-4626-b565-c4fe3423adbf" />


The fix probably looks a little bit ugly as I had to remove the last line break before dumping and then adding it again.
I tried to do the dump already one step before at:
https://github.com/elastic/detection-rules/blob/0b15511ef5f92ce710f388177f20e93d27ace8ce/detection_rules/rule_formatter.py#L88

But this broke other things.

## How To Test

1. Export the example rule from the related issue or use whatever rule with a filter containing backslashes and being longer than 120 characters.
2. Check the exported toml file for the number of backslashes.


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
