### PR TITLE
[New] EKS Access Entry Granted Cluster Admin Policy

### DIFF
--- a/rules/integrations/aws/persistence_eks_access_entry_modified.toml
+++ b/rules/integrations/aws/persistence_eks_access_entry_modified.toml
@@ -23,7 +23,7 @@ from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "EKS Access Entry Modified"
+name = "AWS EKS Access Entry Modified"
 note = """## Triage and analysis
 
 ### Investigating EKS Access Entry Modified

--- a/rules/integrations/aws/persistence_eks_access_entry_modified.toml
+++ b/rules/integrations/aws/persistence_eks_access_entry_modified.toml
@@ -1,0 +1,128 @@
+[metadata]
+creation_date = "2026/05/06"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/06"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects successful Amazon EKS Access Entries API operations that create, update, attach, detach, or delete authentication
+mappings between IAM principals and the cluster. Changes to access entries alter who can authenticate to Kubernetes and
+what Kubernetes-level permissions they receive, without requiring edits to in-cluster RBAC objects. Unexpected callers
+or timing may indicate persistence or privilege abuse. Common automation identities (service-linked roles, eksctl,
+Terraform, CloudFormation role patterns) are excluded to reduce noise; tune further for your deployment pipelines.
+"""
+false_positives = [
+    """
+    Cluster provisioning, GitOps, or approved platform automation may perform these APIs under IAM principals whose ARNs do
+    not match the exclusion patterns. Baseline expected roles and expand exclusions if needed.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "EKS Access Entry Modified"
+note = """## Triage and analysis
+
+### Investigating EKS Access Entry Modified
+
+Review aws.cloudtrail.user_identity (ARN, type), user.name, source.ip, user_agent.original, cloud.account.id, and
+cloud.region. Map event.action to intent: new principal (CreateAccessEntry), policy binding changes (AssociateAccessPolicy,
+DisassociateAccessPolicy), metadata updates (UpdateAccessEntry), or removal (DeleteAccessEntry).
+
+### Possible investigation steps
+
+- Inspect aws.cloudtrail.request_parameters and response_elements for cluster name, principal ARN, and policy ARNs.
+- Compare against change management and infrastructure-as-code deploy windows.
+- Correlate with Kubernetes audit logs for subsequent API activity from identities tied to the affected access entry.
+- Pair with the higher-fidelity rule EKS Access Entry Granted Cluster Admin Policy when AssociateAccessPolicy fires.
+
+### Response and remediation
+
+- If unauthorized, revert access entry changes via AWS APIs or console; restrict eks:* permissions and review SCPs.
+- Rotate credentials for compromised IAM principals as appropriate.
+
+### Additional information
+
+- [Amazon EKS access entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html)
+"""
+references = [
+    "https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html",
+    "https://attack.mitre.org/techniques/T1098/",
+]
+risk_score = 47
+rule_id = "90c0ce77-3fb4-484f-a8ad-4648e12b35b1"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+query = '''
+data_stream.dataset:"aws.cloudtrail" and event.provider:"eks.amazonaws.com" and
+event.action:("CreateAccessEntry" or "AssociateAccessPolicy" or "UpdateAccessEntry" or "DisassociateAccessPolicy" or "DeleteAccessEntry") and
+event.outcome:"success" and
+not aws.cloudtrail.user_identity.arn:(*AWSServiceRoleForAmazonEKS* or *eksctl* or *terraform* or *AWSCloudFormation*)
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.006"
+name = "Additional Container Cluster Roles"
+reference = "https://attack.mitre.org/techniques/T1098/006/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.006"
+name = "Additional Container Cluster Roles"
+reference = "https://attack.mitre.org/techniques/T1098/006/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"

--- a/rules/integrations/aws/persistence_eks_access_entry_modified.toml
+++ b/rules/integrations/aws/persistence_eks_access_entry_modified.toml
@@ -50,7 +50,6 @@ DisassociateAccessPolicy), metadata updates (UpdateAccessEntry), or removal (Del
 """
 references = [
     "https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html",
-    "https://attack.mitre.org/techniques/T1098/",
 ]
 risk_score = 47
 rule_id = "90c0ce77-3fb4-484f-a8ad-4648e12b35b1"

--- a/rules/integrations/aws/persistence_eks_access_entry_modified.toml
+++ b/rules/integrations/aws/persistence_eks_access_entry_modified.toml
@@ -26,7 +26,7 @@ license = "Elastic License v2"
 name = "AWS EKS Access Entry Modified"
 note = """## Triage and analysis
 
-### Investigating EKS Access Entry Modified
+### Investigating AWS EKS Access Entry Modified
 
 Review aws.cloudtrail.user_identity (ARN, type), user.name, source.ip, user_agent.original, cloud.account.id, and
 cloud.region. Map event.action to intent: new principal (CreateAccessEntry), policy binding changes (AssociateAccessPolicy,

--- a/rules/integrations/aws/privilege_escalation_eks_access_entry_granted_cluster_admin_policy.toml
+++ b/rules/integrations/aws/privilege_escalation_eks_access_entry_granted_cluster_admin_policy.toml
@@ -27,7 +27,7 @@ license = "Elastic License v2"
 name = "AWS EKS Access Entry Granted Cluster Admin Policy"
 note = """## Triage and analysis
 
-### Investigating EKS Access Entry Granted Cluster Admin Policy
+### Investigating AWS EKS Access Entry Granted Cluster Admin Policy
 
 Successful AssociateAccessPolicy with AmazonEKSClusterAdminPolicy or AmazonEKSAdminPolicy binds highly privileged
 Kubernetes access to an IAM principal. Review who invoked the API (user.name, aws.cloudtrail.user_identity fields),

--- a/rules/integrations/aws/privilege_escalation_eks_access_entry_granted_cluster_admin_policy.toml
+++ b/rules/integrations/aws/privilege_escalation_eks_access_entry_granted_cluster_admin_policy.toml
@@ -24,7 +24,7 @@ from = "now-6m"
 index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "EKS Access Entry Granted Cluster Admin Policy"
+name = "AWS EKS Access Entry Granted Cluster Admin Policy"
 note = """## Triage and analysis
 
 ### Investigating EKS Access Entry Granted Cluster Admin Policy

--- a/rules/integrations/aws/privilege_escalation_eks_access_entry_granted_cluster_admin_policy.toml
+++ b/rules/integrations/aws/privilege_escalation_eks_access_entry_granted_cluster_admin_policy.toml
@@ -55,7 +55,6 @@ source.ip, user_agent.original, cloud.account.id, and cloud.region.
 references = [
     "https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html",
     "https://docs.aws.amazon.com/eks/latest/APIReference/API_AssociateAccessPolicy.html",
-    "https://attack.mitre.org/techniques/T1098/",
 ]
 risk_score = 73
 rule_id = "9550ec87-e73c-4baa-ad44-e448a33fbc3d"

--- a/rules/integrations/aws/privilege_escalation_eks_access_entry_granted_cluster_admin_policy.toml
+++ b/rules/integrations/aws/privilege_escalation_eks_access_entry_granted_cluster_admin_policy.toml
@@ -1,0 +1,134 @@
+[metadata]
+creation_date = "2026/05/06"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/06"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when the AmazonEKSClusterAdminPolicy or AmazonEKSAdminPolicy is associated with a principal via the EKS
+Access Entries API. This grants full cluster-admin equivalent access to the specified IAM user or role. Unlike the
+legacy aws-auth ConfigMap which is only visible in Kubernetes audit logs, Access Entries modifications appear in
+CloudTrail, providing an additional detection surface. Attackers who have obtained IAM permissions to manage EKS
+access entries can use this API to backdoor cluster access for persistence, mapping attacker-controlled IAM
+identities to cluster-admin privileges without modifying any Kubernetes resources.
+"""
+false_positives = [
+    """
+    Platform or security teams may legitimately associate these policies during cluster onboarding, break-glass admin
+    setup, or controlled RBAC migrations from aws-auth. Validate the caller, change ticket, and target IAM principal.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "EKS Access Entry Granted Cluster Admin Policy"
+note = """## Triage and analysis
+
+### Investigating EKS Access Entry Granted Cluster Admin Policy
+
+Successful AssociateAccessPolicy with AmazonEKSClusterAdminPolicy or AmazonEKSAdminPolicy binds highly privileged
+Kubernetes access to an IAM principal. Review who invoked the API (user.name, aws.cloudtrail.user_identity fields),
+source.ip, user_agent.original, cloud.account.id, and cloud.region.
+
+### Possible investigation steps
+
+- Parse aws.cloudtrail.request_parameters and response elements for cluster name, access entry ARN, and policy ARN.
+- Confirm whether the IAM principal receiving the policy is expected to have cluster-admin-class access.
+- Correlate with other EKS API calls (CreateAccessEntry, UpdateAccessEntry) and with Kubernetes audit activity from
+  newly authorized principals.
+- Compare against change records for migrations from aws-auth or new administrator onboarding.
+
+### Response and remediation
+
+- If unauthorized, disassociate the policy or remove the access entry per AWS guidance; audit who can call eks:*
+  APIs in IAM.
+- Rotate credentials for any suspected compromised IAM principal; review organizational SCPs and cluster auth mode.
+
+### Additional information
+
+- [Amazon EKS access entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html)
+- [AssociateAccessPolicy](https://docs.aws.amazon.com/eks/latest/APIReference/API_AssociateAccessPolicy.html)
+"""
+references = [
+    "https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html",
+    "https://docs.aws.amazon.com/eks/latest/APIReference/API_AssociateAccessPolicy.html",
+    "https://attack.mitre.org/techniques/T1098/",
+]
+risk_score = 73
+rule_id = "9550ec87-e73c-4baa-ad44-e448a33fbc3d"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Use Case: Threat Detection",
+    "Tactic: Privilege Escalation",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+query = '''
+data_stream.dataset:"aws.cloudtrail" and
+event.provider:"eks.amazonaws.com" and
+event.action:"AssociateAccessPolicy" and
+event.outcome:"success" and
+aws.cloudtrail.request_parameters:(*AmazonEKSClusterAdminPolicy* or *AmazonEKSAdminPolicy*)
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.006"
+name = "Additional Container Cluster Roles"
+reference = "https://attack.mitre.org/techniques/T1098/006/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.006"
+name = "Additional Container Cluster Roles"
+reference = "https://attack.mitre.org/techniques/T1098/006/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"


### PR DESCRIPTION
Detects when the AmazonEKSClusterAdminPolicy or AmazonEKSAdminPolicy is associated with a principal via the EKS Access Entries API. This grants full cluster-admin equivalent access to the specified IAM user or role.

<img width="881" height="239" alt="image" src="https://github.com/user-attachments/assets/5da139a1-4eeb-4dd0-9dde-1592ac557f27" />
