### PR TITLE
[Tuning] M365 Identity Login from Impossible Travel Location

### DIFF
--- a/rules/integrations/o365/initial_access_entra_id_portal_login_impossible_travel.toml
+++ b/rules/integrations/o365/initial_access_entra_id_portal_login_impossible_travel.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/09/04"
 integration = ["o365"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/06/05"
 
 [rule]
 author = ["Elastic"]
@@ -75,7 +75,6 @@ data_stream.dataset:o365.audit and
     event.outcome:success and
     o365.audit.Target.Type:(0 or 10 or 2 or 3 or 5 or 6) and
     o365.audit.UserId:(* and not "Not Available") and
-    source.geo.region_iso_code:* and
     not o365.audit.ApplicationId:(
         29d9ed98-a469-4536-ade2-f981bc1d605e or
         38aa3b87-a06d-4817-b275-7a316988d93b or


### PR DESCRIPTION
remove the requirement that `source.geo.region_iso_code` is populated, this may happen in some rare cases (source.ip enrichment processor by o365 integration can't find that info) and causes FNs. The rule logic is not impacted since its a threshold based rule keying on `source.geo.country_name`.