### PR TITLE
[FR] May Dependency Updates

### DIFF
--- a/.github/workflows/add-guidelines.yml
+++ b/.github/workflows/add-guidelines.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set environment variable for early exit control
         id: check_label
@@ -47,7 +47,7 @@ jobs:
 
       - name: Fail if no relevant labels are found
         if: env.GUIDELINES_FILE == ''
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             core.setFailed('No appropriate GitHub label found in the PR. Failing the job.')

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
       github.event.pull_request.state == 'open' && !github.event.pull_request.draft
     steps:
       - name: 'Apply default "backport: auto" label'
-        uses: actions/github-script@10b53a9ec6c222bb4ce97aa6bd2b5f739696b536 # v4
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: |
           !contains(github.event.pull_request.labels.*.name, 'backport: auto') &&
           !contains(github.event.pull_request.labels.*.name, 'backport: skip')
@@ -34,7 +34,7 @@ jobs:
               labels: ['backport: auto']
             })
       - name: 'Remove "backport: auto" if "backport: skip" is set'
-        uses: actions/github-script@10b53a9ec6c222bb4ce97aa6bd2b5f739696b536 # v4
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: |
           contains(github.event.pull_request.labels.*.name, 'backport: auto') &&
           contains(github.event.pull_request.labels.*.name, 'backport: skip')
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.WRITE_TRADEBOT_DETECTION_RULES_TOKEN }}
           ref: main

--- a/.github/workflows/branch-status-checks.yml
+++ b/.github/workflows/branch-status-checks.yml
@@ -25,7 +25,7 @@ jobs:
         bearerToken: ${{ secrets.READ_ELASTIC_DETECTION_RULES_ORG_TOKEN }}
 
     - name: Check Backport Status
-      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
       with:
         script: |
           const workflow_status = ${{ toJSON(fromJSON(steps.get_backport_status.outputs.response).workflow_runs[0].status) }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 1
 

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if member of elastic org
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         id: membership
         with:
           github-token: ${{ secrets.READ_ELASTIC_DETECTION_RULES_ORG_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
 
 
       - name: Add label for community members
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         if: ${{ steps.membership.outputs.result == 'notMember' }}
         with:
           script: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -10,4 +10,4 @@ permissions:
   pull-requests: read
 jobs:
   build:
-    uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
+    uses: elastic/docs-actions/.github/workflows/docs-build.yml@8cbb71bfe60d6f28d51ff23f6d7983fdddc2f323 # v1

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -11,4 +11,4 @@ permissions:
   actions: read
 jobs:
   deploy:
-    uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
+    uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@8cbb71bfe60d6f28d51ff23f6d7983fdddc2f323 # v1

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -9,4 +9,4 @@ permissions:
   id-token: write
 jobs:
   cleanup:
-    uses: elastic/docs-actions/.github/workflows/docs-preview-cleanup.yml@v1
+    uses: elastic/docs-actions/.github/workflows/docs-preview-cleanup.yml@8cbb71bfe60d6f28d51ff23f6d7983fdddc2f323 # v1

--- a/.github/workflows/esql-validation.yml
+++ b/.github/workflows/esql-validation.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Setup Detection Rules
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
             fetch-depth: 0
             path: detection-rules
@@ -45,7 +45,7 @@ jobs:
           DR_CLOUD_ID: ${{ secrets.dr_cloud_id }}
           DR_API_KEY: ${{ secrets.dr_api_key }}
         if: ${{ !env.DR_CLOUD_ID && !env.DR_API_KEY && env.run_esql == 'true' }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: elastic-container
           repository: peasead/elastic-container

--- a/.github/workflows/get-target-branches.yml
+++ b/.github/workflows/get-target-branches.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       matrix: ${{ steps.get-branch-list.outputs.matrix }}
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/kibana-mitre-update.yml
+++ b/.github/workflows/kibana-mitre-update.yml
@@ -14,7 +14,7 @@ jobs:
       KIBANA_ISSUE_NUMBER: 166152  # Define the Kibana issue number as a variable
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Get MITRE Attack changed files
         id: changed-attack-files

--- a/.github/workflows/lock-versions.yml
+++ b/.github/workflows/lock-versions.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Validate the source branch
-        uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             if ('refs/heads/main' !== '${{github.event.ref}}') {
@@ -22,7 +22,7 @@ jobs:
             }
 
       - name: Checkout detection-rules
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
           DR_CLOUD_ID: ${{ secrets.dr_cloud_id }}
           DR_API_KEY: ${{ secrets.dr_api_key }}
         if: ${{ !env.DR_CLOUD_ID && !env.DR_API_KEY }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           path: elastic-container
           repository: peasead/elastic-container
@@ -135,7 +135,7 @@ jobs:
           labels: "backport: auto"
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: release-files
           path: |

--- a/.github/workflows/manual-backport.yml
+++ b/.github/workflows/manual-backport.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
 
       - name: Checkout detection-rules
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.WRITE_TRADEBOT_DETECTION_RULES_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 1
 
@@ -55,7 +55,7 @@ jobs:
         python -m detection_rules dev build-release $GENERATE_NAVIGATOR_FILES
 
     - name: Archive production artifacts for branch builds
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: |
         github.event_name == 'push'
       with:

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout detection-rules
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: detection-rules
           fetch-depth: 0
 
       - name: Checkout elastic/security-docs
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.WRITE_DOCS_DETECTION_RULES_TOKEN }}
           repository: "elastic/security-docs"

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -39,14 +39,14 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Validate the source branch
-          uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3
+          uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
           with:
             script: |
               if ('refs/heads/main' === '${{github.ref}}') {
                 core.setFailed('Forbidden branch')
               }
         - name: Checkout detection-rules
-          uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
           with:
             path: detection-rules
             fetch-depth: 0
@@ -66,7 +66,7 @@ jobs:
             git checkout $COMMIT_HASH
 
         - name: Checkout elastic/integrations
-          uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
           with:
             token: ${{ secrets.WRITE_INTEGRATIONS_DETECTION_RULES_TOKEN }}
             repository: ${{github.event.inputs.target_repo}}
@@ -117,7 +117,7 @@ jobs:
             DR_CLOUD_ID: ${{ secrets.dr_cloud_id }}
             DR_API_KEY: ${{ secrets.dr_api_key }}
           if: ${{ !env.DR_CLOUD_ID && !env.DR_API_KEY }}
-          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+          uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
           with:
             path: elastic-container
             repository: peasead/elastic-container
@@ -200,7 +200,7 @@ jobs:
               $DRAFT_ARGS
 
         - name: Archive production artifacts
-          uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+          uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
           with:
             name: release-files
             path: |

--- a/.github/workflows/version-code-and-release.yml
+++ b/.github/workflows/version-code-and-release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Ensure PR has Version Bump Label
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
           git push origin "dev-v$version"
 
       - name: Run Release Drafter
-        uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v6.1.0
+        uses: release-drafter/release-drafter@6a93d829887aa2e0748befe2e808c66c0ec6e4c7 # v6.4.0
         with:
           config-name: release-drafter.yml
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.36"
+version = "1.6.37"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -39,7 +39,7 @@ dependencies = [
   "typing-extensions>=4.12",
   "XlsxWriter~=3.2.0",
   "semver==3.0.4",
-  "PyGithub==2.8.1",
+  "PyGithub==2.9.1",
   "detection-rules-kql @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql",
   "detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana",
   "setuptools==78.1.1"
@@ -53,10 +53,10 @@ dev = [
   "nodeenv==1.9.1",
   "pre-commit==3.8.0",
   "ruff>=0.11",
-  "pyright==1.1.408",
+  "pyright==1.1.409",
 ]
 
-hunting = ["tabulate==0.9.0"]
+hunting = ["tabulate==0.10.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/elastic/detection-rules"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves #5984
Resolves #5946
Resolves #5898
Resolves #6086
Resolves #6096
Resolves #6087
Resolves #5945
Resolves #5912

## Summary - What I changed

Grouped dependency updates from the following.

### Python Deps

  - #5984  pyright 1.1.408 → 1.1.409 (dev extra). Patch release on a dev-only type checker; no code impact.                                         
  - #5946  tabulate 0.9.0 → 0.10.0 (hunting extra). Only consumed by hunting/__main__.py via the stable tabulate(data, headers=…, tablefmt="fancy_grid") API; verified python -m hunting hunt-summary renders correctly.                                                             
  - #5898 PyGithub 2.8.1 → 2.9.1 (runtime). Drops Python 3.8 (we already require ≥3.12). Deprecated APIs (Reaction.delete, Organization.edit_hook, Team.add_to_members/remove_from_members, Issue.assignee) are not used in the repo. Only standard get_repo / get_pull / create_pull / get_pulls / get_releases calls are used  

### GitHub Actions

  GitHub Actions (workflow SHA pins)                                                                                                  
                                                                                                                                        
  - #6086  release-drafter/release-drafter v6.1.0 → v6.4.0 (b1476f6e → 6a93d829). Adds excluded-paths and include-pre-releases inputs;
  we use neither, so behavior is unchanged. Affects version-code-and-release.yml.                                                       
  - #6096  actions/upload-artifact v4 → v7 (ea165f8d → 043fb46d). Major bump but our usage is minimal — name + path only. The v5/v6/v7 changelogs do not break that surface. Affects lock-versions.yml, pythonpackage.yml, release-fleet.yml.                       
  - #6087  actions/github-script v3/v4/v6/v7 → v9 (ffc2c79a/10b53a9e/d7906e4a/f28e40c7 → 3a2844b7). Consolidates four pinned majors onto v9. Scripts in this repo only call core.setFailed, github.issues.addLabels github.issues.removeLabel, github.rest.issues.addLabels, and github.rest.orgs.getMembershipForUser, all of which are stable across these majors. Affects add-guidelines.yml, backport.yml, branch-status-checks.yml, community.yml, lock-versions.yml, release-fleet.yml, version-code-and-release.yml.
  - #5945  elastic/docs-actions reusable workflows pinned to commit 8cbb71bfe60d6f28d51ff23f6d7983fdddc2f323 (still tagged v1). Replaces the floating @v1 ref with an immutable digest pin per repo policy. Affects docs-build.yml, docs-deploy.yml, docs-preview-cleanup.yml.
  - #5912  actions/checkout digest refresh (still tagged v4 / v5). v4 08eba0b2 → 34e11487, v5 08c6903c → 93cb6efe. No tag/major change, just rotates the pinned commit to current. Affects 12 workflow files.   

## How To Test

Unit tests should be sufficient. 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
