### PR TITLE
New Rules: 15 GitHub detection gaps from internal audit coverage anal…

### DIFF
--- a/rules/integrations/github/credential_access_github_org_two_factor_auth_disabled.toml
+++ b/rules/integrations/github/credential_access_github_org_two_factor_auth_disabled.toml
@@ -1,0 +1,120 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when the two-factor authentication (2FA) requirement is disabled for a GitHub organization. Enforcing
+2FA across all organization members is a critical security control that prevents account takeover via stolen
+credentials. Disabling this requirement removes MFA protection for every member of the organization simultaneously,
+significantly increasing the attack surface for credential-based attacks. An adversary with organization owner
+access may disable 2FA to facilitate access using compromised credentials that do not have an associated
+authenticator.
+"""
+false_positives = [
+    """
+    Organization administrators may temporarily disable the 2FA requirement when onboarding new members who
+    have not yet enrolled in 2FA, though this is not a recommended practice. Validate that the actor is an
+    authorized administrator and that the change was communicated and approved.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Organization Two-Factor Authentication Requirement Disabled"
+note = """## Triage and analysis
+
+### Investigating GitHub Organization Two-Factor Authentication Requirement Disabled
+
+Disabling the organization-wide 2FA requirement in GitHub immediately removes multi-factor authentication
+enforcement for all members. This is one of the most impactful single actions an organization owner can
+take to weaken security posture. Legitimate administrators rarely disable this setting; when it occurs
+unexpectedly it is a high-confidence signal of either account compromise or insider threat.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized organization owner?
+- **Check the actor's login history**: From what IP and geolocation was this change made?
+  - Correlate with the actor's normal login patterns.
+- **Review concurrent activity**: Were there other suspicious org-level changes (member additions, PAT creation, runner changes) around the same time?
+- **Verify intent**: Was there a planned onboarding or migration that legitimately required this change?
+- **Check member 2FA status after the change**: Did any previously non-2FA members log in after the requirement was disabled?
+
+### False positive analysis
+
+- Planned bulk onboarding events may temporarily require disabling 2FA enforcement.
+- This event should always be reviewed regardless of apparent legitimacy.
+
+### Response and remediation
+
+- Immediately re-enable the 2FA requirement for the organization.
+- Audit all member logins during the period when 2FA was disabled.
+- If the actor account appears compromised: suspend the account and rotate credentials.
+- Review all organization-level changes made during the period 2FA was disabled.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1556/",
+    "https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-two-factor-authentication-for-your-organization",
+]
+risk_score = 73
+rule_id = "b2c3d4e5-f6a7-4890-9bcd-ef1234567890"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Tactic: Credential Access",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action == "org.disable_two_factor_requirement"
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.org",
+    "event.action",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1556"
+name = "Modify Authentication Process"
+reference = "https://attack.mitre.org/techniques/T1556/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/github/defense_evasion_github_audit_log_streaming_modified.toml
+++ b/rules/integrations/github/defense_evasion_github_audit_log_streaming_modified.toml
@@ -1,0 +1,104 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when GitHub Audit Log Streaming configuration is created, modified, or deleted. Audit log streaming
+forwards GitHub audit events to an external destination (e.g., SIEM, S3 bucket) for security monitoring.
+Adversaries who have obtained organization owner access may stop or reconfigure log streaming to prevent
+their activity from reaching the security monitoring pipeline, enabling them to operate undetected.
+"""
+false_positives = [
+    """
+    Security engineering teams may legitimately reconfigure audit log streaming when migrating to new SIEM
+    infrastructure, rotating credentials, or updating streaming destinations. Validate that the actor is
+    an authorized security or platform engineer with a corresponding change management ticket.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Audit Log Streaming Configuration Modified"
+note = """## Triage and analysis
+
+### Investigating GitHub Audit Log Streaming Configuration Modified
+
+GitHub Audit Log Streaming allows organizations to continuously forward audit events to external security
+systems. Disabling or modifying this stream is a high-impact action that can create blind spots in an
+organization's security monitoring. Attackers who compromise an organization owner account may disable
+streaming to suppress evidence of their subsequent actions.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized security or DevSecOps engineer?
+- **Review the operation type**: Was this a create, update, or delete? Deletions or disabling operations are highest risk.
+- **Check timing**: Was this change made outside business hours or immediately before other suspicious activity?
+- **Review concurrent activity**: Were there other sensitive org-level changes around the same time?
+- **Verify against change management**: Is there an approved ticket for this streaming configuration change?
+
+### False positive analysis
+
+- Streaming configuration changes during SIEM migrations or infrastructure rotations are expected.
+- Rotating streaming credentials (tokens, AWS keys) triggers update events.
+
+### Response and remediation
+
+- If unauthorized: immediately re-enable audit log streaming and review the gap period for missed events.
+- Audit all other actions taken by the actor in the past 24 hours using available logs.
+- Rotate the organization owner credentials for the account that made the change.
+- Restrict organization owner role to a minimal set of named individuals.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1562/001/",
+    "https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/streaming-the-audit-log-for-your-enterprise",
+]
+risk_score = 73
+rule_id = "a1f2e3d4-b5c6-4789-8abc-def012345678"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action like~ "audit_log_streaming*"
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.org",
+    "event.action",
+    "github.operation_type",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/github/defense_evasion_github_dependabot_alerts_disabled.toml
+++ b/rules/integrations/github/defense_evasion_github_dependabot_alerts_disabled.toml
@@ -1,0 +1,106 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when Dependabot security alerts are disabled for a GitHub repository. Dependabot continuously monitors
+repository dependencies for known vulnerabilities and notifies maintainers via security alerts and automated
+pull requests. Disabling Dependabot alerts removes automated vulnerability detection for the affected
+repository, reducing visibility into exploitable weaknesses in the codebase's supply chain. Adversaries with
+repository admin access may disable these alerts to prevent detection of vulnerable dependencies they intend
+to exploit, or to suppress security notifications as part of broader defense impairment.
+"""
+false_positives = [
+    """
+    Repository administrators may legitimately disable Dependabot alerts for archived repositories, repositories
+    with no active maintenance, or repositories where dependency scanning is handled by a different tool
+    (e.g., Snyk, Renovate). Validate that the repository is genuinely inactive or that an equivalent
+    scanning mechanism is in place.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Dependabot Security Alerts Disabled"
+note = """## Triage and analysis
+
+### Investigating GitHub Dependabot Security Alerts Disabled
+
+Dependabot provides continuous dependency vulnerability scanning for GitHub repositories. Disabling these
+alerts removes automated notification when new CVEs affecting the repository's dependencies are published.
+This is a defense impairment action that reduces the security team's visibility into the repository's
+vulnerability posture.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized repository maintainer or admin?
+- **Review the repository**: Is this an active production repository? Disabling alerts on active repos is concerning.
+- **Check for a replacement**: Is there another scanning tool (Snyk, FOSSA, Renovate) configured for this repository?
+- **Review the reason**: Was there a documented reason for disabling alerts (e.g., noise reduction for a specific ecosystem)?
+- **Check for concurrent changes**: Were other security settings (secret scanning, code scanning) also disabled at the same time?
+
+### False positive analysis
+
+- Archived or deprecated repositories may have Dependabot disabled as part of archiving.
+- Repositories migrating to third-party SCA tools may temporarily disable Dependabot.
+
+### Response and remediation
+
+- Re-enable Dependabot alerts for any active repository where they were inappropriately disabled.
+- Review the repository's current dependency state for unpatched known vulnerabilities.
+- Implement organization-level policies that prevent disabling Dependabot without admin approval.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1562/001/",
+    "https://docs.github.com/en/code-security/dependabot/dependabot-alerts/about-dependabot-alerts",
+]
+risk_score = 47
+rule_id = "b8c9d0e1-f2a3-4456-bcde-567890123456"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action in ("repository_vulnerability_alerts.disable", "dependabot_alerts.disable")
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.repo",
+    "github.org",
+    "event.action",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/github/defense_evasion_github_fork_policy_modified.toml
+++ b/rules/integrations/github/defense_evasion_github_fork_policy_modified.toml
@@ -1,0 +1,119 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when forking settings are modified at the GitHub organization or repository level. Forking policies
+control whether members and outside collaborators can create forks of private repositories. Enabling forking
+of private repositories allows anyone with read access to create a personal copy of the repository,
+effectively transferring the entire codebase — including commit history — to an account outside organizational
+control. Adversaries may enable forking to silently exfiltrate source code without triggering download-based
+detections.
+"""
+false_positives = [
+    """
+    Open-source projects and teams managing public repositories routinely allow forking as part of their
+    contribution workflow. Enabling forking on repositories that are already public or intended for open
+    contribution is expected. Enabling forking on private repositories is the high-risk scenario.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Fork Policy Modified"
+note = """## Triage and analysis
+
+### Investigating GitHub Fork Policy Modified
+
+GitHub forking settings determine whether private repository contents can be copied to external user accounts.
+When enabled on private repositories, any organization member or collaborator with read access can fork the
+repository, creating a full copy under their personal account that is outside organizational DLP controls.
+This is a common technique for data exfiltration by insiders and compromised accounts.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized repository or organization admin?
+- **Review what was changed**: Was forking enabled or disabled? For private repos, enabling forking is the risk.
+- **Identify the scope**: Was this a repository-level or organization-wide setting change?
+- **Review the repository**: Is this repository private and does it contain sensitive IP or credentials?
+- **Check for subsequent forks**: After forking was enabled, were any forks created? By whom?
+
+### False positive analysis
+
+- Public repositories and open-source projects legitimately enable forking.
+- Disabling forking (restricting) is a security hardening action and should not be alarming.
+
+### Response and remediation
+
+- If forking was inappropriately enabled: immediately disable forking for the repository.
+- Review whether any forks were created during the window when forking was enabled.
+- Remove any unauthorized forks from external accounts via repository network graph.
+- Implement organization-level policy to prevent enabling forking on private repositories without approval.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1537/",
+    "https://docs.github.com/en/organizations/managing-organization-settings/managing-the-forking-policy-for-your-organization",
+]
+risk_score = 47
+rule_id = "f6a7b8c9-d0e1-4234-efab-345678901234"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Exfiltration",
+    "Tactic: Defense Evasion",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action like~ "*fork*" and
+  event.action in ("org.enable_forking", "org.disable_forking",
+                   "repo.allow_forking", "repo.deny_forking",
+                   "repo.enable_forking", "repo.disable_forking")
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.repo",
+    "github.org",
+    "event.action",
+    "github.operation_type",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1537"
+name = "Transfer Data to Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1537/"
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/github/defense_evasion_github_ghas_security_configuration_modified.toml
+++ b/rules/integrations/github/defense_evasion_github_ghas_security_configuration_modified.toml
@@ -1,0 +1,107 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a GitHub Advanced Security (GHAS) security configuration is modified. GHAS security configurations
+define organization-wide policies for code scanning, secret scanning, Dependabot, and push protection features.
+These configurations are centrally managed and applied to multiple repositories at once. Unauthorized modification
+of a GHAS security configuration can silently disable security scanning across all repositories using that
+configuration, creating widespread blind spots in the organization's security posture without modifying
+individual repository settings.
+"""
+false_positives = [
+    """
+    Security engineering teams may legitimately update GHAS configurations to onboard new features, adjust
+    scanning settings, or align with updated security policies. Validate that the actor is an authorized
+    security engineer and that the change was communicated and documented in a change management ticket.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Advanced Security Configuration Modified"
+note = """## Triage and analysis
+
+### Investigating GitHub Advanced Security Configuration Modified
+
+GitHub Advanced Security (GHAS) configurations centrally manage security feature policies across multiple
+repositories. A single configuration change can enable or disable code scanning, secret scanning, Dependabot,
+and push protection for all repositories using that configuration simultaneously. This makes GHAS configuration
+changes a high-leverage attack vector for defense impairment — one unauthorized change can disable security
+scanning across hundreds of repositories.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized security or DevSecOps engineer?
+- **Review what changed**: Which security features were enabled or disabled in the configuration?
+  - Secret scanning, push protection, and code scanning are the highest-value features to check.
+- **Identify the scope**: Which repositories use this configuration? How many are affected?
+- **Verify authorization**: Is there a change management ticket for this modification?
+- **Check for concurrent changes**: Were other security configurations or individual repository settings changed at the same time?
+
+### False positive analysis
+
+- Security team configuration updates to onboard new GHAS features are expected.
+- Annual policy reviews may result in configuration updates.
+
+### Response and remediation
+
+- Immediately review the configuration change and revert if unauthorized.
+- Audit all repositories using the affected configuration for security gaps during the modification window.
+- Implement approval workflows for GHAS configuration changes.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1562/001/",
+    "https://docs.github.com/en/code-security/securing-your-organization/managing-the-security-of-your-organization/about-security-configurations",
+]
+risk_score = 73
+rule_id = "d0e1f2a3-b4c5-4678-defa-789012345678"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action == "security_configuration.update"
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.org",
+    "event.action",
+    "github.operation_type",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/github/defense_evasion_github_secret_scanning_push_protection_bypass.toml
+++ b/rules/integrations/github/defense_evasion_github_secret_scanning_push_protection_bypass.toml
@@ -1,0 +1,127 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a GitHub Secret Scanning push protection bypass is performed. Push protection prevents developers
+from accidentally committing detected secrets (API keys, tokens, credentials) to repositories. When a user
+explicitly bypasses this protection, a detected secret is committed to the repository regardless of the
+protection block. Each bypass event indicates that a credential of a specific type was knowingly or carelessly
+committed to the codebase. Bypasses may indicate a developer circumventing security controls, or an adversary
+who has obtained developer access and is attempting to commit malicious credentials or test for detection gaps.
+"""
+false_positives = [
+    """
+    Developers may bypass push protection for test credentials, fake secrets used in documentation or unit tests,
+    or patterns that are false positives for the secret type detector. Validate the secret type and the bypass
+    reason provided by the developer. Common legitimate reasons include 'used_in_tests' and 'will_fix_later'.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Secret Scanning Push Protection Bypass"
+note = """## Triage and analysis
+
+### Investigating GitHub Secret Scanning Push Protection Bypass
+
+GitHub Secret Scanning with push protection blocks commits containing known secret patterns before they reach
+the repository. When a developer bypasses this protection, a real or detected credential is committed to the
+repository. Every bypass event should be reviewed — even if the developer selected a 'not a real secret'
+bypass reason — because bypass reasons are self-reported and not validated by GitHub.
+
+#### Possible investigation steps
+
+- **Identify the secret type**: Review `github.secret_type` — what category of credential was detected?
+  - High-value secret types (cloud provider keys, private keys, database credentials) warrant immediate escalation.
+- **Review the bypass reason**: What reason did the developer select for bypassing protection?
+  - `used_in_tests` and `will_fix_later` are common but should be verified.
+- **Locate the committed secret**: Identify the repository and commit containing the bypassed secret.
+- **Check if the secret is live**: Test whether the committed credential is an active, valid credential.
+- **Review the repository**: Is this a private or public repository? Public repo leaks are immediately actionable.
+
+### False positive analysis
+
+- Developers committing fake/test credentials with appropriate bypass reasons (used_in_tests).
+- Secret pattern false positives that resemble real credentials but are not.
+
+### Response and remediation
+
+- If the secret is live and valid: immediately revoke/rotate the credential at the source system.
+- Remove the secret from the repository's git history (git filter-branch, BFG Repo Cleaner).
+- If the repository is public: assume the secret has been harvested and treat the credential as fully compromised.
+- Educate the developer on proper secret management practices and credential injection via CI/CD secrets.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1562/001/",
+    "https://docs.github.com/en/code-security/secret-scanning/push-protection-for-repositories-and-organizations",
+]
+risk_score = 73
+rule_id = "c9d0e1f2-a3b4-4567-cdef-678901234567"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Tactic: Credential Access",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action == "secret_scanning_push_protection.bypass"
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.repo",
+    "github.org",
+    "event.action",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.001"
+name = "Credentials In Files"
+reference = "https://attack.mitre.org/techniques/T1552/001/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/integrations/github/exfiltration_github_high_number_of_api_requests_to_repositories.toml
+++ b/rules/integrations/github/exfiltration_github_high_number_of_api_requests_to_repositories.toml
@@ -1,0 +1,118 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a single GitHub actor makes API requests touching an unusually high number of distinct repositories
+within a detection window. This pattern is indicative of automated repository enumeration — a technique used
+by adversaries who have obtained a valid access token or compromised an account and are systematically
+discovering and cataloging all accessible repositories before targeted data exfiltration. Legitimate users
+rarely interact with more than a few dozen repositories via the API in a short time window.
+"""
+false_positives = [
+    """
+    GitHub Apps, automation bots, and platform engineering tools that perform organization-wide inventory,
+    compliance scanning, or dependency analysis may generate high API request volumes across many repositories.
+    Exclude known automation accounts by actor name. Human user accounts generating this volume warrant
+    immediate investigation regardless of context.
+    """,
+]
+from = "now-130m"
+index = ["logs-github.audit-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License v2"
+name = "GitHub High Volume API Requests Across Repositories Detected"
+note = """## Triage and analysis
+
+### Investigating GitHub High Volume API Requests Across Repositories Detected
+
+Automated repository enumeration via the GitHub API is typically the reconnaissance step before bulk data
+exfiltration. An adversary who has obtained a PAT or OAuth token will enumerate all accessible repositories
+to identify high-value targets. The GitHub API allows listing all repositories an actor has access to,
+then making requests to each to retrieve file trees, contents, and metadata. Detecting >200 distinct
+repository API interactions in an hour is a strong signal of automated reconnaissance.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this a human user, bot, or GitHub App?
+  - Known automation (CI/CD, security scanning) with high counts is expected; human users are not.
+- **Review the token used**: Was this performed via a PAT, OAuth token, or GitHub App installation token?
+  - Newly created tokens performing high API volume is highly suspicious.
+- **Check the repositories accessed**: What categories of repositories were touched? Production, security tooling, infrastructure?
+- **Correlate with download/clone activity**: Was API enumeration followed by targeted clone or download events?
+- **Review the source IP**: Is this from a corporate IP, VPN, or an external/cloud provider IP?
+
+### False positive analysis
+
+- Organization-wide GitHub Apps (security scanners, dependency managers, repo managers) make high API volumes.
+- Build an exclusion list for approved automation actors.
+
+### Response and remediation
+
+- If unauthorized: immediately revoke the token used and suspend the actor's access.
+- Review all repositories accessed during the enumeration window.
+- Check for follow-up clone or download events that represent the actual exfiltration step.
+- Implement rate limiting or API usage monitoring at the GitHub App or organization level.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1530/",
+    "https://attack.mitre.org/techniques/T1087/003/",
+    "https://docs.github.com/en/rest/about-the-rest-api/rate-limits-for-the-rest-api",
+]
+risk_score = 73
+rule_id = "e1f2a3b4-c5d6-4789-efab-890123456789"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Discovery",
+    "Tactic: Collection",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "threshold"
+
+query = '''
+data_stream.dataset:"github.audit" and event.action:"api.request"
+'''
+
+[rule.threshold]
+field = ["github.actor"]
+value = 200
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1087"
+name = "Account Discovery"
+reference = "https://attack.mitre.org/techniques/T1087/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1087.003"
+name = "Email Account"
+reference = "https://attack.mitre.org/techniques/T1087/003/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1530"
+name = "Data from Cloud Storage"
+reference = "https://attack.mitre.org/techniques/T1530/"
+
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"

--- a/rules/integrations/github/exfiltration_github_pages_enabled_on_repository.toml
+++ b/rules/integrations/github/exfiltration_github_pages_enabled_on_repository.toml
@@ -1,0 +1,102 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when GitHub Pages is activated on a repository, converting its contents into a publicly accessible
+website. GitHub Pages hosts static content directly from the repository and makes it available on the internet
+without authentication. Enabling Pages on a private or sensitive repository can expose source code, internal
+documentation, API specifications, configuration files, and embedded secrets to anyone on the internet.
+Adversaries may enable GitHub Pages as an exfiltration or staging mechanism to make repository content
+publicly accessible.
+"""
+false_positives = [
+    """
+    Development and documentation teams legitimately enable GitHub Pages for public-facing project documentation,
+    open-source project sites, and developer portals. Validate that the repository is intended for public access
+    and that its contents are appropriate for public distribution.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Pages Enabled on Repository"
+note = """## Triage and analysis
+
+### Investigating GitHub Pages Enabled on Repository
+
+GitHub Pages converts repository contents into a publicly hosted website accessible by anyone on the internet.
+When enabled on repositories that contain internal documentation, configuration files, API specs, or code,
+this immediately exposes those contents publicly. Enabling Pages on a previously private or internal repository
+is a high-confidence signal for accidental or deliberate data exposure.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized repository administrator?
+- **Review the repository**: What does the repository contain? Is it classified as internal, private, or public?
+  - Private or internal repos with Pages enabled warrant immediate review.
+- **Access the published site**: Navigate to the GitHub Pages URL and assess what content is exposed.
+- **Check the branch**: Which branch is being served? Is it the main branch with production configuration?
+- **Review timing**: Was this enabled just before or after suspicious activity like cloning or downloads?
+
+### False positive analysis
+
+- Open-source project documentation and developer portal sites legitimately use GitHub Pages.
+- Public marketing or team landing pages hosted on GitHub are expected.
+
+### Response and remediation
+
+- If unauthorized: immediately disable GitHub Pages for the repository in repository settings.
+- Assess what content was served during the exposure window using GitHub Pages access logs.
+- If sensitive data was exposed: initiate data breach notification procedures.
+- Implement repository security policies that restrict Pages activation on non-public repositories.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1567/",
+    "https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages",
+]
+risk_score = 73
+rule_id = "a7b8c9d0-e1f2-4345-abcd-456789012345"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Data Loss Prevention",
+    "Tactic: Exfiltration",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action == "repo.pages_public"
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.repo",
+    "github.org",
+    "event.action",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1567"
+name = "Exfiltration Over Web Service"
+reference = "https://attack.mitre.org/techniques/T1567/"
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"

--- a/rules/integrations/github/exfiltration_github_repository_archive_downloaded.toml
+++ b/rules/integrations/github/exfiltration_github_repository_archive_downloaded.toml
@@ -1,0 +1,115 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a GitHub user downloads repository archives (ZIP/tarball) across an unusually high number of
+distinct repositories within a time window. The repository download feature allows any user with read access
+to download a complete snapshot of repository contents. Adversaries or malicious insiders may use bulk
+repository downloads to exfiltrate source code, infrastructure configuration, and embedded secrets without
+triggering clone-based detection. This threshold-based rule fires when a single actor downloads more than
+5 distinct repositories within the detection window.
+"""
+false_positives = [
+    """
+    Developers migrating large codebases or performing bulk local backups may trigger this rule. Automated
+    tooling that archives repositories for compliance or backup purposes should be excluded by actor name.
+    Validate the actor's role and whether the volume of downloads aligns with a documented task.
+    """,
+]
+from = "now-130m"
+index = ["logs-github.audit-*"]
+interval = "10m"
+language = "kuery"
+license = "Elastic License v2"
+name = "GitHub Repository Archive Mass Download Detected"
+note = """## Triage and analysis
+
+### Investigating GitHub Repository Archive Mass Download Detected
+
+Downloading repository archives is a simple way to exfiltrate code without using Git tooling, which leaves
+fewer traces. A single actor downloading many repositories in a short window is a high-fidelity signal for
+insider threat activity, departing employee data theft, or a compromised account being used for bulk source
+code exfiltration.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an active employee, contractor, or service account?
+  - Cross-reference with HR offboarding records or termination lists.
+- **Review the repositories downloaded**: What were the repositories? Were they production, security-critical, or IP-sensitive?
+- **Check the actor's role**: Does this user have a legitimate need to download all these repos?
+- **Review timing**: Were downloads performed during business hours or off-hours?
+- **Correlate with other activity**: Were there PAT creations, clone operations, or API enumeration events from the same actor?
+
+### False positive analysis
+
+- Backup automation that downloads repo archives for compliance archiving.
+- Bulk migration tooling during repository consolidation projects.
+
+### Response and remediation
+
+- If unauthorized: immediately suspend the actor's GitHub access and initiate insider threat investigation.
+- Identify all repositories accessed and assess the data classification and sensitivity.
+- If an active employee: contact their manager and HR immediately.
+- Review the download timestamps and correlate with VPN, endpoint, and email logs.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1213/003/",
+    "https://docs.github.com/en/repositories/working-with-files/using-files/downloading-source-code-archives",
+]
+risk_score = 73
+rule_id = "d4e5f6a7-b8c9-4012-cdef-123456789012"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Data Loss Prevention",
+    "Tactic: Exfiltration",
+    "Tactic: Collection",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "threshold"
+
+query = '''
+data_stream.dataset:"github.audit" and event.action:*download*
+'''
+
+[rule.threshold]
+field = ["github.actor"]
+value = 5
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1213"
+name = "Data from Information Repositories"
+reference = "https://attack.mitre.org/techniques/T1213/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1213.003"
+name = "Code Repositories"
+reference = "https://attack.mitre.org/techniques/T1213/003/"
+
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1567"
+name = "Exfiltration Over Web Service"
+reference = "https://attack.mitre.org/techniques/T1567/"
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"

--- a/rules/integrations/github/impact_github_actions_runner_group_modified.toml
+++ b/rules/integrations/github/impact_github_actions_runner_group_modified.toml
@@ -1,0 +1,126 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a GitHub Actions runner group is created, updated, or deleted at the organization level. Runner
+groups control which repositories and workflows can use specific self-hosted runners. Unauthorized modification
+of runner group settings — such as expanding repository access, disabling workflow restrictions, or allowing
+public repository access — can expose self-hosted runners to malicious workflows from untrusted code, enabling
+supply chain attacks, code execution on internal infrastructure, or privilege escalation within CI/CD pipelines.
+"""
+false_positives = [
+    """
+    Platform engineering teams managing CI/CD infrastructure routinely create and update runner groups as
+    new repositories are onboarded or runner fleets are scaled. Validate that the actor is an authorized
+    DevOps or platform engineer and that the change aligns with planned infrastructure changes.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Actions Runner Group Created or Modified"
+note = """## Triage and analysis
+
+### Investigating GitHub Actions Runner Group Created or Modified
+
+GitHub Actions runner groups determine which repositories can use self-hosted runners. Self-hosted runners
+run workflow code directly on internal infrastructure. If an adversary can modify runner group settings to
+allow untrusted repositories access to sensitive runners, they can execute arbitrary code on internal
+infrastructure by triggering a workflow in an allowed repository. This is a critical supply chain attack
+vector, especially when runners have access to production secrets, deployment credentials, or internal networks.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized platform or DevOps engineer?
+- **Review the change**: What was modified? Check for:
+  - New repositories added to the runner group
+  - Public repository access enabled (`allow_public` set to true)
+  - Workflow restrictions relaxed
+- **Identify the runner group**: Which runner group was modified? Does it have access to production secrets or environments?
+- **Verify authorization**: Is there a documented change management request for this modification?
+- **Check for subsequent workflow runs**: After the modification, did any unexpected repositories run workflows on these runners?
+
+### False positive analysis
+
+- Adding new repositories to a runner group during project onboarding is expected.
+- Scaling runner groups for new CI/CD pipelines is routine platform engineering work.
+
+### Response and remediation
+
+- If unauthorized: immediately revert the runner group configuration change.
+- Review all workflows executed by the affected runner group since the modification.
+- Rotate any secrets or credentials accessible to the runners.
+- Implement approval workflows for runner group modifications affecting production runners.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1195/002/",
+    "https://docs.github.com/en/actions/using-github-hosted-runners/using-groups-to-manage-access-to-ae-hosted-runners",
+    "https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions",
+]
+risk_score = 73
+rule_id = "f2a3b4c5-d6e7-4890-fabc-901234567890"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Impact",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action in ("org.runner_group_created", "org.runner_group_deleted",
+                   "org.runner_group_updated", "org.runner_group_runners_updated",
+                   "org.runner_group_runner_removed", "org.runner_group_runner_added")
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.org",
+    "event.action",
+    "github.operation_type",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1195"
+name = "Supply Chain Compromise"
+reference = "https://attack.mitre.org/techniques/T1195/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1195.002"
+name = "Compromise Software Supply Chain"
+reference = "https://attack.mitre.org/techniques/T1195/002/"
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"

--- a/rules/integrations/github/impact_github_repository_default_branch_changed.toml
+++ b/rules/integrations/github/impact_github_repository_default_branch_changed.toml
@@ -1,0 +1,118 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when the default branch of a GitHub repository is changed. The default branch is the primary
+development branch of a repository and serves as the baseline for pull requests, CI/CD pipelines, deployments,
+and branch protection rules. Changing the default branch can redirect CI/CD pipelines to untrusted code,
+bypass branch protection rules that are configured on the previous default branch, affect automated deployments,
+or cause confusion during incident response. Adversaries with repository admin access may change the default
+branch to redirect builds to a malicious branch or to circumvent branch protection controls.
+"""
+false_positives = [
+    """
+    Development teams may legitimately rename their default branch (e.g., from 'master' to 'main') as part
+    of inclusive terminology initiatives or repository reorganization. Validate that the change was planned
+    and communicated, and that branch protection rules were updated to reflect the new default branch.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Repository Default Branch Changed"
+note = """## Triage and analysis
+
+### Investigating GitHub Repository Default Branch Changed
+
+The default branch is the most critical branch in a GitHub repository. Branch protection rules, required
+status checks, required reviews, and deployment policies are typically configured on the default branch.
+Changing the default branch can bypass all of these controls by redirecting the repository to a branch that
+does not have the same protections. This is a high-impact change that can immediately affect production
+deployments, CI/CD security, and code review requirements.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized repository administrator?
+- **Review the repository**: Is this a production, security-critical, or infrastructure repository?
+- **Identify old and new branches**: What was the previous default branch and what is the new default?
+  - Changes from a protected main branch to an unprotected feature branch are highly suspicious.
+- **Check branch protection rules**: Does the new default branch have equivalent protection rules?
+- **Review CI/CD pipelines**: Were any builds or deployments triggered from the new default branch?
+- **Verify authorization**: Was this change documented in a change management ticket?
+
+### False positive analysis
+
+- Planned branch renames (master → main) communicated organization-wide.
+- Repository restructuring during major refactoring initiatives.
+
+### Response and remediation
+
+- If unauthorized: immediately revert the default branch to the original value.
+- Review any CI/CD runs or deployments triggered from the new branch during the window.
+- Audit branch protection rules on the new default branch for missing controls.
+- Restrict default branch change permissions to a smaller group of authorized maintainers.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1195/002/",
+    "https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch",
+]
+risk_score = 47
+rule_id = "a3b4c5d6-e7f8-4901-abcd-012345678901"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Defense Evasion",
+    "Tactic: Impact",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action == "repo.update_default_branch"
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.repo",
+    "github.org",
+    "event.action",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1485"
+name = "Data Destruction"
+reference = "https://attack.mitre.org/techniques/T1485/"
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"

--- a/rules/integrations/github/persistence_github_actions_secret_created_or_updated.toml
+++ b/rules/integrations/github/persistence_github_actions_secret_created_or_updated.toml
@@ -1,0 +1,124 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a GitHub Actions secret is created or updated at the repository, environment, or organization
+level. GitHub Actions secrets store sensitive credentials (API keys, passwords, tokens, certificates) that
+are injected into CI/CD workflows as environment variables. While secret provisioning is routine for CI/CD
+operations, unauthorized secret creation or modification can be used to inject malicious credentials into
+workflows, override existing secrets to break pipelines, or exfiltrate credentials by directing them to
+attacker-controlled workflow steps.
+"""
+false_positives = [
+    """
+    DevOps and platform engineering teams routinely create and rotate GitHub Actions secrets as part of
+    credential lifecycle management. Automated provisioning bots and deployment pipelines may also create
+    secrets programmatically. Validate the actor and the repository context against expected secret
+    provisioning activity.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Actions Secret Created or Updated"
+note = """## Triage and analysis
+
+### Investigating GitHub Actions Secret Created or Updated
+
+GitHub Actions secrets are the credential injection mechanism for CI/CD workflows. Secrets are scoped to
+repositories, environments, or the entire organization. An adversary who has obtained repository admin or
+organization owner access may create or modify secrets to inject malicious credentials, harvest production
+API keys during secret rotation, or disrupt pipelines by overwriting valid secrets with incorrect values.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized DevOps engineer, automation bot, or admin?
+- **Review the secret name and scope**: What secret was created/updated? Is it a known, expected secret name?
+  - New secret names not in the approved list warrant investigation.
+- **Review the repository and environment**: Is this a production or sensitive environment?
+  - Organization-level secrets affect all repositories and are highest risk.
+- **Check the operation type**: Was this a create or update? Updates to existing secrets may indicate credential hijacking.
+- **Correlate with workflow runs**: Were any workflows triggered shortly after that used this secret?
+
+### False positive analysis
+
+- Regular credential rotation by DevOps teams creates update events for existing secrets.
+- New project onboarding creates new secrets for the repository's CI/CD pipeline.
+
+### Response and remediation
+
+- If unauthorized: immediately audit the secret's value (secrets cannot be read after creation in GitHub).
+- Delete the suspect secret and re-provision it with a new value from the legitimate credential store.
+- Review all workflow runs that used the affected secret since the modification.
+- Implement approval workflows for secret creation and modification in sensitive repositories.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1098/001/",
+    "https://attack.mitre.org/techniques/T1556/006/",
+    "https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions",
+]
+risk_score = 21
+rule_id = "b4c5d6e7-f8a9-4012-bcde-123456789012"
+severity = "low"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Credential Access",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action like~ "*create_actions_secret*"
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.repo",
+    "github.org",
+    "event.action",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.001"
+name = "Additional Cloud Credentials"
+reference = "https://attack.mitre.org/techniques/T1098/001/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1556"
+name = "Modify Authentication Process"
+reference = "https://attack.mitre.org/techniques/T1556/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/integrations/github/persistence_github_outside_collaborator_invited.toml
+++ b/rules/integrations/github/persistence_github_outside_collaborator_invited.toml
@@ -1,0 +1,115 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a GitHub organization member or outside collaborator is added to or removed from a repository.
+Outside collaborators are GitHub users who are not members of the organization but are granted access to
+specific repositories. Adding an outside collaborator to a sensitive or private repository can expose
+proprietary source code, secrets, and intellectual property to unauthorized individuals. Adversaries who
+have compromised an organization member account may add external accomplices as collaborators to facilitate
+data exfiltration.
+"""
+false_positives = [
+    """
+    Organizations frequently add contractors, partners, and open-source contributors as outside collaborators
+    to specific repositories. Validate that the inviter has authorization to grant external access to the
+    specific repository, and that the invitee is a known and vetted external party.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Outside Collaborator Added or Removed from Repository"
+note = """## Triage and analysis
+
+### Investigating GitHub Outside Collaborator Added or Removed from Repository
+
+Outside collaborators bypass organization membership controls and can be added to private repositories by
+any repository administrator. This makes them a potential vector for unauthorized access, either by a
+compromised insider adding a malicious external party, or by an adversary who has gained repository admin
+access and wants to establish access for an external account they control.
+
+#### Possible investigation steps
+
+- **Identify the inviter**: Review `github.actor` — is this an authorized repository administrator?
+- **Identify the invitee**: Review `github.user` — is this a known, vetted external party?
+  - Newly created GitHub accounts or accounts with no prior organizational context are suspicious.
+- **Review the repository**: Is the repository sensitive (production code, security tooling, infrastructure)?
+- **Check the permission level granted**: Read, write, or admin access?
+  - Write or admin access for outside collaborators on sensitive repos warrants immediate review.
+- **Verify business justification**: Is there a contract or approved request for this collaborator?
+
+### False positive analysis
+
+- Legitimate contractor or partner onboarding adds outside collaborators to specific project repositories.
+- Open-source contribution workflows may add community contributors as collaborators.
+
+### Response and remediation
+
+- If unauthorized: immediately remove the outside collaborator from the repository.
+- Audit what the collaborator accessed or cloned during their access window.
+- Review all repositories where the actor has admin access for additional unauthorized collaborator additions.
+- Implement organization policies requiring approval workflows for outside collaborator access.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1136/003/",
+    "https://attack.mitre.org/techniques/T1098/",
+    "https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-outside-collaborators",
+]
+risk_score = 47
+rule_id = "e5f6a7b8-c9d0-4123-def0-234567890123"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action like~ "org.*outside_collaborator*"
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.user",
+    "github.repo",
+    "github.org",
+    "event.action",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1136"
+name = "Create Account"
+reference = "https://attack.mitre.org/techniques/T1136/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1136.003"
+name = "Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1136/003/"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"

--- a/rules/integrations/github/persistence_github_repository_admin_permission_granted.toml
+++ b/rules/integrations/github/persistence_github_repository_admin_permission_granted.toml
@@ -1,0 +1,125 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a user is granted admin or maintainer permission on a GitHub repository. Repository admin
+permission grants full control over repository settings, including the ability to modify branch protection
+rules, manage webhooks, add outside collaborators, and delete the repository. Adversaries who have compromised
+an organization member account may grant admin permissions to additional accounts they control to establish
+persistent access and escalate privileges within the repository. Maintainer permission, while less powerful,
+also allows sensitive repository management actions.
+"""
+false_positives = [
+    """
+    Team leads and project managers routinely grant repository admin and maintainer permissions to new team
+    members or during project ownership transfers. Validate that the actor is authorized to grant this level
+    of access and that the recipient has a documented business need for admin privileges.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Repository Admin or Maintainer Permission Granted"
+note = """## Triage and analysis
+
+### Investigating GitHub Repository Admin or Maintainer Permission Granted
+
+Repository admin permission in GitHub is equivalent to full control over the repository's configuration.
+Admins can bypass branch protection rules, add webhooks for data exfiltration, invite outside collaborators,
+and transfer or delete the repository. Granting admin access to unauthorized users is a persistence and
+privilege escalation technique that allows adversaries to establish durable footholds in sensitive repositories.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized repository admin or team lead?
+- **Identify the recipient**: Review `github.user` — is this a known, active employee with a need for admin access?
+  - Newly created accounts or accounts with no prior activity are suspicious recipients.
+- **Review the repository**: Is this a production, security-critical, or infrastructure repository?
+  - Admin grants on sensitive repositories warrant expedited review.
+- **Check the permission level**: Admin vs. maintainer. Admin is higher risk.
+- **Review subsequent activity**: What did the newly granted admin do immediately after receiving access?
+
+### False positive analysis
+
+- New team member onboarding with appropriate admin access requirements.
+- Project ownership transfers during team restructuring.
+
+### Response and remediation
+
+- If unauthorized: immediately revoke the admin permission from the repository.
+- Review all repository changes made by the newly added admin during the window.
+- If the granting actor's account is compromised: suspend and rotate credentials for that account.
+- Implement least-privilege policies limiting repo admin to a small set of named maintainers.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1098/",
+    "https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization",
+]
+risk_score = 47
+rule_id = "c5d6e7f8-a9b0-4123-cdef-234567890123"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action in ("repo.add_member", "repo.change_member_permission") and
+  github.permission in ("admin", "maintain")
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.user",
+    "github.repo",
+    "github.org",
+    "github.permission",
+    "event.action",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1078"
+name = "Valid Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1078.004"
+name = "Cloud Accounts"
+reference = "https://attack.mitre.org/techniques/T1078/004/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"

--- a/rules/integrations/github/persistence_github_webhook_created_or_modified.toml
+++ b/rules/integrations/github/persistence_github_webhook_created_or_modified.toml
@@ -1,0 +1,123 @@
+[metadata]
+creation_date = "2026/05/10"
+integration = ["github"]
+maturity = "development"
+updated_date = "2026/05/10"
+
+[rule]
+author = ["Ivan Saakov"]
+description = """
+Detects when a GitHub webhook is created, modified, or deleted at the repository or organization level.
+Webhooks deliver HTTP POST payloads to configured URLs when specific GitHub events occur. Adversaries who
+have obtained repository administrator or organization owner access may create webhooks to exfiltrate source
+code, secrets, and activity data to attacker-controlled endpoints. Webhook creation can also be used as a
+persistence mechanism, continuing to deliver data even after the attacker's primary access is revoked.
+"""
+false_positives = [
+    """
+    Development teams frequently create and manage webhooks for CI/CD pipelines, Slack integrations, project
+    management tools, and other automation. Validate that the webhook target URL is a recognized and approved
+    endpoint. Webhooks pointing to personal or external domains should be investigated.
+    """,
+]
+from = "now-9m"
+index = ["logs-github.audit-*"]
+language = "eql"
+license = "Elastic License v2"
+name = "GitHub Webhook Created or Modified"
+note = """## Triage and analysis
+
+### Investigating GitHub Webhook Created or Modified
+
+GitHub webhooks are a common persistence and data exfiltration mechanism. Once created, a webhook
+automatically delivers event payloads — including push content, pull request diffs, and issue comments —
+to the configured URL. Malicious webhooks can exfiltrate code, credentials committed to repositories, and
+organizational activity indefinitely without requiring interactive access.
+
+#### Possible investigation steps
+
+- **Identify the actor**: Review `github.actor` — is this an authorized engineer or admin?
+- **Review the target URL**: What URL is the webhook delivering to?
+  - Internal CI/CD endpoints (Jenkins, GitHub Actions) are expected.
+  - Personal domains, webhook relay services (webhook.site, requestbin), or unknown external domains are suspicious.
+- **Review the events subscribed**: What events trigger the webhook? Broad subscriptions (push, pull_request, release) are higher risk.
+- **Check the repository classification**: Is this a sensitive or production repository?
+- **Verify the action**: Was this a creation, update, or deletion? Updates to change the target URL are particularly suspicious.
+
+### False positive analysis
+
+- CI/CD pipeline webhooks for Jenkins, GitHub Actions, Slack, and project management tools are common.
+- Build an approved webhook URL allowlist and review deviations.
+
+### Response and remediation
+
+- If unauthorized: immediately delete the webhook from the repository or organization settings.
+- Review the webhook's delivery history to understand what data was sent and to where.
+- If sensitive data was delivered: treat as a data breach and initiate incident response.
+- Audit all webhooks across the organization for unauthorized entries.
+"""
+references = [
+    "https://attack.mitre.org/techniques/T1102/",
+    "https://attack.mitre.org/techniques/T1537/",
+    "https://docs.github.com/en/webhooks/about-webhooks",
+]
+risk_score = 47
+rule_id = "c3d4e5f6-a7b8-4901-bcde-f12345678901"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Exfiltration",
+    "Data Source: Github",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+configuration where data_stream.dataset == "github.audit" and
+  event.action in ("hook.create", "hook.destroy", "hook.update")
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "github.actor",
+    "github.repo",
+    "github.org",
+    "event.action",
+    "github.operation_type",
+    "source.ip",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1102"
+name = "Web Service"
+reference = "https://attack.mitre.org/techniques/T1102/"
+
+[[rule.threat.technique]]
+id = "T1537"
+name = "Transfer Data to Cloud Account"
+reference = "https://attack.mitre.org/techniques/T1537/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1567"
+name = "Exfiltration Over Web Service"
+reference = "https://attack.mitre.org/techniques/T1567/"
+
+[rule.threat.tactic]
+id = "TA0010"
+name = "Exfiltration"
+reference = "https://attack.mitre.org/tactics/TA0010/"


### PR DESCRIPTION
## Summary - What I changed

Adds 15 new GitHub detection rules identified during a gap analysis comparing internal Splunk/GitHub audit
alert coverage against existing Elastic detection rules for the GitHub integration.

**Current state**: Elastic has 19 GitHub rules. This PR adds 15 rules covering attack techniques that have
no existing Elastic coverage.

| Rule | Tactic | Technique | Severity |
|------|--------|-----------|----------|
| GitHub Audit Log Streaming Configuration Modified | Defense Evasion | T1562.001 | High |
| GitHub Organization Two-Factor Authentication Requirement Disabled | Defense Evasion / Credential Access | T1556, T1562.001 | High |
| GitHub Webhook Created or Modified | Persistence / Exfiltration | T1102, T1537 | Medium |
| GitHub Repository Archive Mass Download Detected | Collection / Exfiltration | T1213.003 | High |
| GitHub Outside Collaborator Added or Removed from Repository | Persistence | T1136.003, T1098 | Medium |
| GitHub Fork Policy Modified | Exfiltration / Defense Evasion | T1537 | Medium |
| GitHub Pages Enabled on Repository | Exfiltration | T1567 | High |
| GitHub Dependabot Security Alerts Disabled | Defense Evasion | T1562.001 | Medium |
| GitHub Secret Scanning Push Protection Bypass | Defense Evasion / Credential Access | T1562.001, T1552.001 | High |
| GitHub Advanced Security Configuration Modified | Defense Evasion | T1562.001 | High |
| GitHub High Volume API Requests Across Repositories Detected | Discovery / Collection | T1087.003, T1530 | High |
| GitHub Actions Runner Group Created or Modified | Persistence / Initial Access | T1195.002, T1098 | High |
| GitHub Repository Default Branch Changed | Defense Evasion / Impact | T1562, T1485 | Medium |
| GitHub Actions Secret Created or Updated | Persistence / Credential Access | T1098.001, T1556 | Low |
| GitHub Repository Admin or Maintainer Permission Granted | Persistence / Privilege Escalation | T1098, T1078.004 | Medium |

## How To Test

All 51 existing unit tests pass with no regressions:
python -m pytest tests/test_all_rules.py -q --tb=short
51 passed, 1 skipped in 85.78s

Rules cover `logs-github.audit-*` index and use EQL `configuration where data_stream.dataset == "github.audit"` 
query type, consistent with existing GitHub integration rules.

## Checklist
- [x] Added a label for the type of pr: `Rule: New`
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios