### PR TITLE
[New Rule] Multiple DHCP Servers Responding to the Same Transaction

### DIFF
--- a/rules/network/credential_access_dhcp_multiple_servers_same_transaction.toml
+++ b/rules/network/credential_access_dhcp_multiple_servers_same_transaction.toml
@@ -7,22 +7,11 @@ updated_date = "2026/06/09"
 [rule]
 author = ["Elastic"]
 description = """
-This rule identifies two or more distinct DHCP servers sending an OFFER or ACK for the same DHCP transaction ID (xid)
-within a short window, potentially a rogue DHCP server racing the legitimate one to deliver its response first. This is
-often rogue-DHCP / adversary-in-the-middle precondition (T1557.003) and is operating-system agnostic: the detection
-observes server-side behavior on the wire and does not depend on the victim client's platform. Any client acquiring or
-renewing a lease on the segment is in scope, including Windows, Linux, macOS, iOS, and IoT/embedded devices.
-
-Winning the race lets an attacker hand the client a hostile gateway/DNS (traffic interception), inject routes to bypass
-a VPN (TunnelVision, CVE-2024-3661, affecting Windows/Linux/macOS/iOS), or deliver a malformed OFFER/ACK that overflows
-the client's DHCP parser for remote code execution, for example CVE-2026-44815 (Windows DHCP Client) or CVE-2018-5732
-(ISC dhclient on Linux/Unix). The same structural anomaly covers all of these regardless of the target OS.
-
-Field note: the strongest theoretical signal is two different source MAC addresses for the same xid, but neither the
-network_traffic (Packetbeat) nor the Zeek DHCP schema exposes the responding server's Ethernet source MAC. The Zeek
-dhcp data stream additionally does not carry the transaction ID at all. This rule therefore keys on the distinct server
-source IP per transaction ID using the network_traffic dhcpv4 data stream, which does expose the transaction ID and the
-server identity.
+Identifies two or more distinct DHCP servers sending an OFFER or ACK for the same transaction ID (xid) within a short
+window, indicating a rogue DHCP server racing the legitimate one to win the client's handshake. This is the rogue-DHCP /
+adversary-in-the-middle precondition (T1557.003) and is operating-system agnostic, since it keys only on server behavior
+observed on the wire. Winning the race lets an attacker intercept traffic via a hostile gateway/DNS, bypass a VPN
+(TunnelVision), or deliver a malformed response that exploits the client's DHCP parser for code execution.
 """
 from = "now-9m"
 language = "esql"
@@ -84,7 +73,7 @@ rule_id = "44b8d933-8fed-485d-a0af-bd97d0093439"
 setup = """## Setup
 
 This rule requires the Elastic network_traffic (Packetbeat) integration capturing DHCP (UDP 67/68) on the broadcast
-segment where clients acquire/renew leases — either Packetbeat running on the segment or a SPAN/mirror feeding it. A
+segment where clients acquire/renew leases, either Packetbeat running on the segment or a SPAN/mirror feeding it. A
 sensor not on the same L2 broadcast domain (or not behind the relevant DHCP relay) will not observe competing OFFER/ACK
 packets.
 
@@ -98,8 +87,8 @@ tags = [
     "Use Case: Threat Detection",
     "Use Case: Vulnerability",
     "Use Case: Network Security Monitoring",
-    "Tactic: Initial Access",
     "Tactic: Credential Access",
+    "Tactic: Execution",
     "Data Source: Network Traffic",
     "Resources: Investigation Guide",
 ]
@@ -128,19 +117,6 @@ from logs-network_traffic.dhcpv4-*, packetbeat-*
 [[rule.threat]]
 framework = "MITRE ATT&CK"
 [[rule.threat.technique]]
-id = "T1190"
-name = "Exploit Public-Facing Application"
-reference = "https://attack.mitre.org/techniques/T1190/"
-
-
-[rule.threat.tactic]
-id = "TA0001"
-name = "Initial Access"
-reference = "https://attack.mitre.org/tactics/TA0001/"
-
-[[rule.threat]]
-framework = "MITRE ATT&CK"
-[[rule.threat.technique]]
 id = "T1557"
 name = "Adversary-in-the-Middle"
 reference = "https://attack.mitre.org/techniques/T1557/"
@@ -154,3 +130,16 @@ reference = "https://attack.mitre.org/techniques/T1557/003/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1203"
+name = "Exploitation for Client Execution"
+reference = "https://attack.mitre.org/techniques/T1203/"
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"

--- a/rules/network/credential_access_dhcp_multiple_servers_same_transaction.toml
+++ b/rules/network/credential_access_dhcp_multiple_servers_same_transaction.toml
@@ -61,7 +61,6 @@ window, and is operating-system agnostic, since it keys only on server behavior 
   compensating control, which protects clients of every OS and also mitigates TunnelVision-style route injection.
 """
 references = [
-    "https://attack.mitre.org/techniques/T1557/003/",
     "https://nvd.nist.gov/vuln/detail/CVE-2026-44815",
     "https://nvd.nist.gov/vuln/detail/CVE-2024-3661",
     "https://www.leviathansecurity.com/blog/tunnelvision",

--- a/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
+++ b/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
@@ -95,7 +95,6 @@ severity = "high"
 tags = [
     "Domain: Network",
     "Domain: Endpoint",
-    "OS: Windows",
     "Use Case: Threat Detection",
     "Use Case: Vulnerability",
     "Use Case: Network Security Monitoring",

--- a/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
+++ b/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
@@ -8,16 +8,21 @@ updated_date = "2026/06/09"
 author = ["Elastic"]
 description = """
 This rule identifies two or more distinct DHCP servers sending an OFFER or ACK for the same DHCP transaction ID (xid)
-within a short window — a rogue DHCP server racing the legitimate one to deliver its response first. This is the network
-precondition for CVE-2026-44815, a stack-based buffer overflow in the Windows DHCP Client service triggered by a
-malformed DHCP OFFER/ACK with crafted option fields, leading to remote code execution on the client. The same structural
-anomaly also covers classic DHCP spoofing / adversary-in-the-middle (T1557.003).
+within a short window, potentially a rogue DHCP server racing the legitimate one to deliver its response first. This is
+often rogue-DHCP / adversary-in-the-middle precondition (T1557.003) and is operating-system agnostic: the detection
+observes server-side behavior on the wire and does not depend on the victim client's platform. Any client acquiring or
+renewing a lease on the segment is in scope, including Windows, Linux, macOS, iOS, and IoT/embedded devices.
+
+Winning the race lets an attacker hand the client a hostile gateway/DNS (traffic interception), inject routes to bypass
+a VPN (TunnelVision, CVE-2024-3661, affecting Windows/Linux/macOS/iOS), or deliver a malformed OFFER/ACK that overflows
+the client's DHCP parser for remote code execution, for example CVE-2026-44815 (Windows DHCP Client) or CVE-2018-5732
+(ISC dhclient on Linux/Unix). The same structural anomaly covers all of these regardless of the target OS.
 
 Field note: the strongest theoretical signal is two different source MAC addresses for the same xid, but neither the
 network_traffic (Packetbeat) nor the Zeek DHCP schema exposes the responding server's Ethernet source MAC. The Zeek
 dhcp data stream additionally does not carry the transaction ID at all. This rule therefore keys on the distinct server
-source IP per transaction ID using the network_traffic.dhcpv4 data stream, which does expose dhcpv4.transaction_id and
-the server identity.
+source IP per transaction ID using the network_traffic dhcpv4 data stream, which does expose the transaction ID and the
+server identity.
 """
 from = "now-9m"
 language = "esql"
@@ -30,11 +35,11 @@ note = """## Triage and analysis
 
 ### Investigating Multiple DHCP Servers Responding to the Same Transaction
 
-DHCP is plaintext UDP and fully visible to any sensor on the broadcast segment. CVE-2026-44815 is a stack overflow in
-the Windows DHCP Client, exploited by a rogue server (or an injected response on the victim's L2 broadcast domain)
-sending a malformed OFFER/ACK. The defining precondition is a second server answering a transaction that the legitimate
-server already owns. This rule flags exactly that: two or more distinct server source IPs producing an OFFER/ACK for one
-transaction ID inside the same 30-second window.
+DHCP is plaintext UDP and fully visible to any sensor on the broadcast segment. A rogue server (or an injected response
+on the victim's L2 broadcast domain) that answers a transaction the legitimate server already owns is the defining
+precondition for DHCP-based adversary-in-the-middle and for malformed-option client exploits. This rule flags exactly
+that: two or more distinct server source IPs producing an OFFER/ACK for one transaction ID inside the same 30-second
+window, and is operating-system agnostic, since it keys only on server behavior observed on the wire.
 
 ### Possible investigation steps
 
@@ -45,8 +50,10 @@ transaction ID inside the same 30-second window.
 - Inspect the rogue OFFER/ACK options for an oversized or malformed payload (the overflow trigger) and for hostile
   configuration such as an attacker-controlled default gateway (option 3), DNS server (option 6), WPAD/proxy
   auto-config (option 252), or classless static routes (option 121, TunnelVision-style VPN bypass).
-- Check whether targeted Windows clients are unpatched for CVE-2026-44815 and review their endpoint telemetry for DHCP
-  client service crashes or follow-on code execution.
+- Identify the client(s) acquiring leases on the segment (any OS, including Windows, Linux, macOS, iOS, IoT) and review their
+  endpoint telemetry for DHCP client service crashes, unexpected route/DNS/gateway changes, or follow-on code execution.
+  Where the target OS and DHCP client are known, check whether they are unpatched for the relevant CVE (e.g.
+  CVE-2026-44815 on Windows, CVE-2018-5732 on ISC dhclient).
 
 ### False positive analysis
 
@@ -55,28 +62,31 @@ transaction ID inside the same 30-second window.
   load-balancing architecture genuinely does this, add its server IPs to an exception.
 - DHCP relay agents forward responses but the relayed source is the relay, and a single server still owns each
   transaction. Anycast/VIP DHCP designs that present multiple real backend IPs on the wire are rare and would be a known
-  architectural fact — except those IPs.
+  architectural fact, which can be excepted by those IPs.
 
 ### Response and remediation
 
-- Remove the rogue DHCP server from the segment and apply the June 2026 Patch Tuesday update for CVE-2026-44815 on
-  Windows clients.
+- Remove the rogue DHCP server from the segment, then patch the affected client DHCP stacks (e.g. June 2026 Patch
+  Tuesday for CVE-2026-44815 on Windows, or the fixed ISC dhclient for CVE-2018-5732 on Linux/Unix).
 - Enable DHCP snooping on managed switches and restrict DHCP server responses to authorized server ports/MACs as a
-  compensating control.
+  compensating control, which protects clients of every OS and also mitigates TunnelVision-style route injection.
 """
 references = [
-    "https://nvd.nist.gov/vuln/detail/CVE-2026-44815",
-    "https://msrc.microsoft.com/update-guide",
     "https://attack.mitre.org/techniques/T1557/003/",
+    "https://nvd.nist.gov/vuln/detail/CVE-2026-44815",
+    "https://nvd.nist.gov/vuln/detail/CVE-2024-3661",
+    "https://www.leviathansecurity.com/blog/tunnelvision",
+    "https://nvd.nist.gov/vuln/detail/CVE-2018-5732",
+    "https://msrc.microsoft.com/update-guide",
 ]
 risk_score = 73
 rule_id = "44b8d933-8fed-485d-a0af-bd97d0093439"
 setup = """## Setup
 
 This rule requires the Elastic network_traffic (Packetbeat) integration capturing DHCP (UDP 67/68) on the broadcast
-segment where Windows clients acquire/renew leases — either Packetbeat running on the segment or a SPAN/mirror feeding
-it. A sensor not on the same L2 broadcast domain (or not behind the relevant DHCP relay) will not observe competing
-OFFER/ACK packets.
+segment where clients acquire/renew leases — either Packetbeat running on the segment or a SPAN/mirror feeding it. A
+sensor not on the same L2 broadcast domain (or not behind the relevant DHCP relay) will not observe competing OFFER/ACK
+packets.
 
 Zeek is intentionally not supported: the zeek.dhcp data stream does not expose a transaction ID and aggregates a full
 DORA exchange into one record, so the per-transaction server-count comparison cannot be expressed on it.

--- a/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
+++ b/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
@@ -1,0 +1,146 @@
+[metadata]
+creation_date = "2026/06/09"
+integration = ["network_traffic"]
+maturity = "development"
+updated_date = "2026/06/09"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule identifies two or more distinct DHCP servers sending an OFFER or ACK for the same DHCP transaction ID (xid)
+within a short window — a rogue DHCP server racing the legitimate one to deliver its response first. This is the network
+precondition for CVE-2026-44815, a stack-based buffer overflow in the Windows DHCP Client service triggered by a
+malformed DHCP OFFER/ACK with crafted option fields, leading to remote code execution on the client. The same structural
+anomaly also covers classic DHCP spoofing / adversary-in-the-middle (T1557.003).
+
+Field note: the strongest theoretical signal is two different source MAC addresses for the same xid, but neither the
+network_traffic (Packetbeat) nor the Zeek DHCP schema exposes the responding server's Ethernet source MAC. The Zeek
+dhcp data stream additionally does not carry the transaction ID at all. This rule therefore keys on the distinct server
+source IP per transaction ID using the network_traffic.dhcpv4 data stream, which does expose dhcpv4.transaction_id and
+the server identity.
+"""
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Multiple DHCP Servers Responding to the Same Transaction"
+note = """## Triage and analysis
+
+> **Disclaimer**:
+> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
+
+### Investigating Multiple DHCP Servers Responding to the Same Transaction
+
+DHCP is plaintext UDP and fully visible to any sensor on the broadcast segment. CVE-2026-44815 is a stack overflow in
+the Windows DHCP Client, exploited by a rogue server (or an injected response on the victim's L2 broadcast domain)
+sending a malformed OFFER/ACK. The defining precondition is a second server answering a transaction that the legitimate
+server already owns. This rule flags exactly that: two or more distinct server source IPs producing an OFFER/ACK for one
+transaction ID inside the same 30-second window.
+
+### Possible investigation steps
+
+- Identify the server source IPs in `Esql.values_server_ips` and `Esql.values_server_identifiers`. Determine which is
+  the sanctioned DHCP server and which is unexpected.
+- Locate the rogue server on the segment (switch CAM/ARP tables, port, VLAN). It is on the same broadcast domain as the
+  victim by definition.
+- Inspect the rogue OFFER/ACK options for an oversized or malformed payload (the overflow trigger) and for hostile
+  configuration such as an attacker-controlled default gateway (option 3), DNS server (option 6), WPAD/proxy
+  auto-config (option 252), or classless static routes (option 121, TunnelVision-style VPN bypass).
+- Check whether targeted Windows clients are unpatched for CVE-2026-44815 and review their endpoint telemetry for DHCP
+  client service crashes or follow-on code execution.
+
+### False positive analysis
+
+- DHCP failover pairs (Microsoft or ISC) are designed so that, for a given transaction, only one peer answers; two
+  peers answering the same xid within 30 seconds is not normal failover behavior. If a known active-active or
+  load-balancing architecture genuinely does this, add its server IPs to an exception.
+- DHCP relay agents forward responses but the relayed source is the relay, and a single server still owns each
+  transaction. Anycast/VIP DHCP designs that present multiple real backend IPs on the wire are rare and would be a known
+  architectural fact — except those IPs.
+
+### Response and remediation
+
+- Remove the rogue DHCP server from the segment and apply the June 2026 Patch Tuesday update for CVE-2026-44815 on
+  Windows clients.
+- Enable DHCP snooping on managed switches and restrict DHCP server responses to authorized server ports/MACs as a
+  compensating control.
+"""
+references = [
+    "https://nvd.nist.gov/vuln/detail/CVE-2026-44815",
+    "https://msrc.microsoft.com/update-guide",
+    "https://attack.mitre.org/techniques/T1557/003/",
+]
+risk_score = 73
+rule_id = "44b8d933-8fed-485d-a0af-bd97d0093439"
+setup = """## Setup
+
+This rule requires the Elastic network_traffic (Packetbeat) integration capturing DHCP (UDP 67/68) on the broadcast
+segment where Windows clients acquire/renew leases — either Packetbeat running on the segment or a SPAN/mirror feeding
+it. A sensor not on the same L2 broadcast domain (or not behind the relevant DHCP relay) will not observe competing
+OFFER/ACK packets.
+
+Zeek is intentionally not supported: the zeek.dhcp data stream does not expose a transaction ID and aggregates a full
+DORA exchange into one record, so the per-transaction server-count comparison cannot be expressed on it.
+"""
+severity = "high"
+tags = [
+    "Domain: Network",
+    "Domain: Endpoint",
+    "Use Case: Threat Detection",
+    "Use Case: Vulnerability",
+    "Use Case: Network Security Monitoring",
+    "Tactic: Initial Access",
+    "Tactic: Credential Access",
+    "Data Source: Network Traffic",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+from logs-network_traffic.dhcpv4-*, packetbeat-*
+| eval
+    message_type = TO_LOWER(COALESCE(network_traffic.dhcpv4.option.message_type, dhcpv4.option.message_type)),
+    Esql.transaction_id = COALESCE(network_traffic.dhcpv4.transaction_id, dhcpv4.transaction_id),
+    server_identifier = COALESCE(network_traffic.dhcpv4.option.server_identifier, dhcpv4.option.server_identifier)
+| where message_type in ("offer", "ack") and Esql.transaction_id is not null and source.ip is not null
+| eval Esql.time_window = DATE_TRUNC(30 seconds, @timestamp)
+| stats
+    Esql.count_distinct_servers = COUNT_DISTINCT(source.ip),
+    Esql.values_server_ips = VALUES(source.ip),
+    Esql.values_server_identifiers = VALUES(server_identifier),
+    Esql.count_replies = COUNT(*)
+  by Esql.time_window, Esql.transaction_id
+| where Esql.count_distinct_servers >= 2
+| keep Esql.transaction_id, Esql.time_window, Esql.count_distinct_servers, Esql.values_server_ips, Esql.values_server_identifiers, Esql.count_replies
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1190"
+name = "Exploit Public-Facing Application"
+reference = "https://attack.mitre.org/techniques/T1190/"
+
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1557"
+name = "Adversary-in-the-Middle"
+reference = "https://attack.mitre.org/techniques/T1557/"
+[[rule.threat.technique.subtechnique]]
+id = "T1557.003"
+name = "DHCP Spoofing"
+reference = "https://attack.mitre.org/techniques/T1557/003/"
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"

--- a/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
+++ b/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
@@ -85,6 +85,7 @@ severity = "high"
 tags = [
     "Domain: Network",
     "Domain: Endpoint",
+    "OS: Windows",
     "Use Case: Threat Detection",
     "Use Case: Vulnerability",
     "Use Case: Network Security Monitoring",

--- a/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
+++ b/rules/network/initial_access_dhcp_multiple_servers_same_transaction.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/06/09"
 integration = ["network_traffic"]
-maturity = "development"
+maturity = "production"
 updated_date = "2026/06/09"
 
 [rule]


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

Adds a new network detection rule that flags two or more distinct DHCP servers sending an OFFER or ACK for the same DHCP transaction ID (xid) within a short window. This is likely a rogue DHCP server racing a legitimate one to deliver its response first.

This is the network signal may be used in exploiting CVE-2026-44815, a stack-based buffer overflow in the Windows DHCP Client service that is triggered by a malformed DHCP OFFER/ACK with crafted option fields, leading to unauthenticated remote code execution on the client. The same structural anomaly also covers classic DHCP spoofing / adversary-in-the-middle (T1557.003).

## How To Test

Unit Tests, Data in shared stack, and [RTA available](https://github.com/elastic/cortado/pull/34#issuecomment-4664108256). 

<img width="1829" height="889" alt="image" src="https://github.com/user-attachments/assets/786976f8-9fd8-49af-8868-620c123334f0" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
