### PR TITLE
[New Rule] AWS Bedrock Agent Created by IAM User or Root

### DIFF
--- a/rules/integrations/aws/persistence_bedrock_agent_created.toml
+++ b/rules/integrations/aws/persistence_bedrock_agent_created.toml
@@ -1,8 +1,8 @@
 [metadata]
-creation_date = "2026/06/03"
+creation_date = "2026/06/04"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/06/03"
+updated_date = "2026/06/04"
 
 [rule]
 author = ["Elastic"]
@@ -69,7 +69,7 @@ references = [
     "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_CreateAgent.html",
 ]
 risk_score = 21
-rule_id = "3a2ee582-3b4d-4907-8a75-48df2ddc1087"
+rule_id = "4e2dcdf4-f012-4b67-980b-1551b7149305"
 severity = "low"
 tags = [
     "Domain: Cloud",
@@ -105,10 +105,6 @@ id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
 
-[rule.alert_suppression]
-group_by = ["aws.cloudtrail.user_identity.arn"]
-missing_fields_strategy = "suppress"
-
 [rule.investigation_fields]
 field_names = [
     "@timestamp",
@@ -125,8 +121,3 @@ field_names = [
     "aws.cloudtrail.request_parameters",
     "aws.cloudtrail.response_elements",
 ]
-
-[rule.alert_suppression.duration]
-unit = "m"
-value = 5
-

--- a/rules/integrations/aws/persistence_bedrock_agent_created.toml
+++ b/rules/integrations/aws/persistence_bedrock_agent_created.toml
@@ -23,7 +23,7 @@ false_positives = [
     """,
 ]
 from = "now-6m"
-index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+index = ["logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Bedrock Agent Created by IAM User or Root"

--- a/rules/integrations/aws/persistence_bedrock_agent_created.toml
+++ b/rules/integrations/aws/persistence_bedrock_agent_created.toml
@@ -74,6 +74,8 @@ severity = "low"
 tags = [
     "Domain: Cloud",
     "Domain: LLM",
+    "Data Source: AWS",
+    "Data Source: AWS CloudTrail",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Threat Detection",

--- a/rules/integrations/aws/persistence_bedrock_agent_created.toml
+++ b/rules/integrations/aws/persistence_bedrock_agent_created.toml
@@ -1,0 +1,132 @@
+[metadata]
+creation_date = "2026/06/03"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/06/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies AWS Bedrock Agent creation performed directly by an IAM user or the root account. Bedrock Agents are
+autonomous AI systems that execute multi-step tasks, invoke Lambda action groups to call external APIs, and query
+knowledge bases. Adversaries with access to an AWS account can create rogue agents configured to exfiltrate data via
+action group Lambda functions, pivot to other services, or act as a persistent AI-driven command-and-control channel.
+This rule is scoped to IAMUser and Root identity types — AssumedRole sessions (which represent automated CI/CD pipelines
+and SSO-federated engineers) are excluded to avoid global false positives from legitimate deployment automation that
+varies widely across customer environments.
+"""
+false_positives = [
+    """
+    Developers or administrators creating Bedrock agents interactively using personal IAM user credentials. This is the
+    intended detection surface — validate the identity against known developer accounts and confirm the agent
+    configuration (instruction, action groups, model) matches a known project.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Bedrock Agent Created by IAM User or Root"
+note = """## Triage and analysis
+
+### Investigating AWS Bedrock Agent Created by IAM User or Root
+
+AWS Bedrock Agents can autonomously perform complex tasks by combining foundation models with action groups
+(Lambda functions) and knowledge bases. A rogue agent could serve as a persistent AI-driven foothold, executing
+attacker-controlled instructions via inference requests.
+
+#### Possible investigation steps
+
+- **Identity**: `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.type`. This rule fires only
+  for IAMUser or Root — both are direct human credentials, not automated pipeline roles. Confirm the user is
+  known and authorized to create agents.
+
+- **Agent configuration** in `aws.cloudtrail.request_parameters`:
+  - `agentName` — does the name match known internal projects?
+  - `foundationModel` — which model was selected? Expensive models (Claude Opus-class) indicate higher cost risk.
+  - `instruction` — the system prompt. Adversarial, minimal, or exfiltration-oriented instructions are a red flag.
+  - `actionGroupExecutor.lambda` — Lambda ARN presence means the agent can invoke external code.
+
+- **Cross-account indicators**: Lambda ARNs in action groups belonging to a different account than
+  `cloud.account.id` indicate external code execution capability.
+
+- **Follow-on activity**: Look for `PrepareAgent`, `CreateAgentAlias`, `CreateAgentActionGroup`, or
+  `AssociateAgentKnowledgeBase` from the same identity within the next hour.
+
+### False positive analysis
+- Developers creating agents interactively with personal IAM user credentials. Confirm the agent is for a known
+  project and the IAM user is authorized. Production agent deployment should use IAM roles — personal key use
+  is itself a misconfiguration worth noting.
+
+### Response and remediation
+- Delete the unauthorized agent using `DeleteAgent`.
+- Review and remove associated action groups and aliases.
+- Audit Lambda functions referenced in action group executors for malicious code.
+- Restrict `bedrock:CreateAgent` to specific deployment roles via IAM policy or SCP.
+"""
+references = [
+    "https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_CreateAgent.html",
+]
+risk_score = 21
+rule_id = "3a2ee582-3b4d-4907-8a75-48df2ddc1087"
+severity = "low"
+tags = [
+    "Domain: Cloud",
+    "Domain: LLM",
+    "Data Source: Amazon Web Services",
+    "Data Source: Amazon Bedrock",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset: "aws.cloudtrail"
+    and event.provider: "bedrock.amazonaws.com"
+    and event.action: "CreateAgent"
+    and event.outcome: "success"
+    and aws.cloudtrail.user_identity.type: ("IAMUser" or "Root")
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1505"
+name = "Server Software Component"
+reference = "https://attack.mitre.org/techniques/T1505/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[rule.alert_suppression]
+group_by = ["aws.cloudtrail.user_identity.arn"]
+missing_fields_strategy = "suppress"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements",
+]
+
+[rule.alert_suppression.duration]
+unit = "m"
+value = 5
+


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/920

## Summary - What I changed

Adds a new detection rule for the Amazon Bedrock control plane (AWS CloudTrail, `event.provider: bedrock.amazonaws.com`):

**AWS Bedrock Agent Created by IAM User or Root** — `rules/integrations/aws/persistence_bedrock_agent_created.toml`
**Type:** `query` · **Language:** `kuery` · **Severity:** low (risk_score 21) · **Maturity:** production
**ATT&CK:** Persistence: T1505 Server Software Component
**Data source:** AWS CloudTrail — index `filebeat-*, logs-aws.cloudtrail-*`

Identifies AWS Bedrock Agent creation performed directly by an IAM user or the root account. Bedrock Agents are autonomous AI systems that execute multi-step tasks, invoke Lambda action groups to call external APIs, and query knowledge bases. Adversaries with access to an AWS account can create rogue agents configured to exfiltrate data via action group Lambda functions, pivot to other services, or act as a persistent AI-driven command-and-control channel. This rule is scoped to IAMUser and Root identity types — AssumedRole sessions (which represent automated CI/CD pipelines and SSO-federated engineers) are excluded to avoid global false positives from legitimate deployment automation that varies widely across customer environments.

## How To Test

Tested locally E2E.

Validated locally against a Python 3.12 `detection-rules` checkout:

```bash
python -m detection_rules validate-rule rules/integrations/aws/persistence_bedrock_agent_created.toml
python -m detection_rules test     # full unit test suite (same checks CI runs)
```

- `validate-rule` (schema + ATT&CK mapping + KQL/EQL parse): PASS
- `toml-lint` (canonical formatting): PASS
- Full `detection_rules test` unit suite runs in CI

## Checklist

- [x] Added a label for the type of pr: `Rule: New`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation