### PR TITLE
[Rule Tuning] Add Google Workspace bulk group member upload action

### DIFF
--- a/rules/integrations/google_workspace/initial_access_external_user_added_to_google_workspace_group.toml
+++ b/rules/integrations/google_workspace/initial_access_external_user_added_to_google_workspace_group.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/02/16"
 integration = ["google_workspace"]
 maturity = "production"
-updated_date = "2026/05/22"
+updated_date = "2026/06/13"
 
 [rule]
 author = ["Elastic"]
@@ -98,7 +98,7 @@ timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''
-iam where data_stream.dataset == "google_workspace.admin" and event.action == "ADD_GROUP_MEMBER" and
+iam where data_stream.dataset == "google_workspace.admin" and event.action in ("ADD_GROUP_MEMBER", "GROUP_MEMBER_BULK_UPLOAD") and
   not endsWith(user.target.domain, user.target.group.domain)
 '''
 


### PR DESCRIPTION
## Summary
Adds GROUP_MEMBER_BULK_UPLOAD to the External User Added to Google Workspace Group rule so bulk group membership uploads are covered alongside ADD_GROUP_MEMBER.

Fixes #4128.

## Tests
- uv run python -m detection_rules validate-rule rules/integrations/google_workspace/initial_access_external_user_added_to_google_workspace_group.toml
- git diff --check