### PR TITLE
[Rule Tunings] Google Workspace Domain-Wide Delegation and First Time OAuth Login

### DIFF
--- a/rules/integrations/google_workspace/defense_evasion_google_workspace_new_oauth_login_from_third_party_application.toml
+++ b/rules/integrations/google_workspace/defense_evasion_google_workspace_new_oauth_login_from_third_party_application.toml
@@ -2,14 +2,14 @@
 creation_date = "2023/03/30"
 integration = ["google_workspace"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/06/15"
 
 [rule]
 author = ["Elastic"]
 description = """
-Detects the first time a third-party application logs in and authenticated with OAuth. OAuth is used to grant
-permissions to specific resources and services in Google Workspace. Compromised credentials or service accounts could
-allow an adversary to authenticate to Google Workspace as a valid user and inherit their privileges.
+Detects the first time a user authorizes a third-party Google OAuth application that requests identity or sign-in
+scopes. Adversaries may abuse compromised credentials or phishing-linked consent flows to register novel OAuth clients,
+obtain refresh tokens, and authenticate as valid users while evading password-only detections.
 """
 false_positives = [
     """
@@ -18,57 +18,75 @@ false_positives = [
     """,
 ]
 from = "now-130m"
-index = ["filebeat-*", "logs-google_workspace*"]
+index = ["logs-google_workspace.token-*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
 name = "First Time Seen Google Workspace OAuth Login from Third-Party Application"
 note = """## Triage and analysis
 
-> **Disclaimer**:
-> This investigation guide was created using generative AI technology and has been reviewed to improve its accuracy and relevance. While every effort has been made to ensure its quality, we recommend validating the content and adapting it to suit your specific environment and operational needs.
-
 ### Investigating First Time Seen Google Workspace OAuth Login from Third-Party Application
 
-OAuth is a protocol that allows third-party applications to access user data without exposing credentials, enhancing security in Google Workspace. However, adversaries can exploit OAuth by using compromised credentials to gain unauthorized access, mimicking legitimate users. The detection rule identifies unusual OAuth logins by monitoring authorization events linked to new third-party applications, flagging potential misuse for further investigation.
+Threat actors may trick users into authorizing adversary-controlled OAuth applications after credential theft, AiTM
+relay, or spearphishing. A successful `authorize` grant issues tokens the application can reuse to act on behalf of the
+user. Novel third-party client IDs are a strong signal as malicious consent often appears as a first-time application in the tenant.
+
+This rule uses `new_terms` to flag the first appearance of a `google_workspace.token.client.id` when
+a user grants at least one identity or sign-in scope in `google_workspace.token.scope.value` (for example `openid`,
+`userinfo.email`, `userinfo.profile`, or `OAuthLogin`).
 
 ### Possible investigation steps
 
-- Review the event details to identify the specific third-party application involved by examining the google_workspace.token.client.id field.
-- Check the google_workspace.token.scope.data field to understand the scope of permissions granted to the third-party application and assess if they align with expected usage.
-- Investigate the user account associated with the OAuth authorization event to determine if there are any signs of compromise or unusual activity.
-- Correlate the timestamp of the OAuth login event with other security logs to identify any concurrent suspicious activities or anomalies.
-- Verify if the third-party application is known and authorized within the organization by consulting with relevant stakeholders or reviewing application whitelists.
-- Assess the risk and impact of the OAuth login by considering the privileges of the user account and the sensitivity of the accessed resources.
+- Identify the user who authorized the application by reviewing `user.email` or `user.name`, and note `source.ip` and `event.ingested` if present in the alert.
+- Identify the application by reviewing `google_workspace.token.app_name` and `google_workspace.token.client.id`.
+- Review granted scopes in `google_workspace.token.scope.value` to determine whether the app received identity-only access or additional permissions (for example calendar, drive, or mail scopes on the same grant).
+- Determine whether the authorization is expected and authorized:
+  - If `source.ip` or timing is unusual for the user, treat the alert as higher priority until proven benign.'
+
+- Search Kibana for related activity:
+  - Find prior authorizations for the same client in the org:
+    ```
+    data_stream.dataset: "google_workspace.token" and event.action: "authorize" and google_workspace.token.client.id: "<CLIENT_ID>"
+    ```
+  - Correlate with sign-in anomalies for the same user:
+    ```
+    data_stream.dataset: "google_workspace.login" and user.email: "<USER_EMAIL>"
+    ```
+  - Scope for other OAuth or admin changes from the same `user.email` within the last 48 hours.
 
 ### False positive analysis
 
-- New legitimate third-party applications: Users may frequently integrate new third-party applications for productivity or collaboration. To manage this, maintain a whitelist of known and trusted applications and exclude them from triggering alerts.
-- Regular updates to existing applications: Some applications may update their OAuth client IDs during version upgrades. Monitor application update logs and adjust the detection rule to exclude these known updates.
-- Internal development and testing: Organizations developing their own applications may trigger this rule during testing phases. Coordinate with development teams to identify and exclude these internal applications from alerts.
-- Frequent use of service accounts: Service accounts used for automation or integration purposes might appear as new logins. Document and exclude these service accounts from the detection rule to prevent false positives.
+- Internal development or QA OAuth clients may appear as new `client.id` values during testing; coordinate with engineering teams and exclude known test clients if needed.
+- Some vendors rotate OAuth client IDs during major upgrades, which can look like a new application, confirm with the vendor or IT owner before closing as benign.
 
 ### Response and remediation
 
-- Immediately revoke the OAuth token associated with the suspicious third-party application to prevent further unauthorized access.
-- Conduct a thorough review of the affected user's account activity to identify any unauthorized actions or data access that may have occurred.
-- Reset the credentials of the affected user and any other users who may have been compromised, ensuring that strong, unique passwords are used.
-- Notify the affected user and relevant stakeholders about the incident, providing guidance on recognizing phishing attempts and securing their accounts.
-- Implement additional monitoring for the affected user and similar OAuth authorization events to detect any further suspicious activity.
-- Escalate the incident to the security operations team for a deeper investigation into potential lateral movement or data exfiltration.
-- Review and update OAuth application permissions and policies to ensure that only trusted applications have access to sensitive data and services.
+- Initiate the incident response process based on triage findings.
+- If the authorization is not clearly authorized, revoke the application's access for the affected user under Security > Access and data control > API controls (or remove the user token via admin OAuth reports).
+- If the user account is suspected compromised, reset credentials, revoke active sessions, and review all OAuth grants for that user.
+- Review activity performed with the new token (Drive, Gmail, Calendar, or other services implied by `google_workspace.token.scope.value`).
+- Identify the possible impact of the incident and prioritize accordingly; the following actions can help you gain context:
+    - Identify the account role in the cloud environment.
+    - Assess the criticality of affected services and servers.
+    - Work with your IT team to identify and minimize the impact on users.
+    - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
+    - Identify any regulatory or legal ramifications related to this activity.
+- Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
+- Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
+- Implement security best practices [outlined](https://support.google.com/a/answer/7587183) by Google.
+- Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
+- Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
 
 ## Setup
 
 The Google Workspace Fleet integration, Filebeat module, or similarly structured data is required to be compatible with this rule.
+
 ### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
 - This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
-- To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
-  - https://support.google.com/a/answer/7061566
-  - https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-module-google_workspace.html"""
+  - https://support.google.com/a/answer/7061566"""
 references = [
     "https://www.elastic.co/security-labs/google-workspace-attack-surface-part-one",
     "https://www.elastic.co/security-labs/google-workspace-attack-surface-part-two",
@@ -78,69 +96,90 @@ references = [
 risk_score = 47
 rule_id = "21bafdf0-cf17-11ed-bd57-f661ea17fbcc"
 severity = "medium"
-tags = ["Domain: Cloud", "Data Source: Google Workspace", "Tactic: Defense Evasion", "Tactic: Initial Access", "Resources: Investigation Guide"]
+tags = [
+    "Domain: Cloud",
+    "Data Source: Google Workspace",
+    "Tactic: Defense Evasion",
+    "Tactic: Initial Access",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+]
 timestamp_override = "event.ingested"
 type = "new_terms"
 
 query = '''
-data_stream.dataset: "google_workspace.token" and event.action: "authorize" and
-google_workspace.token.scope.data: *Login and google_workspace.token.client.id: *apps.googleusercontent.com
+data_stream.dataset: "google_workspace.token"
+  and event.action: "authorize"
+  and google_workspace.token.scope.value: (*openid* or *userinfo.email* or *userinfo.profile* or *Login*)
+  and google_workspace.token.client.id: *apps.googleusercontent.com
 '''
 
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"
-
 [[rule.threat.technique]]
 id = "T1550"
 name = "Use Alternate Authentication Material"
 reference = "https://attack.mitre.org/techniques/T1550/"
-
 [[rule.threat.technique.subtechnique]]
 id = "T1550.001"
 name = "Application Access Token"
 reference = "https://attack.mitre.org/techniques/T1550/001/"
 
+
+
 [rule.threat.tactic]
 id = "TA0005"
 name = "Defense Evasion"
 reference = "https://attack.mitre.org/tactics/TA0005/"
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
-
 [[rule.threat.technique]]
 id = "T1078"
 name = "Valid Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/"
-
 [[rule.threat.technique.subtechnique]]
 id = "T1078.004"
 name = "Cloud Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/004/"
+
+
 
 [rule.threat.tactic]
 id = "TA0001"
 name = "Initial Access"
 reference = "https://attack.mitre.org/tactics/TA0001/"
-
 [[rule.threat]]
 framework = "MITRE ATT&CK"
-
 [[rule.threat.technique]]
 id = "T1078"
 name = "Valid Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/"
-
 [[rule.threat.technique.subtechnique]]
 id = "T1078.004"
 name = "Cloud Accounts"
 reference = "https://attack.mitre.org/techniques/T1078/004/"
 
+
+
 [rule.threat.tactic]
 id = "TA0003"
 name = "Persistence"
 reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[rule.investigation_fields]
+field_names = [
+    "user.name",
+    "user.email",
+    "source.ip",
+    "user.domain",
+    "event.action",
+    "google_workspace.token.app_name",
+    "google_workspace.token.client.type",
+    "google_workspace.token.client.id",
+    "google_workspace.token.scope.value",
+]
+
 [rule.new_terms]
 field = "new_terms_fields"
 value = ["google_workspace.token.client.id"]

--- a/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_dwd.toml
+++ b/rules/integrations/google_workspace/persistence_google_workspace_api_access_granted_via_dwd.toml
@@ -2,14 +2,15 @@
 creation_date = "2020/11/12"
 integration = ["google_workspace"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/06/15"
 
 [rule]
 author = ["Elastic"]
 description = """
-Detects when a domain-wide delegation of authority is granted to a service account. Domain-wide delegation can be
-configured to grant third-party and internal applications to access the data of Google Workspace users. An adversary may
-configure domain-wide delegation to maintain access to their target’s data.
+Detects when a super administrator authorizes domain-wide delegation (DWD) API client access for a Google Cloud service
+account or OAuth client. DWD lets an application impersonate users and access Workspace APIs across the tenant.
+Adversaries with admin access may register or authorize a malicious client with broad scopes to maintain API-based
+persistence and access mail, drive, and directory data without relying on a single user's password alone.
 """
 false_positives = [
     """
@@ -17,8 +18,9 @@ false_positives = [
     configuration change was expected. Exceptions can be added to this rule to filter expected behavior.
     """,
 ]
-from = "now-9m"
-index = ["filebeat-*", "logs-google_workspace*"]
+from = "now-130m"
+interval = "10m"
+index = ["filebeat-*", "logs-google_workspace.admin-*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "Google Workspace API Access Granted via Domain-Wide Delegation"
@@ -26,32 +28,60 @@ note = """## Triage and analysis
 
 ### Investigating Google Workspace API Access Granted via Domain-Wide Delegation
 
-Domain-wide delegation is a feature that allows apps to access users' data across an organization's Google Workspace environment. Only super admins can manage domain-wide delegation, and they must specify each API scope that the application can access. Google Workspace services all have APIs that can be interacted with after domain-wide delegation is established with an OAuth2 client ID of the application. Typically, GCP service accounts and applications are created where the Google Workspace APIs are enabled, thus allowing the application to access resources and services in Google Workspace.
+Domain-wide delegation (DWD) allows a Google Cloud service account or OAuth client to access Workspace user data on
+behalf of users across the domain. Only super administrators can authorize DWD, and each grant specifies API scopes
+that define what the client can read or modify (for example Gmail, Drive, Directory, or Calendar APIs). Over-scoped DWD
+grants create durable third-party access paths that survive individual user password resets.
 
-Applications authorized to interact with Google Workspace resources and services through APIs have a wide range of capabilities depending on the scopes applied. If the principle of least privilege (PoLP) is not practiced when setting API scopes, threat actors could abuse additional privileges if the application is compromised. New applications created and given API access could indicate an attempt by a threat actor to register their malicious application with the Google Workspace domain in an attempt to establish a command and control foothold.
+This rule matches `AUTHORIZE_API_CLIENT_ACCESS` events in the `google_workspace.admin` data stream.
 
-This rule identifies when an application is authorized API client access.
+### Possible investigation steps
 
-#### Possible investigation steps
-
-- Identify the associated user accounts by reviewing `user.name` or `user.email` fields in the alert.
-  - Only users with super admin privileges can authorize API client access.
-- Identify the API client name by reviewing the `google_workspace.admin.api.client.name` field in the alert.
-  - If GCP audit logs are ingested, pivot to reviewing the last 48 hours of activity related to the service account ID.
-  - Search for the `google_workspace.admin.api.client.name` value with wildcards in the `gcp.audit.resource_name` field.
-  - Search for API client name and aggregated results on `event.action` to determine what the service account is being used for in GWS.
-- After identifying the involved user, verify super administrative privileges to access domain-wide delegation settings.
+- Identify the administrator who authorized access by reviewing `user.email` or `user.name`, and note `user.domain` and
+  `event.ingested` if present in the alert.
+- Identify the authorized client by reviewing `google_workspace.admin.api.client.name` and confirm the affected tenant
+  with `google_workspace.admin.domain.name`.
+- Review granted API scopes in `google_workspace.admin.api.scopes` against least-privilege expectations. Broad scopes
+  (for example full mail or drive access) warrant higher urgency.
+- Determine whether the change is expected and authorized:
+  - Validate there is an approved change request or vendor onboarding record for the client and scopes.
+  - If the actor account is unusual or the scopes exceed documented requirements, treat as higher priority until proven benign.
+- Review DWD configuration in the Google Admin console:
+  - Sign in to [admin.google.com](https://admin.google.com) with an authorized administrator account.
+  - Navigate to Security > Access and data control > API controls > Domain-wide delegation.
+  - Confirm the client ID, client name, and scopes match the alert fields.
+- Search Kibana for related admin activity:
+  - Find other DWD grants or revocations by the same administrator:
+    ```
+    data_stream.dataset: "google_workspace.admin" and user.email: "<ACTOR_EMAIL>" and event.action: ("AUTHORIZE_API_CLIENT_ACCESS" or "REVOKE_API_CLIENT_ACCESS")
+    ```
+  - Scope for all grants to the same API client:
+    ```
+    data_stream.dataset: "google_workspace.admin" and event.action: "AUTHORIZE_API_CLIENT_ACCESS" and google_workspace.admin.api.client.name: "<CLIENT_NAME>"
+    ```
+  - Correlate with other high-risk admin actions from the same actor in the last 48 hours:
+    ```
+    data_stream.dataset: "google_workspace.admin" and user.email: "<ACTOR_EMAIL>" and event.action: ("ASSIGN_ROLE" or "ADD_APPLICATION" or "CREATE_ROLE")
+    ```
+- If GCP audit logs are ingested, pivot on the service account or client:
+  - Search for the client name in `gcp.audit.resource_name` and review `event.action` over the last 48 hours to determine
+    how the service account is being used after authorization.
 
 ### False positive analysis
 
-- Changes to domain-wide delegation require super admin privileges. Check with the user to ensure these changes were expected.
-- Review scheduled maintenance notes related to expected API access changes.
+- Platform or security teams may authorize DWD for approved automation, backup, or migration tooling — validate against
+  known service accounts and documented scope requirements.
+- Vendor onboarding sometimes requires temporary broad scopes; confirm timing against change windows before closing as benign.
 
 ### Response and remediation
 
-- Initiate the incident response process based on the outcome of the triage.
-- Review the scope of the authorized API client access in Google Workspace.
-- Disable or limit the account during the investigation and response.
+- Initiate the incident response process based on triage findings.
+- If the grant is not clearly authorized, revoke domain-wide delegation for the client under Security > Access and data
+  control > API controls > Domain-wide delegation while the investigation proceeds.
+- Rotate or disable the associated GCP service account keys if the client is suspected malicious.
+- If the initiating admin account is suspected compromised, reset credentials, revoke active sessions, and review
+  delegated admin roles assigned to that account.
+- Review activity performed with the authorized client based on scopes in `google_workspace.admin.api.scopes`.
 - Identify the possible impact of the incident and prioritize accordingly; the following actions can help you gain context:
     - Identify the account role in the cloud environment.
     - Assess the criticality of affected services and servers.
@@ -59,7 +89,7 @@ This rule identifies when an application is authorized API client access.
     - Identify if the attacker is moving laterally and compromising other accounts, servers, or services.
     - Identify any regulatory or legal ramifications related to this activity.
 - Investigate credential exposure on systems compromised or used by the attacker to ensure all compromised accounts are identified. Reset passwords or delete API keys as needed to revoke the attacker's access to the environment. Work with your IT teams to minimize the impact on business operations during these actions.
-- Review the permissions assigned to the implicated user to ensure that the least privilege principle is being followed.
+- Review the permissions assigned to the implicated administrator to ensure that the least privilege principle is being followed.
 - Implement security best practices [outlined](https://support.google.com/a/answer/7587183) by Google.
 - Determine the initial vector abused by the attacker and take action to prevent reinfection via the same vector.
 - Using the incident response data, update logging and audit policies to improve the mean time to detect (MTTD) and the mean time to respond (MTTR).
@@ -70,6 +100,7 @@ The Google Workspace Fleet integration, Filebeat module, or similarly structured
 
 ### Important Information Regarding Google Workspace Event Lag Times
 - As per Google's documentation, Google Workspace administrators may observe lag times ranging from minutes up to 3 days between the time of an event's occurrence and the event being visible in the Google Workspace admin/audit logs.
+- This rule is configured to run every 10 minutes with a lookback time of 130 minutes.
 - To reduce the risk of false negatives, consider reducing the interval that the Google Workspace (formerly G Suite) Filebeat module polls Google's reporting API for new events.
 - By default, `var.interval` is set to 2 hours (2h). Consider changing this interval to a lower value, such as 10 minutes (10m).
 - See the following references for further information:
@@ -89,18 +120,26 @@ tags = [
     "Use Case: Identity and Access Audit",
     "Resources: Investigation Guide",
     "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
 ]
 timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
 data_stream.dataset:google_workspace.admin
-  and event.provider:admin
-  and event.category:iam
   and event.action:AUTHORIZE_API_CLIENT_ACCESS
-  and event.outcome:success
 '''
 
+[rule.investigation_fields]
+field_names = [
+    "user.name",
+    "user.email",
+    "user.domain",
+    "event.action",
+    "google_workspace.admin.api.client.name",
+    "google_workspace.admin.api.scopes",
+    "google_workspace.admin.domain.name",
+]
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
- https://github.com/elastic/ia-trade-team/issues/905

## Summary - What I changed

### First Time Seen Google Workspace OAuth Login from Third-Party Application
- `google_workspace.token.scope.data` is not populated on the current integration mapping. Identity/sign-in scopes are stored in `google_workspace.token.scope.value` so this field is used instead. Without this change the rule matched zero events in TRaDE lab.
- Replaced scope filter with google_workspace.token.scope.value: (*openid* or *userinfo.email* or *userinfo.profile* or *Login*) to include additional indicators of login behavior
- Narrowed index to logs-google_workspace.token-* and removed filebeat which does not support `token` datastream
- Added investigation_fields; updated description and investigation guide

#### Screenshot of working query capturing additional login activity
<img width="1650" height="668" alt="image" src="https://github.com/user-attachments/assets/c681f340-26de-46c9-8af4-ccd36240eb95" />

### Google Workspace API Access Granted via Domain-Wide Delegation
- Removed event.outcome:success. event.outcome is no longer present in integration mapping for these google_workspace.admin events
- Also removed event.provider / event.category filters
- narrowed index to `logs-google_workspace.admin-*`
- increased schedule/lookback (10m / 130m) to account for 2h default filebeat ingest lag time, and added investigation_fields.

#### Screenshot of working query with no event.outcome populated
<img width="1650" height="580" alt="image" src="https://github.com/user-attachments/assets/efe987d2-6596-45df-a926-3490a5bac7f0" />

## How To Test

Tested both rules manually, data is in our TRaDE stack