### PR TITLE
[Rule Tuning] Accepted Default Telnet Port Connection

### DIFF
--- a/rules/network/command_and_control_accepted_default_telnet_port_connection.toml
+++ b/rules/network/command_and_control_accepted_default_telnet_port_connection.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["network_traffic", "panw", "fortinet_fortigate", "sonicwall_firewall", "suricata"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/05/27"
 
 [rule]
 author = ["Elastic"]
@@ -94,9 +94,11 @@ query = '''
 (data_stream.dataset:(fortinet_fortigate.log or network_traffic.flow
         or sonicwall_firewall.log or suricata.eve or panw.panos)
     or event.category:(network or network_traffic))
-    and event.type:(connection and not end) and not event.action:(
-        flow_dropped or flow_denied or denied or deny or
-        flow_terminated or timeout or Reject or network_flow)
+    and event.type:(connection and not end)
+    and not event.action:(flow_dropped or flow_denied or denied or deny or
+        flow_terminated or timeout or Reject or network_flow or connection-denied)
+    and not (event.action:netflow_flow and not network.packets > 1)
+    and not network.application:traceroute
     and destination.port:23
 '''
 

--- a/rules/network/command_and_control_accepted_default_telnet_port_connection.toml
+++ b/rules/network/command_and_control_accepted_default_telnet_port_connection.toml
@@ -96,9 +96,10 @@ query = '''
     or event.category:(network or network_traffic))
     and event.type:(connection and not end)
     and not event.action:(flow_dropped or flow_denied or denied or deny or
-        flow_terminated or timeout or Reject or network_flow or connection-denied)
+        flow_terminated or timeout or Reject or network_flow or connection-denied or
+        connection-end or server-rst or client-rst)
     and not (event.action:netflow_flow and not network.packets > 1)
-    and not network.application:traceroute
+    and not network.application:(traceroute or stretchoid-scanning)
     and destination.port:23
 '''
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/5576 

## Summary - What I changed

Small update to filter out false positives such port scanning (a single non-rejected packet is not a TP) and duplicated alerts on connection end in certain firewall applications such as SonicWall. 

## How To Test

Verify reduction in telemetry. 

And/or use RTAs in https://github.com/elastic/cortado/pull/34

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
