### PR TITLE
[Rule Tuning] DNS Request for IP Lookup Service via Unsigned Binary

### DIFF
--- a/rules/macos/discovery_dns_request_for_ip_lookup_service.toml
+++ b/rules/macos/discovery_dns_request_for_ip_lookup_service.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/01/30"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/02/09"
+updated_date = "2026/05/08"
 
 [rule]
 author = ["Elastic"]
@@ -61,7 +61,7 @@ tags = [
 timestamp_override = "event.ingested"
 type = "eql"
 query = '''
-dns where host.os.type == "macos" and event.action == "lookup_result" and 
+network where host.os.type == "macos" and event.action == "lookup_result" and 
   (process.code_signature.trusted == false or process.code_signature.exists == false) and
   dns.question.name like~ ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
                            "*api.npoint.io*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",


### PR DESCRIPTION
## Summary

https://github.com/elastic/detection-rules/pull/5658 introduced several versions of rules converted from endpoint. This rule was not adjusted to use the network category as the SIEM doesn't have a `dns` event category, that's Endpoint only.