### PR TITLE
[New Rule] AWS S3 Credential File Retrieved from Bucket

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -194,6 +194,7 @@
     "auditd.data.a3": "keyword"
   },
   "logs-aws.cloudtrail-*": {
+    "aws.cloudtrail.flattened.request_parameters.key": "keyword",
     "aws.cloudtrail.flattened.request_parameters.ipPermissions.items.ipRanges.items.cidrIp": "keyword",
     "aws.cloudtrail.flattened.request_parameters.ipPermissions.items.fromPort": "keyword",
     "aws.cloudtrail.flattened.request_parameters.serialNumber": "keyword",

--- a/rules/integrations/aws/credential_access_credentials_in_s3_bucket.toml
+++ b/rules/integrations/aws/credential_access_credentials_in_s3_bucket.toml
@@ -7,11 +7,12 @@ updated_date = "2026/05/27"
 [rule]
 author = ["Elastic"]
 description = """
-Detects successful S3 GetObject calls targeting high-value credential files: AWS credentials files
-(".aws/credentials") and SSH private keys ("id_rsa"). These file types are high-yield targets for
-credential harvesting from S3 — AWS credentials provide direct account access and SSH keys enable
-lateral movement. The rule excludes AWSService identity type to suppress S3 replication, Glacier
-restore, and other AWS-internal data movement that legitimately reads these files.
+Detects successful S3 GetObject calls targeting high-value credential and secret files commonly
+stored in S3 buckets: AWS credentials files (".aws/credentials", ".aws/config"), SSH private keys
+("id_rsa", "id_ed25519", "id_ecdsa", "id_dsa"), environment files (".env"), PEM and PuTTY key files,
+and other private key patterns. These file types are high-yield targets for credential harvesting
+from S3. The rule excludes AWSService identity type to suppress S3 replication, Glacier restore,
+and other AWS-internal data movement that legitimately reads these files.
 """
 false_positives = [
     """
@@ -95,7 +96,18 @@ data_stream.dataset: "aws.cloudtrail" and
     event.outcome: "success" and
     aws.cloudtrail.flattened.request_parameters.key: (
         */.aws/credentials or
-        */id_rsa
+        */.aws/config or
+        */id_rsa or
+        */id_ed25519 or
+        */id_ecdsa or
+        */id_dsa or
+        */.env or
+        */.env.* or
+        *.ppk or
+        *.pem or
+        *.key or
+        *private_key* or
+        */.ssh/authorized_keys
     ) and
     not aws.cloudtrail.user_identity.type: "AWSService"
 '''
@@ -132,7 +144,7 @@ name = "Collection"
 reference = "https://attack.mitre.org/tactics/TA0009/"
 
 [rule.alert_suppression]
-group_by = ["aws.cloudtrail.user_identity.arn"]
+group_by = ["source.ip", "cloud.account.id"]
 duration = {value = 5, unit = "m"}
 missing_fields_strategy = "suppress"
 

--- a/rules/integrations/aws/credential_access_credentials_in_s3_bucket.toml
+++ b/rules/integrations/aws/credential_access_credentials_in_s3_bucket.toml
@@ -1,5 +1,5 @@
 [metadata]
-creation_date = "2026/05/19"
+creation_date = "2026/05/27"
 integration = ["aws"]
 maturity = "production"
 updated_date = "2026/05/27"
@@ -8,7 +8,7 @@ updated_date = "2026/05/27"
 author = ["Elastic"]
 description = """
 Detects successful S3 GetObject calls targeting high-value credential files: AWS credentials files
-(`.aws/credentials`) and SSH private keys (`id_rsa`). These file types are high-yield targets for
+(".aws/credentials") and SSH private keys ("id_rsa"). These file types are high-yield targets for
 credential harvesting from S3 — AWS credentials provide direct account access and SSH keys enable
 lateral movement. The rule excludes AWSService identity type to suppress S3 replication, Glacier
 restore, and other AWS-internal data movement that legitimately reads these files.
@@ -25,13 +25,7 @@ index = ["filebeat-*", "logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS S3 Credential File Retrieved from Bucket"
-note = """## Setup
-
-**S3 data event logging required**: This rule detects S3 `GetObject` events, which are data plane events
-not logged by default. To enable: CloudTrail console → Trails → [trail name] → Data events → Add S3 →
-select the buckets to monitor (or all buckets with a wildcard). Without this, the rule produces no alerts.
-
-## Triage and analysis
+note = """## Triage and analysis
 
 ### Investigating AWS S3 Credential File Retrieved from Bucket
 
@@ -48,14 +42,40 @@ names are accessed, it warrants investigation to ensure that the retrieval was a
   pattern was intentionally exposed.
 - **Look for downstream actions**: Search for subsequent IAM, STS, or console actions from the same
   identity shortly after the object retrieval, which may indicate successful credential use.
+
+### False positive analysis
+
+- Legitimate backup or restore processes may access credential files stored in S3 as part of their
+  workflow. Validate the calling identity and user agent against known automation accounts.
+- CI/CD pipelines that retrieve secrets from S3 during deployment may trigger this rule. Verify the
+  source IP and ARN match expected automation infrastructure.
+
+### Response and remediation
+
+- Immediately disable the access key identified in `aws.cloudtrail.user_identity.access_key_id` if
+  the retrieval is determined to be unauthorized.
+- Audit the S3 bucket for overly permissive policies or public access configurations.
+- Rotate any credentials stored in the accessed object — treat them as compromised.
+- Review all CloudTrail events from the same identity in the preceding 30 minutes for signs of
+  lateral movement, IAM changes, or resource creation.
+- Implement S3 bucket policies or IAM conditions restricting access to credential files to only
+  authorized identities and source IPs.
 """
 references = [
     "https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html",
-    "https://attack.mitre.org/techniques/T1552/001/",
 ]
 risk_score = 47
 rule_id = "2f0ee9fe-4529-4b9e-9f78-6c81ef33c6ba"
 severity = "medium"
+setup = """S3 data event logging is required for this rule. This rule detects S3 GetObject events,
+which are data plane events not logged by default. To enable: CloudTrail console → Trails →
+[trail name] → Data events → Add S3 → select the buckets to monitor (or all buckets with a wildcard).
+Without this configuration, the rule produces no alerts.
+
+Refer to the AWS documentation on
+https://docs.aws.amazon.com/awscloudtrail/latest/userguide/logging-data-events-with-cloudtrail.html[logging data events]
+for detailed steps.
+"""
 tags = [
     "Domain: Cloud",
     "Data Source: AWS",
@@ -69,15 +89,15 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-data_stream.dataset: "aws.cloudtrail"
-    and event.provider: "s3.amazonaws.com"
-    and event.action: "GetObject"
-    and event.outcome: "success"
-    and not aws.cloudtrail.user_identity.type: "AWSService"
-    and aws.cloudtrail.flattened.request_parameters.key: (
+data_stream.dataset: "aws.cloudtrail" and
+    event.provider: "s3.amazonaws.com" and
+    event.action: "GetObject" and
+    event.outcome: "success" and
+    aws.cloudtrail.flattened.request_parameters.key: (
         */.aws/credentials or
         */id_rsa
-    )
+    ) and
+    not aws.cloudtrail.user_identity.type: "AWSService"
 '''
 
 [[rule.threat]]
@@ -122,6 +142,7 @@ field_names = [
     "user.name",
     "user_agent.original",
     "source.ip",
+    "source.as.number",
     "aws.cloudtrail.user_identity.arn",
     "aws.cloudtrail.user_identity.type",
     "aws.cloudtrail.user_identity.access_key_id",

--- a/rules/integrations/aws/credential_access_credentials_in_s3_bucket.toml
+++ b/rules/integrations/aws/credential_access_credentials_in_s3_bucket.toml
@@ -1,0 +1,134 @@
+[metadata]
+creation_date = "2026/05/19"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/05/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects successful S3 GetObject calls targeting high-value credential files: AWS credentials files
+(`.aws/credentials`) and SSH private keys (`id_rsa`). These file types are high-yield targets for
+credential harvesting from S3 — AWS credentials provide direct account access and SSH keys enable
+lateral movement. The rule excludes AWSService identity type to suppress S3 replication, Glacier
+restore, and other AWS-internal data movement that legitimately reads these files.
+"""
+false_positives = [
+    """
+    Legitimate CI/CD pipelines, infrastructure tooling, or configuration management systems may retrieve
+    secret files from S3 as part of their normal operation. Validate the calling identity, user agent,
+    and source IP against known automation accounts and expected access patterns.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS S3 Credential File Retrieved from Bucket"
+note = """## Setup
+
+**S3 data event logging required**: This rule detects S3 `GetObject` events, which are data plane events
+not logged by default. To enable: CloudTrail console → Trails → [trail name] → Data events → Add S3 →
+select the buckets to monitor (or all buckets with a wildcard). Without this, the rule produces no alerts.
+
+## Triage and analysis
+
+### Investigating AWS S3 Credential File Retrieved from Bucket
+
+S3 is frequently used to store configuration files, scripts, and secrets. When files with credential-like
+names are accessed, it warrants investigation to ensure that the retrieval was authorized.
+
+### Possible investigation steps
+
+- **Identify the accessed file**: Review `aws.cloudtrail.request_parameters` for the bucket name and key.
+  Determine whether the bucket is intended to store secrets.
+- **Verify the caller**: Inspect `aws.cloudtrail.user_identity.arn` and `source.ip`. If the caller is not
+  an approved automation role, escalate immediately.
+- **Check bucket permissions**: Determine if the bucket is publicly accessible or if the key naming
+  pattern was intentionally exposed.
+- **Look for downstream actions**: Search for subsequent IAM, STS, or console actions from the same
+  identity shortly after the object retrieval, which may indicate successful credential use.
+"""
+references = [
+    "https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html",
+    "https://attack.mitre.org/techniques/T1552/001/",
+]
+risk_score = 47
+rule_id = "2f0ee9fe-4529-4b9e-9f78-6c81ef33c6ba"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS S3",
+    "Use Case: Identity and Access Audit",
+    "Tactic: Credential Access",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset: "aws.cloudtrail"
+    and event.provider: "s3.amazonaws.com"
+    and event.action: "GetObject"
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService"
+    and aws.cloudtrail.flattened.request_parameters.key: (
+        */.aws/credentials or
+        */id_rsa
+    )
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.001"
+name = "Credentials In Files"
+reference = "https://attack.mitre.org/techniques/T1552/001/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1530"
+name = "Data from Cloud Storage"
+reference = "https://attack.mitre.org/techniques/T1530/"
+
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"
+
+[rule.alert_suppression]
+group_by = ["aws.cloudtrail.user_identity.arn"]
+duration = {value = 5, unit = "m"}
+missing_fields_strategy = "suppress"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.provider",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+]


### PR DESCRIPTION
  ## Summary - What I changed

  New rule detecting successful S3 `GetObject` calls targeting high-value credential files: AWS credentials files (`.aws/credentials`) and SSH private keys (`id_rsa`).
  
These are high-yield targets for credential harvesting from S3 buckets.

  - **MITRE**: T1552.001 (Credentials In Files), T1530 (Data from Cloud Storage)
  - **Tactic**: Credential Access, Collection
  - **Data source**: CloudTrail S3 data events
  - **Noise tuning**: Excludes `AWSService` identity type to suppress S3 replication and Glacier restore. Excludes `.tfstate` files (high-volume Terraform remote state reads).

The rule has been tested on our TRaDE instance and verified with telemetry.

<img width="1335" height="468" alt="image" src="https://github.com/user-attachments/assets/06543868-430c-4f78-9d3b-61939a8bed58" />

aws.cloudtrail.flattened.request_parameters: {  "bucketName": "<bucketname>",  "Host": "<host>",  "key": "home/user/.aws/credentials"}

  ## How To Test

  1. Enable S3 data event logging on a test bucket in CloudTrail
  2. Upload a file named `.aws/credentials` or `id_rsa` to the bucket
  3. Call `s3:GetObject` on that file using an IAM user or role identity
  4. Verify in Discover:
     data_stream.dataset: "aws.cloudtrail"
     and event.provider: "s3.amazonaws.com"
     and event.action: "GetObject"
     and event.outcome: "success"
  5. Confirm alert fires in Security → Alerts

  ## Checklist

  - [x] Added a label for the type of pr: `Rule: New`
  - [x] Secret and sensitive material has been managed correctly
  - [x] Documentation and comments were added for features that require
  explanation