### PR TITLE
[Rule Tuning] ESQL Rule List Search Fix

### DIFF
--- a/rules/cross-platform/defense_evasion_long_base64_encoded_interpreter_command_line.toml
+++ b/rules/cross-platform/defense_evasion_long_base64_encoded_interpreter_command_line.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/03/27"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/27"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -63,6 +63,7 @@ type = "esql"
 query = '''
 FROM logs-endpoint.events.process-* METADATA _id, _index, _version, _ignored
 | MV_EXPAND _ignored
+| MV_EXPAND event.type
 | WHERE _ignored == "process.command_line"
 | WHERE event.category == "process" and event.type == "start"
 | EVAL command_line = TO_LOWER(process.command_line.text), pname = TO_LOWER(process.name)

--- a/rules/cross-platform/defense_evasion_whitespace_padding_command_line.toml
+++ b/rules/cross-platform/defense_evasion_whitespace_padding_command_line.toml
@@ -86,7 +86,7 @@ type = "esql"
 
 query = '''
 FROM logs-* metadata _id, _version, _index 
-| where event.category == "process" KQL("event.type:start and not event.action:fork")
+| where event.category == "process" and KQL("event.type:start and not event.action:fork")
 // more than 100 spaces in process.command_line
 | eval multi_spaces = LOCATE(process.command_line, space(100)) 
 | where multi_spaces > 0 

--- a/rules/cross-platform/defense_evasion_whitespace_padding_command_line.toml
+++ b/rules/cross-platform/defense_evasion_whitespace_padding_command_line.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/30"
 integration = ["endpoint", "system", "windows", "auditd_manager", "m365_defender", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -86,7 +86,7 @@ type = "esql"
 
 query = '''
 FROM logs-* metadata _id, _version, _index 
-| where event.category == "process" and event.type == "start" and event.action != "fork"
+| where event.category == "process" KQL("event.type:start and not event.action:fork")
 // more than 100 spaces in process.command_line
 | eval multi_spaces = LOCATE(process.command_line, space(100)) 
 | where multi_spaces > 0 

--- a/rules/cross-platform/execution_suspicious_python_command_execution.toml
+++ b/rules/cross-platform/execution_suspicious_python_command_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/03/26"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -62,9 +62,9 @@ type = "esql"
 query = '''
 FROM logs-endpoint.events.process-* METADATA _id, _version, _index
 
-| WHERE host.os.type in ("linux", "macos") and event.type == "start" and TO_LOWER(process.parent.name) like "python*" and
+| WHERE host.os.type in ("linux", "macos") and TO_LOWER(process.parent.name) like "python*" and
   process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
-  KQL("""event.action:"exec" and process.args:("-c" or "-cl" or "-lc")""")
+  KQL("""event.action:"exec" and event.type:"start" and process.args:("-c" or "-cl" or "-lc")""")
 
 // truncate timestamp to 1-minute window
 | EVAL Esql.time_window_date_trunc = DATE_TRUNC(1 minutes, @timestamp)

--- a/rules/linux/command_and_control_frequent_egress_netcon_from_sus_executable.toml
+++ b/rules/linux/command_and_control_frequent_egress_netcon_from_sus_executable.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -93,11 +93,9 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.network-* metadata _id, _index, _version
-| mv_expand event.action 
 | where
     host.os.type == "linux" and
-    event.type == "start" and
-    event.action == "connection_attempted" and
+    KQL("event.type:start and event.action:connection_attempted") and
     (
         process.executable like "/tmp/*" or
         process.executable like "/var/tmp/*" or

--- a/rules/linux/credential_access_potential_linux_local_account_bruteforce.toml
+++ b/rules/linux/credential_access_potential_linux_local_account_bruteforce.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/07/26"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -61,7 +61,8 @@ from logs-endpoint.events.process* metadata _id, _index, _version
 | eval Esql.time_window_date_trunc = date_trunc(1 minute, @timestamp)
 
 // Ensure event.action values in a list are expanded
-| mv_expand event.action 
+| mv_expand event.action
+| mv_expand event.type
 
 | where
   event.category == "process" and event.type == "start" and event.action == "exec" and process.name == "su" and 

--- a/rules/linux/credential_access_potential_linux_local_account_bruteforce.toml
+++ b/rules/linux/credential_access_potential_linux_local_account_bruteforce.toml
@@ -60,7 +60,7 @@ from logs-endpoint.events.process* metadata _id, _index, _version
 // Create 1-minute time buckets
 | eval Esql.time_window_date_trunc = date_trunc(1 minute, @timestamp)
 
-// Ensure event.action values in a list are expanded
+// Ensure event.action and event.type values in a list are expanded
 | mv_expand event.action
 | mv_expand event.type
 

--- a/rules/linux/credential_access_potential_password_spraying_attack.toml
+++ b/rules/linux/credential_access_potential_password_spraying_attack.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/12/24"
 integration = ["system"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -65,8 +65,9 @@ from logs-system.auth-* metadata _id, _index, _version
 // Create 5-minute time buckets
 | eval Esql.time_window_date_trunc = date_trunc(5 minutes, @timestamp)
 
-// Ensure event.action values in a list are expanded
-| mv_expand event.action 
+// Ensure event.category and event.action values in a list are expanded
+| mv_expand event.category
+| mv_expand event.action
 
 | where
   event.category == "authentication" and event.action in ("ssh_login", "user_login") and event.outcome == "failure" and

--- a/rules/linux/defense_evasion_base64_decoding_activity.toml
+++ b/rules/linux/defense_evasion_base64_decoding_activity.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -95,6 +95,8 @@ type = "esql"
 query = '''
 from logs-endpoint.events.process-* metadata _id, _index, _version
 | mv_expand event.action 
+| mv_expand event.type
+| mv_expand process.args
 | where
     host.os.type == "linux" and
     event.type == "start" and

--- a/rules/linux/discovery_port_scanning_activity_from_compromised_host.toml
+++ b/rules/linux/discovery_port_scanning_activity_from_compromised_host.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -95,11 +95,9 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.network-* metadata _id, _index, _version
-| mv_expand event.action
 | where
     host.os.type == "linux" and
-    event.type == "start" and
-    event.action == "connection_attempted" and
+    KQL("event.type:start and event.action:connection_attempted") and
     network.direction  == "egress" and
     destination.port < 32768 and
     not (

--- a/rules/linux/discovery_subnet_scanning_activity_from_compromised_host.toml
+++ b/rules/linux/discovery_subnet_scanning_activity_from_compromised_host.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -94,11 +94,9 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.network-* metadata _id, _index, _version
-| mv_expand event.action
 | where
     host.os.type == "linux" and
-    event.type == "start" and
-    event.action == "connection_attempted" and
+    KQL("event.type:start and event.action:connection_attempted") and
     not (
       process.executable in ("/usr/local/bin/prometheus", "/app/extra/chrome", "/usr/lib/virtualbox/VBoxHeadless", "/usr/bin/prometheus") or
       process.executable like "/usr/local/prometheus/*/prometheus" or

--- a/rules/linux/exfiltration_unusual_file_transfer_utility_launched.toml
+++ b/rules/linux/exfiltration_unusual_file_transfer_utility_launched.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/21"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -93,11 +93,9 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.process-* metadata _id, _index, _version
-| mv_expand event.action 
 | where
     host.os.type == "linux" and
-    event.type == "start" and
-    event.action == "exec" and
+    KQL("event.type:start and event.action:exec") and
     process.name in ("scp", "ftp", "sftp", "vsftpd", "sftp-server", "rsync") and (
         (process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish")) or
         (

--- a/rules/linux/impact_potential_bruteforce_malware_infection.toml
+++ b/rules/linux/impact_potential_bruteforce_malware_infection.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -97,13 +97,9 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.network-* metadata _id, _index, _version
-
-| mv_expand event.action 
-
 | where
     host.os.type == "linux" and
-    event.type == "start" and
-    event.action == "connection_attempted" and
+    KQL("event.type:start and event.action:connection_attempted") and
     destination.port in (22, 222, 2222, 10022, 2022, 2200, 62612, 8022) and
     not (
       cidr_match(

--- a/rules/linux/persistence_web_server_sus_child_spawned.toml
+++ b/rules/linux/persistence_web_server_sus_child_spawned.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -96,11 +96,9 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.process-* metadata _id, _index, _version
-| mv_expand event.action
 | where
     host.os.type == "linux" and
-    event.type == "start" and
-    event.action == "exec" and (
+    KQL("event.type:start and event.action:exec") and (
       (
         process.parent.name in (
             "apache", "nginx", "apache2", "httpd", "lighttpd", "caddy", "mongrel_rails", "gunicorn",
@@ -109,10 +107,7 @@ from logs-endpoint.events.process-* metadata _id, _index, _version
             "php-fcgi", "php-cgi.cagefs", "catalina.sh", "hiawatha", "lswsctrl"
         ) or
         process.parent.name like "php-fpm*" or
-        user.name in ("apache", "www-data", "httpd", "nginx", "lighttpd", "tomcat", "tomcat8", "tomcat9") or
-        user.id in ("33", "498", "48") or
-        (process.parent.name == "java" and process.parent.working_directory like "/u0?/*") or
-        process.parent.working_directory like "/var/www/*"
+        (process.parent.name == "java" and process.parent.working_directory like "/u0?/*")
       )
     ) and (
         process.name in (

--- a/rules/linux/persistence_web_server_sus_command_execution.toml
+++ b/rules/linux/persistence_web_server_sus_command_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -103,11 +103,9 @@ timestamp_override = "event.ingested"
 type = "esql"
 query = '''
 from logs-endpoint.events.process-* metadata _id, _index, _version
-| mv_expand event.action
 | where
     host.os.type == "linux" and
-    event.type == "start" and
-    event.action == "exec" and (
+    KQL("event.type:start and event.action:exec and process.args:(-c or -cl or -lc)") and (
       (
         process.parent.name in (
             "apache", "nginx", "apache2", "httpd", "lighttpd", "caddy", "mongrel_rails", "gunicorn",
@@ -116,14 +114,11 @@ from logs-endpoint.events.process-* metadata _id, _index, _version
             "php-fcgi", "php-cgi.cagefs", "catalina.sh", "hiawatha", "lswsctrl"
         ) or
         process.parent.name like "php-fpm*" or
-        user.name in ("apache", "www-data", "httpd", "nginx", "lighttpd", "tomcat", "tomcat8", "tomcat9") or
-        user.id in ("33", "498", "48") or
-        (process.parent.name == "java" and process.parent.working_directory like "/u0?/*") or
-        process.parent.working_directory like "/var/www/*"
+        (process.parent.name == "java" and process.parent.working_directory like "/u0?/*")
       )
     ) and
     process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
-    process.command_line like "* -c *" and not (
+    not (
         process.working_directory like "/home/*" or
         process.working_directory == "/" or
         process.working_directory like "/vscode/vscode-server/*" or

--- a/rules/macos/command_and_control_aws_s3_connection_via_script.toml
+++ b/rules/macos/command_and_control_aws_s3_connection_via_script.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -62,7 +62,7 @@ type = "esql"
 query = '''
 FROM logs-endpoint.events.network-*
 | WHERE host.os.type == "macos" 
-    AND event.type == "start"
+    AND KQL("event.type:start")
     AND (process.name == "osascript" 
          OR process.name == "node" 
          OR process.name LIKE "python*")

--- a/rules/macos/defense_evasion_suspicious_tcc_access_granted.toml
+++ b/rules/macos/defense_evasion_suspicious_tcc_access_granted.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/05"
 
 [rule]
 author = ["Elastic"]
@@ -68,7 +68,7 @@ The Transparency, Consent, and Control (TCC) framework is macOS's privacy protec
 query = '''
 FROM logs-endpoint.events.*
 | WHERE host.os.type == "macos" 
-    AND event.action == "tcc_modify" 
+    AND KQL("event.action:tcc_modify") 
     AND Tcc.right == "allowed"
     AND Tcc.update_type == "create"
     AND Tcc.service IN ("SystemPolicyDocumentsFolder", "SystemPolicyDownloadsFolder", "SystemPolicyDesktopFolder")


### PR DESCRIPTION
## Summary
There is a "feature" where using ES|QL to search a list using the `==` or `in` operators, will return `null`. For example, searching the `event.action` list `[exec, fork, end]` by searching `event.action == "exec"` will result in `null`, effectively making the query hit a FN. 

This PR fixes this, by either using the `KQL()` function where possible or using `mv_expand` where the `KQL()` function is not possible (e.g. `KQL` after an `EVAL` is unsupported).