### PR TITLE
[New/Tuning] Potential Privilege Escalation via unshare Followed by Root

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -1,6 +1,8 @@
 {
   "auditbeat-*": {
     "auditd.data.addr": "keyword",
+    "auditd.data.a0": "keyword",
+    "auditd.data.class": "keyword",
     "auditd.data.grantors": "keyword",
     "auditd.data.syscall": "keyword",
     "auditd.data.terminal": "keyword",

--- a/rules/linux/privilege_escalation_overlayfs_local_privesc.toml
+++ b/rules/linux/privilege_escalation_overlayfs_local_privesc.toml
@@ -2,20 +2,20 @@
 creation_date = "2023/07/28"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/08"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies an attempt to exploit a local privilege escalation (CVE-2023-2640 and CVE-2023-32629) via a flaw in Ubuntu's
-modifications to OverlayFS. These flaws allow the creation of specialized executables, which, upon execution, grant the
-ability to escalate privileges to root on the affected machine.
+Identifies potentially suspicious use of unshare to create a user namespace context followed by a UID change event
+indicating a transition to root. Adversaries may use unshare-based primitives as part of local privilege escalation
+chains. This rule is intentionally generic and can surface multiple local privesc patterns beyond a single CVE.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.process*"]
 language = "eql"
 license = "Elastic License v2"
-name = "Potential Privilege Escalation via OverlayFS"
+name = "Potential Privilege Escalation via unshare and UID Change"
 references = [
     "https://www.wiz.io/blog/ubuntu-overlayfs-vulnerability",
     "https://twitter.com/liadeliyahu/status/1684841527959273472",
@@ -60,9 +60,9 @@ tags = [
 type = "eql"
 
 query = '''
-sequence by process.parent.entity_id, host.id with maxspan=5s
+sequence by process.parent.entity_id, host.id with maxspan=60s
   [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-    process.name == "unshare" and process.args : ("-r", "-rm", "m") and process.args : "*cap_setuid*"  and user.id != "0"]
+    process.name == "unshare" and process.args : ("-r", "-rm", "m", "-U", "--user") and user.id != "0"]
   [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
     user.id == "0"]
 '''
@@ -71,36 +71,32 @@ note = """## Triage and analysis
 > **Disclaimer**:
 > This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
 
-### Investigating Potential Privilege Escalation via OverlayFS
+### Investigating Potential Privilege Escalation via unshare and UID Change
 
-OverlayFS is a union filesystem used in Linux environments to overlay one filesystem on top of another, allowing for efficient file management and updates. Adversaries exploit vulnerabilities in Ubuntu's OverlayFS modifications to execute crafted executables that escalate privileges to root. The detection rule identifies suspicious sequences involving the 'unshare' command with specific arguments and subsequent UID changes to root, indicating potential exploitation attempts.
+The unshare utility can create new namespaces, including user namespaces. In some exploit chains, an attacker uses
+unshare (often with user namespace flags) as a precursor step and then achieves a transition to root. This rule detects
+a short sequence where a non-root user executes unshare with user-namespace related arguments and a subsequent uid_change
+event indicates the user became root, which can represent a successful local privilege escalation attempt.
 
 ### Possible investigation steps
 
-- Review the alert details to confirm the presence of the 'unshare' command with the specific arguments '-r', '-rm', 'm', and '*cap_setuid*' as indicated in the query. This will help verify if the command execution aligns with the known exploitation pattern.
-- Check the process tree and parent process information using the process.parent.entity_id to understand the context in which the 'unshare' command was executed. This can provide insights into whether the command was part of a legitimate operation or a potential attack.
-- Investigate the user account associated with the process execution (user.id != "0") to determine if the account has a history of suspicious activity or if it has been compromised.
-- Examine the host.id and host.os.type fields to identify the specific Linux host involved and assess its vulnerability status regarding CVE-2023-2640 and CVE-2023-32629. This can help determine if the host is susceptible to the exploitation attempt.
-- Analyze any subsequent UID changes to root (user.id == "0") to confirm if the privilege escalation was successful and identify any unauthorized access or actions taken by the elevated process.
-- Review system logs and other security alerts around the time of the event to identify any additional indicators of compromise or related suspicious activities that might corroborate the exploitation attempt.
+- Review unshare arguments in the first event to confirm user namespace related flags were used (for example -U/--user or -r).
+- Check the process tree and parent context (process.parent.entity_id) to understand what launched unshare and whether it originated from an interactive session or user-writable path.
+- Confirm whether the uid_change corresponds to the same activity and identify the first root process spawned after the uid_change event.
+- Review other host signals around the same time for exploit activity such as compilation in /tmp, suspicious downloads, or execution of unusual binaries.
 
 ### False positive analysis
 
-- Legitimate administrative tasks using the 'unshare' command with similar arguments may trigger the rule. Review the context of the command execution and verify if it aligns with routine system maintenance or configuration changes.
-- Automated scripts or system management tools that utilize 'unshare' for containerization or namespace isolation might cause false positives. Identify these scripts and consider excluding their specific process names or paths from the rule.
-- Development environments where developers frequently test applications with elevated privileges could inadvertently match the rule criteria. Implement user-based exceptions for known developer accounts to reduce noise.
-- Security tools or monitoring solutions that simulate privilege escalation scenarios for testing purposes may be flagged. Whitelist these tools by their process hash or signature to prevent unnecessary alerts.
-- Custom applications that require temporary privilege elevation for legitimate operations should be reviewed. If deemed safe, add these applications to an exception list based on their unique identifiers.
+- Legitimate sandboxing or container tooling may use unshare and then legitimately trigger uid_change events; validate the parent process and user context.
+- Security testing, exploit validation, or developer environments may intentionally exercise namespace-related behavior; tune by users, hosts, or maintenance windows.
 
 ### Response and remediation
 
-- Immediately isolate the affected host from the network to prevent further exploitation or lateral movement by the adversary.
-- Terminate any suspicious processes identified by the detection rule, particularly those involving the 'unshare' command with the specified arguments.
-- Conduct a thorough review of user accounts and privileges on the affected system to ensure no unauthorized changes have been made, especially focusing on accounts with root access.
-- Apply the latest security patches and updates to the affected system, specifically addressing CVE-2023-2640 and CVE-2023-32629, to mitigate the vulnerability in OverlayFS.
-- Monitor for any further attempts to exploit the vulnerability by setting up alerts for similar sequences of commands and UID changes.
-- Escalate the incident to the security operations team for a detailed forensic analysis to understand the scope and impact of the exploitation attempt.
-- Implement additional security measures, such as enhanced logging and monitoring, to detect and respond to privilege escalation attempts more effectively in the future."""
+- Immediately isolate the affected host to prevent further privilege abuse or lateral movement.
+- Terminate suspicious processes and collect forensic data (process tree, binaries, and relevant files in temp locations).
+- Patch and harden the host; review policies that allow unprivileged user namespaces if not required in your environment.
+- Escalate for incident response when root access is confirmed and scope for follow-on persistence.
+"""
 
 
 [[rule.threat]]

--- a/rules/linux/privilege_escalation_unshare_to_root_process_auditd_sequence.toml
+++ b/rules/linux/privilege_escalation_unshare_to_root_process_auditd_sequence.toml
@@ -93,9 +93,9 @@ sequence by host.id, process.parent.pid with maxspan=30s
   (
    (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
    (process.name == "unshare" and process.args in ("-U", "--user", "-r"))
-   ) and user.name != "root"]
+   ) and user.id != "0" and user.id != null]
  [process where host.os.type == "linux" and 
-  user.name == "root" and 
+  user.id == "0" and user.id != null and 
   process.name in ("su", "sudo", "pkexec", "passwd", "chsh", "newgrp", "sudo", "dash", "sh", "bash", "zsh", "fish")]
 '''
 

--- a/rules/linux/privilege_escalation_unshare_to_root_process_auditd_sequence.toml
+++ b/rules/linux/privilege_escalation_unshare_to_root_process_auditd_sequence.toml
@@ -1,0 +1,114 @@
+[metadata]
+creation_date = "2026/05/08"
+integration = ["auditd_manager"]
+maturity = "production"
+updated_date = "2026/05/08"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects a short sequence where a non-root user performs unshare-related namespace activity (often associated with user
+namespace privilege escalation primitives) and then a root process is executed shortly after. This can indicate a
+successful local privilege escalation attempt or suspicious namespace manipulation captured in Auditd Manager telemetry.
+"""
+false_positives = [
+    """
+    Legitimate sandboxing, container tooling, or maintenance scripts may use unshare and spawn privileged helpers under
+    controlled workflows. Baseline approved tools and tune by host role, parent process, or user accounts.
+    """,
+]
+from = "now-9m"
+index = ["auditbeat-*", "logs-auditd_manager.auditd-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Privilege Escalation via unshare Followed by Root Process"
+note = """## Triage and analysis
+
+### Investigating Potential Privilege Escalation via unshare Followed by Root Process
+
+Validate that the initiating user and parent process should be using unshare. Then confirm whether the subsequent root
+process aligns with an approved administrative workflow or represents an unexpected transition to root.
+
+### Possible investigation steps
+
+- Review auditd.data.* (syscall, class, and a0) and process args to understand the unshare intent.
+- Identify the first root process spawned and its command line, then look for follow-on persistence or credential access.
+- Correlate with recent downloads/compilation in temp directories and other local privesc indicators on the host.
+
+### Response and remediation
+
+- If unauthorized, isolate the host, capture forensic artifacts, and patch/harden user namespace settings as appropriate.
+"""
+references = [
+    "https://docs.elastic.co/integrations/auditd_manager",
+    "https://attack.mitre.org/techniques/T1068/",
+]
+risk_score = 73
+rule_id = "0dd84246-a723-49ba-9f4e-a1e1dfa15990"
+setup = """## Setup
+
+This rule relies on Auditd Manager (or Auditbeat) process telemetry that captures:
+
+- Process execution events (execve/execveat) to populate process.name, process.args, and process.parent.pid
+- Namespace-related activity to populate auditd.data.syscall, auditd.data.class, and auditd.data.a0 for unshare calls
+- Privilege transitions so processes started as root can be correlated after the namespace action
+
+Ensure your auditd ruleset includes coverage for unshare and exec-related syscalls and that arguments are collected. If
+your environment does not populate auditd.data.class/a0 for unshare, keep the process-based fallback branch (process.name
+== unshare with -U/--user/-r args) enabled and consider extending auditing to enrich those auditd.data fields.
+
+### Example auditd rules
+
+The following example syscall rules are commonly used to capture the signals required by this detection. Adjust keys and
+scope to your environment (these examples are intentionally broad).
+
+- Capture unshare (namespace activity):
+  -a always,exit -F arch=b64 -S unshare -k namespace
+  -a always,exit -F arch=b32 -S unshare -k namespace
+
+- Capture process execution (argv collection depends on your auditd/auditbeat pipeline configuration):
+  -a always,exit -F arch=b64 -S execve -S execveat -k exec
+  -a always,exit -F arch=b32 -S execve -S execveat -k exec
+
+- Capture UID transition syscalls often associated with privilege changes:
+  -a always,exit -F arch=b64 -S setuid -S setreuid -S setresuid -S setfsuid -k uid_change
+  -a always,exit -F arch=b32 -S setuid -S setreuid -S setresuid -S setfsuid -k uid_change
+
+See https://docs.elastic.co/integrations/auditd_manager
+"""
+severity = "high"
+tags = [
+    "Data Source: Auditd Manager",
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Privilege Escalation",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+sequence by host.id, process.parent.pid with maxspan=30s
+ [process where host.os.type == "linux" and 
+  (
+   (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
+   (process.name == "unshare" and process.args in ("-U", "--user", "-r"))
+   ) and user.name != "root"]
+ [process where host.os.type == "linux" and 
+  user.name == "root" and 
+  process.name in ("su", "sudo", "pkexec", "passwd", "chsh", "newgrp", "sudo", "dash", "sh", "bash", "zsh", "fish")]
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1068"
+name = "Exploitation for Privilege Escalation"
+reference = "https://attack.mitre.org/techniques/T1068/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+

--- a/rules/linux/privilege_escalation_unshare_to_root_process_auditd_sequence.toml
+++ b/rules/linux/privilege_escalation_unshare_to_root_process_auditd_sequence.toml
@@ -92,7 +92,8 @@ sequence by host.id, process.parent.pid with maxspan=30s
  [process where host.os.type == "linux" and 
   (
    (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
-   (process.name == "unshare" and process.args in ("-U", "--user", "-r"))
+   (process.name == "unshare" and  
+    (process.args in ("--user", "--map-root-user", "--map-current-user") or process.args like ("-*U*", "-*r*")))
    ) and user.id != "0" and user.id != null]
  [process where host.os.type == "linux" and 
   user.id == "0" and user.id != null and 

--- a/rules/linux/privilege_escalation_unshare_to_root_process_auditd_sequence.toml
+++ b/rules/linux/privilege_escalation_unshare_to_root_process_auditd_sequence.toml
@@ -92,7 +92,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
  [process where host.os.type == "linux" and 
   (
    (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
-   (process.name == "unshare" and process.args in ("-U", "--user", "-r"))
+   (process.name == "unshare" and process.args in ("-r", "-rm", "-m", "-U", "--user"))
    ) and user.id != "0" and user.id != null]
  [process where host.os.type == "linux" and 
   user.id == "0" and user.id != null and 


### PR DESCRIPTION
Detects a short sequence where a non-root user performs unshare-related namespace activity (often associated with user namespace privilege escalation primitives) and then a root process is executed shortly after. This can indicate a successful local privilege escalation attempt or suspicious namespace manipulation.

<img width="767" height="504" alt="image" src="https://github.com/user-attachments/assets/3c0490de-236d-4f8b-b97f-5fb1f61ffc10" />
