### PR TITLE
[New Rule] AWS Bedrock Resource-Based Policy Modified or Deleted & AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt

### DIFF
--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
@@ -1,0 +1,149 @@
+[metadata]
+creation_date = "2026/06/02"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/06/02"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects failed, access-denied attempts to modify or delete resource-based access policies on AWS Bedrock resources via
+the PutResourcePolicy and DeleteResourcePolicy API calls. Resource-based policies govern which principals (including
+external accounts) may access Bedrock resources such as agents, knowledge bases, and custom models. A principal that is
+repeatedly denied when attempting to attach or remove these policies may be a compromised or under-privileged identity
+probing for the ability to grant external or cross-account access, or to weaken existing access controls. Unlike the
+companion rule that detects successful changes, this rule surfaces the attempt itself, which is a high-signal indicator
+of credential boundary-testing even though no change occurred.
+"""
+false_positives = [
+    """
+    Access-denied errors can result from benign permission gaps: a newly created role or user whose IAM policy has not
+    yet been provisioned, infrastructure-as-code pipelines running ahead of permission grants, or developers
+    experimenting in non-production accounts. Verify whether the user identity, user agent, and source IP are expected
+    to manage Bedrock resource policies in your environment. Recurring denials from known automation or onboarding
+    workflows can be exempted from the rule.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt"
+note = """## Triage and analysis
+
+### Investigating AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt
+
+AWS Bedrock resource-based policies control which principals can access Bedrock resources such as agents,
+knowledge bases, and custom models. An adversary who has compromised a credential may attempt to attach a policy
+that grants an external principal access for persistence or cross-account access, or delete a policy to break
+existing access controls. This rule detects `PutResourcePolicy` and `DeleteResourcePolicy` calls that were denied
+(`AccessDenied` / unauthorized), which indicates an identity attempting an action it is not permitted to perform —
+a strong signal of boundary-testing by a compromised or under-privileged principal even though the change did not
+take effect.
+
+#### Possible investigation steps
+
+- **Identify the actor and context**
+  - Review `aws.cloudtrail.user_identity.arn`, `aws.cloudtrail.user_identity.type`,
+    `aws.cloudtrail.user_identity.access_key_id`, `user_agent.original`, and `source.ip`.
+  - Determine whether this identity has any legitimate reason to manage Bedrock resource policies. A denial for an
+    identity that should never touch these APIs is more suspicious than one from an admin with a transient gap.
+- **Assess the attempt**
+  - Inspect `aws.cloudtrail.error_code` and `aws.cloudtrail.error_message` to confirm the denial reason.
+  - For `PutResourcePolicy`, review `aws.cloudtrail.request_parameters` and
+    `aws.cloudtrail.flattened.request_parameters` for the target resource ARN and the attempted policy document.
+    Look for `Principal` values referencing external AWS account IDs, `"*"`, or unfamiliar roles.
+- **Correlate activity**
+  - Look for repeated denials across Bedrock or IAM APIs from the same identity, which can indicate permission
+    enumeration or escalation attempts.
+  - Check whether the identity later succeeded (e.g., after acquiring new permissions) on the same or related
+    resources, and review any IAM changes in the surrounding window.
+
+### False positive analysis
+
+- **Permission gaps**: Newly provisioned roles/users or IaC pipelines running before policy grants are applied may
+  generate transient denials. Validate against change tickets and known automation.
+- **Exploration in non-production**: Developers testing in sandbox accounts may hit denials. Confirm the account and
+  identity context.
+
+### Response and remediation
+
+- If the attempt is unexpected, treat the identity as potentially compromised: disable or rotate the credentials in
+  `aws.cloudtrail.user_identity.access_key_id` and review the actor's recent activity.
+- Review all Bedrock and IAM activity from the same identity in the surrounding time window for successful access
+  grants, permission changes, or other persistence attempts.
+- Confirm least-privilege on `bedrock:PutResourcePolicy` and `bedrock:DeleteResourcePolicy`, and alert on both denied
+  and successful calls.
+"""
+references = [
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_PutResourcePolicy.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_DeleteResourcePolicy.html"
+]
+risk_score = 21
+rule_id = "dc920351-88b5-41e2-ba46-bddabca7a781"
+severity = "low"
+tags = [
+    "Domain: Cloud",
+    "Data Source: Amazon Web Services",
+    "Data Source: Amazon Bedrock",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Persistence",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset: "aws.cloudtrail" and
+    event.provider: "bedrock.amazonaws.com" and
+    event.action: ("PutResourcePolicy" or "DeleteResourcePolicy") and
+    event.outcome: "failure" and
+    aws.cloudtrail.error_code: (
+        "AccessDenied" or
+        "AccessDeniedException" or
+        "UnauthorizedOperation" or
+        "Client.UnauthorizedOperation"
+    )
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[rule.alert_suppression]
+group_by = ["aws.cloudtrail.user_identity.arn"]
+missing_fields_strategy = "doNotSuppress"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.provider",
+    "event.outcome",
+    "aws.cloudtrail.error_code",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements",
+]
+
+[rule.alert_suppression.duration]
+unit = "m"
+value = 60
+

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
@@ -103,9 +103,7 @@ data_stream.dataset: "aws.cloudtrail" and
     event.outcome: "failure" and
     aws.cloudtrail.error_code: (
         "AccessDenied" or
-        "AccessDeniedException" or
-        "UnauthorizedOperation" or
-        "Client.UnauthorizedOperation"
+        "AccessDeniedException"
     )
 '''
 

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
@@ -85,6 +85,8 @@ severity = "low"
 tags = [
     "Domain: Cloud",
     "Domain: LLM",
+    "Data Source: AWS",
+    "Data Source: AWS CloudTrail",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Identity and Access Audit",

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
@@ -1,8 +1,8 @@
 [metadata]
-creation_date = "2026/06/02"
+creation_date = "2026/06/04"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/06/02"
+updated_date = "2026/06/04"
 
 [rule]
 author = ["Elastic"]
@@ -25,7 +25,7 @@ false_positives = [
     """,
 ]
 from = "now-6m"
-index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+index = ["logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt"
@@ -80,10 +80,11 @@ references = [
     "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_DeleteResourcePolicy.html"
 ]
 risk_score = 21
-rule_id = "dc920351-88b5-41e2-ba46-bddabca7a781"
+rule_id = "2e99477f-6099-48a9-ae0e-68801d97079c"
 severity = "low"
 tags = [
     "Domain: Cloud",
+    "Domain: LLM",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Identity and Access Audit",
@@ -106,7 +107,6 @@ data_stream.dataset: "aws.cloudtrail" and
     )
 '''
 
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 
@@ -119,10 +119,6 @@ reference = "https://attack.mitre.org/techniques/T1098/"
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
-
-[rule.alert_suppression]
-group_by = ["aws.cloudtrail.user_identity.arn"]
-missing_fields_strategy = "doNotSuppress"
 
 [rule.investigation_fields]
 field_names = [
@@ -142,8 +138,4 @@ field_names = [
     "aws.cloudtrail.request_parameters",
     "aws.cloudtrail.response_elements",
 ]
-
-[rule.alert_suppression.duration]
-unit = "m"
-value = 60
 

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
@@ -138,4 +138,4 @@ field = "new_terms_fields"
 value = ["aws.cloudtrail.user_identity.arn", "source.as.number"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
-value = "now-14d"
+value = "now-7d"

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
@@ -83,6 +83,8 @@ severity = "medium"
 tags = [
     "Domain: Cloud",
     "Domain: LLM",
+    "Data Source: AWS",
+    "Data Source: AWS CloudTrail",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Identity and Access Audit",

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
@@ -92,7 +92,7 @@ tags = [
     "Tactic: Persistence",
 ]
 timestamp_override = "event.ingested"
-type = "query"
+type = "new_terms"
 
 query = '''
 data_stream.dataset: "aws.cloudtrail" and
@@ -133,3 +133,9 @@ field_names = [
     "aws.cloudtrail.response_elements",
 ]
 
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["aws.cloudtrail.user_identity.arn", "source.as.number"]
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-14d"

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
@@ -1,8 +1,8 @@
 [metadata]
-creation_date = "2026/06/03"
+creation_date = "2026/06/04"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/06/03"
+updated_date = "2026/06/04"
 
 [rule]
 author = ["Elastic"]
@@ -23,7 +23,7 @@ false_positives = [
     """,
 ]
 from = "now-6m"
-index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+index = ["logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "AWS Bedrock Resource-Based Policy Modified or Deleted"
@@ -78,10 +78,11 @@ references = [
     "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_DeleteResourcePolicy.html"
 ]
 risk_score = 47
-rule_id = "8a6c2f1d-4b9e-4a7c-9f3b-2d5e7c1a8f64"
+rule_id = "de0e9ed8-b68f-4249-957a-2c2bbdbd1c1b"
 severity = "medium"
 tags = [
     "Domain: Cloud",
+    "Domain: LLM",
     "Data Source: Amazon Web Services",
     "Data Source: Amazon Bedrock",
     "Use Case: Identity and Access Audit",
@@ -112,10 +113,6 @@ id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
 
-[rule.alert_suppression]
-group_by = ["aws.cloudtrail.user_identity.arn"]
-missing_fields_strategy = "doNotSuppress"
-
 [rule.investigation_fields]
 field_names = [
     "@timestamp",
@@ -133,8 +130,4 @@ field_names = [
     "aws.cloudtrail.request_parameters",
     "aws.cloudtrail.response_elements",
 ]
-
-[rule.alert_suppression.duration]
-unit = "m"
-value = 60
 

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
@@ -135,7 +135,7 @@ field_names = [
 
 [rule.new_terms]
 field = "new_terms_fields"
-value = ["aws.cloudtrail.user_identity.arn", "source.as.number"]
+value = ["aws.cloudtrail.user_identity.arn"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
 value = "now-7d"

--- a/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
+++ b/rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
@@ -1,0 +1,140 @@
+[metadata]
+creation_date = "2026/06/03"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/06/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects modification or deletion of resource-based access policies on AWS Bedrock resources via the PutResourcePolicy
+and DeleteResourcePolicy API calls. Resource-based policies govern which principals (including external accounts) may
+access Bedrock resources such as agents, knowledge bases, and custom models. An adversary may attach a resource policy
+granting an external or unexpected principal access to a Bedrock resource to establish persistence or enable
+cross-account access, or may delete an existing policy to weaken access controls. These changes should be validated for
+principal ownership and least-privilege intent.
+"""
+false_positives = [
+    """
+    Resource policy changes may be performed by administrators, infrastructure-as-code pipelines, or automation during
+    legitimate onboarding, sharing, or access-management activities. Verify whether the user identity, user agent, and
+    source IP are expected to manage Bedrock resource policies in your environment. Known automation can be exempted
+    from the rule.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Bedrock Resource-Based Policy Modified or Deleted"
+note = """## Triage and analysis
+
+### Investigating AWS Bedrock Resource-Based Policy Modified or Deleted
+
+AWS Bedrock resource-based policies control which principals can access Bedrock resources such as agents,
+knowledge bases, and custom models. Adversaries can attach a policy that grants an external principal
+access for persistence or cross-account access, or delete a policy to break existing access controls. This
+rule detects successful `PutResourcePolicy` and `DeleteResourcePolicy` calls against the Bedrock control
+plane.
+
+#### Possible investigation steps
+
+- **Identify the actor and context**
+  - Review `aws.cloudtrail.user_identity.arn`, `aws.cloudtrail.user_identity.type`,
+    `aws.cloudtrail.user_identity.access_key_id`, `user_agent.original`, and `source.ip`.
+  - Confirm the identity is expected to manage Bedrock resource policies and that a related change request
+    exists.
+- **Validate the policy change**
+  - For `PutResourcePolicy`, inspect `aws.cloudtrail.request_parameters` and
+    `aws.cloudtrail.flattened.request_parameters` for the target resource ARN and the policy document.
+    Look for `Principal` values referencing external AWS account IDs, `"*"`, or unfamiliar roles.
+  - For `DeleteResourcePolicy`, determine which resource lost its policy and whether that resource should
+    have remained restricted.
+- **Correlate activity**
+  - Look for related Bedrock actions (model invocation, agent updates, knowledge base access) from the same
+    identity or the newly granted principal.
+  - Check for prior enumeration of Bedrock resources or other recent IAM/resource-policy changes.
+
+### False positive analysis
+
+- **Planned access management**: Legitimate sharing or onboarding may add or remove resource policies.
+  Validate against change tickets and standard templates.
+- **Automation**: IaC or platform pipelines may set or remove resource policies during deployment. Confirm
+  the actor matches known automation infrastructure.
+
+### Response and remediation
+
+- If the change is unauthorized, revert the resource policy to its approved state and remove any external
+  or overly permissive principals.
+- Disable or rotate the credentials in `aws.cloudtrail.user_identity.access_key_id` if compromise is
+  suspected.
+- Review all Bedrock and IAM activity from the same identity in the surrounding time window for further
+  access grants or persistence.
+- Restrict `bedrock:PutResourcePolicy` and `bedrock:DeleteResourcePolicy` to administrative roles and
+  enforce least-privilege resource policies.
+"""
+references = [
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_PutResourcePolicy.html",
+    "https://docs.aws.amazon.com/bedrock/latest/APIReference/API_DeleteResourcePolicy.html"
+]
+risk_score = 47
+rule_id = "8a6c2f1d-4b9e-4a7c-9f3b-2d5e7c1a8f64"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Data Source: Amazon Web Services",
+    "Data Source: Amazon Bedrock",
+    "Use Case: Identity and Access Audit",
+    "Resources: Investigation Guide",
+    "Tactic: Persistence",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset: "aws.cloudtrail" and
+    event.provider: "bedrock.amazonaws.com" and
+    event.action: ("PutResourcePolicy" or "DeleteResourcePolicy") and
+    event.outcome: "success"
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[rule.alert_suppression]
+group_by = ["aws.cloudtrail.user_identity.arn"]
+missing_fields_strategy = "doNotSuppress"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.provider",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements",
+]
+
+[rule.alert_suppression.duration]
+unit = "m"
+value = 60
+


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/920

## Summary - What I changed

Adds a new detection rule for the Amazon Bedrock control plane (AWS CloudTrail, `event.provider: bedrock.amazonaws.com`):

**AWS Bedrock Resource-Based Policy Modified or Deleted** — `rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml`
**Type:** `query` · **Language:** `kuery` · **Severity:** medium (risk_score 47) · **Maturity:** production
**ATT&CK:** Persistence: T1098 Account Manipulation
**Data source:** AWS CloudTrail — index `filebeat-*, logs-aws.cloudtrail-*`

Detects modification or deletion of resource-based access policies on AWS Bedrock resources via the PutResourcePolicy and DeleteResourcePolicy API calls. Resource-based policies govern which principals (including external accounts) may access Bedrock resources such as agents, knowledge bases, and custom models. An adversary may attach a resource policy granting an external or unexpected principal access to a Bedrock resource to establish persistence or enable cross-account access, or may delete an existing policy to weaken access controls. These changes should be validated for principal ownership and least-privilege intent.

This PR also includes its outcome companion **AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt** (`rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml`), both rules ship together in this PR.

## How To Test

Test locally E2E.

Validated locally against a Python 3.12 `detection-rules` checkout:

```bash
python -m detection_rules validate-rule rules/integrations/aws/persistence_bedrock_resource_based_policy_denied_attempt.toml
python -m detection_rules validate-rule rules/integrations/aws/persistence_bedrock_resource_based_policy_modified_or_deleted.toml
python -m detection_rules test     # full unit test suite (same checks CI runs)
```

- `validate-rule` (schema + ATT&CK mapping + KQL/EQL parse): PASS
- `toml-lint` (canonical formatting): PASS
- Full `detection_rules test` unit suite runs in CI

## Checklist

- [x] Added a label for the type of pr: `Rule: New`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation