### PR TITLE
[New Rule] AWS Lambda Function URL Created with Public Access

### DIFF
--- a/rules/integrations/aws/persistence_lambda_function_url_public_access.toml
+++ b/rules/integrations/aws/persistence_lambda_function_url_public_access.toml
@@ -31,39 +31,27 @@ note = """## Triage and analysis
 
 ### Investigating AWS Lambda Function URL Created with Public Access
 
-A Lambda function URL is a dedicated HTTPS endpoint for a function. When configured with `authType=NONE`, anyone on the
-internet can invoke the function without AWS authentication. Adversaries use this to create a public, persistent entry
-point for command and control, data exfiltration, or running attacker-controlled code without needing AWS credentials.
+A Lambda function URL is a dedicated HTTPS endpoint for a function. When configured with `authType=NONE`, anyone on the internet can invoke the function without AWS authentication. Adversaries use this to create a public, persistent entry point for command and control, data exfiltration, or running attacker-controlled code without needing AWS credentials.
 
-This rule detects successful `CreateFunctionUrlConfig` and `UpdateFunctionUrlConfig` calls where the auth type is set to
-NONE.
+This rule detects successful `CreateFunctionUrlConfig` and `UpdateFunctionUrlConfig` calls where the auth type is set to NONE.
 
 #### Possible investigation steps
 
-- Identify the actor in `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.type`, and review
-  `source.ip` and `user_agent.original` to determine how the change was made.
-- Inspect `aws.cloudtrail.request_parameters` for the `functionName` and the auth type, and review
-  `aws.cloudtrail.response_elements` for the resulting `functionUrl`.
-- Determine whether the function is intended to be public and whether the owning team requested an unauthenticated
-  endpoint.
-- Review the function's code, execution role, and recent changes (`UpdateFunctionCode`, `UpdateFunctionConfiguration`,
-  `AddPermission`) for signs of tampering.
-- Correlate with other activity by the same principal, and check the function's invocation and access logs for traffic
-  from unexpected sources after the URL was exposed.
+- Identify the actor in `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.type`, and review `source.ip` and `user_agent.original` to determine how the change was made.
+- Inspect `aws.cloudtrail.request_parameters` for the `functionName` and the auth type, and review `aws.cloudtrail.response_elements` for the resulting `functionUrl`.
+- Determine whether the function is intended to be public and whether the owning team requested an unauthenticated endpoint.
+- Review the function's code, execution role, and recent changes (`UpdateFunctionCode`, `UpdateFunctionConfiguration`, `AddPermission`) for signs of tampering.
+- Correlate with other activity by the same principal, and check the function's invocation and access logs for traffic from unexpected sources after the URL was exposed.
 
 ### False positive analysis
 
-- Public webhooks, simple APIs, and front-end integrations sometimes use unauthenticated function URLs intentionally.
-  Confirm the exposure is approved and exclude known public endpoints on `functionName` or
-  `aws.cloudtrail.user_identity.arn` after validation.
+- Public webhooks, simple APIs, and front-end integrations sometimes use unauthenticated function URLs intentionally. Confirm the exposure is approved and exclude known public endpoints on `functionName` or `aws.cloudtrail.user_identity.arn` after validation.
 
 ### Response and remediation
 
-- If the exposure is unauthorized, change the function URL auth type to `AWS_IAM` or delete the function URL
-  configuration, and review the function code and execution role for compromise.
+- If the exposure is unauthorized, change the function URL auth type to `AWS_IAM` or delete the function URL configuration, and review the function code and execution role for compromise.
 - Examine invocation logs for unauthenticated requests received while the URL was public and assess potential impact.
-- Rotate or restrict credentials for the principal if compromise is suspected, and constrain
-  `lambda:CreateFunctionUrlConfig` and `lambda:UpdateFunctionUrlConfig` to trusted roles.
+- Rotate or restrict credentials for the principal if compromise is suspected, and constrain `lambda:CreateFunctionUrlConfig` and `lambda:UpdateFunctionUrlConfig` to trusted roles.
 
 ### Additional information
 

--- a/rules/integrations/aws/persistence_lambda_function_url_public_access.toml
+++ b/rules/integrations/aws/persistence_lambda_function_url_public_access.toml
@@ -35,7 +35,7 @@ A Lambda function URL is a dedicated HTTPS endpoint for a function. When configu
 
 This rule detects successful `CreateFunctionUrlConfig` and `UpdateFunctionUrlConfig` calls where the auth type is set to NONE.
 
-#### Possible investigation steps
+### Possible investigation steps
 
 - Identify the actor in `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.type`, and review `source.ip` and `user_agent.original` to determine how the change was made.
 - Inspect `aws.cloudtrail.request_parameters` for the `functionName` and the auth type, and review `aws.cloudtrail.response_elements` for the resulting `functionUrl`.

--- a/rules/integrations/aws/persistence_lambda_function_url_public_access.toml
+++ b/rules/integrations/aws/persistence_lambda_function_url_public_access.toml
@@ -72,6 +72,7 @@ tags = [
     "Data Source: AWS Lambda",
     "Use Case: Threat Detection",
     "Tactic: Persistence",
+    "Tactic: Defense Evasion",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/integrations/aws/persistence_lambda_function_url_public_access.toml
+++ b/rules/integrations/aws/persistence_lambda_function_url_public_access.toml
@@ -1,0 +1,148 @@
+[metadata]
+creation_date = "2026/06/18"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/06/18"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies the creation or update of an AWS Lambda function URL configured with an authentication type of NONE, which
+exposes the function to unauthenticated invocation directly from the public internet. Adversaries can use a public
+function URL to establish a durable, internet-reachable entry point for command and control, data egress, or on-demand
+execution of attacker-controlled code, bypassing the need for valid AWS credentials to invoke the function. Function
+URLs with public access should be rare and deliberate, so this configuration warrants review.
+"""
+false_positives = [
+    """
+    Some public-facing applications, webhooks, and lightweight APIs legitimately use Lambda function URLs with no
+    authentication and enforce access control elsewhere. Verify the function, the principal in
+    `aws.cloudtrail.user_identity.arn`, and the intended exposure with the owning team. Known public endpoints can be
+    excluded after validation.
+    """,
+]
+from = "now-6m"
+index = ["logs-aws.cloudtrail-*"]
+interval = "5m"
+language = "eql"
+license = "Elastic License v2"
+name = "AWS Lambda Function URL Created with Public Access"
+note = """## Triage and analysis
+
+### Investigating AWS Lambda Function URL Created with Public Access
+
+A Lambda function URL is a dedicated HTTPS endpoint for a function. When configured with `authType=NONE`, anyone on the
+internet can invoke the function without AWS authentication. Adversaries use this to create a public, persistent entry
+point for command and control, data exfiltration, or running attacker-controlled code without needing AWS credentials.
+
+This rule detects successful `CreateFunctionUrlConfig` and `UpdateFunctionUrlConfig` calls where the auth type is set to
+NONE.
+
+#### Possible investigation steps
+
+- Identify the actor in `aws.cloudtrail.user_identity.arn` and `aws.cloudtrail.user_identity.type`, and review
+  `source.ip` and `user_agent.original` to determine how the change was made.
+- Inspect `aws.cloudtrail.request_parameters` for the `functionName` and the auth type, and review
+  `aws.cloudtrail.response_elements` for the resulting `functionUrl`.
+- Determine whether the function is intended to be public and whether the owning team requested an unauthenticated
+  endpoint.
+- Review the function's code, execution role, and recent changes (`UpdateFunctionCode`, `UpdateFunctionConfiguration`,
+  `AddPermission`) for signs of tampering.
+- Correlate with other activity by the same principal, and check the function's invocation and access logs for traffic
+  from unexpected sources after the URL was exposed.
+
+### False positive analysis
+
+- Public webhooks, simple APIs, and front-end integrations sometimes use unauthenticated function URLs intentionally.
+  Confirm the exposure is approved and exclude known public endpoints on `functionName` or
+  `aws.cloudtrail.user_identity.arn` after validation.
+
+### Response and remediation
+
+- If the exposure is unauthorized, change the function URL auth type to `AWS_IAM` or delete the function URL
+  configuration, and review the function code and execution role for compromise.
+- Examine invocation logs for unauthenticated requests received while the URL was public and assess potential impact.
+- Rotate or restrict credentials for the principal if compromise is suspected, and constrain
+  `lambda:CreateFunctionUrlConfig` and `lambda:UpdateFunctionUrlConfig` to trusted roles.
+
+### Additional information
+
+- [Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html)
+- [Security and auth model for Lambda function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html)
+"""
+references = [
+    "https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html",
+    "https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html",
+]
+risk_score = 73
+rule_id = "53bb8f53-3550-4805-b6bd-728ded8d5564"
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Data Source: AWS",
+    "Data Source: Amazon Web Services",
+    "Data Source: AWS Lambda",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "eql"
+
+query = '''
+any where data_stream.dataset == "aws.cloudtrail"
+    and event.provider == "lambda.amazonaws.com"
+    and event.outcome == "success"
+    and (event.action : "CreateFunctionUrlConfig*" or event.action : "UpdateFunctionUrlConfig*")
+    and stringContains(aws.cloudtrail.request_parameters, "authType=NONE")
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1133"
+name = "External Remote Services"
+reference = "https://attack.mitre.org/techniques/T1133/"
+
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1578"
+name = "Modify Cloud Compute Infrastructure"
+reference = "https://attack.mitre.org/techniques/T1578/"
+[[rule.threat.technique.subtechnique]]
+id = "T1578.005"
+name = "Modify Cloud Compute Configurations"
+reference = "https://attack.mitre.org/techniques/T1578/005/"
+
+
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "user.name",
+    "user_agent.original",
+    "source.ip",
+    "aws.cloudtrail.user_identity.arn",
+    "aws.cloudtrail.user_identity.type",
+    "aws.cloudtrail.user_identity.access_key_id",
+    "aws.cloudtrail.user_identity.session_context.session_issuer.arn",
+    "aws.cloudtrail.request_parameters",
+    "aws.cloudtrail.response_elements",
+    "event.action",
+    "event.outcome",
+    "cloud.account.id",
+    "cloud.region",
+]
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

* https://github.com/elastic/ia-trade-team/issues/920

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed
Add detection of the creation or update of an AWS Lambda function URL configured with an authentication type of NONE, which exposes the function to unauthenticated invocation directly from the public internet. Adversaries can use a public function URL to establish a durable, internet-reachable entry point for command and control, data egress, or on-demand execution of attacker-controlled code, bypassing the need for valid AWS credentials to invoke the function. Function URLs with public access should be rare and deliberate, so this configuration warrants review.

<img width="1473" height="134" alt="image" src="https://github.com/user-attachments/assets/214cdd1f-ec33-43d8-b376-e5226a1ba350" />


<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test
Query & data can be assessed in TRADE stack and other telemetry stacks.

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?