### PR TITLE
[Rule Tuning] First-Time FortiGate Administrator Login

### DIFF
--- a/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
+++ b/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/28"
 integration = ["fortinet_fortigate"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/06"
 
 [rule]
 author = ["Elastic"]
@@ -88,6 +88,7 @@ FROM logs-fortinet_fortigate.*, filebeat-* metadata _id
 | stats Esql.logon_count = count(*),
         Esql.first_time_seen = MIN(@timestamp),
         Esql.source_ip_values = VALUES(source.ip),
+        Esql.fortinet_firewall_profiles = VALUES(fortinet.firewall.profile),
         Esql.message_values = VALUES(message) by source.user.name
 
 // first time seen is within 6m of the rule execution time and for the last 5d of events history
@@ -97,7 +98,14 @@ FROM logs-fortinet_fortigate.*, filebeat-* metadata _id
 // move dynamic fields to ECS equivalent for rule exceptions
 | eval source.ip = MV_FIRST(Esql.source_ip_values)
 
-| keep source.ip, source.user.name, Esql.*
+| keep source.ip,
+       source.user.name,
+       Esql.logon_count,
+       Esql.first_time_seen,
+       Esql.source_ip_values,
+       Esql.fortinet_firewall_profiles,
+       Esql.message_values,
+       Esql.recent
 '''
 
 

--- a/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
+++ b/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
@@ -37,6 +37,7 @@ Because administrator access provides full control over network security devices
 - **Review login context**
   - Examine associated FortiGate log messages for details such as login method, interface, or authentication source.
   - Check for additional administrative actions following the login (policy changes, user creation, configuration exports).
+  - Review `Esql.fortinet_firewall_profiles` (sourced from `fortinet.firewall.profile`) to identify the FortiGate Admin Profile the identity logged in under.
 
 - **Correlate with recent changes**
   - Verify whether there were recent change requests, onboarding activities, or maintenance windows that explain the login.

--- a/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
+++ b/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
@@ -87,10 +87,9 @@ FROM logs-fortinet_fortigate.*, filebeat-* metadata _id
         event.category == "authentication" and event.action == "login" and
         event.outcome == "success" and source.user.roles == "Administrator" and source.user.name is not null
 | stats Esql.logon_count = count(*),
-        Esql.first_time_seen = MIN(@timestamp),
-        Esql.source_ip_values = VALUES(source.ip),
-        Esql.fortinet_firewall_profiles = VALUES(fortinet.firewall.profile),
-        Esql.message_values = VALUES(message) by source.user.name
+       Esql.first_time_seen = MIN(@timestamp),
+       Esql.source_ip_values = VALUES(source.ip),
+       Esql.message_values = VALUES(message) by source.user.name, fortinet.firewall.profile
 
 // first time seen is within 6m of the rule execution time and for the last 5d of events history
 | eval Esql.recent = DATE_DIFF("minute", Esql.first_time_seen, now())

--- a/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
+++ b/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
@@ -37,7 +37,7 @@ Because administrator access provides full control over network security devices
 - **Review login context**
   - Examine associated FortiGate log messages for details such as login method, interface, or authentication source.
   - Check for additional administrative actions following the login (policy changes, user creation, configuration exports).
-  - Review `Esql.fortinet_firewall_profiles` (sourced from `fortinet.firewall.profile`) to identify the FortiGate Admin Profile the identity logged in under.
+  - Review  `fortinet.firewall.profile` to identify the FortiGate Admin Profile the identity logged in under.
 
 - **Correlate with recent changes**
   - Verify whether there were recent change requests, onboarding activities, or maintenance windows that explain the login.

--- a/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
+++ b/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
@@ -100,6 +100,7 @@ FROM logs-fortinet_fortigate.*, filebeat-* metadata _id
 
 | keep source.ip,
        source.user.name,
+       fortinet.firewall.profile,
        Esql.logon_count,
        Esql.first_time_seen,
        Esql.source_ip_values,

--- a/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
+++ b/rules/network/initial_access_newly_observed_fortigate_admin_logon.toml
@@ -103,7 +103,6 @@ FROM logs-fortinet_fortigate.*, filebeat-* metadata _id
        Esql.logon_count,
        Esql.first_time_seen,
        Esql.source_ip_values,
-       Esql.fortinet_firewall_profiles,
        Esql.message_values,
        Esql.recent
 '''


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/6020

## Summary - What I changed

Small PR to add the firewall profile names to the First-Time FortiGate Administrator Login rule. 

Field reference: https://github.com/elastic/integrations/blob/main/packages/fortinet_fortigate/data_stream/log/fields/fields.yml#L1201-L1204


The primary factor reviewers should consider is the purpose of including this new field. Generally speaking this is useful for triage, but also useful for writing exceptions. However, given some of the ES|QL shortcomings this would need to be mapped back to an ECS field in order to write exceptions for the rule. 

E.g.
```
| eval user.roles = Esql.fortinet_firewall_profiles
``` 

I expect we would not want to map this back to ECS as we have not done so for other rules, but I pose that question for reviewers for input. 

## How To Test

ES|QL remote validate is the primary test for this change. Telemetry verification is only somewhat useful in this case as this field would not be preserved in the rule's current state.

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
