### PR TITLE
[Rule Tuning] Suspicious macOS MS Office Child Process

### DIFF
--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -128,11 +128,6 @@ process where event.action == "exec" and host.os.type == "macos" and
         process.name : ("sh", "bash") and
         process.command_line : "*com.microsoft.Outlook/Data/tmp/Outlook*Temp*" and
           process.parent.name : "Microsoft Outlook" and
-          process.parent.code_signature.trusted == true and
-          process.parent.code_signature.subject_name : (
-            "Developer ID Application: Microsoft Corporation (UBF8T346G9)",
-            "Apple Mac OS Application Signing"
-          ) and process.code_signature.trusted == true
     )
 '''
 note = """## Triage and analysis

--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -127,7 +127,7 @@ process where event.action == "exec" and host.os.type == "macos" and
     not (
         process.name : ("sh", "bash") and
         process.command_line : "*com.microsoft.Outlook/Data/tmp/Outlook*Temp*" and
-          process.parent.name : "Microsoft Outlook"
+         process.parent.executable :in ("/Applications/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook",  "/Applications/Microsoft Outlook 2.app/Contents/MacOS/Microsoft Outlook", "/Applications/Microsoft/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook"
     )
 '''
 note = """## Triage and analysis

--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/07"
 
 [rule]
 author = ["Elastic"]
@@ -123,7 +123,17 @@ process where event.action == "exec" and host.os.type == "macos" and
         "/Library/Elastic/Agent/*",
         "/opt/jc/bin/jumpcloud-agent",
         "/usr/sbin/networksetup"
-      )
+      ) and
+    not (
+        process.name : ("sh", "bash") and
+        process.command_line : "*com.microsoft.Outlook/Data/tmp/Outlook*Temp*" and
+          process.parent.name : "Microsoft Outlook" and
+          process.parent.code_signature.trusted == true and
+          process.parent.code_signature.subject_name : (
+            "Developer ID Application: Microsoft Corporation (UBF8T346G9)",
+            "Apple Mac OS Application Signing"
+          ) and process.code_signature.trusted == true
+    )
 '''
 note = """## Triage and analysis
 

--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -127,7 +127,7 @@ process where event.action == "exec" and host.os.type == "macos" and
     not (
         process.name : ("sh", "bash") and
         process.command_line : "*com.microsoft.Outlook/Data/tmp/Outlook*Temp*" and
-          process.parent.name : "Microsoft Outlook" and
+          process.parent.name : "Microsoft Outlook"
     )
 '''
 note = """## Triage and analysis

--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -125,9 +125,9 @@ process where event.action == "exec" and host.os.type == "macos" and
         "/usr/sbin/networksetup"
       ) and
     not (
-        process.name : ("sh", "bash") and
-        process.command_line : "*com.microsoft.Outlook/Data/tmp/Outlook*Temp*" and
-         process.parent.executable :in ("/Applications/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook",  "/Applications/Microsoft Outlook 2.app/Contents/MacOS/Microsoft Outlook", "/Applications/Microsoft/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook"
+        process.name in ("sh", "bash") and
+        process.command_line like "*com.microsoft.Outlook/Data/tmp/Outlook*Temp*" and
+         process.parent.executable in ("/Applications/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook", "/Applications/Microsoft Outlook 2.app/Contents/MacOS/Microsoft Outlook", "/Applications/Microsoft/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook"
     )
 '''
 note = """## Triage and analysis

--- a/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
+++ b/rules/macos/initial_access_suspicious_mac_ms_office_child_process.toml
@@ -125,9 +125,13 @@ process where event.action == "exec" and host.os.type == "macos" and
         "/usr/sbin/networksetup"
       ) and
     not (
-        process.name in ("sh", "bash") and
-        process.command_line like "*com.microsoft.Outlook/Data/tmp/Outlook*Temp*" and
-         process.parent.executable in ("/Applications/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook", "/Applications/Microsoft Outlook 2.app/Contents/MacOS/Microsoft Outlook", "/Applications/Microsoft/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook"
+      process.name in ("sh", "bash") and
+      process.command_line like "*com.microsoft.Outlook/Data/tmp/Outlook*Temp*" and
+      process.parent.executable in (
+        "/Applications/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook",
+        "/Applications/Microsoft Outlook 2.app/Contents/MacOS/Microsoft Outlook",
+        "/Applications/Microsoft/Microsoft Outlook.app/Contents/MacOS/Microsoft Outlook"
+      )
     )
 '''
 note = """## Triage and analysis


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/5886

## Summary - What I changed

- Exclude Microsoft Outlook's benign temp cache cleanup by adding a signature anchored filter that requires the parent process to be a trusted, code signed Microsoft Outlook binary.
- We are covering both Developer ID Application: Microsoft Corporation (UBF8T346G9) (direct download/enterprise deployment) and Apple Mac OS Application Signing (Mac App Store)
- This ensuring the exclusion is tightly scoped to this specific benign operation and cannot be bypassed by an unsigned or spoofed binary at the same path.

## How To Test

- Exclusions tested on Stack

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
