### PR TITLE
[Bug] ESQL Remote Validation Data Stream and Patch Version Validation

### DIFF
--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -279,7 +279,7 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
 
 def find_least_compatible_version(
     package: str,
-    integration: str,
+    integration: str | None,
     current_stack_version: str,
     packages_manifest: dict[str, Any],
 ) -> str:

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -250,17 +250,14 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
     # package (and newly-added data streams) behind a later patch (e.g. azure ~8.19.10). Resolving
     # against the literal .0 falls back to an older package that predates the stream. Return the
     # latest patch a package gates on for the minor, i.e. the stack patch needed to receive the most
-    # up-to-date integration package on that minor. Only the supplied packages are inspected rather
-    # than the full manifest, so the scan stays small.
+    # up-to-date integration package on that minor. Scan each package once and track the newest
+    # matching package manifest.
     manifests = load_integrations_manifests()
     latest_patch = 0
     for package in packages:
-        # Manifests sorted newest-first: a package raises its floor as it adds features, so the newest
-        # version gating the minor carries the controlling patch and we can stop at the first match.
-        package_manifests = sorted(
-            manifests.get(package, {}).items(), key=lambda kv: Version.parse(kv[0]), reverse=True
-        )
-        for _, manifest in package_manifests:
+        latest_package_version: Version | None = None
+        latest_package_patch = 0
+        for package_version, manifest in manifests.get(package, {}).items():
             version_requirement = manifest.get("conditions", {}).get("kibana", {}).get("version")
             if not version_requirement:
                 continue
@@ -270,9 +267,13 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
                 # Skip manifests whose kibana condition uses tokens we cannot parse.
                 continue
             floors = [lo.patch for lo, _ in clauses if lo.major == major and lo.minor == minor]
-            if floors:
-                latest_patch = max(latest_patch, *floors)
-                break
+            if not floors:
+                continue
+            parsed_package_version = Version.parse(package_version)
+            if latest_package_version is None or parsed_package_version > latest_package_version:
+                latest_package_version = parsed_package_version
+                latest_package_patch = max(floors)
+        latest_patch = max(latest_patch, latest_package_patch)
     return latest_patch
 
 

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -295,7 +295,7 @@ def find_least_compatible_version(
     # compatibility alone (e.g. for synthetic manifests in tests).
     # Loaded only when an integration is specified, to avoid decompressing the schemas for
     # package-only lookups where the schema check is never consulted.
-    package_schemas = load_integrations_schemas().get(package, {}) if integration else {}
+    package_schemas: dict[str, Any] = load_integrations_schemas().get(package, {}) if integration else {}
 
     # filter integration_manifests to only the latest major entries
     major_versions = sorted(

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -250,8 +250,13 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
     # package (and newly-added data streams) behind a later patch (e.g. azure ~8.19.10). Resolving
     # against the literal .0 falls back to an older package that predates the stream. Return the
     # latest patch a package gates on for the minor, i.e. the stack patch needed to receive the most
-    # up-to-date integration package on that minor. Scan each package once and track the newest
-    # matching package manifest.
+    # up-to-date integration package on that minor.
+    #
+    # Track the *newest* package version's floor (not the max floor across all versions): Fleet always
+    # installs the latest compatible package, so that floor is the patch a stack actually needs. A
+    # newer package occasionally lowers its floor (e.g. apm 7.16.1 gates ^7.16.1 but the newer 7.16.2
+    # gates ^7.16.0); honoring the newest version matches what Fleet installs rather than an older,
+    # higher floor that would never be installed on that stack.
     manifests = load_integrations_manifests()
     latest_patch = 0
     for package in packages:

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -293,7 +293,9 @@ def find_least_compatible_version(
     # the data streams present per package version, so use them to skip versions that predate the
     # integration. Only filter when schema data exists for a version, otherwise fall back to kibana
     # compatibility alone (e.g. for synthetic manifests in tests).
-    package_schemas = load_integrations_schemas().get(package, {})
+    # Loaded only when an integration is specified, to avoid decompressing the schemas for
+    # package-only lookups where the schema check is never consulted.
+    package_schemas = load_integrations_schemas().get(package, {}) if integration else {}
 
     # filter integration_manifests to only the latest major entries
     major_versions = sorted(

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -9,7 +9,7 @@ import fnmatch
 import gzip
 import json
 from collections import OrderedDict, defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -244,6 +244,38 @@ def _satisfies_kibana_range(stack: Version, version_requirement: str) -> bool:
     return any(lo <= stack and (hi is None or stack < hi) for lo, hi in _parse_kibana_range(version_requirement))
 
 
+def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int, minor: int) -> int:
+    """Find the latest stack patch the given integration packages need for a major.minor."""
+    # The stack-schema-map keys stacks at MAJOR.MINOR.0, but an integration may gate its latest
+    # package (and newly-added data streams) behind a later patch (e.g. azure ~8.19.10). Resolving
+    # against the literal .0 falls back to an older package that predates the stream. Return the
+    # latest patch a package gates on for the minor, i.e. the stack patch needed to receive the most
+    # up-to-date integration package on that minor. Only the supplied packages are inspected rather
+    # than the full manifest, so the scan stays small.
+    manifests = load_integrations_manifests()
+    latest_patch = 0
+    for package in packages:
+        # Manifests sorted newest-first: a package raises its floor as it adds features, so the newest
+        # version gating the minor carries the controlling patch and we can stop at the first match.
+        package_manifests = sorted(
+            manifests.get(package, {}).items(), key=lambda kv: Version.parse(kv[0]), reverse=True
+        )
+        for _, manifest in package_manifests:
+            version_requirement = manifest.get("conditions", {}).get("kibana", {}).get("version")
+            if not version_requirement:
+                continue
+            try:
+                clauses = _parse_kibana_range(version_requirement)
+            except ValueError:
+                # Skip manifests whose kibana condition uses tokens we cannot parse.
+                continue
+            floors = [lo.patch for lo, _ in clauses if lo.major == major and lo.minor == minor]
+            if floors:
+                latest_patch = max(latest_patch, *floors)
+                break
+    return latest_patch
+
+
 def find_least_compatible_version(
     package: str,
     integration: str,
@@ -253,6 +285,14 @@ def find_least_compatible_version(
     """Finds least compatible version for specified integration based on stack version supplied."""
     integration_manifests = dict(sorted(packages_manifest[package].items(), key=lambda x: Version.parse(x[0])))
     stack_version = Version.parse(current_stack_version, optional_minor_and_patch=True)
+
+    # The manifest's kibana condition only tells us whether the *package* installs on the stack, not
+    # whether this particular integration/data stream exists yet in that package version (e.g. azure
+    # added aadgraphactivitylogs in 1.37.0, but 1.0.0 already installs on 8.19). The schemas record
+    # the data streams present per package version, so use them to skip versions that predate the
+    # integration. Only filter when schema data exists for a version, otherwise fall back to kibana
+    # compatibility alone (e.g. for synthetic manifests in tests).
+    package_schemas = load_integrations_schemas().get(package, {})
 
     # filter integration_manifests to only the latest major entries
     major_versions = sorted(
@@ -270,8 +310,11 @@ def find_least_compatible_version(
             sorted(major_integration_manifests.items(), key=lambda x: Version.parse(x[0]))
         ).items():
             version_requirement = manifest["conditions"]["kibana"]["version"]
-            if _satisfies_kibana_range(stack_version, version_requirement):
-                return f"^{version}"
+            if not _satisfies_kibana_range(stack_version, version_requirement):
+                continue
+            if integration and version in package_schemas and integration not in package_schemas[version]:
+                continue
+            return f"^{version}"
 
     raise ValueError(f"no compatible version for integration {package}:{integration}")
 

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -41,6 +41,7 @@ from .index_mappings import (
     prepare_mappings,
 )
 from .integrations import (
+    find_latest_integration_patch_for_minor,
     get_integration_schema_data,
     load_integrations_manifests,
     parse_datasets,
@@ -924,8 +925,18 @@ class ESQLValidator(QueryValidator):
         # mismatch error, as the EsqlSchemaError and EsqlSyntaxError errors from the stack
         # will not be impacted by the difference in schema type mapping.
         mappings_lookup: dict[str, dict[str, Any]] = {stack_version: combined_mappings}
-        versions = get_stack_versions()
-        for version in versions:
+
+        # The schema-map keys stacks at MAJOR.MINOR.0, but an integration may gate its data stream
+        # behind a later patch (e.g. azure ~8.19.10). Validating at the literal .0 resolves an older
+        # package that predates the stream, so for each minor use the latest patch the rule's own
+        # integrations gate on. Only the rule's packages are inspected, not the full manifest.
+        rule_packages = set(get_rule_integrations(metadata))
+        rule_packages.update(integration.package for integration in event_dataset_integrations)
+
+        for version in get_stack_versions():
+            parsed = Version.parse(version)
+            inferred_patch = find_latest_integration_patch_for_minor(rule_packages, parsed.major, parsed.minor)
+            version = str(parsed.replace(patch=max(parsed.patch, inferred_patch)))  # noqa: PLW2901
             if version in mappings_lookup:
                 continue
             _, _, combined_mappings = prepare_mappings(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.47"
+version = "1.6.48"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -6,6 +6,7 @@
 """Test integration version resolution against EPR manifest ranges."""
 
 import unittest
+import unittest.mock
 
 from semver import Version
 
@@ -257,3 +258,43 @@ class TestFindLeastCompatibleVersion(unittest.TestCase):
         """OR'd clauses are honored by the least-compatible search."""
         manifests = {"pkg": {"1.0.0": _manifest("^8.12.0 || ^9.0.0")}}
         self.assertEqual(find_least_compatible_version("pkg", "pkg", "9.1.0", manifests), "^1.0.0")
+
+    def test_skips_versions_missing_integration(self):
+        """Kibana-compatible versions whose schema lacks the integration are skipped for a later one."""
+        # Mirrors a data stream added in a later package (e.g. azure aadgraphactivitylogs in 1.37.0):
+        # older packages still install on the stack but predate the data stream.
+        manifests = {
+            "pkg": {
+                "1.0.0": _manifest("^8.12.0"),
+                "1.5.0": _manifest("^8.12.0"),
+                "1.9.0": _manifest("^8.12.0"),
+            }
+        }
+        schemas = {
+            "pkg": {
+                "1.0.0": {"existing_ds": {}},
+                "1.5.0": {"existing_ds": {}},
+                "1.9.0": {"existing_ds": {}, "new_ds": {}},
+            }
+        }
+        with unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas):
+            # 1.0.0/1.5.0 are kibana-compatible but lack new_ds; 1.9.0 is the oldest that has it.
+            self.assertEqual(find_least_compatible_version("pkg", "new_ds", "8.12.0", manifests), "^1.9.0")
+            # An integration present in every version is unaffected and still resolves to the oldest.
+            self.assertEqual(find_least_compatible_version("pkg", "existing_ds", "8.12.0", manifests), "^1.0.0")
+
+    def test_no_schema_data_falls_back_to_kibana_only(self):
+        """Versions without schema data are not filtered; kibana compatibility alone decides."""
+        manifests = {"pkg": {"1.0.0": _manifest("^8.12.0"), "1.5.0": _manifest("^8.12.0")}}
+        with unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value={}):
+            self.assertEqual(find_least_compatible_version("pkg", "new_ds", "8.12.0", manifests), "^1.0.0")
+
+    def test_all_compatible_versions_missing_integration_raises(self):
+        """Raise when every kibana-compatible version's schema lacks the requested integration."""
+        manifests = {"pkg": {"1.0.0": _manifest("^8.12.0"), "1.5.0": _manifest("^8.12.0")}}
+        schemas = {"pkg": {"1.0.0": {"existing_ds": {}}, "1.5.0": {"existing_ds": {}}}}
+        with (
+            unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
+            self.assertRaises(ValueError),
+        ):
+            find_least_compatible_version("pkg", "new_ds", "8.12.0", manifests)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -364,6 +364,15 @@ class TestVersions(unittest.TestCase):
 class TestESQLValidation(unittest.TestCase):
     """Test ESQL rule validation"""
 
+    def setUp(self):
+        """Force local validation for these tests."""
+        # These cases exercise local AST/semantic validation (KEEP/METADATA checks). Routing them
+        # through remote validation is possible, but the explicit goal of these is to use local vs remote,
+        # so we patch the environment variable to force local validation regardless of other settings.
+        patcher = unittest.mock.patch.dict(os.environ, {"DR_REMOTE_ESQL_VALIDATION": ""})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_esql_data_validation(self):
         """Test ESQL rule data validation"""
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/detection-rules/issues/6213


## Summary - What I changed

Fixes integration version resolution that ignored whether a referenced data stream actually exists in the resolved package, causing ES|QL remote validation and `related_integrations` to use the wrong package version. This surfaced on rules using `logs-azure.aadgraphactivitylogs-*` (added in azure `1.37.0`), which resolved against older packages that predate the data stream. Please see the related issue for more details.

Changes by file:

- `detection_rules/integrations.py` / `find_latest_integration_patch_for_minor()`: The `stack-schema-map.yaml` keys stacks at `MAJOR.MINOR.0`, but an integration may gate its latest package behind a later patch (e.g. azure `~8.19.10`). Validating at the literal `.0` resolves an older package that predates the data stream. This helper reads the integration manifests and returns the latest patch the rule's own integrations gate on for a given minor, so the inferred stack version reflects what a customer on that minor would actually receive. Only the rule's packages are inspected, not the full manifest.

- `detection_rules/rule_validators.py` / `ESQLValidator.remote_validate_rule()`: The stack-version sweep now infers the patch per minor from the rule's integrations (e.g. `8.19.0` -> `8.19.10`, `9.4.0` stays `9.4.0`) instead of using the literal `.0`, so each minor resolves the up-to-date package based on whether or not this is needed for the integration versions.

- `detection_rules/integrations.py` / `find_least_compatible_version()`: Previously this code decided compatibility from the package-level `conditions.kibana.version` only and never checked whether the requested integration/data stream existed in that version (the `integration` argument was used only in the error message). It now consults the integration schemas and skips versions that predate the data stream, so e.g. `azure:aadgraphactivitylogs @ 8.19.10` resolves to `^1.37.0` instead of `^1.0.0`. It falls back to kibana-compatibility alone when no schema data exists for a version.


## How To Test

1. Checkout `new-rule/azure-ad-graph-potential-roadrecon-enum`
2. Run `python -m detection_rules view-rule rules/integrations/azure/discovery_aad_graph_roadrecon_aiohttp_enumeration.toml --esql-remote-validation`
3. Before the fix: the version sweep starts at the literal `8.19.0`, resolves azure `1.34.1` (no `aadgraphactivitylogs`), and fails with:

```
Error (EsqlUnknownIndexError): Unknown index pattern(s): logs-azure.aadgraphactivitylogs-*. Known patterns: logs-azure.eventhub*, logs-azure.platformlogs*, logs-azure.activitylogs-*, logs-azure.platformlogs-* ...
```

After the fix: the related integrations populate correctly from the datastream, with the correct version of the package that is validated on the correct patch version of the stack.
```
  "related_integrations": [
    {
      "package": "azure",
      "version": "^1.22.0"
    },
    {
      "integration": "aadgraphactivitylogs",
      "package": "azure",
      "version": "^1.37.0"
    }
  ],
```

<img width="788" height="466" alt="Screenshot from 2026-06-04 10-06-50" src="https://github.com/user-attachments/assets/ce48e9f2-0c9e-4987-a90b-04404c20765b" />


<details><summary>ES|QL Rule testing results</summary>
<p>

[fr_esql_validation.txt](https://github.com/user-attachments/files/28602443/fr_esql_validation.txt)


</p>
</details> 


Backport tests

<img width="1918" height="1023" alt="Screenshot from 2026-06-04 11-57-25" src="https://github.com/user-attachments/assets/73166d34-9417-4fb3-9017-f91f58e4a8f9" />


Note if you reproduce these manually, you will need to set an `env GITHUB_EVENT_NAME=push` to properly duplicate the results.

> [!NOTE]
> When reviewing it will be necessary to have a remote stack setup for ES|QL validation. One must also verify that unit tests pass with this remote validation, as unit tests on the PR will not have the remote validation set since there are no ES|QL rule changes here.

Remote testing passed

<img width="1474" height="187" alt="image" src="https://github.com/user-attachments/assets/b0bf0cec-d585-47a8-a1d4-e843693f7a87" />



## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
