### PR TITLE
[Bug] Update Min Stack Calculation to Include Patch Version

### DIFF
--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -22,7 +22,6 @@ from semver import Version
 
 from . import ecs
 from .beats import flatten_ecs_schema
-from .config import load_current_package_version
 from .schemas import definitions, get_stack_versions
 from .utils import cached, get_etc_path, read_gzip, unzip
 
@@ -525,6 +524,7 @@ def find_latest_compatible_version(
     integration: str,
     rule_stack_version: Version,
     packages_manifest: dict[str, Any],
+    package_schemas: dict[str, Any] | None = None,
 ) -> tuple[str, list[str]]:
     """Finds latest compatible version for specified integration based on stack version supplied."""
 
@@ -547,6 +547,12 @@ def find_latest_compatible_version(
             raise ValueError(f"Manifest for {package}:{integration} version {version} is missing conditions.")
 
         if _satisfies_kibana_range(rule_stack_version, version_requirement):
+            if (
+                integration
+                and package_schemas is not None
+                and not _package_version_has_integration(version, integration, package_schemas)
+            ):
+                continue
             if newest_skipped is not None:
                 skipped_version, skipped_floor = newest_skipped
                 integration_label = f" {integration.strip()}" if integration else ""
@@ -630,16 +636,23 @@ def get_integration_schema_data(
         for stack_version, mapping in meta.get_validation_stack_versions().items():
             ecs_version = mapping["ecs"]
             endgame_version = mapping["endgame"]
+            parsed_stack_version = Version.parse(stack_version)
+            patch_floor = find_latest_integration_patch_for_minor(
+                {pk_int["package"] for pk_int in package_integrations},
+                parsed_stack_version.major,
+                parsed_stack_version.minor,
+            )
+            min_stack = Version(
+                parsed_stack_version.major,
+                parsed_stack_version.minor,
+                max(parsed_stack_version.patch, patch_floor),
+            )
 
             ecs_schema = ecs.flatten_multi_fields(ecs.get_schema(ecs_version, name="ecs_flat"))
 
             for pk_int in package_integrations:
                 package = pk_int["package"]
                 integration = pk_int["integration"]
-
-                # Use the minimum stack version from the package not the rule
-                min_stack = meta.min_stack_version or load_current_package_version()
-                min_stack = Version.parse(min_stack, optional_minor_and_patch=True)
 
                 # Extract the integration schema fields
                 integration_schema, package_version = get_integration_schema_fields(
@@ -674,7 +687,14 @@ def get_integration_schema_fields(  # noqa: PLR0913
 ) -> tuple[dict[str, Any], str]:
     data: QueryRuleData = data  # type: ignore[reportAssignmentType]  # noqa: PLW0127
     """Extracts the integration fields to schema based on package integrations."""
-    package_version, notice = find_latest_compatible_version(package, integration, min_stack, packages_manifest)
+    package_schemas = integrations_schemas.get(package, {}) if integration else None
+    package_version, notice = find_latest_compatible_version(
+        package,
+        integration,
+        min_stack,
+        packages_manifest,
+        package_schemas=package_schemas,
+    )
     notify_user_if_update_available(data, notice, integration)
 
     schema = collect_schema_fields(integrations_schemas, package, package_version, integration)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -34,6 +34,7 @@ from .esql_errors import EsqlSemanticError
 from .integrations import (
     UNKNOWN_PACKAGE_INTEGRATION,
     find_compatible_version_range,
+    find_latest_integration_patch_for_minor,
     get_integration_schema_fields,
     load_integrations_manifests,
     load_integrations_schemas,
@@ -673,12 +674,22 @@ class QueryValidator:
         package_integrations = parse_datasets(list(datasets), packages_manifest)
         int_schema: dict[str, Any] = {}
         data = {"notify": False}
+        patch_floor = find_latest_integration_patch_for_minor(
+            {pk_int["package"] for pk_int in package_integrations},
+            current_version.major,
+            current_version.minor,
+        )
+        min_stack = Version(
+            current_version.major,
+            current_version.minor,
+            max(current_version.patch, patch_floor),
+        )
 
         for pk_int in package_integrations:
             package = pk_int["package"]
             integration = pk_int["integration"]
             schema, _ = get_integration_schema_fields(
-                integrations_schemas, package, integration, current_version, packages_manifest, {}, data
+                integrations_schemas, package, integration, min_stack, packages_manifest, {}, data
             )
             int_schema.update(schema)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.51"
+version = "1.6.52"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -22,6 +22,7 @@ from detection_rules.integrations import (
     find_latest_compatible_version,
     find_latest_integration_patch_for_minor,
 )
+from detection_rules.rule_validators import KQLValidator
 from detection_rules.schemas import get_stack_versions
 
 
@@ -259,6 +260,35 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
                 manifests,
                 package_schemas=schemas,
             )
+
+    def test_required_fields_uses_patch_floor_for_integration_schema(self):
+        """Required fields resolve integration schemas using a non-zero patch floor when needed."""
+        package = "pkg"
+        integration = "new_ds"
+        field_name = "pkg.new_ds.some_field"
+        manifests = {
+            package: {
+                "1.0.0": _manifest("^9.0.0"),
+                "1.1.0": _manifest("~9.2.1 || ^9.3.0"),
+            }
+        }
+        schemas = {
+            package: {
+                "1.0.0": {"old_ds": {}},
+                "1.1.0": {integration: {field_name: "keyword"}},
+            }
+        }
+        validator = KQLValidator(f"data_stream.dataset:{package}.{integration} and {field_name}:*")
+
+        with (
+            unittest.mock.patch("detection_rules.rule.load_current_package_version", return_value="9.2.0"),
+            unittest.mock.patch("detection_rules.rule.load_integrations_manifests", return_value=manifests),
+            unittest.mock.patch("detection_rules.rule.load_integrations_schemas", return_value=schemas),
+            unittest.mock.patch("detection_rules.integrations.load_integrations_manifests", return_value=manifests),
+        ):
+            required_fields = validator.get_required_fields([])
+
+        self.assertIn({"name": field_name, "type": "keyword", "ecs": False}, required_fields)
 
 
 class TestFindCompatibleVersionRange(unittest.TestCase):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -20,6 +20,7 @@ from detection_rules.integrations import (
     _stack_majors_supported_by_package,
     find_compatible_version_range,
     find_latest_compatible_version,
+    find_latest_integration_patch_for_minor,
 )
 from detection_rules.schemas import get_stack_versions
 
@@ -219,6 +220,45 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         """Unknown package raises ``ValueError``."""
         with self.assertRaises(ValueError):
             find_latest_compatible_version("missing", "missing", Version(9, 1, 0), {})
+
+    def test_skips_schema_versions_missing_integration_after_patch_floor(self):
+        """A non-zero patch floor can select a package version that contains the requested data stream."""
+        package = "pkg"
+        integration = "new_ds"
+        older_version = "1.0.0"
+        newer_version = "1.1.0"
+        manifests = {
+            package: {
+                older_version: _manifest("^9.0.0"),
+                newer_version: _manifest("~9.2.1 || ^9.3.0"),
+            }
+        }
+        schemas = {
+            older_version: {"old_ds": {}},
+            newer_version: {"old_ds": {}, integration: {}},
+        }
+
+        with unittest.mock.patch("detection_rules.integrations.load_integrations_manifests", return_value=manifests):
+            patch_floor = find_latest_integration_patch_for_minor({package}, 9, 2)
+        self.assertGreater(patch_floor, 0)
+
+        version, _ = find_latest_compatible_version(
+            package,
+            integration,
+            Version(9, 2, patch_floor),
+            manifests,
+            package_schemas=schemas,
+        )
+        self.assertEqual(version, newer_version)
+
+        with self.assertRaises(ValueError):
+            find_latest_compatible_version(
+                package,
+                integration,
+                Version(9, 2, 0),
+                manifests,
+                package_schemas=schemas,
+            )
 
 
 class TestFindCompatibleVersionRange(unittest.TestCase):


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:
* Related: https://github.com/elastic/detection-rules/pull/6251

## Summary - What I changed

Fixes integration version resolution for local KQL validation when a rule references a data stream that was added in a later package version. This surfaced on rules using `logs-azure.aadgraphactivitylogs-*` because the validator resolved Azure `1.34.1`, which is Kibana-compatible with the local `9.2.0` package version but predates the `aadgraphactivitylogs` data stream. The correct Azure package floor for this data stream is `1.37.0`, gated behind `~9.2.4` on the 9.2 branch.


### Changes by file:

- `detection_rules/integrations.py` / `find_latest_compatible_version()`: Adds optional schema-aware filtering so Kibana-compatible package versions are skipped when their bundled schemas do not contain the requested integration/data stream.

- `detection_rules/integrations.py` / `get_integration_schema_data()`: Infers the latest required stack patch for the rule's package set before resolving integration schemas. This keeps validation on the same stack minor while avoiding stale `.0` package resolution, e.g. `9.2.0` resolves package schemas as `9.2.4` for Azure when needed.

- `detection_rules/rule.py` / `QueryValidator.get_required_fields()`: Applies the same patch-aware package version lookup for required-field generation, so `view-rule` does not fail after query validation succeeds.


## How To Test
1. Grab a test rule e.g. 
[initial_access_aad_graph_unusual_asn.toml.txt](https://github.com/user-attachments/files/29068673/initial_access_aad_graph_unusual_asn.toml.txt)

2. Run `python -m detection_rules view-rule rules/integrations/azure/initial_access_aad_graph_unusual_asn.toml` using the local repo virtualenv.

Before the fix: `view-rule` resolves Azure `1.34.1`, then fails because that package does not include `aadgraphactivitylogs`.

<img width="1248" height="576" alt="image" src="https://github.com/user-attachments/assets/e6c5f68c-9401-4dcf-bbe9-effc052ce96f" />


```
ValueError: Integration aadgraphactivitylogs not found in package azure version 1.34.1
```

3. Apply the diff of this branch locally to a local checkout of 9.2 and re-run
[kql_validation_aadgraphactivitylogs.patch.txt](https://github.com/user-attachments/files/29068829/kql_validation_aadgraphactivitylogs.patch.txt)

After the fix: `view-rule` succeeds and emits the expected related integration floor.

```
"related_integrations": [
  {
    "integration": "aadgraphactivitylogs",
    "package": "azure",
    "version": "^1.37.0 || ^2.0.0"
  }
]
```

<img width="1248" height="576" alt="image" src="https://github.com/user-attachments/assets/ffaa577d-c26c-489f-8dff-63d40adec011" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
