### PR TITLE
[New] 15 AWS CloudTrail detection rules covering IAM, EC2, and org-level security gaps

### DIFF
--- a/rules/integrations/aws/credential_access_console_login_brute_force_by_ip.toml
+++ b/rules/integrations/aws/credential_access_console_login_brute_force_by_ip.toml
@@ -1,0 +1,107 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Identifies a high number of failed AWS Management Console authentication attempts from a single source IP
+address. This pattern may indicate a brute force or credential stuffing attack targeting IAM user accounts.
+Unlike root brute-force attempts, this rule targets all non-root console login failures and groups them by
+source IP, making it effective for detecting distributed password spraying from a single origin or
+automated credential testing tools.
+"""
+false_positives = [
+    """
+    Automated processes attempting to authenticate with expired credentials may generate multiple failures.
+    Users who have forgotten their passwords may also trigger this rule. Validate whether the source IP is
+    a known corporate network or VPN exit point before escalating.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Management Console Brute Force by Source IP"
+note = """## Triage and analysis
+
+### Investigating AWS Management Console Brute Force by Source IP
+
+This rule detects a spike in failed console login attempts from a single source IP. Brute force and
+credential stuffing attacks often originate from a single host or small range before the attacker
+rotates IPs. A high volume of failures from one IP targeting multiple usernames is a classic password
+spray pattern.
+
+#### Possible investigation steps
+
+- Review `source.ip` and `source.geo` to assess whether the source is known or suspicious.
+- Check `user.name` across the failed attempts — multiple distinct usernames indicate password spraying.
+- Look for any successful `ConsoleLogin` from the same IP around the same time.
+- Review subsequent API activity from any accounts that had successful logins.
+
+### Response and remediation
+
+- Block the offending IP at the AWS WAF or network level.
+- Reset passwords for any accounts that successfully authenticated from this IP.
+- Enable MFA for all IAM users to mitigate the impact of credential compromise.
+"""
+references = [
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html",
+]
+risk_score = 47
+rule_id = "2e3f68e1-5f05-4a50-abca-60991d7ea753"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS Sign-In",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Credential Access",
+]
+timestamp_override = "event.ingested"
+type = "threshold"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:signin.amazonaws.com and
+event.action:ConsoleLogin and
+event.outcome:failure and
+not aws.cloudtrail.user_identity.type:Root
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "source.ip",
+    "source.geo.country_name",
+    "user.name",
+    "aws.cloudtrail.user_identity.arn",
+    "event.outcome",
+    "cloud.account.id",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.003"
+name = "Password Spraying"
+reference = "https://attack.mitre.org/techniques/T1110/003/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.threshold]
+field = ["source.ip"]
+value = 10

--- a/rules/integrations/aws/credential_access_console_login_brute_force_by_ip.toml
+++ b/rules/integrations/aws/credential_access_console_login_brute_force_by_ip.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/credential_access_console_login_brute_force_by_user.toml
+++ b/rules/integrations/aws/credential_access_console_login_brute_force_by_user.toml
@@ -1,0 +1,107 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Identifies repeated failed AWS Management Console login attempts targeting a single IAM user identity.
+A high number of failures against one username may indicate a targeted brute force attack against a
+specific account, particularly a privileged user such as an IAM administrator or account owner. This
+rule complements the source-IP based brute force rule by detecting attacks distributed across multiple
+source IPs that converge on a single target account.
+"""
+false_positives = [
+    """
+    A user who has forgotten their password may generate multiple failed attempts before contacting
+    help desk. Automated scripts configured with outdated credentials may also trigger this rule.
+    Validate whether the target account is high-value and whether failures come from multiple source
+    IPs, which would indicate a coordinated attack rather than a lockout scenario.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Management Console Brute Force Targeting Single User"
+note = """## Triage and analysis
+
+### Investigating AWS Management Console Brute Force Targeting Single User
+
+Targeted brute force against a specific IAM user — especially a privileged one — is a high-risk event.
+Attackers with knowledge of the target's username (obtained via OSINT, phishing, or previous recon) may
+attempt password guessing from multiple IPs to avoid rate limiting.
+
+#### Possible investigation steps
+
+- Identify the target username from `user.name` and assess their privilege level.
+- Check whether failures originate from multiple source IPs — a strong indicator of distributed attack.
+- Look for successful `ConsoleLogin` from any IP around the same time.
+- Verify whether the user has MFA enabled.
+
+### Response and remediation
+
+- Temporarily disable the target user's console access and force a password reset via secure channel.
+- Enable MFA for the account if not already configured.
+- Review CloudTrail for any successful API calls made under this identity.
+"""
+references = [
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_account-policy.html",
+]
+risk_score = 47
+rule_id = "f39e16f9-b9a4-48d5-a622-388765b05c07"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS Sign-In",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Credential Access",
+]
+timestamp_override = "event.ingested"
+type = "threshold"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:signin.amazonaws.com and
+event.action:ConsoleLogin and
+event.outcome:failure and
+not aws.cloudtrail.user_identity.type:Root
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "source.ip",
+    "source.geo.country_name",
+    "user.name",
+    "aws.cloudtrail.user_identity.arn",
+    "event.outcome",
+    "cloud.account.id",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.001"
+name = "Password Guessing"
+reference = "https://attack.mitre.org/techniques/T1110/001/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.threshold]
+field = ["user.name"]
+value = 10

--- a/rules/integrations/aws/credential_access_console_login_brute_force_by_user.toml
+++ b/rules/integrations/aws/credential_access_console_login_brute_force_by_user.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/defense_evasion_ec2_imdsv1_enabled.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_imdsv1_enabled.toml
@@ -1,0 +1,176 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects modification of EC2 instance metadata service (IMDS) options to enable IMDSv1, the legacy version
+of the metadata endpoint. IMDSv2 introduced session-oriented requests that require a PUT-based token, providing
+protection against server-side request forgery (SSRF) attacks that attempt to steal instance credentials. When
+an instance is configured to allow IMDSv1 (by setting httpTokens to "optional"), attackers who exploit SSRF
+vulnerabilities in applications running on that instance can issue simple HTTP GET requests to the metadata endpoint
+to retrieve IAM role credentials without requiring the session token that IMDSv2 mandates.
+"""
+false_positives = [
+    """
+    Legacy applications, older AMIs, or third-party software that has not been updated to support IMDSv2 may require
+    IMDSv1 to function correctly. Infrastructure-as-code automation may also set httpTokens to "optional" during
+    instance configuration if the application compatibility requirements have not been assessed. Validate whether the
+    instance and application have a documented need for IMDSv1, and if so, track such exceptions with a compensating
+    control. Any unexpected or undocumented change to IMDSv1 should be investigated.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS EC2 IMDSv1 Enabled on Instance"
+note = """## Triage and analysis
+
+### Investigating AWS EC2 IMDSv1 Enabled on Instance
+
+The EC2 Instance Metadata Service (IMDS) provides running instances with access to instance-specific data, including
+IAM role temporary credentials. IMDSv2 (launched in 2019) requires session-oriented requests using a token obtained
+via a PUT request, which prevents unauthenticated SSRF-based credential theft. Enabling IMDSv1 by setting
+`httpTokens` to `optional` removes this protection and allows simple GET requests to reach the metadata endpoint.
+
+This rule detects successful `ModifyInstanceMetadataOptions` API calls that set `httpTokens` to `optional`,
+effectively re-enabling IMDSv1 on the instance.
+
+#### Possible investigation steps
+
+- **Identify the actor**
+  - Review `aws.cloudtrail.user_identity.arn` to determine who made the change.
+  - Verify whether this principal typically manages EC2 instance configurations.
+  - Check `user_agent.original` to determine if this was a console action, CLI, or SDK call.
+
+- **Identify the target instance**
+  - Review `aws.cloudtrail.request_parameters` to identify the EC2 instance ID (`instanceId`).
+  - Determine the instance's purpose, the IAM role attached to it, and the applications running on it.
+  - Assess the sensitivity of the IAM role credentials accessible via the metadata endpoint.
+
+- **Validate the change**
+  - Confirm with the instance owner or platform team whether this change was authorized.
+  - Check for related change tickets, Terraform plans, or configuration management updates.
+  - Review whether the change aligns with a known application compatibility requirement.
+
+- **Check for SSRF exposure**
+  - Determine whether the instance hosts a web application or API that processes user-supplied URLs.
+  - If yes, assess whether the application is patched against SSRF and whether WAF rules are in place.
+
+- **Correlate with subsequent metadata access**
+  - Look for unusual `GetSessionToken` or `AssumeRole` calls made shortly after the change using the instance role.
+  - Review VPC Flow Logs for outbound connections from the instance to unusual destinations following the change.
+
+### False positive analysis
+
+- **Legacy application requirements**
+  - Some older applications do not support IMDSv2. If this is documented and accepted, the instance should be
+    tracked in an IMDSv1 exception register with compensating controls.
+- **IaC automation**
+  - Automated deployments may set `httpTokens: optional` when IMDSv2 compatibility has not been assessed. Align
+    with infrastructure teams to enforce `required` as the default in all Terraform/CloudFormation templates.
+
+### Response and remediation
+
+- **Immediate containment**
+  - Re-enable IMDSv2 enforcement by calling `ModifyInstanceMetadataOptions` with `HttpTokens=required`.
+  - If the change was unauthorized, review recent API activity from the instance's IAM role for signs of credential abuse.
+
+- **Hardening**
+  - Use AWS Config rule `ec2-imdsv2-check` to detect and alert on all instances not enforcing IMDSv2.
+  - Apply an SCP that denies `ec2:ModifyInstanceMetadataOptions` with `httpTokens=optional` across all accounts.
+  - Use launch templates and AMI policies to enforce `HttpTokens=required` on all new instances at launch.
+
+- **Investigation**
+  - If SSRF exploitation is suspected, capture instance memory or review application logs for requests to `169.254.169.254`.
+  - Rotate the IAM role's trust policy or create a new role to revoke any potentially exfiltrated credentials.
+
+### Additional information
+
+- **[AWS IMDSv2 Announcement](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/)**
+- **[ModifyInstanceMetadataOptions API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceMetadataOptions.html)**
+- **[AWS Config IMDSv2 Check](https://docs.aws.amazon.com/config/latest/developerguide/ec2-imdsv2-check.html)**
+"""
+references = [
+    "https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/",
+    "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyInstanceMetadataOptions.html",
+    "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html",
+]
+risk_score = 47
+rule_id = "5855c0a0-0e20-4dad-ac28-5c0d704caa0b"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Data Source: AWS EC2",
+    "Use Case: Configuration Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Tactic: Credential Access",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:ec2.amazonaws.com and
+event.action:ModifyInstanceMetadataOptions and
+event.outcome:success and
+aws.cloudtrail.request_parameters:*optional*
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.request_parameters",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.005"
+name = "Cloud Instance Metadata API"
+reference = "https://attack.mitre.org/techniques/T1552/005/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/integrations/aws/defense_evasion_ec2_imdsv1_enabled.toml
+++ b/rules/integrations/aws/defense_evasion_ec2_imdsv1_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/defense_evasion_iam_saml_provider_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_iam_saml_provider_deleted.toml
@@ -1,0 +1,113 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects the deletion of an IAM SAML identity provider. SAML providers enable federated SSO access
+to AWS using external identity providers such as Okta, Azure AD, or Active Directory. Deleting a SAML
+provider can be used by an adversary as a destructive or disruptive action that breaks SSO access for
+all users relying on that federation path, forcing manual IAM user creation and weakening MFA enforcement.
+It can also be used to remove forensic artifacts of a rogue SAML provider that was previously created
+for persistent access, effectively covering tracks after a Golden SAML attack.
+"""
+false_positives = [
+    """
+    SAML providers may be legitimately deleted during SSO migrations, IdP replacements, or account
+    decommissioning. Validate whether this aligns with a documented change management request. Deletion
+    outside of approved windows or by unexpected identities should be treated as suspicious.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS IAM SAML Provider Deleted"
+note = """## Triage and analysis
+
+### Investigating AWS IAM SAML Provider Deleted
+
+Deletion of a SAML provider is a rare and high-impact action. It can indicate an attacker covering their
+tracks after a Golden SAML attack (where a rogue provider was previously created for persistent access),
+or a destructive action to disrupt SSO access across the organization.
+
+#### Possible investigation steps
+
+- Review `aws.cloudtrail.user_identity.arn` to identify who deleted the provider.
+- Check `aws.cloudtrail.request_parameters` for the SAML provider ARN that was deleted.
+- Correlate with preceding `CreateSAMLProvider` events to determine if a rogue provider was created and then removed.
+- Assess impact: which IAM roles had trust policies referencing this provider?
+
+### Response and remediation
+
+- If the deletion was unauthorized, recreate the SAML provider with the correct metadata document.
+- Review IAM roles with SAML trust relationships for unauthorized modifications.
+- Check for `AssumeRoleWithSAML` calls using the now-deleted provider prior to deletion.
+"""
+references = [
+    "https://docs.aws.amazon.com/IAM/latest/APIReference/API_DeleteSAMLProvider.html",
+    "https://www.cyberark.com/resources/threat-research-blog/golden-saml-newly-discovered-attack-technique-forges-authentication-to-cloud-services",
+]
+risk_score = 47
+rule_id = "35c38de2-85cf-47a0-a502-d4a2de2fb9df"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Data Source: AWS IAM",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Tactic: Impact",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:iam.amazonaws.com and
+event.action:DeleteSAMLProvider and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.request_parameters",
+    "event.action",
+    "cloud.account.id",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1556"
+name = "Modify Authentication Process"
+reference = "https://attack.mitre.org/techniques/T1556/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1531"
+name = "Account Access Removal"
+reference = "https://attack.mitre.org/techniques/T1531/"
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"

--- a/rules/integrations/aws/defense_evasion_iam_saml_provider_deleted.toml
+++ b/rules/integrations/aws/defense_evasion_iam_saml_provider_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/defense_evasion_macie_or_inspector_disabled.toml
+++ b/rules/integrations/aws/defense_evasion_macie_or_inspector_disabled.toml
@@ -1,0 +1,157 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects the disabling of Amazon Macie or Amazon Inspector, two AWS security services that provide
+data classification and vulnerability assessment capabilities. Amazon Macie uses machine learning to
+discover and protect sensitive data stored in S3, while Amazon Inspector assesses EC2 instances and
+container images for software vulnerabilities. Disabling these services removes visibility into data
+exposure risks and known vulnerabilities. Adversaries who have obtained administrative access may disable
+these services to prevent detection of exfiltration activities (Macie) or to delay remediation of
+vulnerabilities they plan to exploit (Inspector). These actions can also be used to degrade an
+organization's security posture before a destructive attack.
+"""
+false_positives = [
+    """
+    Amazon Macie or Amazon Inspector may be intentionally disabled in non-production accounts, during cost
+    optimization reviews, or as part of planned infrastructure decommissioning. Automated account cleanup
+    pipelines may also disable these services in accounts being retired. Validate whether the actor is an
+    authorized administrator performing a documented change. Any disabling of Macie or Inspector in production
+    or regulated environments without a corresponding change ticket should be treated as suspicious.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Macie or Inspector Security Service Disabled"
+note = """## Triage and analysis
+
+### Investigating AWS Macie or Inspector Security Service Disabled
+
+Amazon Macie and Amazon Inspector are AWS-managed security services that provide ongoing visibility into data
+exposure and software vulnerability risks. Macie continuously monitors S3 buckets for sensitive data such as
+PII, credentials, and financial information. Inspector assesses EC2 instances and container images for known
+CVEs. Disabling either service removes an important layer of detective control.
+
+This rule detects successful API calls that disable Macie (`DisableMacie`) or Inspector (`Disable` on
+`inspector2.amazonaws.com`).
+
+#### Possible investigation steps
+
+- **Identify the actor**
+  - Review `aws.cloudtrail.user_identity.arn` to determine who disabled the service.
+  - Determine whether this identity is authorized to manage AWS security services.
+  - Check `user_agent.original` to distinguish console actions from CLI or SDK calls.
+
+- **Determine the scope of impact**
+  - For Macie: identify which S3 buckets and accounts are now unmonitored for sensitive data exposure.
+  - For Inspector: identify which EC2 instances or ECR repositories are no longer being scanned.
+  - Check whether the service was disabled in a single account or across the entire organization.
+
+- **Validate authorization**
+  - Confirm with the security team whether this change was approved and documented in a change ticket.
+  - Determine whether the action aligns with a planned infrastructure decommission or cost review.
+
+- **Correlate with other suspicious activity**
+  - Look for concurrent S3 data access or export operations that Macie would have flagged.
+  - Check for any other security service disabling events around the same time: GuardDuty, Security Hub, Config.
+  - Review for any CloudTrail tampering (StopLogging, DeleteTrail) that may indicate a broader cover-up.
+
+- **Assess pre-disabling findings**
+  - Review any open Macie or Inspector findings before the service was disabled for indicators of active threats.
+
+### False positive analysis
+
+- **Non-production account management**
+  - These services may be intentionally disabled in sandbox or development accounts to reduce cost.
+- **Account retirement**
+  - Automated pipelines decommissioning accounts may disable all security services as part of cleanup.
+
+### Response and remediation
+
+- **Immediate containment**
+  - Re-enable the disabled service and configure it to monitor the affected resources.
+  - For Macie: use `EnableMacie` and re-add monitored S3 buckets.
+  - For Inspector: use `Enable` and re-associate the affected EC2 instances or ECR repositories.
+
+- **Investigation**
+  - Review CloudTrail for sensitive data access or unusual S3 GetObject/PutObject calls during the period Macie was disabled.
+  - Check for any new Inspector findings now that it has been re-enabled.
+
+- **Hardening**
+  - Use AWS Organizations SCPs to prevent `macie2:DisableMacie` and `inspector2:Disable` without explicit approval.
+  - Enable AWS Config rules to detect when Macie or Inspector is not enabled in an account.
+  - Centralize Macie findings to a Security Hub or SIEM for cross-account visibility.
+
+### Additional information
+
+- **[Amazon Macie Documentation](https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html)**
+- **[Amazon Inspector Documentation](https://docs.aws.amazon.com/inspector/latest/user/what-is-inspector.html)**
+- **[DisableMacie API Reference](https://docs.aws.amazon.com/macie/latest/APIReference/macie.html)**
+"""
+references = [
+    "https://docs.aws.amazon.com/macie/latest/APIReference/macie.html",
+    "https://docs.aws.amazon.com/inspector/latest/APIReference/API_Disable.html",
+    "https://docs.aws.amazon.com/macie/latest/user/what-is-macie.html",
+]
+risk_score = 47
+rule_id = "86cc5213-2b08-46a8-8805-82480d47369a"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Use Case: Configuration Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.outcome:success and
+(
+    (event.provider:macie2.amazonaws.com and event.action:DisableMacie) or
+    (event.provider:inspector2.amazonaws.com and event.action:Disable)
+)
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "event.provider",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/aws/defense_evasion_macie_or_inspector_disabled.toml
+++ b/rules/integrations/aws/defense_evasion_macie_or_inspector_disabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/defense_evasion_organizations_leave_organization.toml
+++ b/rules/integrations/aws/defense_evasion_organizations_leave_organization.toml
@@ -1,0 +1,121 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects a member account leaving an AWS Organization. The LeaveOrganization API call causes a member
+account to exit the AWS Organizations hierarchy, immediately removing it from the organization's
+management scope. This action strips the account of all Service Control Policy (SCP) guardrails that
+the organization enforces, removes it from centralized CloudTrail aggregation, disables organization-level
+GuardDuty and Security Hub coverage, and eliminates the ability of the management account to audit or
+control it. An adversary who has gained root or management access in a member account may use this
+technique to escape organizational security controls and operate in an unmonitored environment.
+"""
+false_positives = [
+    """
+    Accounts may legitimately leave an organization during company splits, divestitures, or significant
+    structural changes. This action requires the account's root credentials or an explicit organization
+    policy allowing member accounts to leave. Any unexpected LeaveOrganization event should be treated
+    as a critical incident requiring immediate investigation.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Member Account Left Organization"
+note = """## Triage and analysis
+
+### Investigating AWS Member Account Left Organization
+
+Leaving an AWS Organization immediately removes all SCP-based guardrails from the account, cuts off
+centralized monitoring, and eliminates the management account's ability to audit the departed account.
+This is a critical security event that should be investigated immediately.
+
+#### Possible investigation steps
+
+- Identify which account left via `cloud.account.id` and `aws.cloudtrail.request_parameters`.
+- Determine who initiated the action using `aws.cloudtrail.user_identity.arn` — only root or a principal
+  with `organizations:LeaveOrganization` permission can do this.
+- Immediately contact the account owner and management to confirm intent.
+- Review the account's CloudTrail logs for suspicious activity before departure.
+
+### Response and remediation
+
+- Use `InviteAccountToOrganization` from the management account to reinvite the departed account.
+- If the departure was unauthorized, treat the account as potentially compromised.
+- Revoke all credentials associated with the actor who initiated the action.
+- Review the departed account for unauthorized resource creation or data access during the unmonitored period.
+"""
+references = [
+    "https://docs.aws.amazon.com/organizations/latest/APIReference/API_LeaveOrganization.html",
+    "https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_remove.html",
+]
+risk_score = 73
+rule_id = "96f15495-ecd1-4957-bf48-c577f24941d4"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+    "Tactic: Impact",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:organizations.amazonaws.com and
+event.action:LeaveOrganization and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.008"
+name = "Disable or Modify Cloud Logs"
+reference = "https://attack.mitre.org/techniques/T1562/008/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1531"
+name = "Account Access Removal"
+reference = "https://attack.mitre.org/techniques/T1531/"
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"

--- a/rules/integrations/aws/defense_evasion_organizations_leave_organization.toml
+++ b/rules/integrations/aws/defense_evasion_organizations_leave_organization.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/exfiltration_vpc_peering_connection_to_external_account.toml
+++ b/rules/integrations/aws/exfiltration_vpc_peering_connection_to_external_account.toml
@@ -1,0 +1,116 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects the creation of an AWS VPC peering connection request to an external AWS account. VPC peering
+enables direct network routing between two VPCs, potentially across different AWS accounts. While
+legitimate for multi-account architectures, an unauthorized peering connection to an attacker-controlled
+account can establish a persistent network tunnel into the victim's VPC, enabling direct access to
+internal services, databases, and EC2 instances without going through the internet. This technique
+can be used for lateral movement, data exfiltration, or establishing command and control channels
+through private IP space that may bypass perimeter controls.
+"""
+false_positives = [
+    """
+    VPC peering connections are commonly created for legitimate multi-account architectures, shared
+    services VPCs, and managed service provider integrations. Validate whether the peer account ID
+    in the request parameters is a known, trusted internal account. Cross-account peering outside
+    of documented architecture decisions should be investigated.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS VPC Peering Connection Request to External Account"
+note = """## Triage and analysis
+
+### Investigating AWS VPC Peering Connection Request to External Account
+
+VPC peering creates a direct networking connection between two VPCs. When initiated to an external account,
+it can expose internal resources to a third party. The requesting side creates the peering connection;
+it becomes active only when the peer account accepts it.
+
+#### Possible investigation steps
+
+- Review `aws.cloudtrail.request_parameters` for the peer VPC ID and peer account ID (`peerOwnerId`).
+- Determine whether the peer account ID is a known internal or partner account.
+- Check whether the peering connection was subsequently accepted (look for `AcceptVpcPeeringConnection` in the peer account's CloudTrail).
+- Identify which VPC and CIDR range is being peered and what services are exposed in that subnet.
+
+### Response and remediation
+
+- Delete the peering connection using `DeleteVpcPeeringConnection` if unauthorized.
+- Review VPC route tables for routes pointing to the peering connection.
+- Audit security groups for rules that allow traffic from the peer CIDR range.
+"""
+references = [
+    "https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html",
+    "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpcPeeringConnection.html",
+]
+risk_score = 47
+rule_id = "de6c954b-7d29-47ef-a4ae-69399348f6af"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Data Source: AWS EC2",
+    "Use Case: Network Security Monitoring",
+    "Resources: Investigation Guide",
+    "Tactic: Exfiltration",
+    "Tactic: Lateral Movement",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:ec2.amazonaws.com and
+event.action:CreateVpcPeeringConnection and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.request_parameters",
+    "event.action",
+    "cloud.account.id",
+    "cloud.region",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1537"
+name = "Transfer Data to Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1537/"
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1199"
+name = "Trusted Relationship"
+reference = "https://attack.mitre.org/techniques/T1199/"
+
+[rule.threat.tactic]
+id = "TA0008"
+name = "Lateral Movement"
+reference = "https://attack.mitre.org/tactics/TA0008/"

--- a/rules/integrations/aws/exfiltration_vpc_peering_connection_to_external_account.toml
+++ b/rules/integrations/aws/exfiltration_vpc_peering_connection_to_external_account.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/impact_aws_account_closed.toml
+++ b/rules/integrations/aws/impact_aws_account_closed.toml
@@ -1,0 +1,114 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects the closure of an AWS account. The CloseAccount API call initiates account closure, which
+triggers a 90-day grace period during which the account is suspended before permanent termination.
+Account closure is an irreversible and destructive action that removes all resources, data, and access
+within the account. An adversary with root-level or AWS Organizations administrative access may close
+accounts to destroy evidence, disrupt business operations, or eliminate compute and data resources used
+by the organization. This action can also be used by a malicious insider to sabotage an organization's
+cloud infrastructure.
+"""
+false_positives = [
+    """
+    AWS accounts may be legitimately closed as part of organizational restructuring, account consolidation,
+    or decommissioning of workloads. Account closures should always have corresponding change management
+    tickets and executive approval. Any account closure without documented authorization should be treated
+    as a critical incident.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Account Closed"
+note = """## Triage and analysis
+
+### Investigating AWS Account Closed
+
+AWS account closure is one of the most destructive actions that can be performed in an AWS environment.
+Even during the 90-day grace period, resources are inaccessible. The action requires root or Organizations
+admin access, making any unauthorized closure a critical security incident.
+
+#### Possible investigation steps
+
+- Identify who initiated the closure via `aws.cloudtrail.user_identity.arn`.
+- Determine which account was closed from `aws.cloudtrail.request_parameters` or `cloud.account.id`.
+- Contact the account owner immediately to confirm intent.
+- If unauthorized, use AWS Organizations to cancel the closure during the 90-day suspension window.
+- Review the closing actor's other actions before and after the closure event.
+
+### Response and remediation
+
+- Contact AWS Support immediately to attempt account restoration within the 90-day grace period.
+- Revoke the actor's credentials and escalate to incident response.
+- Preserve all available CloudTrail logs from the closed account before access expires.
+"""
+references = [
+    "https://docs.aws.amazon.com/accounts/latest/reference/API_CloseAccount.html",
+    "https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_close.html",
+]
+risk_score = 99
+rule_id = "c85ca192-7d15-42a2-91d0-0d9224b1076a"
+severity = "critical"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Resources: Investigation Guide",
+    "Tactic: Impact",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:account.amazonaws.com and
+event.action:CloseAccount and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1485"
+name = "Data Destruction"
+reference = "https://attack.mitre.org/techniques/T1485/"
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1531"
+name = "Account Access Removal"
+reference = "https://attack.mitre.org/techniques/T1531/"
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"

--- a/rules/integrations/aws/impact_aws_account_closed.toml
+++ b/rules/integrations/aws/impact_aws_account_closed.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/impact_dynamodb_table_or_backup_deleted.toml
+++ b/rules/integrations/aws/impact_dynamodb_table_or_backup_deleted.toml
@@ -1,0 +1,118 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects destructive operations against AWS DynamoDB, including deletion of tables, deletion of backups,
+or disabling of point-in-time recovery (UpdateContinuousBackups with PointInTimeRecoveryEnabled set to
+DISABLED). DynamoDB tables often store critical application state, user data, and business records.
+Deleting tables or their backups can cause irreversible data loss and service disruption. Disabling
+continuous backups removes the ability to restore the table to any point in the preceding 35 days,
+eliminating a key recovery option before a subsequent destructive action. These actions may be part
+of a ransomware or data destruction attack, insider threat activity, or an attacker attempting to
+destroy evidence.
+"""
+false_positives = [
+    """
+    DynamoDB tables and backups are legitimately deleted during application decommissioning, environment
+    cleanup, and cost optimization. Infrastructure-as-code pipelines may delete and recreate tables as
+    part of deployments. Validate whether the action aligns with a planned change. Deletion of tables
+    in production or regulated environments without a change ticket should be investigated.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS DynamoDB Table or Backup Deleted or Recovery Disabled"
+note = """## Triage and analysis
+
+### Investigating AWS DynamoDB Table or Backup Deleted or Recovery Disabled
+
+DynamoDB is a managed NoSQL database that may store critical application and business data. Destructive
+operations against it — whether deleting tables, removing backups, or disabling point-in-time recovery —
+can result in permanent data loss if not quickly detected and remediated.
+
+#### Possible investigation steps
+
+- Review `aws.cloudtrail.user_identity.arn` to identify the actor.
+- Examine `aws.cloudtrail.request_parameters` for the table name and backup ARN affected.
+- Determine the business criticality of the affected table.
+- Check for other destructive operations against S3, RDS, or other data stores around the same time.
+- Look for preceding reconnaissance: `ListTables`, `DescribeTable`, `ListBackups`.
+
+### Response and remediation
+
+- For deleted tables: attempt recovery from DynamoDB on-demand backups or AWS Backup.
+- For deleted backups: assess whether point-in-time recovery or other backups are still available.
+- For disabled PITR: re-enable using `UpdateContinuousBackups` with `PointInTimeRecoveryEnabled: ENABLED`.
+- Revoke the actor's DynamoDB permissions pending investigation.
+"""
+references = [
+    "https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteTable.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DeleteBackup.html",
+    "https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateContinuousBackups.html",
+]
+risk_score = 73
+rule_id = "fa156ebd-b621-400e-801b-2a916d910ccd"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Use Case: Asset Visibility",
+    "Resources: Investigation Guide",
+    "Tactic: Impact",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:dynamodb.amazonaws.com and
+event.action:(DeleteTable or DeleteBackup or UpdateContinuousBackups) and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.request_parameters",
+    "event.action",
+    "cloud.account.id",
+    "cloud.region",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1485"
+name = "Data Destruction"
+reference = "https://attack.mitre.org/techniques/T1485/"
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1490"
+name = "Inhibit System Recovery"
+reference = "https://attack.mitre.org/techniques/T1490/"
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"

--- a/rules/integrations/aws/impact_dynamodb_table_or_backup_deleted.toml
+++ b/rules/integrations/aws/impact_dynamodb_table_or_backup_deleted.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/initial_access_console_login_without_mfa.toml
+++ b/rules/integrations/aws/initial_access_console_login_without_mfa.toml
@@ -1,0 +1,156 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Identifies a successful AWS Management Console login where Multi-Factor Authentication (MFA) was not used.
+MFA provides a critical additional layer of protection against credential theft and account takeover. A successful
+console login without MFA may indicate the use of compromised credentials, a misconfigured IAM policy that does not
+enforce MFA, or an attacker who has obtained the target's username and password but has not bypassed MFA requirements.
+All console logins — particularly for privileged IAM users — should require MFA as a baseline security control.
+"""
+false_positives = [
+    """
+    Some IAM users may be intentionally configured without MFA enforcement for automation or legacy compatibility
+    reasons. Break-glass accounts accessed in emergencies may also lack MFA. Validate whether the identity is an
+    expected MFA-exempt user and whether the login occurred from a known, trusted source IP. If both conditions are
+    met, the alert may represent legitimate activity. Any unrecognized login without MFA should be investigated
+    immediately as a potential credential compromise.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Management Console Login Without MFA"
+note = """## Triage and analysis
+
+### Investigating AWS Management Console Login Without MFA
+
+Multi-Factor Authentication (MFA) is a foundational control for AWS console access. When a user logs in to the AWS
+Management Console without MFA, it means only a password was used to authenticate. This significantly increases the
+risk of account takeover if credentials have been compromised via phishing, credential stuffing, or data breaches.
+
+This rule detects successful `ConsoleLogin` events where `additionalEventData.MFAUsed` is `No`. It excludes assumed
+roles, which authenticate via temporary credentials rather than console MFA.
+
+#### Possible investigation steps
+
+- **Identify the user and context**
+  - Review `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.type` to identify who logged in.
+  - Check whether this user is expected to log in to the console (some service accounts should not have console access).
+  - Verify if MFA is configured for this IAM user via the IAM console or `ListMFADevices` API.
+
+- **Assess source and location**
+  - Review `source.ip` and `source.geo` fields.
+  - Determine whether the source IP matches known corporate networks, VPN exit points, or trusted locations.
+  - A login from an unfamiliar country or cloud provider IP is a strong indicator of credential compromise.
+
+- **Review session activity**
+  - Query CloudTrail for API calls made by this identity in the 30–60 minutes following the login.
+  - Look for high-risk actions: `CreateUser`, `CreateAccessKey`, `AttachUserPolicy`, `DeleteTrail`, `AssumeRole`.
+
+- **Check MFA configuration**
+  - Verify whether MFA is enabled for this user and why it was not used during this login.
+  - If MFA is not configured, escalate to enforce it immediately.
+
+- **Correlate with threat intelligence**
+  - Cross-reference `source.ip` against threat intelligence feeds for known malicious infrastructure.
+
+### False positive analysis
+
+- **MFA-exempt accounts**
+  - Some organizations configure specific service or break-glass accounts without MFA for operational reasons.
+  - Confirm the user is in an approved MFA-exempt list before closing the alert.
+- **Legacy IAM users**
+  - Older IAM users created before MFA enforcement policies were implemented may not have MFA configured.
+  - Use this alert as an opportunity to remediate missing MFA configurations.
+
+### Response and remediation
+
+- **Immediate containment**
+  - If the login cannot be attributed to a known, authorized user, revoke the active session by detaching or disabling the IAM user.
+  - Reset the IAM user's console password and require a new password on next sign-in.
+
+- **Enforce MFA**
+  - Enable MFA for the affected user immediately.
+  - Use AWS IAM Policies or AWS Organizations Service Control Policies (SCPs) to deny console access without MFA across all accounts.
+
+- **Investigation**
+  - Review all API activity from this identity for the duration of the session.
+  - Determine whether any sensitive resources were accessed or configuration changes were made.
+
+- **Hardening**
+  - Implement an SCP that denies all actions except `iam:CreateVirtualMFADevice` and `iam:EnableMFADevice` for users without MFA.
+  - Enable AWS Security Hub and activate the "IAM.2: IAM users should have MFA enabled" control.
+  - Consider requiring hardware MFA for privileged accounts with access to production environments.
+
+### Additional information
+
+- **[AWS IAM Best Practices: Using MFA](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#enable-mfa-for-privileged-users)**
+- **[Enforcing MFA with IAM Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage-mfa-only.html)**
+- **[AWS Security Hub: IAM.2 Control](https://docs.aws.amazon.com/securityhub/latest/userguide/iam-controls.html#iam-2)**
+"""
+references = [
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html",
+    "https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-event-reference-user-identity.html",
+]
+risk_score = 47
+rule_id = "e9cb28a9-fda6-476a-9c90-e579ddea3a2e"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS Sign-In",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Initial Access",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:signin.amazonaws.com and
+event.action:ConsoleLogin and
+event.outcome:success and
+aws.cloudtrail.console_login.additional_eventdata.mfa_used:No and
+not aws.cloudtrail.user_identity.type:AssumedRole
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "source.geo.country_name",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.console_login.additional_eventdata.mfa_used",
+    "event.outcome",
+    "cloud.account.id",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1078.004"
+name = "Cloud Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/004/"
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"

--- a/rules/integrations/aws/initial_access_console_login_without_mfa.toml
+++ b/rules/integrations/aws/initial_access_console_login_without_mfa.toml
@@ -119,7 +119,7 @@ data_stream.dataset:aws.cloudtrail and
 event.provider:signin.amazonaws.com and
 event.action:ConsoleLogin and
 event.outcome:success and
-aws.cloudtrail.console_login.additional_eventdata.mfa_used:No and
+aws.cloudtrail.console_login.additional_eventdata.mfa_used:false and
 not aws.cloudtrail.user_identity.type:AssumedRole
 '''
 

--- a/rules/integrations/aws/initial_access_console_login_without_mfa.toml
+++ b/rules/integrations/aws/initial_access_console_login_without_mfa.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/persistence_aws_new_region_enabled.toml
+++ b/rules/integrations/aws/persistence_aws_new_region_enabled.toml
@@ -1,0 +1,100 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects the enabling of a new AWS region for an account. AWS accounts have a set of regions enabled by
+default; additional regions must be explicitly opted into using the `EnableRegion` API call on the
+account service. An adversary who has compromised an AWS account may enable a new, rarely monitored
+region to deploy resources — such as EC2 instances, Lambda functions, or IAM changes — outside the
+visibility of existing regional monitoring, alerting, and compliance controls. This technique allows
+attackers to operate in shadow infrastructure where logging pipelines, GuardDuty detectors, and Security
+Hub may not yet be configured, reducing the likelihood of detection.
+"""
+false_positives = [
+    """
+    New regions are legitimately enabled when an organization expands its geographic footprint, meets data
+    residency requirements, or evaluates new services only available in specific regions. Validate whether
+    the region being enabled aligns with a planned expansion or infrastructure decision. Enablement of
+    obscure regions not used in the organization's architecture should be investigated.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS New Region Enabled for Account"
+note = """## Triage and analysis
+
+### Investigating AWS New Region Enabled for Account
+
+Enabling a new AWS region is a rare administrative action. When done by an unauthorized actor, it can
+create a blind spot where attacker activity occurs in a region without existing monitoring coverage.
+
+#### Possible investigation steps
+
+- Review `aws.cloudtrail.user_identity.arn` to determine who enabled the region.
+- Identify the region enabled from `aws.cloudtrail.request_parameters`.
+- Check whether CloudTrail, GuardDuty, and Security Hub are configured in the newly enabled region.
+- Query the new region's CloudTrail for any API activity after the region was enabled.
+- Correlate with other suspicious activity from the same actor around the same time.
+
+### Response and remediation
+
+- If unauthorized, disable the region using `DisableRegion` on the account service.
+- Enable all detective controls (CloudTrail, GuardDuty, Config, Security Hub) in the region.
+- Review any resources that were created in the region during the period it was unmonitored.
+"""
+references = [
+    "https://docs.aws.amazon.com/accounts/latest/reference/API_EnableRegion.html",
+    "https://docs.aws.amazon.com/general/latest/gr/rande-manage.html",
+]
+risk_score = 47
+rule_id = "3faca98f-1155-4219-b2a0-93b5fa953923"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Use Case: Configuration Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Defense Evasion",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:account.amazonaws.com and
+event.action:EnableRegion and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.request_parameters",
+    "event.action",
+    "cloud.account.id",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1535"
+name = "Unused/Unsupported Cloud Regions"
+reference = "https://attack.mitre.org/techniques/T1535/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/aws/persistence_aws_new_region_enabled.toml
+++ b/rules/integrations/aws/persistence_aws_new_region_enabled.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/persistence_ec2_import_key_pair.toml
+++ b/rules/integrations/aws/persistence_ec2_import_key_pair.toml
@@ -1,0 +1,108 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects the import of an external SSH key pair into AWS EC2. The ImportKeyPair API call allows an IAM
+principal to upload a public key of their own choosing, which AWS will then associate with a key pair name
+that can be specified when launching EC2 instances. Unlike CreateKeyPair, where AWS generates the private
+key and the user receives it once, ImportKeyPair allows an attacker who has already generated their own
+RSA or ED25519 key pair to register the public component with AWS. This provides persistent SSH access to
+any EC2 instance launched with that key pair name, even after IAM credential rotation, and may not be
+detected by controls that only monitor CreateKeyPair events.
+"""
+false_positives = [
+    """
+    Importing existing SSH key pairs is common when migrating from other cloud providers or when using
+    infrastructure-as-code tools that generate and manage key pairs externally. DevOps teams may import
+    shared key pairs for fleet-wide SSH access. Validate whether the actor and key pair name align with
+    a known operational pattern or change management request.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS EC2 External SSH Key Pair Imported"
+note = """## Triage and analysis
+
+### Investigating AWS EC2 External SSH Key Pair Imported
+
+This rule detects `ImportKeyPair` API calls that register an externally generated SSH public key with AWS EC2.
+This is distinct from `CreateKeyPair` (where AWS generates the private key), because `ImportKeyPair` allows
+the caller to control which private key will correspond to the imported public key — meaning the attacker
+retains the private key and AWS never sees it.
+
+#### Possible investigation steps
+
+- Review `aws.cloudtrail.user_identity.arn` to determine who imported the key.
+- Examine `aws.cloudtrail.request_parameters` for the key pair name and the public key material.
+- Check whether any EC2 instances were launched with this key pair name after import.
+- Determine whether the key pair name follows your organization's naming conventions.
+
+### Response and remediation
+
+- Delete the imported key pair using `DeleteKeyPair` if unauthorized.
+- Review all EC2 instances associated with this key pair name.
+- Terminate or re-image any instances that were launched with the rogue key pair.
+"""
+references = [
+    "https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ImportKeyPair.html",
+    "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html",
+]
+risk_score = 47
+rule_id = "1e379182-c462-4771-bb4c-6550f3910a92"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Data Source: AWS EC2",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Persistence",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:ec2.amazonaws.com and
+event.action:ImportKeyPair and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.request_parameters",
+    "event.action",
+    "cloud.account.id",
+    "cloud.region",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.004"
+name = "SSH Authorized Keys"
+reference = "https://attack.mitre.org/techniques/T1098/004/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"

--- a/rules/integrations/aws/persistence_ec2_import_key_pair.toml
+++ b/rules/integrations/aws/persistence_ec2_import_key_pair.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/persistence_iam_oidc_provider_modified.toml
+++ b/rules/integrations/aws/persistence_iam_oidc_provider_modified.toml
@@ -1,0 +1,120 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects modifications to an existing AWS IAM OpenID Connect (OIDC) identity provider, including updates
+to the provider's thumbprint list or addition of new client IDs. OIDC providers establish trust between
+AWS and external identity providers (such as GitHub Actions, Kubernetes service accounts, or custom IdPs)
+for web identity federation. After an OIDC provider is created, adversaries with IAM administrative access
+may modify the thumbprint list to add a certificate they control, enabling them to forge tokens and assume
+roles that trust this provider. Adding a client ID can expand the set of tokens accepted, potentially
+allowing unauthorized external services to obtain AWS credentials.
+"""
+false_positives = [
+    """
+    OIDC provider thumbprint updates are required when the external IdP rotates its TLS certificate.
+    Client ID additions may occur when new applications are integrated with the federation path.
+    Validate whether the change aligns with a known certificate rotation or integration project.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS IAM OIDC Provider Modified"
+note = """## Triage and analysis
+
+### Investigating AWS IAM OIDC Provider Modified
+
+Modifying an existing OIDC provider is a targeted action that can enable an attacker to forge web identity
+tokens and assume IAM roles that trust the provider. This is particularly dangerous for providers used by
+CI/CD pipelines or Kubernetes workloads that have broad IAM permissions.
+
+#### Possible investigation steps
+
+- Identify the OIDC provider ARN from `aws.cloudtrail.request_parameters`.
+- Determine which IAM roles have trust policies referencing this provider.
+- For thumbprint updates: verify the new thumbprint against the IdP's current TLS certificate.
+- For client ID additions: confirm whether the new client ID corresponds to a known application.
+- Review `AssumeRoleWithWebIdentity` calls using this provider shortly after the modification.
+
+### Response and remediation
+
+- Revert the thumbprint list to the known-good certificate fingerprints.
+- Remove unauthorized client IDs using `RemoveClientIDFromOpenIDConnectProvider`.
+- Audit IAM roles trusting this provider for recent unauthorized `AssumeRoleWithWebIdentity` calls.
+"""
+references = [
+    "https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateOpenIDConnectProviderThumbprint.html",
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html",
+]
+risk_score = 47
+rule_id = "dfe445ab-95c1-4ff6-9cd3-4109cea89374"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Data Source: AWS IAM",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:iam.amazonaws.com and
+event.action:(UpdateOpenIDConnectProviderThumbprint or AddClientIDToOpenIDConnectProvider) and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.request_parameters",
+    "event.action",
+    "cloud.account.id",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1556"
+name = "Modify Authentication Process"
+reference = "https://attack.mitre.org/techniques/T1556/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1556.006"
+name = "Multi-Factor Authentication"
+reference = "https://attack.mitre.org/techniques/T1556/006/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"

--- a/rules/integrations/aws/persistence_iam_oidc_provider_modified.toml
+++ b/rules/integrations/aws/persistence_iam_oidc_provider_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/persistence_iam_update_login_profile.toml
+++ b/rules/integrations/aws/persistence_iam_update_login_profile.toml
@@ -1,0 +1,165 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects updates to an IAM user's login profile (console password) by a different IAM principal. The
+UpdateLoginProfile API call changes the console password for an IAM user. When this action is performed
+by an entity other than the target user themselves, it may indicate an adversary using administrative
+access to reset a user's password and gain console access to that account. This technique allows attackers
+to pivot to a different IAM identity, escalate privileges by targeting more permissive accounts, or establish
+persistence under a legitimate-looking user identity that may not trigger anomaly-based detections.
+"""
+false_positives = [
+    """
+    IAM administrators routinely reset console passwords for users who have been locked out or are onboarding.
+    Automated provisioning systems may also set or reset login profiles as part of account lifecycle management.
+    Validate whether the actor is an authorized IAM administrator performing a documented password reset. If the
+    change was not initiated by a help desk ticket or onboarding workflow, investigate whether the actor's
+    credentials may have been compromised.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS IAM User Login Profile Updated by Another Principal"
+note = """## Triage and analysis
+
+### Investigating AWS IAM User Login Profile Updated by Another Principal
+
+The `UpdateLoginProfile` API call sets or changes the console password for an IAM user. When one IAM entity
+updates the login profile of a different IAM user, it can represent a legitimate administrative password reset
+or an adversary using elevated privileges to take control of another account. Since console access provides a
+graphical interface to the full scope of that user's IAM permissions, this action can be a significant
+privilege escalation or lateral movement step.
+
+This rule detects `UpdateLoginProfile` events where the `requestParameters.userName` (target user) differs
+from the caller's identity, indicating a cross-user password reset.
+
+#### Possible investigation steps
+
+- **Identify the actor and target**
+  - Review `aws.cloudtrail.user_identity.arn` to determine who made the change.
+  - Extract the target username from `aws.cloudtrail.request_parameters` (`requestParameters.userName`).
+  - Determine the IAM permissions and group memberships of the target user.
+
+- **Assess authorization**
+  - Confirm with the IAM administrator team or help desk whether a password reset was requested for this user.
+  - Check for an open IT ticket or onboarding request associated with the password reset.
+
+- **Review follow-on console activity**
+  - Query CloudTrail for subsequent `ConsoleLogin` events by the target user shortly after the password reset.
+  - If a login occurred from an unfamiliar IP or location, treat as a confirmed account takeover.
+
+- **Check if password reset was forced**
+  - Review `aws.cloudtrail.request_parameters` for `passwordResetRequired`. If set to false, the attacker may
+    have set a known password without forcing the user to reset it — a sign of silent takeover.
+
+- **Correlate with other IAM changes**
+  - Look for additional changes to the target user: `CreateAccessKey`, `AttachUserPolicy`, `AddUserToGroup`.
+  - A combination of these actions suggests a systematic account takeover pattern.
+
+### False positive analysis
+
+- **IT help desk password resets**
+  - Routine password resets for locked-out or onboarding users. Validate via ticketing system.
+- **Automated provisioning**
+  - Account lifecycle automation may reset passwords as part of onboarding workflows.
+
+### Response and remediation
+
+- **Immediate containment**
+  - Disable the target user's console access using `UpdateLoginProfile` to set a complex, unknown password.
+  - Revoke any active sessions for the target user.
+
+- **Investigation**
+  - Review all API activity under the target user's identity after the password change.
+  - Determine whether any sensitive resources were accessed or configuration changes were made.
+
+- **Hardening**
+  - Apply least-privilege constraints to `iam:UpdateLoginProfile` — restrict it to dedicated IAM admin roles.
+  - Enable IAM Access Analyzer to detect when users have more permissions than expected.
+  - Require MFA for all console logins to limit the impact of a stolen password.
+
+### Additional information
+
+- **[UpdateLoginProfile API Reference](https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateLoginProfile.html)**
+- **[AWS IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)**
+"""
+references = [
+    "https://docs.aws.amazon.com/IAM/latest/APIReference/API_UpdateLoginProfile.html",
+    "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_admin-change-user.html",
+]
+risk_score = 47
+rule_id = "36e96c36-63a6-4f26-a929-a0cb3b4f95bc"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Data Source: AWS IAM",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:iam.amazonaws.com and
+event.action:UpdateLoginProfile and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.request_parameters",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1078.004"
+name = "Cloud Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/004/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"

--- a/rules/integrations/aws/persistence_iam_update_login_profile.toml
+++ b/rules/integrations/aws/persistence_iam_update_login_profile.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]

--- a/rules/integrations/aws/privilege_escalation_iam_identity_center_permission_set_modified.toml
+++ b/rules/integrations/aws/privilege_escalation_iam_identity_center_permission_set_modified.toml
@@ -1,0 +1,168 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects privilege escalation through AWS IAM Identity Center (formerly AWS SSO) by identifying the creation or
+modification of permission sets, attachment of managed policies to permission sets, or creation of account assignments.
+IAM Identity Center permission sets define what actions users or groups can perform when they federate into AWS
+accounts. An attacker with administrative access to IAM Identity Center can create a new permission set with
+AdministratorAccess, assign it to a controlled user or group, and provision it to one or more AWS accounts — gaining
+persistent, federation-based administrative access that survives IAM user credential rotation and may not be caught
+by traditional IAM monitoring focused on direct IAM user changes.
+"""
+false_positives = [
+    """
+    IAM Identity Center permission sets are routinely created or modified during onboarding, role changes,
+    infrastructure provisioning, or security reviews. Automated pipelines using AWS Control Tower or IaC tools
+    such as Terraform may also create or update permission sets as part of account vending workflows. Validate
+    whether the actor, timing, and target account align with a documented change. Privileged permission set changes
+    performed outside of approved change windows or by unexpected identities should be investigated immediately.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS IAM Identity Center Permission Set Created or Modified"
+note = """## Triage and analysis
+
+### Investigating AWS IAM Identity Center Permission Set Created or Modified
+
+AWS IAM Identity Center (formerly AWS Single Sign-On) centralizes access management for multiple AWS accounts within
+an organization. Permission sets are templates that define the level of access granted when a user or group federates
+into a target account. Modifications to permission sets or their account assignments can grant broad and persistent
+access to AWS resources across an entire organization.
+
+This rule detects several key IAM Identity Center API calls that, individually or in combination, can be used
+to escalate privileges: `CreatePermissionSet`, `UpdatePermissionSet`, `AttachManagedPolicyToPermissionSet`,
+`PutInlinePolicyToPermissionSet`, `CreateAccountAssignment`, and `ProvisionPermissionSet`.
+
+#### Possible investigation steps
+
+- **Identify the actor**
+  - Review `aws.cloudtrail.user_identity.arn` to determine who made the change.
+  - Determine whether this identity is an expected IAM Identity Center administrator.
+  - Check whether the action was performed interactively via the console or via automation.
+
+- **Review the permission set details**
+  - Examine `aws.cloudtrail.request_parameters` for the permission set name, description, and session duration.
+  - If `AttachManagedPolicyToPermissionSet` was called, identify the policy ARN attached.
+  - Look for `arn:aws:iam::aws:policy/AdministratorAccess` or other high-privilege managed policies.
+
+- **Review account assignments**
+  - If `CreateAccountAssignment` was called, identify the target account ID, principal type (USER or GROUP), and principal ID.
+  - Determine whether the assigned principal is a known, authorized identity.
+  - Correlate with `ProvisionPermissionSet` calls that deploy the permission set to target accounts.
+
+- **Check for multi-step privilege escalation chains**
+  - Look for a sequence of: `CreatePermissionSet` → `AttachManagedPolicyToPermissionSet` → `CreateAccountAssignment` → `ProvisionPermissionSet`.
+  - Such a chain, performed rapidly, is a strong indicator of deliberate privilege escalation.
+
+- **Validate authorization**
+  - Confirm with IAM administrators whether this change was part of a planned workflow.
+  - Check for related change management tickets or IaC commit history.
+
+### False positive analysis
+
+- **Account vending pipelines**
+  - AWS Control Tower and similar frameworks automatically create permission sets and account assignments during
+    new account provisioning.
+- **Routine role changes**
+  - HR-driven access reviews or team restructuring may lead to legitimate permission set updates.
+
+### Response and remediation
+
+- **Immediate containment**
+  - If unauthorized, delete the account assignment using `DeleteAccountAssignment` to revoke federated access.
+  - Remove the rogue managed policy attachment using `DetachManagedPolicyFromPermissionSet`.
+  - Delete the unauthorized permission set if applicable.
+
+- **Investigation**
+  - Review CloudTrail for `AssumeRoleWithSAML` or `AssumeRoleWithWebIdentity` calls by the assigned principal.
+  - Check what actions were performed in the target account during the assignment period.
+
+- **Hardening**
+  - Restrict IAM Identity Center administrative actions using AWS Organizations SCPs.
+  - Enable CloudTrail logging for `sso-admin.amazonaws.com` events in the management account.
+  - Require MFA for IAM Identity Center administrators.
+  - Monitor for any permission sets with `AdministratorAccess` or `PowerUserAccess` policies.
+
+### Additional information
+
+- **[AWS IAM Identity Center Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html)**
+- **[Permission Sets in IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/permissionsetsconcept.html)**
+- **[CloudTrail Events for IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/logging-using-cloudtrail.html)**
+"""
+references = [
+    "https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html",
+    "https://docs.aws.amazon.com/singlesignon/latest/userguide/permissionsetsconcept.html",
+    "https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_CreatePermissionSet.html",
+]
+risk_score = 73
+rule_id = "b11ebbdd-4cc0-4b52-a9f6-d429813ba03b"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS CloudTrail",
+    "Data Source: AWS IAM",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Privilege Escalation",
+    "Tactic: Persistence",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:(sso.amazonaws.com or sso-admin.amazonaws.com) and
+event.action:(CreatePermissionSet or UpdatePermissionSet or AttachManagedPolicyToPermissionSet or PutInlinePolicyToPermissionSet or CreateAccountAssignment or ProvisionPermissionSet) and
+event.outcome:success
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "event.action",
+    "aws.cloudtrail.request_parameters",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"

--- a/rules/integrations/aws/privilege_escalation_iam_identity_center_permission_set_modified.toml
+++ b/rules/integrations/aws/privilege_escalation_iam_identity_center_permission_set_modified.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/05/10"
 integration = ["aws"]
-maturity = "production"
+maturity = "development"
 updated_date = "2026/05/10"
 
 [rule]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: Closes #6118

## Summary - What I changed

Added 15 new AWS CloudTrail detection rules covering security gaps not currently present in elastic/detection-rules for AWS integrations. These rules are based on real-world attacker techniques observed across IAM Identity Center, EC2 metadata, credential access, data destruction, and organizational control abuse.

| Rule Name | Tactic | Severity |
|---|---|---|
| AWS Console Login Without MFA | Initial Access | Medium |
| EC2 IMDSv1 Enabled (SSRF risk) | Defense Evasion | Medium |
| IAM Identity Center Permission Set Created or Modified | Privilege Escalation / Persistence | High |
| IAM UpdateLoginProfile by Another Principal | Persistence | High |
| Macie or Inspector Disabled | Defense Evasion | Medium |
| Console Login Brute Force by IP | Credential Access | High |
| Console Login Brute Force by User | Credential Access | High |
| EC2 Key Pair Imported | Persistence | Medium |
| VPC Peering Connection to External Account | Exfiltration | Medium |
| IAM SAML Provider Deleted | Defense Evasion | High |
| IAM OIDC Provider Modified | Persistence | Medium |
| DynamoDB Table or Backup Deleted | Impact | High |
| New AWS Region Enabled | Persistence | Low |
| AWS Account Closed | Impact | Critical |
| Organizations LeaveOrganization | Defense Evasion | Critical |

All rules:
- Use `maturity = "development"`
- Include full investigation guides, false positive analysis, response/remediation steps
- Map to MITRE ATT&CK techniques
- Include `[rule.investigation_fields]`
- Follow ECS field naming conventions

## Checklist

- [x] Added a label for the type of pr: `Rule: New`
- [x] Signed the CLA
- [x] Followed the [contributing guide](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)
- [x] Tests pass locally: `python -m detection_rules test` — 219 passed, 0 failed