### PR TITLE
[Bug] Fix test integrations unit tests for 8.* branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.52"
+version = "1.6.53"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -10,6 +10,7 @@ import unittest.mock
 
 from semver import Version
 
+from detection_rules.config import load_current_package_version
 from detection_rules.integrations import (
     _MAX_UNBOUNDED_STACK_MAJOR_SPAN,
     _find_least_compatible_for_stack,
@@ -228,10 +229,15 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         integration = "new_ds"
         older_version = "1.0.0"
         newer_version = "1.1.0"
+        current_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
+        required_patch = current_version.patch + 1
         manifests = {
             package: {
-                older_version: _manifest("^9.0.0"),
-                newer_version: _manifest("~9.2.1 || ^9.3.0"),
+                older_version: _manifest(f"^{current_version.major}.0.0"),
+                newer_version: _manifest(
+                    f"~{current_version.major}.{current_version.minor}.{required_patch} || "
+                    f"^{current_version.major}.{current_version.minor + 1}.0"
+                ),
             }
         }
         schemas = {
@@ -240,13 +246,17 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         }
 
         with unittest.mock.patch("detection_rules.integrations.load_integrations_manifests", return_value=manifests):
-            patch_floor = find_latest_integration_patch_for_minor({package}, 9, 2)
-        self.assertGreater(patch_floor, 0)
+            patch_floor = find_latest_integration_patch_for_minor(
+                {package},
+                current_version.major,
+                current_version.minor,
+            )
+        self.assertGreater(patch_floor, current_version.patch)
 
         version, _ = find_latest_compatible_version(
             package,
             integration,
-            Version(9, 2, patch_floor),
+            Version(current_version.major, current_version.minor, patch_floor),
             manifests,
             package_schemas=schemas,
         )
@@ -256,7 +266,7 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
             find_latest_compatible_version(
                 package,
                 integration,
-                Version(9, 2, 0),
+                current_version,
                 manifests,
                 package_schemas=schemas,
             )
@@ -266,10 +276,15 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         package = "pkg"
         integration = "new_ds"
         field_name = "pkg.new_ds.some_field"
+        current_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
+        required_patch = current_version.patch + 1
         manifests = {
             package: {
-                "1.0.0": _manifest("^9.0.0"),
-                "1.1.0": _manifest("~9.2.1 || ^9.3.0"),
+                "1.0.0": _manifest(f"^{current_version.major}.0.0"),
+                "1.1.0": _manifest(
+                    f"~{current_version.major}.{current_version.minor}.{required_patch} || "
+                    f"^{current_version.major}.{current_version.minor + 1}.0"
+                ),
             }
         }
         schemas = {
@@ -281,7 +296,6 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         validator = KQLValidator(f"data_stream.dataset:{package}.{integration} and {field_name}:*")
 
         with (
-            unittest.mock.patch("detection_rules.rule.load_current_package_version", return_value="9.2.0"),
             unittest.mock.patch("detection_rules.rule.load_integrations_manifests", return_value=manifests),
             unittest.mock.patch("detection_rules.rule.load_integrations_schemas", return_value=schemas),
             unittest.mock.patch("detection_rules.integrations.load_integrations_manifests", return_value=manifests),


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to https://github.com/elastic/detection-rules/pull/6289

## Summary - What I changed

Small PR to address 8.19 branch unit test failure ([ref](https://github.com/elastic/detection-rules/actions/runs/27770770308/job/82169806271)) caused by new integrations unit tests. 

In short, the unit test that we added to test situations like `aadgraph` needs to be updated to better handle creating a mock manifest on older stack versions. While the stack schema map does include 9.2, it is not loaded, so the old approach will throw the error in the prior ref. We tested this in PR, but on a commit that is one short of where the problem was introduced. 

In the old approach we hard-coded stack values into the mock requirements, the new approach sets these values dynamically based on what the current stack version.

> [!NOTE]
> This PR will need to bypass merge requirements due to 8.19 status check failure. 

## How To Test

1. Checkout 8.19
2. Apply this patch to 8.19 with the fix from this PR
[8_19_unit_test_fix.patch.txt](https://github.com/user-attachments/files/29102564/8_19_unit_test_fix.patch.txt)

3. Run the unit test that previously failed
```
python -m pytest tests/test_integrations.py::TestFindLatestCompatibleVersion::test_required_fields_uses_patch_floor_for_integration_schema -vvvv
```

<img width="1922" height="245" alt="image" src="https://github.com/user-attachments/assets/a06a1a47-9445-43f4-b09a-1767cb475af7" />



## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
