### PR TITLE
[FR] [DaC] Add Basic Support for Response Actions

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -403,6 +403,7 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
     meta: dict[str, Any] | None = None
     note: definitions.Markdown | None = None
     references: list[str] | None = None
+    response_actions: list[dict[str, Any]] | None = None
     risk_score_mapping: list[RiskScoreMapping] | None = None
     rule_name_override: str | None = None
     severity_mapping: list[SeverityMapping] | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.33"
+version = "1.6.34"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.34"
+version = "1.6.35"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -11,6 +11,7 @@ import unittest
 import unittest.mock
 import uuid
 from pathlib import Path
+from typing import Any
 
 import eql
 import pytest
@@ -253,6 +254,65 @@ class TestSchemas(unittest.TestCase):
             build_rule("""
                     process where process.pid == "some string field"
             """)
+
+    def test_response_actions_validation(self) -> None:
+        """Test that response actions are properly validated in the schema."""
+        base_fields: dict[str, Any] = {
+            "author": ["Elastic"],
+            "description": "test description",
+            "index": ["logs-endpoint.events.*"],
+            "language": "kuery",
+            "license": "Elastic License v2",
+            "name": "test rule",
+            "query": "process.name:test.query",
+            "risk_score": 21,
+            "rule_id": str(uuid.uuid4()),
+            "severity": "low",
+            "type": "query",
+        }
+
+        def build_rule(response_actions: list[dict[str, Any]]) -> TOMLRuleContents:
+            """Helper function to build a TOMLRuleContents object."""
+            metadata = {
+                "creation_date": "1970/01/01",
+                "updated_date": "1970/01/01",
+                "min_stack_version": load_current_package_version(),
+            }
+            data = base_fields.copy()
+            data["response_actions"] = response_actions
+            return TOMLRuleContents.from_dict({"metadata": metadata, "rule": data})
+
+        response_actions = [
+            {
+                "action_type_id": ".osquery",
+                "params": {
+                    "query": "select * from processes;",
+                    "timeout": 120,
+                    "ecs_mapping": {"process.pid": {"field": "pid"}},
+                    "queries": [{"id": "processes", "query": "select * from processes;"}],
+                },
+            },
+            {"action_type_id": ".endpoint", "params": {"command": "isolate", "comment": "isolate host"}},
+            {
+                "action_type_id": ".endpoint",
+                "params": {
+                    "command": "kill-process",
+                    "comment": "kill process",
+                    "config": {"field": "", "overwrite": True},
+                },
+            },
+        ]
+        contents = build_rule(response_actions)
+        self.assertEqual(contents.to_api_format()["response_actions"], response_actions)
+
+        with self.assertRaisesRegex(ValidationError, "action_type_id"):
+            build_rule([{"action_type_id": ".email", "params": {}}])
+
+        with self.assertRaisesRegex(ValidationError, "config"):
+            build_rule([{"action_type_id": ".endpoint", "params": {"command": "suspend-process"}}])
+
+        with self.assertRaisesRegex(ValidationError, "timeout"):
+            build_rule([{"action_type_id": ".osquery", "params": {"timeout": 30}}])
 
 
 class TestVersionLockSchema(unittest.TestCase):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -305,15 +305,6 @@ class TestSchemas(unittest.TestCase):
         contents = build_rule(response_actions)
         self.assertEqual(contents.to_api_format()["response_actions"], response_actions)
 
-        with self.assertRaisesRegex(ValidationError, "action_type_id"):
-            build_rule([{"action_type_id": ".email", "params": {}}])
-
-        with self.assertRaisesRegex(ValidationError, "config"):
-            build_rule([{"action_type_id": ".endpoint", "params": {"command": "suspend-process"}}])
-
-        with self.assertRaisesRegex(ValidationError, "timeout"):
-            build_rule([{"action_type_id": ".osquery", "params": {"timeout": 30}}])
-
 
 class TestVersionLockSchema(unittest.TestCase):
     """Test that the version lock has proper entries."""


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*: 

Resolves https://github.com/elastic/detection-rules/issues/6040
Resolves https://github.com/elastic/detection-rules/issues/5003
Closes https://github.com/elastic/detection-rules/pull/6041

## Summary - What I changed

Small PR in the spirit of https://github.com/elastic/detection-rules/pull/6041 to add the response_action field support to DaC.

After discussion with our team, this is the preferred approach we want to take in comparison to a heavier approach we explored in https://github.com/elastic/detection-rules/tree/add_response_actions_support. 

In short, while we could add full validation, this could cause issues with feature discrepancies between stack versions. Instead by using a unit test for validation, the validation can be modified (or ignored) at will by customers using our config options for which tests to enable or disable.

## How To Test

Use one of the following TOML or NJDSON rule contents and move them to and from Kibana to see the response actions are present and preserved.

Example Python Command:
```
python -m detection_rules kibana import-rules -o -e -ac -f custom_rules/rules/test_indicator_match_rule_with_email_actions.toml
```

<img width="1871" height="995" alt="response_action_support" src="https://github.com/user-attachments/assets/58972a64-51b4-4859-8ece-ff7c569ebcea" />

NDJSON Example

```
python -m detection_rules export-rules-from-repo -f custom_rules/rules/test_indicator_match_rule_with_email_actions.toml -o test_action_response.ndjson -e -ac
```

<img width="1871" height="995" alt="test_response_action_ndjson" src="https://github.com/user-attachments/assets/921195a5-307d-4d2f-bf58-5a041c456ce1" />

<details><summary>Example TOML</summary>
<p>

```
[metadata]
creation_date = "2026/05/05"
integration = []
maturity = "production"
updated_date = "2026/05/05"

[rule]
author = ["841510929"]
description = "Checks for bad IP addresses listed in the ip-threat-list index"
enabled = true
exceptions_list = []
false_positives = []
filters = []
from = "now-6m"
index = ["packetbeat-*"]
interval = "5m"
language = "kuery"
license = ""
max_signals = 100
name = "test_indicator_match_rule_with_email_actions"
note = "None"
references = []
related_integrations = []
revision = 9
risk_score = 0
risk_score_mapping = []
rule_id = "4c589d81-2622-4036-8cc7-372ea8f0e038"
setup = "None"
severity = "medium"
severity_mapping = []
tags = []
threat = []
threat_filters = []
threat_index = ["ip-threat-list"]
threat_indicator_path = "threat.indicator"
threat_language = "kuery"
to = "now"
type = "threat_match"
version = 1

query = '''
destination.ip:* or host.ip:*
'''



threat_query = '''
*:*
'''


[[rule.actions]]
action_type_id = ".email"
group = "default"
id = "1b8d347f-2542-4390-85de-2653518311e2"
uuid = "98de9d3f-87e9-468a-b656-26f8c2f64c00"

[rule.actions.frequency]
notifyWhen = "onActiveAlert"
summary = true
[rule.actions.params]
message = "Rule {{context.rule.name}} generated {{state.signals_count}} alerts"
subject = "Test Actions"
to = ["tradebot-elastic@elastic.com"]
[[rule.required_fields]]
ecs = true
name = "destination.ip"
type = "ip"

[[rule.required_fields]]
ecs = true
name = "destination.port"
type = "long"

[[rule.required_fields]]
ecs = true
name = "host.ip"
type = "ip"

[[rule.response_actions]]
action_type_id = ".endpoint"

[rule.response_actions.params]
command = "suspend-process"
comment = "We are suspending process"
[rule.response_actions.params.config]
field = ""
overwrite = true
[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "destination.ip"
type = "mapping"
value = "destination.ip"

[[rule.threat_mapping.entries]]
field = "destination.port"
type = "mapping"
value = "destination.port"

[[rule.threat_mapping]]

[[rule.threat_mapping.entries]]
field = "source.ip"
type = "mapping"
value = "host.ip"

[rule.meta]
kibana_siem_app_url = ""


```


</p>
</details> 


<details><summary>Example NDJSON</summary>
<p>

```
{"actions": [{"action_type_id": ".email", "frequency": {"notifyWhen": "onActiveAlert", "summary": true, "throttle": null}, "group": "default", "id": "1b8d347f-2542-4390-85de-2653518311e2", "params": {"message": "Rule {{context.rule.name}} generated {{state.signals_count}} alerts", "subject": "Test Actions", "to": ["bot-elastic@elastic.com"]}, "uuid": "98de9d3f-87e9-468a-b656-26f8c2f64c00"}], "author": ["841510929"], "description": "Checks for bad IP addresses listed in the ip-threat-list index", "enabled": true, "exceptions_list": [], "false_positives": [], "filters": [], "from": "now-6m", "index": ["packetbeat-*"], "interval": "5m", "language": "kuery", "license": "", "max_signals": 100, "meta": {"kibana_siem_app_url": ""}, "name": "test_indicator_match_rule_with_email_actions", "note": "None", "query": "destination.ip:* or host.ip:*\n", "references": [], "related_integrations": [], "required_fields": [{"ecs": true, "name": "destination.ip", "type": "ip"}, {"ecs": true, "name": "destination.port", "type": "long"}, {"ecs": true, "name": "host.ip", "type": "ip"}], "response_actions": [{"action_type_id": ".endpoint", "params": {"command": "suspend-process", "comment": "We are suspending process", "config": {"field": "", "overwrite": true}}}], "revision": 9, "risk_score": 0, "risk_score_mapping": [], "rule_id": "4c589d81-2622-4036-8cc7-372ea8f0e038", "setup": "None", "severity": "medium", "severity_mapping": [], "tags": [], "threat": [], "threat_filters": [], "threat_index": ["ip-threat-list"], "threat_indicator_path": "threat.indicator", "threat_language": "kuery", "threat_mapping": [{"entries": [{"field": "destination.ip", "type": "mapping", "value": "destination.ip"}, {"field": "destination.port", "type": "mapping", "value": "destination.port"}]}, {"entries": [{"field": "source.ip", "type": "mapping", "value": "host.ip"}]}], "threat_query": "*:*", "to": "now", "type": "threat_match", "version": 1}
{"attributes": {"actionTypeId": ".email", "config": {"from": "bot-elastic@elastic.com", "hasAuth": false, "host": "smtp.gmail.com", "port": 465, "secure": true, "service": "gmail"}, "isMissingSecrets": false, "name": "Elastic-Cloud-Email", "secrets": {}}, "id": "1b8d347f-2542-4390-85de-2653518311e2", "managed": false, "references": [], "type": "action"}


```

</p>
</details> 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
