### PR TITLE
[Rule Tuning] Potential macOS SSH Brute Force Detected

### DIFF
--- a/rules/macos/credential_access_potential_macos_ssh_bruteforce.toml
+++ b/rules/macos/credential_access_potential_macos_ssh_bruteforce.toml
@@ -2,13 +2,15 @@
 creation_date = "2020/11/16"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/05/18"
 
 [rule]
 author = ["Elastic"]
 description = """
-Identifies a high number (20) of macOS SSH KeyGen process executions from the same host. An adversary may attempt a
-brute force attack to obtain unauthorized access to user accounts.
+Identifies a high number (20) of inbound SSH login attempts on a macOS host within a short time window. On macOS, each
+inbound SSH authentication attempt spawns the sshd-keygen-wrapper process once, whether the login succeeds or fails.
+Adversaries may perform password brute force or password spraying against exposed SSH services to obtain unauthorized
+access.
 """
 from = "now-9m"
 index = ["logs-endpoint.events.*"]
@@ -65,34 +67,36 @@ note = """## Triage and analysis
 
 ### Investigating Potential macOS SSH Brute Force Detected
 
-SSH (Secure Shell) is a protocol used to securely access remote systems. On macOS, the `sshd-keygen-wrapper` process is involved in SSH key generation. Adversaries may exploit this by repeatedly attempting to generate keys to gain unauthorized access, a tactic known as brute force. The detection rule identifies unusual activity by monitoring for excessive executions of this process, indicating potential brute force attempts.
+SSH (Secure Shell) is a protocol used to securely access remote systems. On macOS, each inbound SSH authentication attempt spawns
+`sshd-keygen-wrapper` once before handing off to `sshd`, regardless of whether the login succeeds or fails. This rule uses that
+1:1 relationship as a proxy for high inbound SSH login attempt volume on a host. It does not detect SSH key generation or
+key-based brute force activity.
 
 ### Possible investigation steps
 
-- Review the alert details to confirm the host and process information, specifically checking for the host.os.type as macos and the process.name as sshd-keygen-wrapper.
-- Examine the frequency and timing of the sshd-keygen-wrapper process executions to determine if they align with normal user activity or if they suggest an automated brute force attempt.
-- Investigate the parent process, launchd, to ensure it is legitimate and not being used maliciously to spawn the sshd-keygen-wrapper process.
-- Check for any recent successful or failed login attempts on the affected host to identify potential unauthorized access.
-- Correlate the activity with any other alerts or logs from the same host to identify patterns or additional indicators of compromise.
-- Review user account activity on the host to determine if any accounts have been accessed or modified unexpectedly.
+- Review alert details for `host.os.type:macos`, `process.name:sshd-keygen-wrapper`, and `process.parent.name:launchd`.
+- Examine the frequency and timing of `sshd-keygen-wrapper` process starts to determine if they suggest automated login attempts.
+- Review SSH authentication logs on the affected host for failed and successful logins, source IP addresses, and targeted usernames.
+- Determine whether Remote Login is expected to be enabled on this host (for example, build servers or developer workstations).
+- Correlate the activity with other alerts or logs from the same host to identify additional indicators of compromise.
+- Review user account activity on the host to determine if any accounts were accessed or modified unexpectedly.
 
 ### False positive analysis
 
-- Legitimate administrative tasks may trigger the rule if an administrator is performing routine maintenance or updates that involve generating SSH keys. To handle this, create an exception for known administrative accounts or scheduled maintenance windows.
-- Automated scripts or applications that require frequent SSH key generation for legitimate purposes can cause false positives. Identify these scripts or applications and exclude their associated processes or hosts from the detection rule.
-- Development environments where SSH keys are frequently generated for testing purposes might trigger the rule. Consider excluding specific development machines or user accounts from the rule to prevent unnecessary alerts.
-- Continuous integration/continuous deployment (CI/CD) systems that automate SSH key generation as part of their workflow can be a source of false positives. Exclude these systems or their specific processes from the detection rule to avoid disruption.
-- If a known security tool or monitoring system is configured to test SSH key generation as part of its checks, it may trigger the rule. Verify the tool's activity and exclude its processes if deemed non-threatening.
+- Build servers, developer workstations, or CI/CD pipelines that receive many legitimate inbound SSH connections may trigger this rule. Exclude known hosts or maintenance windows if the activity is expected.
+- Automated deployment or configuration management tools that open many SSH sessions in a short period can cause false positives.
+- Internet-facing SSH services may receive high volumes of scanning or credential-stuffing traffic from unrelated sources.
+- Security scanners or health checks that repeatedly test SSH connectivity may generate elevated `sshd-keygen-wrapper` activity.
 
 ### Response and remediation
 
-- Immediately isolate the affected macOS host from the network to prevent further unauthorized access attempts.
-- Terminate any suspicious or unauthorized `sshd-keygen-wrapper` processes running on the affected host to halt ongoing brute force attempts.
-- Review and reset SSH credentials for all user accounts on the affected host to ensure no unauthorized access has been achieved.
-- Implement IP blocking or rate limiting on the SSH service to prevent further brute force attempts from the same source.
-- Conduct a thorough review of the affected host's SSH configuration and logs to identify any unauthorized changes or access.
-- Escalate the incident to the security operations team for further investigation and to determine if additional hosts are affected.
-- Enhance monitoring and alerting for similar SSH brute force patterns across the network to improve early detection and response capabilities."""
+- Review SSH authentication logs to identify source IPs, targeted accounts, and whether any logins succeeded.
+- If unauthorized access is suspected, isolate the affected macOS host from the network.
+- Implement IP blocking or rate limiting on the SSH service to reduce further login attempts.
+- Review and reset credentials for affected user accounts if compromise is confirmed.
+- Conduct a thorough review of the host's SSH configuration and enabled Remote Login settings.
+- Escalate to the security operations team if additional hosts show similar patterns.
+- Enhance monitoring for SSH authentication anomalies across the environment."""
 
 
 [[rule.threat]]

--- a/rules/macos/credential_access_potential_macos_ssh_bruteforce.toml
+++ b/rules/macos/credential_access_potential_macos_ssh_bruteforce.toml
@@ -7,7 +7,7 @@ updated_date = "2026/05/18"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies a high number (20) of inbound SSH login attempts on a macOS host within a short time window. On macOS, each
+Identifies a high number of inbound SSH login attempts on a macOS host within a short time window. On macOS, each
 inbound SSH authentication attempt spawns the sshd-keygen-wrapper process once, whether the login succeeds or fails.
 Adversaries may perform password brute force or password spraying against exposed SSH services to obtain unauthorized
 access.


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: https://github.com/elastic/detection-rules/issues/6139

## Summary - What I changed

- Description is now changed to reflect the rule detects inbound SSH login attempt volume via sshd-keygen-wrapper (one spawn per auth attempt, success or failure), not SSH key generation.
- Investigation guide Updated to match the [Mitten Mac methodology](https://themittenmac.com/detecting-ssh-activity-via-process-monitoring/)
   - Explains the 1:1 login-attempt proxy behavior
   - Investigation steps focus on auth logs and source IPs
- FP section covers CI/CD, build servers, scanners (not “key generation”)
- Remediation focuses on auth log review and rate limiting (removed “terminate sshd-keygen-wrapper”)
- Query Unchanged (logic was already correct).

## How To Test

- Unit test to pass 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [x] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
