### PR TITLE
[Rule Tuning] GitHub Private Repository Turned Public

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -166,8 +166,7 @@
     "github.overridden_codes": "keyword",
     "github.reasons.code": "keyword",
     "github.reasons.message": "text",
-    "github.repository_public": "boolean",
-    "github.previous_visibility": "keyword"
+    "github.repository_public": "boolean"
   },
   "logs-google_workspace*": {
     "gsuite.admin": "keyword",

--- a/rules/integrations/github/exfiltration_github_private_repository_turned_public.toml
+++ b/rules/integrations/github/exfiltration_github_private_repository_turned_public.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/12/16"
 integration = ["github"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/12"
 
 [rule]
 author = ["Elastic"]
@@ -62,7 +62,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 query = '''
 configuration where data_stream.dataset == "github.audit" and github.operation_type == "modify" and github.category == "repo" and
-event.action == "repo.access" and github.previous_visibility == "private" and github.visibility == "public"
+event.action == "repo.access" and github.visibility == "public"
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

Small PR to remove the `previous_visibility` field.

GitHub's Enterprise Cloud audit log emits a `previous_visibility` field on `repo.access` events (when a repository's visibility changes). The Elastic `github` integration does not declare or process this field, so it is dropped at ingest and never lands in `logs-github.audit-*`. Only the new visibility is observable.

This should not impact the functionality. The rest of the rule logic already restricts the rule to a visibility change for a repo where the result is that the repo is public ([ref](https://docs.github.com/en/enterprise-cloud@latest/admin/monitoring-activity-in-your-enterprise/reviewing-audit-logs-for-your-enterprise/audit-log-events-for-your-enterprise#repo)). This should only occur when a non-public repo changes to public. 

## How To Test

Test against representative data and verify in GitHub docs and Elastic integration docs. 

Verified in our test stack that rule still fires.

<img width="1525" height="496" alt="image" src="https://github.com/user-attachments/assets/e9d62e68-b6f9-4081-8697-1ea7559d5cf5" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
