### PR TITLE
[Tuning] LSASS Memory Dump Handle Acces

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -39,6 +39,7 @@
         "ObjectClass": "keyword",
         "ObjectDN": "keyword",
         "ObjectName": "keyword",
+        "ObjectType": "keyword",
         "OldTargetUserName": "keyword",
         "OriginalFileName": "keyword",
         "ParentProcessId": "keyword",

--- a/rules/windows/credential_access_lsass_memdump_handle_access.toml
+++ b/rules/windows/credential_access_lsass_memdump_handle_access.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/16"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/05/12"
 
 [transform]
 [[transform.osquery]]
@@ -128,6 +128,7 @@ host.os.type:"windows" and event.code:"4656" and
     winlog.event_data.AccessMask : ("0x1fffff" or "0x1010" or "0x120089" or "0x1F3FFF") or
     winlog.event_data.AccessMaskDescription : ("READ_CONTROL" or "Read from process memory")
   ) and
+  winlog.event_data.ObjectType : "Process" and 
   winlog.event_data.ObjectName : *\\Windows\\System32\\lsass.exe and
   not winlog.event_data.ProcessName : (
       "C:\Windows\System32\wbem\WmiPrvSE.exe" or
@@ -135,7 +136,13 @@ host.os.type:"windows" and event.code:"4656" and
       "C:\Windows\System32\dllhost.exe" or
       "C:\Windows\System32\svchost.exe" or
       "C:\Windows\System32\msiexec.exe" or
-      "C:\Windows\explorer.exe"
+      "C:\Windows\explorer.exe" or 
+      "C:\\Windows\\Sysmon64.exe" or 
+      "C:\\Windows\\BTPass\\x64\\BTPassSvc.exe" or 
+      "C:\\Windows\\Sysmon.exe" or 
+      "C:\\Windows\\System32\\RtkAudUService64.exe" or 
+      "C:\\Windows\\System32\\RtkAudUService64.exe" or 
+       C\:\\Windows\\System32\\DriverStore\\FileRepository\\fn.inf_amd64_*\\driver\\tphkload.exe
   )
 '''
 


### PR DESCRIPTION
`winlog.event_data.ObjectType` set to Process to avoid FPs for File access type.

https://elasticstack.slack.com/archives/C016E72DWDS/p1778591251364219