### PR TITLE
Add Shashank as Codeowner for release workflow files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,8 @@ hunting/**/*.py          @mikaayenson @eric-forte-elastic
 detection_rules/etc/packages.yaml @mikaayenson @eric-forte-elastic
 detection_rules/etc/*.json        @mikaayenson @eric-forte-elastic
 detection_rules/etc/*/*           @mikaayenson @eric-forte-elastic
+detection_rules/etc/version.lock.json @mikaayenson @eric-forte-elastic @shashank-elastic
+detection_rules/etc/deprecated_rules.json @mikaayenson @eric-forte-elastic @shashank-elastic
 
 ## exclude files from code owners
 


### PR DESCRIPTION

# Pull Request

*Issue link(s)*: NA

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

- This was discussed with @Mikaayenson , adding myself as code owner for release workflow files such as version lock and deprecated rules file. 
- We already have automations to check double bumps and we have tested it over an year and it has identified all double bumps.
- This unblocks dependancies in IST time. 

## How To Test

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
