### PR TITLE
[enhancement]  Reviewing MITRE mapping for the macos rules

### DIFF
--- a/rules/macos/command_and_control_perl_outbound_network_connection.toml
+++ b/rules/macos/command_and_control_perl_outbound_network_connection.toml
@@ -97,7 +97,6 @@ id = "T1059"
 name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
 
-
 [rule.threat.tactic]
 id = "TA0002"
 name = "Execution"

--- a/rules/macos/command_and_control_perl_outbound_network_connection.toml
+++ b/rules/macos/command_and_control_perl_outbound_network_connection.toml
@@ -97,10 +97,6 @@ id = "T1059"
 name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
 
-[[rule.threat.technique.subtechnique]]
-id = "T1059.006"
-name = "Python"
-reference = "https://attack.mitre.org/techniques/T1059/006/"
 
 [rule.threat.tactic]
 id = "TA0002"

--- a/rules/macos/defense_evasion_unload_endpointsecurity_kext.toml
+++ b/rules/macos/defense_evasion_unload_endpointsecurity_kext.toml
@@ -122,7 +122,7 @@ reference = "https://attack.mitre.org/techniques/T1547/006/"
 
 
 [rule.threat.tactic]
-id = "TA0003"
-name = "Persistence"
-reference = "https://attack.mitre.org/tactics/TA0003/"
+id = "TA0112"
+name = "Defense Impairment"
+reference = "https://attack.mitre.org/tactics/TA0112/"
 


### PR DESCRIPTION

# Pull Request

*Issue link(s)*:


## Summary - What I changed

Fixing the mapping for:
 -  Perl Outbound Network Connection
 - Attempt to Unload Elastic Endpoint Security Kernel Extension


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated

