### PR TITLE
[New Rule] AWS SES Sending Enabled or Identity Verified by Rare User

### DIFF
--- a/rules/integrations/aws/resource_development_ses_sending_enabled_by_rare_user.toml
+++ b/rules/integrations/aws/resource_development_ses_sending_enabled_by_rare_user.toml
@@ -1,0 +1,157 @@
+[metadata]
+creation_date = "2026/06/06"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/06/06"
+
+[rule]
+author = ["Aryu Zaw"]
+description = """
+Identifies the first time an IAM identity enables Amazon Simple Email Service (SES) account-level sending, requests
+production access, or verifies and creates a sending identity within a lookback window. Adversaries who obtain leaked or
+stolen long-term AWS access keys frequently weaponize SES to send phishing, business email compromise (BEC), or spam
+from trusted AWS infrastructure that passes SPF, DKIM, and DMARC checks. This is a New Terms rule that flags when the
+`cloud.account.id` and `user.name` pair has not performed these SES sending-setup actions in the configured history
+window.
+"""
+false_positives = [
+    """
+    Marketing, transactional email, or notification platforms and infrastructure-as-code automation may legitimately
+    enable SES sending, request production access, or verify new sending identities, particularly during initial SES
+    onboarding. Validate the calling identity, user agent, and source IP against known automation accounts and expected
+    activity before taking action, and add exceptions for approved principals.
+    """,
+]
+from = "now-6m"
+index = ["filebeat-*", "logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS SES Sending Enabled or Identity Verified by Rare User"
+note = """## Triage and analysis
+
+### Investigating AWS SES Sending Enabled or Identity Verified by Rare User
+
+Amazon Simple Email Service (SES) is a managed email-sending service. Because mail sent through SES originates from AWS infrastructure and can be DKIM-signed and aligned to SPF and DMARC, it is attractive to adversaries who want their phishing, BEC, or spam to bypass reputation- and authentication-based controls. A common pattern is the compromise of long-term IAM access keys leaked in source code, `.env` files, container images, or public storage, followed by the attacker enabling SES sending and standing up sender identities in an account that has never used SES before.
+
+This is a [New Terms](https://www.elastic.co/guide/en/security/current/rules-ui-create.html#create-new-terms-rule) rule that flags the first time a given `cloud.account.id` and `user.name` pair performs SES sending-enablement or identity-setup actions within the history window.
+
+### Possible investigation steps
+
+- Identify the actor by reviewing `aws.cloudtrail.user_identity.arn`, `aws.cloudtrail.user_identity.type`, and `aws.cloudtrail.user_identity.access_key_id`. Activity originating from a long-term IAM user access key (an `AKIA`-prefixed key) is more suspicious than activity from an established role used by automation.
+- Determine the action performed via `event.action` and inspect `aws.cloudtrail.request_parameters`:
+    - `UpdateAccountSendingEnabled` and `PutAccountSendingAttributes` set account-wide sending to enabled.
+    - `PutAccountDetails` requests production access, moving the account out of the SES sandbox so it can email arbitrary recipients.
+    - `VerifyEmailIdentity`, `VerifyDomainIdentity`, and `CreateEmailIdentity` register new sender identities. Examine the email address or domain being verified for spoofed or look-alike branding.
+- Review `user_agent.original` to determine whether the call came from the AWS CLI, an SDK, or the console. Programmatic calls from an unfamiliar user agent are common in this activity.
+- Confirm the origin by inspecting `source.ip`, `source.geo`, and `source.as` and comparing them against known administrative locations. Requests from hosting or VPS providers are a common indicator.
+- Look for the surrounding chain in CloudTrail for the same identity, such as SES reconnaissance (`GetAccount`, `GetSendQuota`, `GetAccountSendingEnabled`, `ListIdentities`, `GetIdentityVerificationAttributes`), requests to raise the sending quota, and the same actions repeated across multiple regions.
+- Determine whether the account historically uses SES at all. New SES activity in an account or region with no prior SES footprint is a strong signal.
+
+### False positive analysis
+
+- Marketing, transactional, or notification platforms and infrastructure-as-code pipelines may legitimately enable sending and verify identities, especially during initial SES onboarding. Correlate with change-management records and the principal's normal behavior.
+- Some AWS solutions provision SES identities on a customer's behalf. Confirm whether the actor is a service-linked or automation role rather than an interactive user.
+- If a principal is expected to manage SES, add an exception scoped by `aws.cloudtrail.user_identity.arn`, ideally combined with `user_agent.original` and `source.ip`.
+
+### Response and remediation
+
+- If the activity is unauthorized, disable or rotate the implicated access key (`aws.cloudtrail.user_identity.access_key_id`) and review the principal's permissions to enforce least privilege.
+- Review SES for attacker-created identities, raised sending quotas, and the account-level sending state, and revert unauthorized changes. Consider disabling account sending while investigating.
+- Inspect SES sending statistics and any configured event destinations for evidence of mail already sent, and notify recipients or downstream parties if phishing was delivered.
+- Search CloudTrail for additional activity from the same identity, including other regions, to scope the compromise, and rotate any other credentials the identity could have exposed.
+"""
+references = [
+    "https://permiso.io/blog/s/aws-ses-pionage-detecting-ses-abuse/",
+    "https://www.datadoghq.com/blog/detect-phishing-activity-amazon-ses/",
+    "https://securelist.com/amazon-ses-phishing-and-bec-attacks/119623/",
+    "https://www.bleepingcomputer.com/news/security/amazon-ses-increasingly-abused-in-phishing-to-evade-detection/",
+    "https://docs.aws.amazon.com/ses/latest/dg/logging-using-cloudtrail.html",
+]
+risk_score = 21
+rule_id = "0fa96502-4150-47ab-af46-900c16c4b6e7"
+severity = "low"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS SES",
+    "Use Case: Threat Detection",
+    "Tactic: Resource Development",
+    "Tactic: Impact",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "new_terms"
+
+query = '''
+data_stream.dataset: "aws.cloudtrail"
+    and event.provider: "ses.amazonaws.com"
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService"
+    and event.action: (
+        "UpdateAccountSendingEnabled" or "PutAccountSendingAttributes" or "PutAccountDetails"
+        or "VerifyEmailIdentity" or "VerifyDomainIdentity" or "CreateEmailIdentity"
+    )
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1584"
+name = "Compromise Infrastructure"
+reference = "https://attack.mitre.org/techniques/T1584/"
+[[rule.threat.technique.subtechnique]]
+id = "T1584.006"
+name = "Web Services"
+reference = "https://attack.mitre.org/techniques/T1584/006/"
+
+
+
+[rule.threat.tactic]
+id = "TA0042"
+name = "Resource Development"
+reference = "https://attack.mitre.org/tactics/TA0042/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1496"
+name = "Resource Hijacking"
+reference = "https://attack.mitre.org/techniques/T1496/"
+[[rule.threat.technique.subtechnique]]
+id = "T1496.004"
+name = "Cloud Service Hijacking"
+reference = "https://attack.mitre.org/techniques/T1496/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "event.action",
+    "event.provider",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+    "aws.cloudtrail.request_parameters",
+]
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["cloud.account.id", "user.name"]
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-10d"
+
+


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- (none linked — full context in summary below)

## Summary - What I changed

Adds a new detection rule for the Amazon SES control plane (AWS CloudTrail, `event.provider: ses.amazonaws.com`):

**AWS SES Sending Enabled or Identity Verified by Rare User** — `rules/integrations/aws/resource_development_ses_sending_enabled_by_rare_user.toml`
**Type:** `new_terms` · **Language:** `kuery` · **Severity:** low (risk_score 21) · **Maturity:** production
**ATT&CK:** Resource Development: T1584.006 Compromise Infrastructure: Web Services · Impact: T1496.004 Resource Hijacking: Cloud Service Hijacking
**Data source:** AWS CloudTrail — index `filebeat-*, logs-aws.cloudtrail-*`
**New Terms:** `cloud.account.id`, `user.name` over a 10-day history window

Identifies the first time an IAM identity enables Amazon SES account-level sending, requests production access (sandbox exit), or verifies/creates a sending identity. Adversaries who harvest leaked or stolen long-term AWS access keys (from source code, `.env` files, container images, or public storage) frequently weaponize SES to send phishing, BEC, or spam from trusted AWS infrastructure that passes SPF, DKIM, and DMARC. Recipients cannot block by sender reputation because the mail originates from AWS IPs, and the only durable on-account evidence is these management-plane actions — `SendEmail`/`SendRawEmail` are CloudTrail data events that are not logged by default.

Query matches the high-fidelity write actions and excludes AWS-internal (`AWSService`) automation:
- Account sending enablement: `UpdateAccountSendingEnabled`, `PutAccountSendingAttributes`
- Production-access / sandbox exit: `PutAccountDetails`
- Sender identity setup: `VerifyEmailIdentity`, `VerifyDomainIdentity`, `CreateEmailIdentity`

**Why a new rule (no overlap):** The only existing SES reference in the repo is the read-only discovery rule `discovery_multiple_discovery_api_calls_via_cli.toml`, which matches `Describe*`/`List*`/`Get*`/`Generate*` bursts and cannot fire on these write actions. No other rule, building block, or hunt covers SES sending enablement or identity setup. Modeled on the accepted `resource_development_sns_topic_created_by_rare_user.toml` (same New-Terms "rare user" shape on a different AWS messaging service) and `discovery_organization_discovery_by_rare_user.toml`.

**Noise / FP expectations:** Low. New-Terms gating on `cloud.account.id` + `user.name` means the rule fires only the first time a principal performs SES sending setup in the window. Benign sources — marketing/transactional/notification platforms and IaC pipelines during initial SES onboarding — are documented in `false_positives` and the investigation guide, with guidance to scope exceptions by ARN + user agent + source IP.

## References
- https://permiso.io/blog/s/aws-ses-pionage-detecting-ses-abuse/ — CloudTrail action breakdown for SES abuse
- https://www.datadoghq.com/blog/detect-phishing-activity-amazon-ses/
- https://securelist.com/amazon-ses-phishing-and-bec-attacks/119623/ — Q1 2026 uptick; leaked-key root cause
- https://www.bleepingcomputer.com/news/security/amazon-ses-increasingly-abused-in-phishing-to-evade-detection/
- https://docs.aws.amazon.com/ses/latest/dg/logging-using-cloudtrail.html — SES management vs. data events in CloudTrail

## How To Test

Validated locally against a `detection-rules` checkout:

```bash
python -m detection_rules validate-rule rules/integrations/aws/resource_development_ses_sending_enabled_by_rare_user.toml
python -m detection_rules toml-lint -f rules/integrations/aws/resource_development_ses_sending_enabled_by_rare_user.toml
python -m detection_rules test     # full unit test suite (same checks CI runs)
```

- `validate-rule` (schema + ATT&CK mapping + KQL parse): PASS
- `toml-lint` (canonical formatting): PASS
- Full `detection_rules test` suite: 237 passed, 19 skipped (remote-only)

Illustrative matching CloudTrail event:
```
event.provider: ses.amazonaws.com
event.action: UpdateAccountSendingEnabled
event.outcome: success
aws.cloudtrail.user_identity.type: IAMUser
```

## Checklist

- [x] Added a label for the type of pr: `Rule: New`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist
- Have you signed the contributor license agreement? Yes
- Have you followed the contributor guidelines? Yes
