### PR TITLE
[Rule Tuning] ES|QL Explicit Null Value Removal

### DIFF
--- a/rules/cross-platform/initial_access_azure_o365_with_network_alert.toml
+++ b/rules/cross-platform/initial_access_azure_o365_with_network_alert.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/04/29"
 integration = ["azure", "o365"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/21"
 
 [rule]
 author = ["Elastic"]
@@ -97,9 +97,9 @@ from logs-o365.audit-*, logs-azure.signinlogs-*, .alerts-security.*
 
 // classify each source ip based on alert type
 | eval
-  Esql.source_ip_mail_access_case = case(data_stream.dataset == "o365.audit" and event.action == "MailItemsAccessed" and event.outcome == "success", to_ip(source.ip), null),
-  Esql.source_ip_azure_signin_case = case(data_stream.dataset == "azure.signinlogs" and event.outcome == "success", to_ip(source.ip), null),
-  Esql.source_ip_network_alert_case = case(kibana.alert.rule.rule_id == "eb079c62-4481-4d6e-9643-3ca499df7aaa" and not data_stream.dataset in ("o365.audit", "azure.signinlogs"), to_ip(source.ip), null)
+  Esql.source_ip_mail_access_case = case(data_stream.dataset == "o365.audit" and event.action == "MailItemsAccessed" and event.outcome == "success", to_ip(source.ip), to_ip(null)),
+  Esql.source_ip_azure_signin_case = case(data_stream.dataset == "azure.signinlogs" and event.outcome == "success", to_ip(source.ip), to_ip(null)),
+  Esql.source_ip_network_alert_case = case(kibana.alert.rule.rule_id == "eb079c62-4481-4d6e-9643-3ca499df7aaa" and not data_stream.dataset in ("o365.audit", "azure.signinlogs"), to_ip(source.ip), to_ip(null))
 
 // aggregate by source ip
 | stats

--- a/rules/cross-platform/initial_access_azure_o365_with_network_alert.toml
+++ b/rules/cross-platform/initial_access_azure_o365_with_network_alert.toml
@@ -97,9 +97,9 @@ from logs-o365.audit-*, logs-azure.signinlogs-*, .alerts-security.*
 
 // classify each source ip based on alert type
 | eval
-  Esql.source_ip_mail_access_case = case(data_stream.dataset == "o365.audit" and event.action == "MailItemsAccessed" and event.outcome == "success", to_ip(source.ip), to_ip(null)),
-  Esql.source_ip_azure_signin_case = case(data_stream.dataset == "azure.signinlogs" and event.outcome == "success", to_ip(source.ip), to_ip(null)),
-  Esql.source_ip_network_alert_case = case(kibana.alert.rule.rule_id == "eb079c62-4481-4d6e-9643-3ca499df7aaa" and not data_stream.dataset in ("o365.audit", "azure.signinlogs"), to_ip(source.ip), to_ip(null))
+  Esql.source_ip_mail_access_case = case(data_stream.dataset == "o365.audit" and event.action == "MailItemsAccessed" and event.outcome == "success", to_ip(source.ip)),
+  Esql.source_ip_azure_signin_case = case(data_stream.dataset == "azure.signinlogs" and event.outcome == "success", to_ip(source.ip)),
+  Esql.source_ip_network_alert_case = case(kibana.alert.rule.rule_id == "eb079c62-4481-4d6e-9643-3ca499df7aaa" and not data_stream.dataset in ("o365.audit", "azure.signinlogs"), to_ip(source.ip))
 
 // aggregate by source ip
 | stats

--- a/rules/integrations/azure/initial_access_entra_id_graph_single_session_from_multiple_addresses.toml
+++ b/rules/integrations/azure/initial_access_entra_id_graph_single_session_from_multiple_addresses.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/05/08"
 integration = ["azure"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/21"
 
 [rule]
 author = ["Elastic"]
@@ -112,8 +112,8 @@ from logs-azure.signinlogs-*, logs-azure.graphactivitylogs-* metadata _id, _vers
         data_stream.dataset == "azure.graphactivitylogs", "graph",
         "other"
     ),
-    Esql.signin_source_asn = case(data_stream.dataset == "azure.signinlogs", source.`as`.organization.name, null),
-    Esql.graph_source_asn = case(data_stream.dataset == "azure.graphactivitylogs", source.`as`.organization.name, null)
+    Esql.signin_source_asn = case(data_stream.dataset == "azure.signinlogs", source.`as`.organization.name, to_string(null)),
+    Esql.graph_source_asn = case(data_stream.dataset == "azure.graphactivitylogs", source.`as`.organization.name, to_string(null))
 
 | where Esql.azure_signinlogs_properties_app_id_coalesce not in (
     "4354e225-50c9-4423-9ece-2d5afd904870",  // Augmentation Loop
@@ -170,8 +170,8 @@ from logs-azure.signinlogs-*, logs-azure.graphactivitylogs-* metadata _id, _vers
     Esql.azure_signinlogs_properties_app_id_coalesce_count_distinct = count_distinct(Esql.azure_signinlogs_properties_app_id_coalesce),
     Esql.event_type_case_values = values(Esql.event_type_case),
     Esql.event_type_case_count_distinct = count_distinct(Esql.event_type_case),
-    Esql.signin_time_min = min(case(Esql.event_type_case == "signin", Esql.@timestamp, null)),
-    Esql.graph_time_min = min(case(Esql.event_type_case == "graph", Esql.@timestamp, null)),
+    Esql.signin_time_min = min(case(Esql.event_type_case == "signin", Esql.@timestamp, to_datetime(null))),
+    Esql.graph_time_min = min(case(Esql.event_type_case == "graph", Esql.@timestamp, to_datetime(null))),
     Esql.url_original_values = values(url.original),
     Esql.azure_graphactivitylogs_properties_scopes_values = values(azure.graphactivitylogs.properties.scopes),
     Esql.event_count = count()

--- a/rules/integrations/azure/initial_access_entra_id_graph_single_session_from_multiple_addresses.toml
+++ b/rules/integrations/azure/initial_access_entra_id_graph_single_session_from_multiple_addresses.toml
@@ -112,8 +112,8 @@ from logs-azure.signinlogs-*, logs-azure.graphactivitylogs-* metadata _id, _vers
         data_stream.dataset == "azure.graphactivitylogs", "graph",
         "other"
     ),
-    Esql.signin_source_asn = case(data_stream.dataset == "azure.signinlogs", source.`as`.organization.name, to_string(null)),
-    Esql.graph_source_asn = case(data_stream.dataset == "azure.graphactivitylogs", source.`as`.organization.name, to_string(null))
+    Esql.signin_source_asn = case(data_stream.dataset == "azure.signinlogs", source.`as`.organization.name),
+    Esql.graph_source_asn = case(data_stream.dataset == "azure.graphactivitylogs", source.`as`.organization.name)
 
 | where Esql.azure_signinlogs_properties_app_id_coalesce not in (
     "4354e225-50c9-4423-9ece-2d5afd904870",  // Augmentation Loop
@@ -170,8 +170,8 @@ from logs-azure.signinlogs-*, logs-azure.graphactivitylogs-* metadata _id, _vers
     Esql.azure_signinlogs_properties_app_id_coalesce_count_distinct = count_distinct(Esql.azure_signinlogs_properties_app_id_coalesce),
     Esql.event_type_case_values = values(Esql.event_type_case),
     Esql.event_type_case_count_distinct = count_distinct(Esql.event_type_case),
-    Esql.signin_time_min = min(case(Esql.event_type_case == "signin", Esql.@timestamp, to_datetime(null))),
-    Esql.graph_time_min = min(case(Esql.event_type_case == "graph", Esql.@timestamp, to_datetime(null))),
+    Esql.signin_time_min = min(case(Esql.event_type_case == "signin", Esql.@timestamp)),
+    Esql.graph_time_min = min(case(Esql.event_type_case == "graph", Esql.@timestamp)),
     Esql.url_original_values = values(url.original),
     Esql.azure_graphactivitylogs_properties_scopes_values = values(azure.graphactivitylogs.properties.scopes),
     Esql.event_count = count()


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

Small PR to remove `null` values in ES|QL rules to avoid runtime issues. Catching this in validation is dependent on representative data being available in the test stack and the stack being on an old enough version that this is not handled elegantly in ES|QL. 


This affects every stack version older than 9.4 (see PR: https://github.com/elastic/elasticsearch/pull/139529).

 This PR refactored ResponseValueUtils.valueAt() and changed NULL from throwing to returning null:
```
  // 8.11 – 9.3.x (all affected)
  case SHORT, BYTE, ..., NULL -> throw EsqlIllegalArgumentException.illegalDataType(dataType);

  // 9.4.0+ (fixed)
  case NULL, UNSUPPORTED -> (block, offset, scratch) -> null;
```

The Null throw was removed in https://github.com/elastic/elasticsearch/pull/139529/changes#diff-d8af013e9d8a9ea6e07f9334bb2aadc8a039999bb9108435398d7cc31329f808L173. 


In 9.3

<img width="693" height="215" alt="image" src="https://github.com/user-attachments/assets/ca8f424d-0895-45a4-9d4b-fe9e2a7e5d61" />

<img width="707" height="294" alt="image" src="https://github.com/user-attachments/assets/1eac0469-b4b5-4315-a0b2-6615f05057fe" />



The screenshots show that on 9.3, even to_ip(null) is seen as type null by the CASE type checker. `to_ip()` on 9.3 requires ip|keyword|text input, and null doesn't satisfy any of those, so it propagates as null type. The fix that works across all affected versions is to remove the explicit else branch entirely. case(cond, value) with no else implicitly returns null for the false case without passing a null-typed argument to CASE's type checker.



> [!NOTE]
> We should probably add unit tests for this, but I am decoupling that from this rule update I expect that will require a code owner review and be a more involved process than tuning the affected rules. 

## How To Test

Run the updated query in test stack and observe its retained functionality.

Both cast and null removed queries return the same result: 

<img width="1776" height="637" alt="image" src="https://github.com/user-attachments/assets/b16dfe05-0ca2-4e68-ac42-223ca8885082" />

<img width="1762" height="584" alt="image" src="https://github.com/user-attachments/assets/5f33691e-0bda-4d64-9336-d1737093ee38" />




## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
