### PR TITLE
[New Rule] Potential Redis CONFIG SET SSH Authorized Key Injection

### DIFF
--- a/rules/network/persistence_potential_redis_config_set_ssh_key_injection.toml
+++ b/rules/network/persistence_potential_redis_config_set_ssh_key_injection.toml
@@ -32,7 +32,7 @@ The full attack chain is:
 3. `SET key "\n\nssh-rsa ATTACKER_KEY\n\n"` — writes the public key with surrounding newlines
 4. `BGSAVE` — flushes the in-memory dataset (including the injected key) to disk
 
-A related variant targets cron persistence (`CONFIG SET dir /etc/cron.d`) for cryptominer deployment. A companion rule covers that pattern.
+A related variant targets cron persistence (`CONFIG SET dir /etc/cron.d`) for cryptominer deployment, as used by the RedisRaider campaign.
 
 ### Possible investigation steps
 

--- a/rules/network/persistence_potential_redis_config_set_ssh_key_injection.toml
+++ b/rules/network/persistence_potential_redis_config_set_ssh_key_injection.toml
@@ -1,0 +1,138 @@
+[metadata]
+creation_date = "2026/06/11"
+integration = ["network_traffic"]
+maturity = "production"
+updated_date = "2026/06/11"
+
+[rule]
+author = ["Elastic"]
+description = """
+This rule detects attempts to abuse Redis CONFIG SET commands to inject SSH authorized keys on Linux hosts.
+Attackers targeting unauthenticated Redis instances issue CONFIG SET dir to an SSH directory such as
+/root/.ssh, set the filename to authorized_keys via CONFIG SET dbfilename, write an attacker-controlled
+public key via SET, and call BGSAVE to flush it to disk, establishing persistent SSH access as root.
+"""
+from = "now-9m"
+index = ["logs-network_traffic.redis*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Potential Redis CONFIG SET SSH Authorized Key Injection"
+note = """## Triage and analysis
+
+> **Disclaimer**:
+> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
+
+### Investigating Potential Redis CONFIG SET SSH Authorized Key Injection
+
+Redis's CONFIG SET command allows runtime reconfiguration of the server, including the working directory (`dir`) and database filename (`dbfilename`). Attackers targeting unauthenticated Redis instances exploit this to redirect BGSAVE output into `/root/.ssh/authorized_keys`, injecting their own SSH public key and establishing persistent root shell access without credentials.
+
+The full attack chain is:
+1. `CONFIG SET dir /root/.ssh` — redirects the save path to the SSH directory
+2. `CONFIG SET dbfilename authorized_keys` — sets the output filename
+3. `SET key "\n\nssh-rsa ATTACKER_KEY\n\n"` — writes the public key with surrounding newlines
+4. `BGSAVE` — flushes the in-memory dataset (including the injected key) to disk
+
+A related variant targets cron persistence (`CONFIG SET dir /etc/cron.d`) for cryptominer deployment. A companion rule covers that pattern.
+
+### Possible investigation steps
+
+- Identify the source IP and determine whether it is an expected Redis client or an external/unknown address. Any external IP issuing CONFIG SET to an SSH directory should be treated as malicious.
+- Check whether the destination Redis instance requires authentication (`requirepass` or ACL). Unauthenticated instances are the prerequisite for this attack.
+- Review subsequent Redis commands from the same source IP for `SET` (key write) and `BGSAVE` (flush to disk), which complete the injection chain.
+- Examine `/root/.ssh/authorized_keys` and other user SSH directories on the Redis host for unexpected or recently modified entries at or after the alert time.
+- Check SSH login events on the Redis host for successful logins from unknown keys or source IPs shortly after the alert.
+- Review outbound connections from the Redis host for lateral movement or C2 activity following a successful key injection.
+
+### False positive analysis
+
+- `CONFIG SET dir` is a legitimate administrative command, but pointing it to any `/.ssh` directory has no legitimate use case. A match on this pattern has an extremely low false positive rate.
+- `CONFIG SET dbfilename authorized_keys` has no legitimate operational use. Any match should be investigated immediately.
+- Automated deployment tooling (Ansible, Chef, Puppet) will never target SSH directories via Redis CONFIG SET — this combination is exclusively malicious.
+
+### Response and remediation
+
+- Immediately inspect `/root/.ssh/authorized_keys` and all user `~/.ssh/authorized_keys` files on the Redis host for unauthorized entries and remove them.
+- Rotate SSH host keys and audit all active SSH sessions on the affected host.
+- Require authentication on all Redis instances (`requirepass` or ACL). Unauthenticated Redis reachable from any network is the root cause.
+- Restrict `CONFIG SET` permissions using Redis ACLs: `ACL SETUSER <user> -config`.
+- Block inbound access to Redis port 6379 from untrusted networks at the host firewall or perimeter.
+- Consider enabling Redis's protected mode, which rejects connections from non-loopback addresses when no authentication is configured.
+"""
+references = [
+    "https://redis.io/docs/latest/operate/oss_and_stack/management/security/",
+    "https://attack.mitre.org/techniques/T1098/004/",
+    "https://attack.mitre.org/techniques/T1190/",
+]
+risk_score = 73
+rule_id = "39ab0f66-efa0-4649-9c9c-8c64682f5fdd"
+setup = """## Setup
+
+This rule requires the Elastic **network_traffic** integration (Packetbeat via Elastic Agent) with the Redis
+protocol module enabled.
+
+### Enabling the Redis module
+
+In the Elastic Agent `network_traffic` integration policy:
+1. Add or confirm **Redis** in the protocols list with `enabled: true`.
+2. Set **ports** to include `6379` (or the custom port your Redis instances listen on).
+3. Deploy the sensor on the Redis host, on a SPAN/mirror port, or on a gateway that receives Redis traffic.
+
+### TLS limitation
+
+This rule requires unencrypted Redis traffic. Redis uses plaintext by default (port 6379). If TLS is configured,
+Packetbeat cannot inspect the payload without TLS decryption.
+"""
+severity = "high"
+tags = [
+    "Domain: Network",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Initial Access",
+    "Data Source: Network Packet Capture",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+network where data_stream.dataset == "network_traffic.redis" and
+  (
+    (
+      network_traffic.redis.query like~ "*CONFIG SET dir*" and
+      network_traffic.redis.query like~ "*/.ssh*"
+    ) or
+    (
+      network_traffic.redis.query like~ "*CONFIG SET dbfilename*" and
+      network_traffic.redis.query like~ "*authorized_keys*"
+    )
+  )
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+[[rule.threat.technique.subtechnique]]
+id = "T1098.004"
+name = "SSH Authorized Keys"
+reference = "https://attack.mitre.org/techniques/T1098/004/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1190"
+name = "Exploit Public-Facing Application"
+reference = "https://attack.mitre.org/techniques/T1190/"
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"

--- a/rules/network/persistence_potential_redis_config_set_ssh_key_injection.toml
+++ b/rules/network/persistence_potential_redis_config_set_ssh_key_injection.toml
@@ -19,9 +19,6 @@ license = "Elastic License v2"
 name = "Potential Redis CONFIG SET SSH Authorized Key Injection"
 note = """## Triage and analysis
 
-> **Disclaimer**:
-> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
-
 ### Investigating Potential Redis CONFIG SET SSH Authorized Key Injection
 
 Redis's CONFIG SET command allows runtime reconfiguration of the server, including the working directory (`dir`) and database filename (`dbfilename`). Attackers targeting unauthenticated Redis instances exploit this to redirect BGSAVE output into `/root/.ssh/authorized_keys`, injecting their own SSH public key and establishing persistent root shell access without credentials.


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

Adds a new `eql` network detection rule targeting the classic Redis unauthorized file write technique used to inject SSH authorized keys on Linux hosts. An attacker with access to an unauthenticated Redis instance issues `CONFIG SET dir /root/.ssh`, `CONFIG SET dbfilename authorized_keys`, writes a public key via `SET`, and calls `BGSAVE` to flush it to disk, establishing persistent root SSH access without credentials. This attack class has been exploited by multiple threat campaigns and toolkits targeting internet-exposed Redis instances.

This kind of attack also targets Redis instances that are not expected to be internet connected E.g. behind cloud Firewalls and/or in VPCs. Misconfigurations either by the cloud provider or on the Redis host can inadvertently expose instances to these kinds of attacks.  


## How To Test

Data in shared stack and [RTA](https://github.com/elastic/cortado/pull/34/commits/910f6381a255ce32720d11047c9fd6937c42daf2).

<img width="1532" height="573" alt="image" src="https://github.com/user-attachments/assets/13fd6c41-10f9-46b2-a8c6-3a435dd0115f" />




## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
