### PR TITLE
[Rule Tuning] Abnormally Large DNS Response

### DIFF
--- a/rules/network/lateral_movement_dns_server_overflow.toml
+++ b/rules/network/lateral_movement_dns_server_overflow.toml
@@ -20,7 +20,7 @@ note = """## Triage and analysis
 
 Detection alerts from this rule indicate possible anomalous activity around large byte DNS responses from a Windows DNS server. This detection rule was created based on activity represented in exploitation of vulnerability (CVE-2020-1350) also known as [SigRed](https://www.elastic.co/blog/detection-rules-for-sigred-vulnerability) during July 2020.
 
-#### Possible investigation steps
+### Possible investigation steps
 
 - This specific rule is sourced from network log activity such as DNS or network level data. It's important to validate the source of the incoming traffic and determine if this activity has been observed previously within an environment.
 - Activity can be further investigated and validated by reviewing any associated Intrusion Detection Signatures (IDS) alerts.

--- a/rules/network/lateral_movement_dns_server_overflow.toml
+++ b/rules/network/lateral_movement_dns_server_overflow.toml
@@ -28,7 +28,7 @@ Detection alerts from this rule indicate possible anomalous activity around larg
 - Validate the patch level and OS of the targeted DNS server to validate the observed activity was not large-scale internet vulnerability scanning.
 - Validate that the source of the network activity was not from an authorized vulnerability scan or compromise assessment.
 
-#### False positive analysis
+### False positive analysis
 
 - Based on this rule, which looks for a threshold of 65k bytes, activity below this value is expected to be legitimate. In packet capture files received by the [SANS Internet Storm Center](https://isc.sans.edu/forums/diary/PATCH+NOW+SIGRed+CVE20201350+Microsoft+DNS+Server+Vulnerability/26356/), byte responses in observed attacks were all greater than 65k bytes.
 - This activity can be triggered by compliance/vulnerability scanning or compromise assessment; it's important to determine the source of the activity and potentially allowlist the source host.

--- a/rules/network/lateral_movement_dns_server_overflow.toml
+++ b/rules/network/lateral_movement_dns_server_overflow.toml
@@ -10,15 +10,6 @@ description = """
 Specially crafted DNS requests can manipulate a known overflow vulnerability in some Windows DNS servers, resulting in
 Remote Code Execution (RCE) or a Denial of Service (DoS) from crashing the service.
 """
-false_positives = [
-    """
-    Environments that leverage DNS responses over 65k bytes will result in false positives - if this traffic is
-    predictable and expected, it should be filtered out. Additionally, this detection rule could be triggered by an
-    authorized vulnerability scan or compromise assessment. Long-lived DNS flow records from network security devices
-    (e.g. PAN-OS, Fortinet, NetFlow) where destination.bytes reflects aggregated session traffic rather than a single
-    response are excluded by this rule.
-    """,
-]
 index = ["logs-network_traffic.*", "logs-panw.panos*"]
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/network/lateral_movement_dns_server_overflow.toml
+++ b/rules/network/lateral_movement_dns_server_overflow.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/07/16"
 integration = ["network_traffic", "panw"]
 maturity = "production"
-updated_date = "2026/04/29"
+updated_date = "2026/05/27"
 
 [rule]
 author = ["Elastic"]
@@ -14,7 +14,9 @@ false_positives = [
     """
     Environments that leverage DNS responses over 60k bytes will result in false positives - if this traffic is
     predictable and expected, it should be filtered out. Additionally, this detection rule could be triggered by an
-    authorized vulnerability scan or compromise assessment.
+    authorized vulnerability scan or compromise assessment. Long-lived or high-volume DNS flow records from network
+    security devices (e.g. PAN-OS, Fortinet, NetFlow) where destination.bytes reflects aggregated session traffic
+    rather than a single response are excluded by this rule.
     """,
 ]
 index = ["logs-network_traffic.*", "logs-panw.panos*"]
@@ -39,6 +41,7 @@ Detection alerts from this rule indicate possible anomalous activity around larg
 
 - Based on this rule, which looks for a threshold of 60k bytes, it is possible for activity to be generated under 65k bytes and related to legitimate behavior. In packet capture files received by the [SANS Internet Storm Center](https://isc.sans.edu/forums/diary/PATCH+NOW+SIGRed+CVE20201350+Microsoft+DNS+Server+Vulnerability/26356/), byte responses were all observed as greater than 65k bytes.
 - This activity can be triggered by compliance/vulnerability scanning or compromise assessment; it's important to determine the source of the activity and potentially allowlist the source host.
+- Network security devices such as PAN-OS firewalls, Fortinet, and NetFlow exporters record `destination.bytes` as the total bytes across an entire session rather than a single DNS response. Long-lived flow records (duration > 60 seconds) or high-volume sessions (> 1000 packets) with `event.action` of `flow_terminated` or `network_flow` are excluded to reduce this noise.
 
 ### Related rules
 
@@ -80,6 +83,10 @@ query = '''
       or data_stream.dataset:(network_traffic.dns or zeek.dns))
     and destination.bytes > 60000
     and event.type:("allowed" or "end" or "protocol" or "start")
+and not (
+  event.action:("flow_terminated" or "network_flow")
+  and (event.duration > 60000000000 or network.packets > 1000)
+)
 '''
 
 

--- a/rules/network/lateral_movement_dns_server_overflow.toml
+++ b/rules/network/lateral_movement_dns_server_overflow.toml
@@ -12,11 +12,11 @@ Remote Code Execution (RCE) or a Denial of Service (DoS) from crashing the servi
 """
 false_positives = [
     """
-    Environments that leverage DNS responses over 60k bytes will result in false positives - if this traffic is
+    Environments that leverage DNS responses over 65k bytes will result in false positives - if this traffic is
     predictable and expected, it should be filtered out. Additionally, this detection rule could be triggered by an
-    authorized vulnerability scan or compromise assessment. Long-lived or high-volume DNS flow records from network
-    security devices (e.g. PAN-OS, Fortinet, NetFlow) where destination.bytes reflects aggregated session traffic
-    rather than a single response are excluded by this rule.
+    authorized vulnerability scan or compromise assessment. Long-lived DNS flow records from network security devices
+    (e.g. PAN-OS, Fortinet, NetFlow) where destination.bytes reflects aggregated session traffic rather than a single
+    response are excluded by this rule.
     """,
 ]
 index = ["logs-network_traffic.*", "logs-panw.panos*"]
@@ -39,9 +39,9 @@ Detection alerts from this rule indicate possible anomalous activity around larg
 
 #### False positive analysis
 
-- Based on this rule, which looks for a threshold of 60k bytes, it is possible for activity to be generated under 65k bytes and related to legitimate behavior. In packet capture files received by the [SANS Internet Storm Center](https://isc.sans.edu/forums/diary/PATCH+NOW+SIGRed+CVE20201350+Microsoft+DNS+Server+Vulnerability/26356/), byte responses were all observed as greater than 65k bytes.
+- Based on this rule, which looks for a threshold of 65k bytes, activity below this value is expected to be legitimate. In packet capture files received by the [SANS Internet Storm Center](https://isc.sans.edu/forums/diary/PATCH+NOW+SIGRed+CVE20201350+Microsoft+DNS+Server+Vulnerability/26356/), byte responses in observed attacks were all greater than 65k bytes.
 - This activity can be triggered by compliance/vulnerability scanning or compromise assessment; it's important to determine the source of the activity and potentially allowlist the source host.
-- Network security devices such as PAN-OS firewalls, Fortinet, and NetFlow exporters record `destination.bytes` as the total bytes across an entire session rather than a single DNS response. Long-lived flow records (duration > 60 seconds) or high-volume sessions (> 1000 packets) with `event.action` of `flow_terminated` or `network_flow` are excluded to reduce this noise.
+- Network security devices such as PAN-OS firewalls, Fortinet, and NetFlow exporters record `destination.bytes` as the total bytes across an entire session rather than a single DNS response. Long-lived flow records (`event.duration` > 60 seconds) with `event.action` of `flow_terminated` or `network_flow` are excluded to reduce this noise. Duration is used rather than packet count because a genuine SigRed TCP exchange completes in seconds and cannot be made to exceed 60 seconds by an attacker continuing to use the connection.
 
 ### Related rules
 
@@ -81,11 +81,11 @@ query = '''
 ((event.category:(network or network_traffic) and destination.port:53) 
       or network.protocol:"dns" 
       or data_stream.dataset:(network_traffic.dns or zeek.dns))
-    and destination.bytes > 60000
+    and destination.bytes >= 65000
     and event.type:("allowed" or "end" or "protocol" or "start")
 and not (
   event.action:("flow_terminated" or "network_flow")
-  and (event.duration > 60000000000 or network.packets > 1000)
+  and event.duration > 60000000000
 )
 '''
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:
Resolves https://github.com/elastic/detection-rules/issues/5509

## Summary - What I changed

Small tuning to further filter detections based on an increased destination bytes size and connection duration. Flow-style network appliances such as PAN-OS may only report the DNS traffic upon completion/termination of the flow, as such they can be FP prone in the current logic. 

TPs would generally not cause a flow duration of over 60 seconds unless specifically crafted to do so. The attack flow causes the DNS server to crash, which would cause the initial connection to terminate. The specific crafting to be able to bypass the rule is not so much a limitation of the rule logic, rather it is a limitation of flow-based detection mechanisms compared to transaction level sources.

## How To Test

Verify in Telemetry. 

And/or use RTAs in https://github.com/elastic/cortado/pull/34

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
