### PR TITLE
[New] Kubernetes Service Account Token Created via TokenRequest API

### DIFF
--- a/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
@@ -79,6 +79,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "query"
 query = '''
+data_stream.dataset:"kubernetes.audit_logs" and 
 kubernetes.audit.verb:"create" and
 kubernetes.audit.objectRef.resource:"serviceaccounts" and
 kubernetes.audit.objectRef.subresource:"token" and

--- a/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
@@ -33,14 +33,34 @@ note = """## Triage and analysis
 
 ### Investigating Kubernetes Service Account Token Created via TokenRequest API
 
-Confirm the actor user.name, namespace, and kubernetes.audit.objectRef.name for the target ServiceAccount. Review
-RBAC: who can create on serviceaccounts/token for that namespace. Correlate with pod creation, RoleBinding changes,
-or cloud API usage that follows the token mint time.
+This alert indicates a successful `create` against the `serviceaccounts/token` subresource (TokenRequest API), which
+issues a new service account token without a filesystem read. In EKS and other managed clusters, this can be abused to
+mint tokens for more privileged service accounts (including IRSA-linked ones) and pivot to cloud APIs.
+
+#### What to review first
+
+- Actor and origin:
+  - `user.name` / `kubernetes.audit.user.username`
+  - `source.ip` / `kubernetes.audit.sourceIPs`
+  - `user_agent.original` / `kubernetes.audit.userAgent`
+  - For cloud identity, review `kubernetes.audit.user.extra.*` (e.g., `arn`, `principalId`).
+- Targeted service account:
+  - `kubernetes.audit.objectRef.namespace` and `kubernetes.audit.objectRef.name`
+  - `kubernetes.audit.requestURI` (should resemble `/api/v1/namespaces/<ns>/serviceaccounts/<sa>/token`)
+- Token issuance hints:
+  - `kubernetes.audit.annotations.authentication_kubernetes_io/issued-credential-id` (token JTI/issued credential id)
+
+#### Scoping
+
+- Identify which Role/ClusterRoleBindings grant the actor `create` on `serviceaccounts/token` in the affected namespace.
+- Pivot on the same `user.name` and `source.ip` for follow-on secret reads, pod exec, RBAC changes, or cloud API calls.
 
 ### Response and remediation
 
-- If malicious, revoke the binding or permission that allows token creation, rotate affected service accounts, and
-  invalidate workload-identity sessions tied to the abused identity.
+- If unauthorized, remove/revert the RBAC permission that allows TokenRequest (`serviceaccounts/token`) and rotate the
+  affected service account credentials where applicable.
+- For IRSA/workload identity cases, rotate/revoke the cloud role session pathways and review cloud audit logs for API
+  activity from the time window of the token mint.
 """
 references = [
     "https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-v1/",

--- a/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
@@ -33,8 +33,8 @@ note = """## Triage and analysis
 
 ### Investigating Kubernetes Service Account Token Created via TokenRequest API
 
-Confirm the actor (`user.name`), namespace, and `kubernetes.audit.objectRef.name` for the target ServiceAccount. Review
-RBAC: who can `create` on `serviceaccounts/token` for that namespace. Correlate with pod creation, RoleBinding changes,
+Confirm the actor user.name, namespace, and kubernetes.audit.objectRef.name for the target ServiceAccount. Review
+RBAC: who can create on serviceaccounts/token for that namespace. Correlate with pod creation, RoleBinding changes,
 or cloud API usage that follows the token mint time.
 
 ### Response and remediation
@@ -48,18 +48,6 @@ references = [
 ]
 risk_score = 47
 rule_id = "4df91789-7859-4bc4-9c5a-6b56bfa81a8b"
-setup = """## Setup
-
-Requires Kubernetes audit logs ingested into `logs-kubernetes.audit_logs-*` with `kubernetes.audit.*` fields populated
-(Fleet Kubernetes integration or equivalent).
-
-Ensure audit policy records **create** requests against **serviceaccounts/token** (TokenRequest API) so this rule can
-evaluate `kubernetes.audit.verb`, `kubernetes.audit.objectRef.resource`, `kubernetes.audit.objectRef.subresource`, and
-`user.name`.
-
-The rule query uses lowercase KQL keywords (`and`, `or`, `not`) so it validates in this repository; the boolean logic is
-unchanged from uppercase equivalents.
-"""
 severity = "medium"
 tags = [
     "Data Source: Kubernetes",

--- a/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
@@ -1,0 +1,111 @@
+[metadata]
+creation_date = "2026/05/05"
+integration = ["kubernetes"]
+maturity = "production"
+updated_date = "2026/05/05"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects the creation of a Kubernetes service account token through the TokenRequest API by a non-system identity. The
+TokenRequest API allows users and workloads to programmatically generate short-lived tokens for any service account
+they have create permissions on, without accessing the filesystem or the mounted projected token. Attackers who have
+gained initial access to a cluster can abuse this API to mint tokens for more privileged service accounts, pivot to
+cloud provider resources via IRSA/workload identity, or generate long-lived tokens that persist beyond pod
+termination. Unlike mounted service account tokens which are detectable through file access monitoring, tokens created
+via the TokenRequest API leave no filesystem footprint, they are only visible in Kubernetes audit logs as a create
+verb on the serviceaccounts/token subresource. This rule excludes legitimate system components such as the kubelet,
+kube-controller-manager, and cloud provider managed identities (EKS, AKS, GKE) that routinely create tokens for pod
+lifecycle management.
+"""
+false_positives = [
+    """
+    New automation, admission webhooks, or platform agents that legitimately call the TokenRequest API under a
+    non-standard user string may require narrow exclusions by user.name or source IP.
+    """,
+]
+from = "now-6m"
+index = ["logs-kubernetes.audit_logs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Kubernetes Service Account Token Created via TokenRequest API"
+note = """## Triage and analysis
+
+### Investigating Kubernetes Service Account Token Created via TokenRequest API
+
+Confirm the actor (`user.name`), namespace, and `kubernetes.audit.objectRef.name` for the target ServiceAccount. Review
+RBAC: who can `create` on `serviceaccounts/token` for that namespace. Correlate with pod creation, RoleBinding changes,
+or cloud API usage that follows the token mint time.
+
+### Response and remediation
+
+- If malicious, revoke the binding or permission that allows token creation, rotate affected service accounts, and
+  invalidate workload-identity sessions tied to the abused identity.
+"""
+references = [
+    "https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-v1/",
+    "https://attack.mitre.org/techniques/T1552/007/",
+]
+risk_score = 47
+rule_id = "4df91789-7859-4bc4-9c5a-6b56bfa81a8b"
+setup = """## Setup
+
+Requires Kubernetes audit logs ingested into `logs-kubernetes.audit_logs-*` with `kubernetes.audit.*` fields populated
+(Fleet Kubernetes integration or equivalent).
+
+Ensure audit policy records **create** requests against **serviceaccounts/token** (TokenRequest API) so this rule can
+evaluate `kubernetes.audit.verb`, `kubernetes.audit.objectRef.resource`, `kubernetes.audit.objectRef.subresource`, and
+`user.name`.
+
+The rule query uses lowercase KQL keywords (`and`, `or`, `not`) so it validates in this repository; the boolean logic is
+unchanged from uppercase equivalents.
+"""
+severity = "medium"
+tags = [
+    "Data Source: Kubernetes",
+    "Domain: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+query = '''
+kubernetes.audit.verb:"create" AND
+kubernetes.audit.objectRef.resource:"serviceaccounts" AND
+kubernetes.audit.objectRef.subresource:"token" AND 
+user.name:(* and not 
+ (system\:kube-controller-manager OR
+  system\:kube-scheduler OR
+  system\:node\:* OR
+  system\:serviceaccount\:kube-system\:* OR
+  eks\:* OR
+  aksService OR
+  aks-service OR
+  masterclient OR
+  nodeclient OR
+  system\:serviceaccount\:gke-managed-system\:* OR
+  system\:serviceaccount\:gke-connect\:* OR
+  system\:serviceaccount\:anthos-identity-service\:* OR
+  system\:gke-controller-manager OR
+  system\:serviceaccount\:tigera-operator\:* OR
+  system\:serviceaccount\:calico-system\:*))
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.007"
+name = "Container API"
+reference = "https://attack.mitre.org/techniques/T1552/007/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
@@ -59,24 +59,24 @@ tags = [
 timestamp_override = "event.ingested"
 type = "query"
 query = '''
-kubernetes.audit.verb:"create" AND
-kubernetes.audit.objectRef.resource:"serviceaccounts" AND
-kubernetes.audit.objectRef.subresource:"token" AND 
+kubernetes.audit.verb:"create" and
+kubernetes.audit.objectRef.resource:"serviceaccounts" and
+kubernetes.audit.objectRef.subresource:"token" and
 user.name:(* and not 
- (system\:kube-controller-manager OR
-  system\:kube-scheduler OR
-  system\:node\:* OR
+ (system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:node\:* or
   system\:serviceaccount\:kube-system\:* OR
-  eks\:* OR
-  aksService OR
-  aks-service OR
-  masterclient OR
-  nodeclient OR
-  system\:serviceaccount\:gke-managed-system\:* OR
-  system\:serviceaccount\:gke-connect\:* OR
-  system\:serviceaccount\:anthos-identity-service\:* OR
-  system\:gke-controller-manager OR
-  system\:serviceaccount\:tigera-operator\:* OR
+  eks\:* or
+  aksService or
+  aks-service or
+  masterclient or
+  nodeclient or
+  system\:serviceaccount\:gke-managed-system\:* or
+  system\:serviceaccount\:gke-connect\:* or
+  system\:serviceaccount\:anthos-identity-service\:* or
+  system\:gke-controller-manager or
+  system\:serviceaccount\:tigera-operator\:* or
   system\:serviceaccount\:calico-system\:*))
 '''
 

--- a/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
+++ b/rules/integrations/kubernetes/credential_access_kubernetes_service_account_token_created_via_tokenrequest.toml
@@ -66,7 +66,7 @@ user.name:(* and not
  (system\:kube-controller-manager or
   system\:kube-scheduler or
   system\:node\:* or
-  system\:serviceaccount\:kube-system\:* OR
+  system\:serviceaccount\:kube-system\:* or
   eks\:* or
   aksService or
   aks-service or


### PR DESCRIPTION
Detects the creation of a Kubernetes service account token through the TokenRequest API by a non-system identity. The TokenRequest API allows users and workloads to programmatically generate short-lived tokens for any service account they have create permissions on, without accessing the filesystem or the mounted projected token. Attackers who have gained initial access to a cluster can abuse this API to mint tokens for more privileged service accounts, pivot to cloud provider resources via IRSA/workload identity, or generate long-lived tokens that persist beyond pod termination. Unlike mounted service account tokens which are detectable through file access monitoring, tokens created via the TokenRequest API leave no filesystem footprint, they are only visible in Kubernetes audit logs as a create verb on the serviceaccounts/token subresource. This rule excludes legitimate system components such as the kubelet, kube-controller-manager, and cloud provider managed identities (EKS, AKS, GKE) that routinely create tokens for pod lifecycle management.

<img width="1013" height="275" alt="image" src="https://github.com/user-attachments/assets/fe72e7ed-0d45-49e8-be9f-432e668045fe" />
