### PR TITLE
[New Rule] AWS Bedrock Foundation Model Access Enabled or Entitlement Granted & AWS Bedrock Unauthorized Foundation Model Access Attempt

### DIFF
--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
@@ -24,7 +24,7 @@ false_positives = [
     roles.
     """,
 ]
-from = "now-9m"
+from = "now-6m"
 index = ["logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
@@ -1,8 +1,8 @@
 [metadata]
-creation_date = "2026/06/03"
+creation_date = "2026/06/04"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/06/03"
+updated_date = "2026/06/04"
 
 [rule]
 author = ["Elastic"]
@@ -67,10 +67,11 @@ references = [
     "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateFoundationModelAgreement.html"
 ]
 risk_score = 21
-rule_id = "7ecf2c9d-c737-45a6-a948-3815a51c0128"
+rule_id = "3d2e8c90-5be7-4a57-9de4-58be75af933f"
 severity = "low"
 tags = [
     "Domain: Cloud",
+    "Domain: LLM",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Threat Detection",
@@ -97,7 +98,6 @@ data_stream.dataset: "aws.cloudtrail"
     )
 '''
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
@@ -110,10 +110,6 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-
-[rule.alert_suppression]
-group_by = ["aws.cloudtrail.user_identity.arn"]
-missing_fields_strategy = "doNotSuppress"
 
 [rule.investigation_fields]
 field_names = [
@@ -130,8 +126,3 @@ field_names = [
     "cloud.region",
     "aws.cloudtrail.request_parameters",
 ]
-
-[rule.alert_suppression.duration]
-unit = "m"
-value = 60
-

--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
@@ -94,9 +94,7 @@ data_stream.dataset: "aws.cloudtrail"
     and event.outcome: "failure"
     and aws.cloudtrail.error_code: (
         "AccessDenied" or
-        "AccessDeniedException" or
-        "UnauthorizedOperation" or
-        "Client.UnauthorizedOperation"
+        "AccessDeniedException"
     )
 '''
 

--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
@@ -72,6 +72,8 @@ severity = "low"
 tags = [
     "Domain: Cloud",
     "Domain: LLM",
+    "Data Source: AWS",
+    "Data Source: AWS CloudTrail",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Threat Detection",

--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
@@ -1,0 +1,137 @@
+[metadata]
+creation_date = "2026/06/03"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/06/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies failed, access-denied attempts to enable account-level access to an Amazon Bedrock foundation model, either
+by granting a foundation-model entitlement, submitting a use case for model access, or creating a foundation-model
+agreement (accepting the EULA). These account-level "model access" actions unlock a foundation model so that it can
+subsequently be invoked. A principal that is repeatedly denied when attempting these actions may be a compromised or
+under-privileged identity probing for the ability to unlock expensive models (LLMjacking) or to establish a durable
+ability to invoke models. Unlike the companion rule that detects successful model-access grants, this rule surfaces the
+attempt itself, which is a high-signal indicator of credential boundary-testing even though access was not granted.
+"""
+false_positives = [
+    """
+    Access-denied errors can result from benign permission gaps: a newly created role or user whose IAM policy has not
+    yet been provisioned, automation pipelines running ahead of permission grants, or ML teams experimenting in
+    non-production accounts during onboarding. Verify that the principal, source IP, and user agent are expected before
+    escalating. Recurring denials from known onboarding or provisioning workflows can be exempted for specific users or
+    roles.
+    """,
+]
+from = "now-9m"
+index = ["logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Bedrock Unauthorized Foundation Model Access Attempt"
+note = """## Triage and analysis
+
+> **Disclaimer**:
+> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
+
+### Investigating AWS Bedrock Unauthorized Foundation Model Access Attempt
+
+Amazon Bedrock exposes account-level "model access" controls that determine which foundation models a principal is allowed to invoke. Granting an entitlement (`PutFoundationModelEntitlement`), submitting a use case for model access (`PutUseCaseForModelAccess`), or creating a foundation-model agreement (`CreateFoundationModelAgreement`, which accepts the model EULA) all unlock a model for subsequent `InvokeModel`/`InvokeModelWithResponseStream` calls.
+
+This rule detects Bedrock control-plane calls that enable model access at the account level but were denied (`AccessDenied` / unauthorized). A denial indicates an identity attempting an action it is not permitted to perform, which is a strong signal of boundary-testing by a compromised or under-privileged principal even though no model access was granted.
+
+### Possible investigation steps
+
+- Identify the principal by reviewing `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.access_key_id`, and determine whether the identity has any legitimate reason to manage Bedrock model access. A denial for an identity that should never touch these APIs is more suspicious than one from an admin with a transient permission gap.
+- Inspect `aws.cloudtrail.error_code` and `aws.cloudtrail.error_message` to confirm the denial reason, and review `event.action` to determine which model-access action was attempted.
+- Verify the `source.ip` and `user_agent.original` of the request. An unexpected IP, geolocation, or automation user agent is suspicious.
+- Confirm the `cloud.account.id` and `cloud.region` are expected for Bedrock usage in your environment.
+- Correlate with recent activity from the same principal, such as new access key creation, IAM permission changes, or repeated denials across Bedrock/IAM APIs, which can indicate permission enumeration or escalation attempts.
+- Determine whether the identity later succeeded on the same or related actions (e.g., after acquiring new permissions), and check for subsequent `InvokeModel`/`InvokeModelWithResponseStream` activity.
+
+### False positive analysis
+
+- Newly provisioned roles/users or infrastructure-as-code pipelines running before model-access permissions are applied may generate transient denials. Validate against change-management records and known provisioning workflows.
+- ML teams exploring model adoption in sandbox accounts may hit denials; confirm the account and identity context.
+
+### Response and remediation
+
+- If the attempt is unexpected, treat the identity as potentially compromised: disable or rotate the credentials (`aws.cloudtrail.user_identity.access_key_id`) and review the actor's recent activity.
+- Review all Bedrock and IAM activity from the same identity in the surrounding window for successful access grants, permission changes, or other persistence attempts.
+- Review and constrain IAM permissions so that only approved principals can call Bedrock model-access APIs, and alert on both denied and successful calls.
+- Implement preventative guardrails (SCPs, IAM conditions) to limit which principals and models can be enabled.
+"""
+references = [
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_PutFoundationModelEntitlement.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_PutUseCaseForModelAccess.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateFoundationModelAgreement.html"
+]
+risk_score = 21
+rule_id = "7ecf2c9d-c737-45a6-a948-3815a51c0128"
+severity = "low"
+tags = [
+    "Domain: Cloud",
+    "Data Source: Amazon Web Services",
+    "Data Source: Amazon Bedrock",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset: "aws.cloudtrail"
+    and event.provider: "bedrock.amazonaws.com"
+    and event.action: (
+        "PutFoundationModelEntitlement" or
+        "PutUseCaseForModelAccess" or
+        "CreateFoundationModelAgreement"
+    )
+    and event.outcome: "failure"
+    and aws.cloudtrail.error_code: (
+        "AccessDenied" or
+        "AccessDeniedException" or
+        "UnauthorizedOperation" or
+        "Client.UnauthorizedOperation"
+    )
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[rule.alert_suppression]
+group_by = ["aws.cloudtrail.user_identity.arn"]
+missing_fields_strategy = "doNotSuppress"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "aws.cloudtrail.error_code",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+]
+
+[rule.alert_suppression.duration]
+unit = "m"
+value = 60
+

--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
@@ -24,7 +24,7 @@ false_positives = [
     consider adding exceptions for those users or roles.
     """,
 ]
-from = "now-9m"
+from = "now-6m"
 index = ["logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
@@ -76,6 +76,8 @@ severity = "medium"
 tags = [
     "Domain: Cloud",
     "Domain: LLM",
+    "Data Source: AWS",
+    "Data Source: AWS CloudTrail",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Threat Detection",

--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
@@ -1,0 +1,126 @@
+[metadata]
+creation_date = "2026/06/03"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/06/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies when access to an Amazon Bedrock foundation model is enabled at the account level, either by granting a
+foundation-model entitlement, submitting a use case for model access, or creating a foundation-model agreement
+(accepting the EULA). These account-level "model access" actions unlock a foundation model so that it can subsequently
+be invoked. Adversaries or a compromised principal may enable model access to abuse expensive models (LLMjacking), to
+establish a durable ability to invoke models within the account, or to bypass organizational controls. This activity is
+distinct from changes to a resource-based model invocation policy and is identified by the Bedrock control-plane API
+calls that grant model entitlements and agreements.
+"""
+false_positives = [
+    """
+    Cloud administrators and machine-learning teams routinely enable model access, submit use cases, and accept model
+    end-user license agreements (EULAs) during account onboarding or when adopting a new foundation model. Verify that
+    the principal, source IP, and user agent are expected and that the change aligns with a known onboarding or
+    provisioning activity before escalating. If this activity is expected and authorized for specific principals,
+    consider adding exceptions for those users or roles.
+    """,
+]
+from = "now-9m"
+index = ["logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Bedrock Foundation Model Access Enabled or Entitlement Granted"
+note = """## Triage and analysis
+
+> **Disclaimer**:
+> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
+
+### Investigating AWS Bedrock Foundation Model Access Enabled or Entitlement Granted
+
+Amazon Bedrock exposes account-level "model access" controls that determine which foundation models a principal is allowed to invoke. Granting an entitlement (`PutFoundationModelEntitlement`), submitting a use case for model access (`PutUseCaseForModelAccess`), or creating a foundation-model agreement (`CreateFoundationModelAgreement`, which accepts the model EULA) all unlock a model for subsequent `InvokeModel`/`InvokeModelWithResponseStream` calls.
+
+Adversaries who gain access to a privileged principal may enable model access to abuse high-cost models (LLMjacking), to maintain a durable capability to invoke models, or to circumvent organizational guardrails on which models are usable.
+
+This rule detects successful Bedrock control-plane API calls that enable model access at the account level. It is distinct from changes to a resource-based model invocation policy.
+
+### Possible investigation steps
+
+- Identify the principal by reviewing `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.access_key_id`, and determine whether the identity is a human user, role, or service account that is expected to manage Bedrock model access.
+- Review `event.action` to determine which model-access action was taken, and examine `aws.cloudtrail.request_parameters` to identify the specific foundation model, model ID, or use case involved.
+- Verify the `source.ip` and `user_agent.original` of the request. Console-driven onboarding differs from programmatic SDK/CLI calls; an unexpected IP, geolocation, or automation user agent is suspicious.
+- Confirm the `cloud.account.id` and `cloud.region` are expected for Bedrock usage in your environment, and whether model access is normally enabled in that region.
+- Correlate with recent activity from the same principal, such as new access key creation, IAM permission changes, or other Bedrock control-plane calls, to determine whether this is part of a broader compromise.
+- Check for subsequent `InvokeModel`/`InvokeModelWithResponseStream` activity from the same principal or account, especially high-volume invocations that could indicate model abuse (LLMjacking).
+- Contact the resource owner to confirm whether enabling this model access was planned and authorized.
+
+### False positive analysis
+
+- Legitimate administrators and ML teams enable model access and accept EULAs during account onboarding or when adopting new foundation models. Validate the change against change-management records and known provisioning workflows.
+- Infrastructure-as-code or automation pipelines may enable model access programmatically; confirm the automation identity and source are expected.
+
+### Response and remediation
+
+- If the activity is unauthorized, revoke the model entitlement/agreement and remove model access for the affected model.
+- Disable or rotate the credentials (`aws.cloudtrail.user_identity.access_key_id`) associated with the principal that performed the action.
+- Review and constrain IAM permissions so that only approved principals can call Bedrock model-access APIs.
+- Investigate for any model invocations that occurred after access was granted and assess potential cost impact and data exposure.
+- Implement preventative guardrails (SCPs, IAM conditions) to limit which principals and models can be enabled, and add monitoring for Bedrock control-plane changes.
+"""
+references = [
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_PutFoundationModelEntitlement.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_PutUseCaseForModelAccess.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateFoundationModelAgreement.html"
+]
+risk_score = 47
+rule_id = "6f8bc3bb-dc23-45df-8cf3-a24aaf6701a9"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: Amazon Web Services",
+    "Data Source: Amazon Bedrock",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset: "aws.cloudtrail"
+    and event.provider: "bedrock.amazonaws.com"
+    and event.action: (
+        "PutFoundationModelEntitlement" or
+        "PutUseCaseForModelAccess" or
+        "CreateFoundationModelAgreement"
+    )
+    and event.outcome: "success"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+]
+

--- a/rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
+++ b/rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
@@ -1,8 +1,8 @@
 [metadata]
-creation_date = "2026/06/03"
+creation_date = "2026/06/04"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/06/03"
+updated_date = "2026/06/04"
 
 [rule]
 author = ["Elastic"]
@@ -71,10 +71,11 @@ references = [
     "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_CreateFoundationModelAgreement.html"
 ]
 risk_score = 47
-rule_id = "6f8bc3bb-dc23-45df-8cf3-a24aaf6701a9"
+rule_id = "aed4b9d5-f853-40cf-8489-4fdcff03e272"
 severity = "medium"
 tags = [
     "Domain: Cloud",
+    "Domain: LLM",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Threat Detection",


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/920

## Summary - What I changed

Adds a new detection rule for the Amazon Bedrock control plane (AWS CloudTrail, `event.provider: bedrock.amazonaws.com`):

**AWS Bedrock Foundation Model Access Enabled or Entitlement Granted** — `rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml`
**Type:** `query` · **Language:** `kuery` · **Severity:** medium (risk_score 47) · **Maturity:** production
**ATT&CK:** Persistence: T1098 Account Manipulation
**Data source:** AWS CloudTrail — index `logs-aws.cloudtrail-*`

Identifies when access to an Amazon Bedrock foundation model is enabled at the account level, either by granting a foundation-model entitlement, submitting a use case for model access, or creating a foundation-model agreement (accepting the EULA). These account-level "model access" actions unlock a foundation model so that it can subsequently
be invoked. Adversaries or a compromised principal may enable model access to abuse expensive models (LLMjacking), to
establish a durable ability to invoke models within the account, or to bypass organizational controls. This activity is distinct from changes to a resource-based model invocation policy and is identified by the Bedrock control-plane API calls that grant model entitlements and agreements.

This PR also includes its outcome companion **AWS Bedrock Unauthorized Foundation Model Access Attempt** (`rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml`).

## How To Test

Tested locally E2E.

Validated locally against a Python 3.12 `detection-rules` checkout:

```bash
python -m detection_rules validate-rule rules/integrations/aws/persistence_bedrock_foundation_model_access_denied_attempt.toml
python -m detection_rules validate-rule rules/integrations/aws/persistence_bedrock_foundation_model_access_enabled_or_entitlement_granted.toml
python -m detection_rules test     # full unit test suite (same checks CI runs)
```

- `validate-rule` (schema + ATT&CK mapping + KQL/EQL parse): PASS
- `toml-lint` (canonical formatting): PASS
- Full `detection_rules test` unit suite runs in CI

## Checklist

- [x] Added a label for the type of pr: `Rule: New`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation