### PR TITLE
[Bug] Pyright Updated Linting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,7 +27,7 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'backport: skip')
         with:
           script: |
-            github.issues.addLabels({
+            github.rest.issues.addLabels({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -40,7 +40,7 @@ jobs:
           contains(github.event.pull_request.labels.*.name, 'backport: skip')
         with:
           script: |
-            github.issues.removeLabel({
+            github.rest.issues.removeLabel({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/detection_rules/action_connector.py
+++ b/detection_rules/action_connector.py
@@ -163,17 +163,17 @@ def build_action_connector_objects(  # noqa: PLR0913
                 raise FileNotFoundError(  # noqa: TRY301
                     "No Action Connector directory is specified. Please specify either in the config or CLI."
                 )
-            actions_path = (
+            actions_path: Path = (  # pyright: ignore[reportUnknownVariableType]
                 Path(action_connectors_directory) / filename
                 if action_connectors_directory
-                else RULES_CONFIG.action_connector_dir / filename
+                else RULES_CONFIG.action_connector_dir / filename  # pyright: ignore[reportOptionalOperand]
             )
             if verbose:
                 output.append(f"[+] Building action connector(s) for {actions_path}")
 
             ac_object = TOMLActionConnector(
                 contents=contents,
-                path=actions_path,
+                path=actions_path,  # pyright: ignore[reportUnknownArgumentType]
             )
             if save_toml:
                 ac_object.save_toml()

--- a/detection_rules/exception.py
+++ b/detection_rules/exception.py
@@ -332,14 +332,16 @@ def build_exception_objects(  # noqa: PLR0913
                 raise FileNotFoundError(  # noqa: TRY301
                     "No Exceptions directory is specified. Please specify either in the config or CLI."
                 )
-            exceptions_path = (
-                Path(exceptions_directory) / filename if exceptions_directory else RULES_CONFIG.exception_dir / filename
+            exceptions_path: Path = (  # pyright: ignore[reportUnknownVariableType]
+                Path(exceptions_directory) / filename
+                if exceptions_directory
+                else RULES_CONFIG.exception_dir / filename  # pyright: ignore[reportOptionalOperand]
             )
             if verbose:
                 output.append(f"[+] Building exception(s) for {exceptions_path}")
             e_object = TOMLException(
                 contents=contents,
-                path=exceptions_path,
+                path=exceptions_path,  # pyright: ignore[reportUnknownArgumentType]
             )
             if save_toml:
                 e_object.save_toml()

--- a/detection_rules/exception.py
+++ b/detection_rules/exception.py
@@ -333,9 +333,7 @@ def build_exception_objects(  # noqa: PLR0913
                     "No Exceptions directory is specified. Please specify either in the config or CLI."
                 )
             exceptions_path: Path = (  # pyright: ignore[reportUnknownVariableType]
-                Path(exceptions_directory) / filename
-                if exceptions_directory
-                else RULES_CONFIG.exception_dir / filename  # pyright: ignore[reportOptionalOperand]
+                Path(exceptions_directory) / filename if exceptions_directory else RULES_CONFIG.exception_dir / filename  # pyright: ignore[reportOptionalOperand]
             )
             if verbose:
                 output.append(f"[+] Building exception(s) for {exceptions_path}")

--- a/detection_rules/utils.py
+++ b/detection_rules/utils.py
@@ -17,7 +17,7 @@ import re
 import shutil
 import subprocess
 import zipfile
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Generator
 from dataclasses import astuple, is_dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -195,7 +195,7 @@ def read_gzip(path: str | Path) -> str:
 
 
 @contextlib.contextmanager
-def unzip(contents: bytes) -> Iterator[zipfile.ZipFile]:
+def unzip(contents: bytes) -> Generator[zipfile.ZipFile]:
     """Get zipped contents."""
     zipped = io.BytesIO(contents)
     archive = zipfile.ZipFile(zipped, mode="r")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.37"
+version = "1.6.38"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to https://github.com/elastic/detection-rules/pull/6103

## Summary - What I changed

Small PR to fix the failing linting on main due to updating Pyright. 

Newer pyright versions flag `@contextlib.contextmanager` functions whose return type is annotated as `Iterator[T]`. The Python typing community now recommends `Generator[T]` for context managers because it more accurately models the protocol (`yield` + `send`/`return` semantics), and pyright emits a `reportDeprecated` warning to nudge migration.

Actions and Exception config paths are typed as `Path | None`. Stricter inference in the new version no longer collapses the union to `Path` for type hinting.

Also updates the add label workflows to the new version.

<img width="1696" height="629" alt="Screenshot from 2026-05-08 15-57-02" src="https://github.com/user-attachments/assets/420afc2d-a74e-4efb-b53f-cf0a4a424f1a" />


## How To Test

Re-install dependencies, run `pyright`.

It is unclear why this was not caught in https://github.com/elastic/detection-rules/pull/6103, perhaps a cached version of pyright in the runner. In either case, we should not rely on unit tests for this linting update. 

<img width="1180" height="75" alt="image" src="https://github.com/user-attachments/assets/a8e62738-d17d-4522-8050-9f371ea1ccea" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
