### PR TITLE
New Rules: Linux detection gaps identified from Falco coverage analysis

### DIFF
--- a/rules/linux/command_and_control_linux_dnscat_dns_tunneling.toml
+++ b/rules/linux/command_and_control_linux_dnscat_dns_tunneling.toml
@@ -1,0 +1,137 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects execution of the dnscat2 DNS tunneling tool or its variants on Linux systems. dnscat2 establishes
+covert command-and-control channels by encapsulating arbitrary data within DNS queries and responses, allowing
+attackers to bypass firewall rules that permit outbound DNS traffic. DNS tunneling tools like dnscat2 are
+used for C2 communication, data exfiltration, and maintaining persistent access in environments where
+direct outbound connections are blocked.
+"""
+false_positives = [
+    """
+    Security researchers and penetration testers may legitimately use dnscat2 in authorized testing environments.
+    Validate the executing user, host, and whether the activity aligns with an approved security assessment.
+    """,
+]
+from = "now-9m"
+index = [
+    "auditbeat-*",
+    "endgame-*",
+    "logs-auditd_manager.auditd-*",
+    "logs-crowdstrike.fdr*",
+    "logs-endpoint.events.process*",
+    "logs-sentinel_one_cloud_funnel.*",
+]
+language = "eql"
+license = "Elastic License v2"
+name = "DNS Tunneling via dnscat Tool Detected"
+note = """## Triage and analysis
+
+### Investigating DNS Tunneling via dnscat Tool Detected
+
+dnscat2 is an open-source tool designed to create encrypted C2 channels over DNS. Because DNS is typically
+allowed through firewalls and not deeply inspected, it is commonly abused by attackers to maintain C2
+connectivity in restricted environments. Detection of dnscat execution is a high-fidelity signal for
+unauthorized C2 activity.
+
+#### Possible investigation steps
+
+- **Identify the binary**: Check `process.executable` and `process.name` — is this a known dnscat binary or renamed variant?
+- **Review arguments**: Check `process.args` — what domain or server is being connected to?
+- **Identify the parent**: What process spawned dnscat? Shell, cron, or a web service parent is highly suspicious.
+- **Check network activity**: Correlate with DNS logs for the host — look for high-frequency DNS queries to unusual domains.
+- **Review the user context**: Which user ran dnscat? A web service or daemon user running this tool is critical.
+- **Check for download activity**: Was dnscat downloaded shortly before execution (curl, wget, chmod patterns)?
+
+### False positive analysis
+
+- Authorized penetration testing with dnscat2 in a pre-approved scope.
+- Security tooling that references dnscat in its own process name (unlikely but possible).
+
+### Response and remediation
+
+- Immediately isolate the host from the network to prevent ongoing C2 communication.
+- Kill the dnscat process and investigate how it was deployed.
+- Review DNS logs for the full C2 communication history.
+- Search for any additional tools or backdoors installed during the session.
+- Conduct a full forensic review of the host.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1071/004/",
+    "https://attack.mitre.org/techniques/T1048/003/",
+    "https://github.com/iagox86/dnscat2",
+]
+risk_score = 73
+rule_id = "e7ccfd60-3e7e-4b3a-958b-7879d0a87b43"
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Command and Control",
+    "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
+    "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+  (
+    process.name == "dnscat" or
+    process.name like~ "dnscat*" or
+    process.executable like~ "*/dnscat*" or
+    process.args like~ "*dnscat*"
+  )
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "host.name",
+    "user.name",
+    "process.name",
+    "process.executable",
+    "process.args",
+    "process.parent.name",
+    "process.parent.executable",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1071"
+name = "Application Layer Protocol"
+reference = "https://attack.mitre.org/techniques/T1071/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1071.004"
+name = "DNS"
+reference = "https://attack.mitre.org/techniques/T1071/004/"
+
+[[rule.threat.technique]]
+id = "T1048"
+name = "Exfiltration Over Alternative Protocol"
+reference = "https://attack.mitre.org/techniques/T1048/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1048.003"
+name = "Exfiltration Over Unencrypted Non-C2 Protocol"
+reference = "https://attack.mitre.org/techniques/T1048/003/"
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"

--- a/rules/linux/command_and_control_linux_gsocket_remote_access.toml
+++ b/rules/linux/command_and_control_linux_gsocket_remote_access.toml
@@ -1,0 +1,131 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects execution of the gsocket toolkit (gs-netcat, gsocket) on Linux systems. gsocket is a NAT-traversal
+and firewall-bypass tool that creates encrypted peer-to-peer connections using a shared secret, without
+requiring port forwarding or direct IP connectivity. Adversaries use gsocket to establish covert remote
+access channels that bypass network controls, making it a popular tool for C2 implants and unauthorized
+remote access in cloud and containerized environments.
+"""
+false_positives = [
+    """
+    Security researchers and authorized system administrators may use gsocket for legitimate remote access
+    in environments where traditional VPN or SSH is not available. Validate that the usage aligns with
+    an approved network architecture or security assessment.
+    """,
+]
+from = "now-9m"
+index = [
+    "auditbeat-*",
+    "endgame-*",
+    "logs-auditd_manager.auditd-*",
+    "logs-crowdstrike.fdr*",
+    "logs-endpoint.events.process*",
+    "logs-sentinel_one_cloud_funnel.*",
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Remote Access via gsocket Tool Detected"
+note = """## Triage and analysis
+
+### Investigating Remote Access via gsocket Tool Detected
+
+gsocket (Global Socket) is a toolkit for creating NAT-traversing network connections using a shared
+secret. Unlike traditional reverse shells that require an attacker-controlled listener with a public IP,
+gsocket connections are mediated through a relay server (gsocket.io), making them difficult to block
+with simple IP-based firewall rules. Detection of gsocket on production Linux hosts is a high-fidelity
+signal for unauthorized remote access tooling.
+
+#### Possible investigation steps
+
+- **Identify the binary**: Check `process.executable` — is this a renamed binary or the original gs-netcat/gsocket?
+- **Review arguments**: Check `process.args` — what secret or relay server is being used?
+- **Identify the parent process**: What spawned gsocket? A web server, container runtime, or CI/CD runner is highly suspicious.
+- **Check container context**: Is this running in a Kubernetes pod or container? Review `container.name` and `container.image.name`.
+- **Review download activity**: Was gsocket downloaded immediately before execution?
+- **Check for persistence**: Was a cron job, systemd service, or rc.local entry created to auto-start gsocket?
+
+### False positive analysis
+
+- Authorized use by sysadmins in environments with strict outbound firewall rules where SSH tunneling is not available.
+- Security research or authorized penetration testing.
+
+### Response and remediation
+
+- Immediately kill the gsocket process and isolate the host.
+- Review network logs for the gsocket relay communication timeline.
+- Search for persistence mechanisms that may restart gsocket after termination.
+- Conduct a full forensic review to identify how gsocket was deployed and what commands were executed.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1572/",
+    "https://attack.mitre.org/techniques/T1219/",
+    "https://github.com/hackerschoice/gsocket",
+]
+risk_score = 73
+rule_id = "d2754edc-5b8f-4e4e-9c1b-56a57db3ab5f"
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Command and Control",
+    "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
+    "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+  (
+    process.name like~ "gs-*" or
+    process.name == "gsocket" or
+    process.executable like~ "*/gsocket*" or
+    process.executable like~ "*/gs-netcat*" or
+    process.args like~ "*gsocket*" or
+    process.args like~ "*gs-netcat*" or
+    process.args like~ "*gsocket.io*"
+  )
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "host.name",
+    "user.name",
+    "process.name",
+    "process.executable",
+    "process.args",
+    "process.parent.name",
+    "process.parent.executable",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1572"
+name = "Protocol Tunneling"
+reference = "https://attack.mitre.org/techniques/T1572/"
+
+[[rule.threat.technique]]
+id = "T1219"
+name = "Remote Access Software"
+reference = "https://attack.mitre.org/techniques/T1219/"
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"

--- a/rules/linux/execution_linux_sshd_python_shell_spawn.toml
+++ b/rules/linux/execution_linux_sshd_python_shell_spawn.toml
@@ -1,0 +1,142 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects a shell process (bash, sh, dash, zsh) spawned by a Python interpreter whose grandparent process is the
+SSH daemon (sshd). This process chain — sshd → python3 → shell — is a strong indicator of a Python-based reverse
+shell or interactive shell upgrade technique executed through an established SSH session. Legitimate SSH sessions
+spawn shells directly from sshd; the insertion of a Python interpreter in the process chain strongly suggests
+post-exploitation activity such as a Python pty shell upgrade or a Python reverse shell spawning an interactive
+terminal.
+"""
+false_positives = [
+    """
+    Developers or system administrators running Python scripts interactively over SSH that subsequently invoke
+    shell commands via subprocess or os.system() may trigger this rule. Legitimate use cases include automation
+    scripts that use subprocess.run(['bash', ...]) or os.execv() to launch shell subprocesses. Validate the
+    specific Python script being executed and whether the spawned shell has an associated TTY or is interactive.
+    """,
+]
+from = "now-9m"
+index = [
+    "auditbeat-*",
+    "endgame-*",
+    "logs-auditd_manager.auditd-*",
+    "logs-crowdstrike.fdr*",
+    "logs-endpoint.events.process*",
+    "logs-sentinel_one_cloud_funnel.*",
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Shell Spawned by Python Under SSH Session"
+note = """## Triage and analysis
+
+### Investigating Shell Spawned by Python Under SSH Session
+
+A common post-exploitation technique after obtaining a limited reverse shell is to upgrade it to a fully
+interactive TTY using Python: `python3 -c 'import pty; pty.spawn("/bin/bash")'`. This technique is used to
+enable job control, tab completion, and interactive commands that are not available in a raw reverse shell.
+When this chain occurs under an SSH session (sshd → python3 → bash), it typically indicates an attacker has
+established initial SSH access and is upgrading their shell for more effective post-exploitation.
+
+#### Possible investigation steps
+
+- **Review the process chain**: Confirm the ancestry: sshd → python* → shell.
+  - Check `process.parent.name`, `process.parent.parent.name` to verify the chain.
+- **Identify the SSH user**: Check `user.name` — which account was used for the SSH session?
+  - Was this account recently created or modified?
+- **Review SSH source**: Check authentication logs for the source IP of the SSH connection.
+  - Is this an IP the user normally connects from?
+- **Review Python arguments**: Check `process.parent.args` — what Python code was executed?
+  - `pty.spawn` or `os.execv` with a shell argument is highly suspicious.
+- **Check for prior lateral movement**: Was this SSH login preceded by unusual authentication events?
+- **Check host for backdoors**: Were any new cron jobs, SSH keys, or services added?
+
+### False positive analysis
+
+- Python automation scripts using subprocess to invoke shell commands over SSH.
+- Admin scripts that use Python to manage system configuration and invoke shell subcommands.
+- Validate by reviewing the specific Python arguments and whether the user has a legitimate reason for the session.
+
+### Response and remediation
+
+- If confirmed malicious: immediately terminate the SSH session and block the source IP.
+- Revoke the SSH key or reset the password for the compromised account.
+- Review all commands executed during the session via shell history and auditd logs.
+- Search for any backdoors or persistence mechanisms installed during the session.
+- Conduct a full forensic review of the host for signs of lateral movement or data exfiltration.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1059/006/",
+    "https://attack.mitre.org/techniques/T1059/004/",
+    "https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Methodology%20and%20Resources/Reverse%20Shell%20Cheatsheet.md",
+]
+risk_score = 73
+rule_id = "dceca838-2a7e-4ec3-9884-9c8648c5e148"
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Execution",
+    "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
+    "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+sequence by host.id, user.name with maxspan=1m
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+   process.name like~ "python*" and
+   process.parent.name in ("sshd", "sshd-session")]
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+   process.name in ("bash", "sh", "dash", "zsh", "ash") and
+   process.parent.name like~ "python*"]
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "host.name",
+    "user.name",
+    "process.name",
+    "process.args",
+    "process.parent.name",
+    "process.parent.args",
+    "process.parent.parent.name",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1059.006"
+name = "Python"
+reference = "https://attack.mitre.org/techniques/T1059/006/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"

--- a/rules/linux/privilege_escalation_linux_sudoers_nopasswd_modification.toml
+++ b/rules/linux/privilege_escalation_linux_sudoers_nopasswd_modification.toml
@@ -1,0 +1,130 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["endpoint", "auditd_manager", "crowdstrike", "sentinel_one_cloud_funnel"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a shell or interpreter process writes a NOPASSWD entry to the sudoers configuration on Linux.
+Adding a NOPASSWD rule to /etc/sudoers or /etc/sudoers.d/ allows a user to execute commands as root without
+providing a password, effectively granting persistent passwordless privilege escalation. This technique is
+commonly used by attackers who have achieved initial access as a non-root user and wish to establish
+persistent root access without triggering password authentication prompts.
+"""
+false_positives = [
+    """
+    Configuration management tools such as Ansible, Puppet, Chef, and Salt routinely write sudoers entries
+    including NOPASSWD directives as part of automated infrastructure provisioning. Validate that the parent
+    process corresponds to an authorized configuration management agent. Manual NOPASSWD additions by
+    interactive users or unexpected parent processes should be treated as suspicious.
+    """,
+]
+from = "now-9m"
+index = [
+    "auditbeat-*",
+    "endgame-*",
+    "logs-auditd_manager.auditd-*",
+    "logs-crowdstrike.fdr*",
+    "logs-endpoint.events.process*",
+    "logs-sentinel_one_cloud_funnel.*",
+]
+language = "eql"
+license = "Elastic License v2"
+name = "Sudoers NOPASSWD Entry Added via Shell or Interpreter"
+note = """## Triage and analysis
+
+### Investigating Sudoers NOPASSWD Entry Added via Shell or Interpreter
+
+Adding a NOPASSWD sudoers entry is a common persistence and privilege escalation technique. Once in place,
+any process running as the specified user can execute root commands without authentication. This is often
+the second step after initial access — the attacker first obtains shell access, then establishes
+persistent root access via sudoers modification.
+
+#### Possible investigation steps
+
+- **Identify the command**: Check `process.args` — what NOPASSWD entry is being written and to which file?
+  - `echo 'user ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers` is the canonical attack pattern.
+- **Identify the parent process**: Check `process.parent.name` and `process.parent.executable`.
+  - A web server, container init, or reverse shell parent is a high-confidence indicator.
+- **Review the user context**: Which user executed this command? A web service or container user is critical.
+- **Check for prior access**: Was this preceded by initial access events (web shell, SSH brute force)?
+- **Review sudoers files**: Immediately check /etc/sudoers and /etc/sudoers.d/ for unauthorized NOPASSWD entries.
+- **Check for subsequent root commands**: Were any commands run with the new NOPASSWD privileges?
+
+### False positive analysis
+
+- Ansible, Puppet, Chef, Salt, and cloud-init frequently write sudoers NOPASSWD entries during provisioning.
+- Validate that the parent process is a known configuration management binary.
+
+### Response and remediation
+
+- Immediately remove any unauthorized NOPASSWD entries from sudoers.
+- Identify and terminate any active sessions established using the sudoers escalation.
+- Investigate how the attacker obtained the initial access that allowed them to modify sudoers.
+- Review all commands executed with root privileges since the NOPASSWD entry was added.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1548/003/",
+    "https://www.sudo.ws/docs/man/sudoers.man/",
+]
+risk_score = 73
+rule_id = "417b28a2-3e18-4b72-9c3f-6f2a3e1d5a89"
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Privilege Escalation",
+    "Data Source: Elastic Defend",
+    "Data Source: Elastic Endgame",
+    "Data Source: Auditd Manager",
+    "Data Source: Crowdstrike",
+    "Data Source: SentinelOne",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+process where host.os.type == "linux" and event.type == "start" and
+  event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+  process.args like~ "*NOPASSWD*" and
+  process.name in ("bash", "sh", "dash", "zsh", "ash", "echo", "printf", "tee", "sed", "awk",
+                   "python", "python3", "python2", "perl", "ruby") and
+  not process.parent.executable like~ (
+    "*/ansible*", "*/puppet*", "*/chef*", "*/salt-minion*",
+    "*/saltstack*", "*/cloud-init*"
+  )
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "host.name",
+    "user.name",
+    "process.name",
+    "process.args",
+    "process.executable",
+    "process.parent.name",
+    "process.parent.executable",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1548"
+name = "Abuse Elevation Control Mechanism"
+reference = "https://attack.mitre.org/techniques/T1548/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1548.003"
+name = "Sudo and Sudo Caching"
+reference = "https://attack.mitre.org/techniques/T1548/003/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"


### PR DESCRIPTION
## Summary

Closes #6124

This PR adds 4 new Linux detection rules identified during a gap analysis comparing inDriver's Falco-based SIEM alerts against existing Elastic detection coverage.

## New Rules

| Rule | Tactic | Technique | Severity |
|------|--------|-----------|----------|
| Command and Control via dnscat DNS Tunneling | C2 | T1071.004, T1048.003 | High |
| Remote Access via gsocket Tool | C2 | T1572, T1219 | High |
| Sudoers NOPASSWD Entry Added via Shell | Privilege Escalation | T1548.003 | High |
| Shell Spawned by Python Under SSH Session | Execution | T1059.006, T1059.004 | High |

## Detection Logic

- **dnscat**: Detects process name/executable/args matching `dnscat` patterns across all supported Linux data sources
- **gsocket**: Detects `gs-netcat`, `gsocket`, and related gsocket toolkit binaries used for NAT-traversal C2
- **NOPASSWD**: Detects shell/interpreter processes writing NOPASSWD to sudoers files, with exclusions for legitimate config management tools (Ansible, Puppet, Chef, Salt)
- **sshd→python→shell**: EQL sequence detecting Python spawned by sshd followed by a shell spawned by Python — a classic reverse shell TTY upgrade chain (`python3 -c 'import pty; pty.spawn("/bin/bash")'`)

## Data Sources

All rules cover: Elastic Defend, Elastic Endgame, Auditd Manager, CrowdStrike, SentinelOne

## Testing

All 51 existing tests pass with 1 skip (no regressions).