### PR TITLE
[FR] Use >= semantic versioning for related integrations for stacks 9.5 and onwards

### DIFF
--- a/.github/workflows/lock-versions.yml
+++ b/.github/workflows/lock-versions.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   pr:
     runs-on: ubuntu-latest
+    env:
+      DR_RELATED_INTEGRATIONS_USE_GTE: "True"
 
     steps:
       - name: Validate the source branch

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,6 +13,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      DR_RELATED_INTEGRATIONS_USE_GTE: "True"
 
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/release-fleet.yml
+++ b/.github/workflows/release-fleet.yml
@@ -40,6 +40,8 @@ jobs:
     fleet-pr:
       name: Build package and create PR to integrations
       runs-on: ubuntu-latest
+      env:
+        DR_RELATED_INTEGRATIONS_USE_GTE: "True"
       steps:
         - name: Validate the source branch
           uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9

--- a/detection_rules/custom_rules.py
+++ b/detection_rules/custom_rules.py
@@ -76,6 +76,19 @@ def create_test_config_content(enable_prebuilt_tests: bool) -> str:
     return "\n".join(lines)
 
 
+def get_stack_schema_map_entry_for_version(
+    stack_schema_map_content: dict[str, dict[str, str]],
+    kibana_version: str,
+) -> dict[str, dict[str, str]]:
+    """Return the stack-schema-map entry matching the requested custom rules package version."""
+    requested_version = Version.parse(kibana_version, optional_minor_and_patch=True)
+    for stack_version, schema_versions in stack_schema_map_content.items():
+        if Version.parse(stack_version, optional_minor_and_patch=True) == requested_version:
+            return {stack_version: schema_versions}
+
+    raise ValueError(f"No stack-schema-map entry found for custom rules package version {requested_version}")
+
+
 @custom_rules.command("setup-config")
 @click.argument("directory", type=Path)
 @click.argument("kibana-version", type=str, default=load_etc_dump(["packages.yaml"])["package"]["name"])
@@ -125,9 +138,8 @@ def setup_config(directory: Path, kibana_version: str, overwrite: bool, enable_p
 
     # Create the stack-schema-map.yaml file
     stack_schema_map_content = load_etc_dump(["stack-schema-map.yaml"])
-    latest_version = max(stack_schema_map_content.keys(), key=Version.parse)
-    latest_entry = {latest_version: stack_schema_map_content[latest_version]}
-    _ = stack_schema_map_config.write_text(yaml.safe_dump(latest_entry, default_flow_style=False))
+    stack_schema_map_entry = get_stack_schema_map_entry_for_version(stack_schema_map_content, kibana_version)
+    _ = stack_schema_map_config.write_text(yaml.safe_dump(stack_schema_map_entry, default_flow_style=False))
 
     # Create default packages.yaml
     package_content = {"package": {"name": kibana_version}}

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -337,6 +337,10 @@ class RelatedIntegrationVersion:
     manifest_versions: tuple[str, ...]
 
 
+class IntegrationVersionNotFoundError(ValueError):
+    """Raised when a package has no compatible version for the requested stack/integration."""
+
+
 def _related_integration_version_operator(stack_version: Version) -> str:
     """Return the semver operator for related_integrations.version on the current stack."""
     return ">=" if stack_version >= RELATED_INTEGRATION_GTE_OPERATOR_MIN_STACK else "^"
@@ -363,7 +367,7 @@ def resolve_related_integration_version(
     )
     if manifest_version is None:
         package_label = f"{package}:{integration}" if integration else package
-        raise ValueError(f"no compatible version for integration {package_label}")
+        raise IntegrationVersionNotFoundError(f"no compatible version for integration {package_label}")
 
     operator = _related_integration_version_operator(current_stack)
     return RelatedIntegrationVersion(expression=f"{operator}{manifest_version}", manifest_versions=(manifest_version,))

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -284,7 +284,7 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
 
 # Sentinel written by ``parse_datasets`` when a rule indexes a package but not a data stream.
 UNKNOWN_PACKAGE_INTEGRATION = "Unknown"
-RELATED_INTEGRATION_GTE_MIN_STACK = Version(9, 5, 0)
+RELATED_INTEGRATION_GTE_OPERATOR_MIN_STACK = Version(9, 5, 0)
 
 
 def _package_version_has_integration(
@@ -330,24 +330,24 @@ def _find_least_compatible_for_stack(
 
 
 @dataclass(frozen=True)
-class CompatibleVersionRange:
-    """Current-stack related integration compatibility range."""
+class RelatedIntegrationVersion:
+    """Resolved related_integrations.version value for the current package stack."""
 
-    range: str
-    anchors: tuple[str, ...]
+    expression: str
+    manifest_versions: tuple[str, ...]
 
 
 def _related_integration_version_operator(stack_version: Version) -> str:
     """Return the semver operator for related_integrations.version on the current stack."""
-    return ">=" if stack_version >= RELATED_INTEGRATION_GTE_MIN_STACK else "^"
+    return ">=" if stack_version >= RELATED_INTEGRATION_GTE_OPERATOR_MIN_STACK else "^"
 
 
-def find_compatible_version_range(
+def resolve_related_integration_version(
     package: str,
     packages_manifest: dict[str, Any],
     integration: str | None = None,
-) -> CompatibleVersionRange:
-    """Return the legacy current-stack related_integrations.version range."""
+) -> RelatedIntegrationVersion:
+    """Return the current-stack related_integrations.version expression."""
     package_manifest = packages_manifest.get(package)
     if package_manifest is None:
         raise ValueError(f"Package {package} not found in manifest.")
@@ -358,13 +358,13 @@ def find_compatible_version_range(
 
     integration_manifests = dict(sorted(package_manifest.items(), key=lambda x: Version.parse(x[0])))
     current_stack = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
-    anchor = _find_least_compatible_for_stack(current_stack, integration_manifests, integration, package_schemas)
-    if anchor is None:
+    manifest_version = _find_least_compatible_for_stack(current_stack, integration_manifests, integration, package_schemas)
+    if manifest_version is None:
         package_label = f"{package}:{integration}" if integration else package
         raise ValueError(f"no compatible version for integration {package_label}")
 
     operator = _related_integration_version_operator(current_stack)
-    return CompatibleVersionRange(range=f"{operator}{anchor}", anchors=(anchor,))
+    return RelatedIntegrationVersion(expression=f"{operator}{manifest_version}", manifest_versions=(manifest_version,))
 
 
 def find_latest_compatible_version(

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -8,6 +8,7 @@
 import fnmatch
 import gzip
 import json
+import os
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
@@ -284,6 +285,7 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
 
 # Sentinel written by ``parse_datasets`` when a rule indexes a package but not a data stream.
 UNKNOWN_PACKAGE_INTEGRATION = "Unknown"
+RELATED_INTEGRATION_GTE_OPERATOR_ENV = "DR_RELATED_INTEGRATIONS_USE_GTE"
 RELATED_INTEGRATION_GTE_OPERATOR_MIN_STACK = Version(9, 5, 0)
 
 
@@ -341,9 +343,16 @@ class IntegrationVersionNotFoundError(ValueError):
     """Raised when a package has no compatible version for the requested stack/integration."""
 
 
+def _related_integration_gte_operator_enabled() -> bool:
+    """Return True when CI/package builds opt into >= related integration versions."""
+    return os.getenv(RELATED_INTEGRATION_GTE_OPERATOR_ENV) == "True"
+
+
 def _related_integration_version_operator(stack_version: Version) -> str:
     """Return the semver operator for related_integrations.version on the current stack."""
-    return ">=" if stack_version >= RELATED_INTEGRATION_GTE_OPERATOR_MIN_STACK else "^"
+    if _related_integration_gte_operator_enabled() and stack_version >= RELATED_INTEGRATION_GTE_OPERATOR_MIN_STACK:
+        return ">="
+    return "^"
 
 
 def resolve_related_integration_version(

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -358,7 +358,9 @@ def resolve_related_integration_version(
 
     integration_manifests = dict(sorted(package_manifest.items(), key=lambda x: Version.parse(x[0])))
     current_stack = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
-    manifest_version = _find_least_compatible_for_stack(current_stack, integration_manifests, integration, package_schemas)
+    manifest_version = _find_least_compatible_for_stack(
+        current_stack, integration_manifests, integration, package_schemas
+    )
     if manifest_version is None:
         package_label = f"{package}:{integration}" if integration else package
         raise ValueError(f"no compatible version for integration {package_label}")

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -285,6 +285,7 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
 
 # Sentinel written by ``parse_datasets`` when a rule indexes a package but not a data stream.
 UNKNOWN_PACKAGE_INTEGRATION = "Unknown"
+# TODO(eric-forte-elastic): Remove this gate after stack 9.7. https://github.com/elastic/detection-rules/issues/6327  # noqa: FIX002, E501
 RELATED_INTEGRATION_GTE_OPERATOR_ENV = "DR_RELATED_INTEGRATIONS_USE_GTE"
 RELATED_INTEGRATION_GTE_OPERATOR_MIN_STACK = Version(9, 5, 0)
 

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -22,7 +22,8 @@ from semver import Version
 
 from . import ecs
 from .beats import flatten_ecs_schema
-from .schemas import definitions, get_stack_versions
+from .config import load_current_package_version
+from .schemas import definitions
 from .utils import cached, get_etc_path, read_gzip, unzip
 
 if TYPE_CHECKING:
@@ -284,17 +285,6 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
 # Sentinel written by ``parse_datasets`` when a rule indexes a package but not a data stream.
 UNKNOWN_PACKAGE_INTEGRATION = "Unknown"
 
-# Cap majors walked for unbounded Kibana clauses (``>=X.Y.Z``). Intersection with
-# ``_shipped_stack_majors()`` keeps only backport lines we ship rules to.
-_MAX_UNBOUNDED_STACK_MAJOR_SPAN = 10
-
-
-def _major_has_compatible_stack(major: int, version_requirement: str) -> bool:
-    """Return True iff the Kibana range overlaps some stack in [major.0.0, (major+1).0.0)."""
-    major_lo = Version(major, 0, 0)
-    major_hi = Version(major + 1, 0, 0)
-    return any(lo < major_hi and (hi is None or hi > major_lo) for lo, hi in _parse_kibana_range(version_requirement))
-
 
 def _package_version_has_integration(
     version: str,
@@ -305,42 +295,6 @@ def _package_version_has_integration(
     if version not in package_schemas:
         return True
     return integration in package_schemas[version]
-
-
-def _majors_overlapping_kibana_clause(
-    lo: Version,
-    hi: Version | None,
-    version_requirement: str,
-) -> list[int]:
-    """Return stack majors whose [M.0.0, (M+1).0.0) band intersects the parsed clause bounds."""
-    if hi is not None:
-        majors_to_check: list[int] = []
-        major = lo.major
-        while Version(major, 0, 0) < hi:
-            majors_to_check.append(major)
-            major += 1
-        return majors_to_check
-
-    # Unbounded upper (``>=``, ``>``): walk forward while the major still overlaps.
-    majors_to_check: list[int] = []
-    major = lo.major
-    while major <= lo.major + _MAX_UNBOUNDED_STACK_MAJOR_SPAN and _major_has_compatible_stack(
-        major, version_requirement
-    ):
-        majors_to_check.append(major)
-        major += 1
-    return majors_to_check
-
-
-def _stack_majors_supported_by_package(integration_manifests: dict[str, Any]) -> set[int]:
-    """Collect Kibana stack majors that any manifest in the package can serve."""
-    stack_majors: set[int] = set()
-    for manifest in integration_manifests.values():
-        version_requirement = manifest["conditions"]["kibana"]["version"]
-        for lo, hi in _parse_kibana_range(version_requirement):
-            for major in _majors_overlapping_kibana_clause(lo, hi, version_requirement):
-                stack_majors.add(major)
-    return stack_majors
 
 
 def _find_least_compatible_for_stack(
@@ -376,109 +330,10 @@ def _find_least_compatible_for_stack(
 
 @dataclass(frozen=True)
 class CompatibleVersionRange:
-    """Stack-invariant related integration compatibility range."""
+    """Current-stack related integration compatibility range."""
 
     range: str
     anchors: tuple[str, ...]
-    forward_anchor: str
-
-
-def _build_compatible_version_range(anchors: list[str]) -> CompatibleVersionRange:
-    """Build a CompatibleVersionRange from manifest-backed anchor versions."""
-    if not anchors:
-        raise ValueError("anchors must not be empty")
-
-    sorted_anchors = tuple(sorted(set(anchors), key=Version.parse))
-    top_major = max(Version.parse(anchor).major for anchor in sorted_anchors)
-    # Forward sentinel for the next integration major (no manifest entry yet).
-    forward_anchor = f"{top_major + 1}.0.0"
-    range_parts = [f"^{anchor}" for anchor in sorted_anchors] + [f"^{forward_anchor}"]
-    return CompatibleVersionRange(
-        range=" || ".join(range_parts),
-        anchors=sorted_anchors,
-        forward_anchor=forward_anchor,
-    )
-
-
-@cached
-def _shipped_stack_majors() -> set[int]:
-    """Stack majors we ship prebuilt rules to (from the stack-schema-map backport lines)."""
-    return {Version.parse(version).major for version in get_stack_versions()}
-
-
-def minimum_schema_package_version(
-    package: str,
-    integration: str,
-    integration_schemas: dict[str, Any],
-) -> str | None:
-    """Return the oldest package version whose schema includes integration, if any."""
-    package_schemas = integration_schemas.get(package)
-    if not package_schemas:
-        return None
-
-    for version in sorted(package_schemas, key=Version.parse):
-        if integration in package_schemas[version]:
-            return version
-    return None
-
-
-def apply_schema_version_floor(
-    result: CompatibleVersionRange,
-    schema_floor: str,
-) -> CompatibleVersionRange:
-    """Raise anchors in the schema floor's package major when below schema_floor."""
-    floor_version = Version.parse(schema_floor)
-    floor_major = floor_version.major
-    bumped_anchors: list[str] = []
-
-    for anchor in result.anchors:
-        anchor_version = Version.parse(anchor)
-        if anchor_version.major == floor_major and anchor_version < floor_version:
-            continue
-        bumped_anchors.append(anchor)
-
-    if not any(Version.parse(anchor).major == floor_major for anchor in bumped_anchors):
-        bumped_anchors.append(schema_floor)
-
-    bumped_tuple = tuple(sorted(bumped_anchors, key=Version.parse))
-    if bumped_tuple == result.anchors:
-        return result
-
-    return _build_compatible_version_range(list(bumped_tuple))
-
-
-def _collect_compatible_anchors(
-    integration_manifests: dict[str, Any],
-    stack_majors: set[int],
-    integration: str | None,
-    package_schemas: dict[str, Any],
-) -> list[str]:
-    """Oldest compatible integration version per shipped stack version line."""
-    anchors: list[str] = []
-    for stack_version_str in get_stack_versions():
-        stack_version = Version.parse(stack_version_str)
-        if stack_version.major not in stack_majors:
-            continue
-        anchor = _find_least_compatible_for_stack(
-            stack_version,
-            integration_manifests,
-            integration,
-            package_schemas,
-        )
-        if anchor and anchor not in anchors:
-            anchors.append(anchor)
-    return anchors
-
-
-def _integration_schema_floor(
-    package: str,
-    integration: str | None,
-    package_schemas: dict[str, Any],
-) -> str | None:
-    """Oldest package version whose schema includes integration, when schemas are loaded."""
-    if not integration or not package_schemas:
-        return None
-    return minimum_schema_package_version(package, integration, {package: package_schemas})
 
 
 def find_compatible_version_range(
@@ -486,9 +341,7 @@ def find_compatible_version_range(
     packages_manifest: dict[str, Any],
     integration: str | None = None,
 ) -> CompatibleVersionRange:
-    """Return a stack-invariant OR'd caret range for related_integrations.version."""
-    # One anchor per shipped stack version line (no build-time stack), OR'd carets, forward sentinel.
-    # With integration set, filter by integration-schemas when present (data-stream floor).
+    """Return the legacy current-stack related_integrations.version caret range."""
     package_manifest = packages_manifest.get(package)
     if package_manifest is None:
         raise ValueError(f"Package {package} not found in manifest.")
@@ -496,27 +349,15 @@ def find_compatible_version_range(
     package_schemas: dict[str, Any] = {}
     if integration:
         package_schemas = load_integrations_schemas().get(package, {})
-    schema_floor = _integration_schema_floor(package, integration, package_schemas)
 
     integration_manifests = dict(sorted(package_manifest.items(), key=lambda x: Version.parse(x[0])))
-    stack_majors = _stack_majors_supported_by_package(integration_manifests) & _shipped_stack_majors()
-
-    if not stack_majors:
-        raise ValueError(f"no compatible version for integration package {package}")
-
-    anchors = _collect_compatible_anchors(integration_manifests, stack_majors, integration, package_schemas)
-
-    if not anchors:
-        if schema_floor:
-            baseline = find_compatible_version_range(package, packages_manifest)
-            return apply_schema_version_floor(baseline, schema_floor)
+    current_stack = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
+    anchor = _find_least_compatible_for_stack(current_stack, integration_manifests, integration, package_schemas)
+    if anchor is None:
         package_label = f"{package}:{integration}" if integration else package
         raise ValueError(f"no compatible version for integration {package_label}")
 
-    result = _build_compatible_version_range(anchors)
-    if schema_floor:
-        result = apply_schema_version_floor(result, schema_floor)
-    return result
+    return CompatibleVersionRange(range=f"^{anchor}", anchors=(anchor,))
 
 
 def find_latest_compatible_version(

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -284,6 +284,7 @@ def find_latest_integration_patch_for_minor(packages: Iterable[str], major: int,
 
 # Sentinel written by ``parse_datasets`` when a rule indexes a package but not a data stream.
 UNKNOWN_PACKAGE_INTEGRATION = "Unknown"
+RELATED_INTEGRATION_GTE_MIN_STACK = Version(9, 5, 0)
 
 
 def _package_version_has_integration(
@@ -336,12 +337,17 @@ class CompatibleVersionRange:
     anchors: tuple[str, ...]
 
 
+def _related_integration_version_operator(stack_version: Version) -> str:
+    """Return the semver operator for related_integrations.version on the current stack."""
+    return ">=" if stack_version >= RELATED_INTEGRATION_GTE_MIN_STACK else "^"
+
+
 def find_compatible_version_range(
     package: str,
     packages_manifest: dict[str, Any],
     integration: str | None = None,
 ) -> CompatibleVersionRange:
-    """Return the legacy current-stack related_integrations.version caret range."""
+    """Return the legacy current-stack related_integrations.version range."""
     package_manifest = packages_manifest.get(package)
     if package_manifest is None:
         raise ValueError(f"Package {package} not found in manifest.")
@@ -357,7 +363,8 @@ def find_compatible_version_range(
         package_label = f"{package}:{integration}" if integration else package
         raise ValueError(f"no compatible version for integration {package_label}")
 
-    return CompatibleVersionRange(range=f"^{anchor}", anchors=(anchor,))
+    operator = _related_integration_version_operator(current_stack)
+    return CompatibleVersionRange(range=f"{operator}{anchor}", anchors=(anchor,))
 
 
 def find_latest_compatible_version(

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -33,11 +33,11 @@ from .esql import get_esql_query_event_dataset_integrations
 from .esql_errors import EsqlSemanticError
 from .integrations import (
     UNKNOWN_PACKAGE_INTEGRATION,
-    find_compatible_version_range,
     find_latest_integration_patch_for_minor,
     get_integration_schema_fields,
     load_integrations_manifests,
     load_integrations_schemas,
+    resolve_related_integration_version,
 )
 from .mixins import MarshmallowDataclassMixin, StackCompatMixin
 from .rule_formatter import nested_normalize, toml_write
@@ -1463,7 +1463,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
                             integration if integration and integration != UNKNOWN_PACKAGE_INTEGRATION else None
                         )
                         try:
-                            result = find_compatible_version_range(
+                            result = resolve_related_integration_version(
                                 package=package["package"],
                                 packages_manifest=packages_manifest,
                                 integration=integration_name,
@@ -1472,12 +1472,12 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
                             if str(exc).startswith("no compatible version for integration "):
                                 continue
                             raise
-                        package["version"] = result.range
+                        package["version"] = result.expression
 
-                        # Union policy templates across manifest-backed anchors only.
+                        # Union policy templates across manifest-backed versions only.
                         policy_templates: set[str] = set()
-                        for anchor in result.anchors:
-                            version_data = packages_manifest.get(package["package"], {}).get(anchor, {})
+                        for manifest_version in result.manifest_versions:
+                            version_data = packages_manifest.get(package["package"], {}).get(manifest_version, {})
                             policy_templates.update(version_data.get("policy_templates", []))
 
                         if package["integration"] not in policy_templates:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1469,7 +1469,8 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
                                 integration=integration_name,
                             )
                         except ValueError as exc:
-                            if str(exc).startswith("no compatible version for integration "):
+                            message = exc.args[0] if exc.args and isinstance(exc.args[0], str) else None
+                            if message and message.startswith("no compatible version for integration "):
                                 continue
                             raise
                         package["version"] = result.expression

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1444,6 +1444,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
             if self.check_restricted_field_version(field_name) and isinstance(
                 self.data, QueryRuleData | MachineLearningRuleData
             ):  # type: ignore[reportUnnecessaryIsInstance]
+                resolved_package_integrations: list[dict[str, Any]] = []
                 if (self.data.get("language") is not None and self.data.get("language") != "lucene") or self.data.get(
                     "type"
                 ) == "machine_learning":
@@ -1461,11 +1462,16 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
                         integration_name = (
                             integration if integration and integration != UNKNOWN_PACKAGE_INTEGRATION else None
                         )
-                        result = find_compatible_version_range(
-                            package=package["package"],
-                            packages_manifest=packages_manifest,
-                            integration=integration_name,
-                        )
+                        try:
+                            result = find_compatible_version_range(
+                                package=package["package"],
+                                packages_manifest=packages_manifest,
+                                integration=integration_name,
+                            )
+                        except ValueError as exc:
+                            if str(exc).startswith("no compatible version for integration "):
+                                continue
+                            raise
                         package["version"] = result.range
 
                         # Union policy templates across manifest-backed anchors only.
@@ -1476,9 +1482,12 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
 
                         if package["integration"] not in policy_templates:
                             del package["integration"]
+                        resolved_package_integrations.append(package)
 
                 # remove duplicate entries
-                package_integrations = list({json.dumps(d, sort_keys=True): d for d in package_integrations}.values())
+                package_integrations = list(
+                    {json.dumps(d, sort_keys=True): d for d in resolved_package_integrations}.values()
+                )
                 obj.setdefault("related_integrations", package_integrations)
 
     def _convert_add_required_fields(self, obj: dict[str, Any]) -> None:

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1469,7 +1469,6 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
                         package["version"] = result.range
 
                         # Union policy templates across manifest-backed anchors only.
-                        # forward_anchor has no manifest entry and is excluded by design.
                         policy_templates: set[str] = set()
                         for anchor in result.anchors:
                             version_data = packages_manifest.get(package["package"], {}).get(anchor, {})

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -33,6 +33,7 @@ from .esql import get_esql_query_event_dataset_integrations
 from .esql_errors import EsqlSemanticError
 from .integrations import (
     UNKNOWN_PACKAGE_INTEGRATION,
+    IntegrationVersionNotFoundError,
     find_latest_integration_patch_for_minor,
     get_integration_schema_fields,
     load_integrations_manifests,
@@ -1468,11 +1469,8 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
                                 packages_manifest=packages_manifest,
                                 integration=integration_name,
                             )
-                        except ValueError as exc:
-                            message = exc.args[0] if exc.args and isinstance(exc.args[0], str) else None
-                            if message and message.startswith("no compatible version for integration "):
-                                continue
-                            raise
+                        except IntegrationVersionNotFoundError:
+                            continue
                         package["version"] = result.expression
 
                         # Union policy templates across manifest-backed versions only.

--- a/docs-dev/developing.md
+++ b/docs-dev/developing.md
@@ -55,6 +55,11 @@ Using the environment variable `DR_BYPASS_ESQL_METADATA_VALIDATION` will bypass 
 In `_config.yaml`, `bypass_optional_elastic_validation: true` enables all of these bypass env vars when config is loaded. You can instead set individual top-level flags (`bypass_note_validation_and_parse`, `bypass_bbr_lookback_validation`, `bypass_tags_validation`, `bypass_timeline_template_validation`, `bypass_esql_keep_validation`, `bypass_esql_metadata_validation`); the bulk flag takes precedence if it is true. See `detection_rules/etc/_config.yaml` for an example.
 
 
+#### Package build environment variables
+
+By default, generated `related_integrations.version` values use caret ranges such as `^1.0.0`, including in local clones. Repository package-build and unit-test workflows set `DR_RELATED_INTEGRATIONS_USE_GTE=True` so stack versions `9.5.0` and newer generate `>=` ranges instead.
+
+
 ## Using the `RuleResource` methods built on detections `_bulk_action` APIs
 
 The following is meant to serve as a simple example of to use the methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "1.6.53"
+version = "1.7.0"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -1,0 +1,33 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+"""Tests for custom rules helpers."""
+
+import unittest
+
+from detection_rules.custom_rules import get_stack_schema_map_entry_for_version
+
+
+class TestCustomRulesSetupConfig(unittest.TestCase):
+    """Test custom rules setup config helpers."""
+
+    def test_stack_schema_map_entry_matches_requested_package_version(self):
+        """The generated custom config must align package name and stack schema map."""
+        stack_schema_map = {
+            "9.3.0": {"beats": "9.3.3", "ecs": "9.3.0", "endgame": "8.4.0"},
+            "9.5.0": {"beats": "9.3.4", "ecs": "9.4.0-rc1", "endgame": "8.4.0"},
+        }
+
+        self.assertEqual(
+            get_stack_schema_map_entry_for_version(stack_schema_map, "9.3"),
+            {"9.3.0": stack_schema_map["9.3.0"]},
+        )
+
+    def test_stack_schema_map_entry_raises_for_unsupported_package_version(self):
+        """Unsupported custom package versions should fail with a clear error."""
+        stack_schema_map = {"9.5.0": {"beats": "9.3.4", "ecs": "9.4.0-rc1", "endgame": "8.4.0"}}
+
+        with self.assertRaisesRegex(ValueError, "No stack-schema-map entry found"):
+            _ = get_stack_schema_map_entry_for_version(stack_schema_map, "9.3")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -505,6 +505,44 @@ class TestMetadataPackageRowDedupe(unittest.TestCase):
         self.assertNotIn(" || ", endpoint_rows[0]["version"])
         self.assertNotIn(" || ", windows_rows[0]["version"])
 
+    def test_unsupported_generated_related_integration_row_is_skipped(self):
+        """Generated rows for data streams unavailable on the package stack should not block API conversion."""
+        from pathlib import Path
+
+        from detection_rules.rule_loader import RuleCollection
+
+        class VersionRange:
+            range = ">=1.0.0"
+            anchors = ("1.0.0",)
+
+        def compatible_side_effect(package, packages_manifest, integration=None):
+            if package == "unsupported":
+                raise ValueError(f"no compatible version for integration {package}:{integration}")
+            return VersionRange()
+
+        packages_manifest = {"endpoint": {"1.0.0": {"policy_templates": ["endpoint"]}}}
+        packaged_integrations = [
+            {"package": "endpoint", "integration": "endpoint"},
+            {"package": "unsupported", "integration": "new_ds"},
+        ]
+        rule = RuleCollection().load_file(Path("rules/windows/persistence_sysmon_wmi_event_subscription.toml"))
+
+        with (
+            unittest.mock.patch("detection_rules.rule.load_integrations_manifests", return_value=packages_manifest),
+            unittest.mock.patch(
+                "detection_rules.rule.TOMLRuleContents.get_packaged_integrations",
+                return_value=packaged_integrations,
+            ),
+            unittest.mock.patch(
+                "detection_rules.rule.find_compatible_version_range",
+                side_effect=compatible_side_effect,
+            ),
+            unittest.mock.patch("detection_rules.rule.QueryRuleData.get_required_fields", return_value=[]),
+        ):
+            related_integrations = rule.contents.to_api_format()["related_integrations"]
+
+        self.assertEqual(related_integrations, [{"package": "endpoint", "integration": "endpoint", "version": ">=1.0.0"}])
+
 
 class TestEsqlPackagedIntegrations(unittest.TestCase):
     """ES|QL must not emit a redundant metadata package row when datasets cover the package."""

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -23,7 +23,7 @@ from detection_rules.integrations import (
     find_latest_integration_patch_for_minor,
     get_integration_schema_data,
 )
-from detection_rules.rule_validators import ESQLValidator, KQLValidator
+from detection_rules.rule_validators import KQLValidator
 
 
 def _manifest(kibana_version: str) -> dict:
@@ -305,53 +305,6 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         self.assertEqual(len(schema_data), 1)
         self.assertEqual(schema_data[0]["package_version"], "1.1.0")
         self.assertEqual(schema_data[0]["stack_version"], "9.2.0")
-
-    def test_esql_remote_validation_uses_patch_floor_for_prepare_mappings(self):
-        """ES|QL remote validation prepares mappings with patch-adjusted stack versions."""
-        query = """
-        FROM logs-pkg.new_ds-* metadata _id, _version, _index
-        | WHERE data_stream.dataset == "pkg.new_ds"
-        | KEEP _id, _version, _index
-        """
-        metadata = SimpleNamespace(integration=["pkg"])
-        prepared_stack_versions: list[str] = []
-
-        def prepare_mappings_side_effect(*args):
-            prepared_stack_versions.append(args[4])
-            return {}, {}, {}
-
-        def patch_floor_side_effect(packages, major, minor):
-            self.assertIn("pkg", packages)
-            return 4 if (major, minor) == (9, 2) else 0
-
-        validator = ESQLValidator(query)
-        with (
-            unittest.mock.patch("detection_rules.rule_validators.get_latest_stack_version", return_value="9.2.0"),
-            unittest.mock.patch("detection_rules.rule_validators.get_stack_versions", return_value=["9.2.0", "9.3.0"]),
-            unittest.mock.patch(
-                "detection_rules.rule_validators.find_latest_integration_patch_for_minor",
-                side_effect=patch_floor_side_effect,
-            ),
-            unittest.mock.patch("detection_rules.rule_validators.prepare_mappings", side_effect=prepare_mappings_side_effect),
-            unittest.mock.patch("detection_rules.rule_validators.create_remote_indices", return_value="test-index"),
-            unittest.mock.patch(
-                "detection_rules.rule_validators.execute_query_against_indices",
-                return_value=([{"name": "data_stream.dataset", "type": "keyword"}], {"ok": True}),
-            ),
-            unittest.mock.patch.object(ESQLValidator, "validate_columns_index_mapping", return_value=True),
-        ):
-            response = validator.remote_validate_rule(
-                kibana_client=SimpleNamespace(get=lambda *_args, **_kwargs: {"version": {"number": "9.2.0"}}),
-                elastic_client=object(),
-                query=query,
-                metadata=metadata,
-                rule_id="test-rule",
-            )
-
-        self.assertEqual(response, {"ok": True})
-        self.assertIn("9.2.0", prepared_stack_versions)
-        self.assertIn("9.2.4", prepared_stack_versions)
-        self.assertIn("9.3.0", prepared_stack_versions)
 
 
 class TestFindCompatibleVersionRange(unittest.TestCase):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -12,19 +12,15 @@ from semver import Version
 
 from detection_rules.config import load_current_package_version
 from detection_rules.integrations import (
-    _MAX_UNBOUNDED_STACK_MAJOR_SPAN,
     _find_least_compatible_for_stack,
-    _majors_overlapping_kibana_clause,
     _parse_clause,
     _parse_kibana_range,
     _satisfies_kibana_range,
-    _stack_majors_supported_by_package,
     find_compatible_version_range,
     find_latest_compatible_version,
     find_latest_integration_patch_for_minor,
 )
 from detection_rules.rule_validators import KQLValidator
-from detection_rules.schemas import get_stack_versions
 
 
 def _manifest(kibana_version: str) -> dict:
@@ -308,8 +304,8 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
 class TestFindCompatibleVersionRange(unittest.TestCase):
     """Behavior coverage for ``find_compatible_version_range``."""
 
-    def test_emits_or_range_across_majors(self):
-        """Emits oldest anchor per shipped stack major plus a forward-looking next-major anchor."""
+    def test_uses_current_stack_single_anchor(self):
+        """Returns only the least compatible anchor for the current package stack."""
         manifests = {
             "pkg": {
                 "1.0.0": _manifest("^8.0.0"),
@@ -318,167 +314,32 @@ class TestFindCompatibleVersionRange(unittest.TestCase):
                 "2.5.0": _manifest("^9.1.0"),
             }
         }
-        result = find_compatible_version_range("pkg", manifests)
-        self.assertEqual(result.range, "^1.0.0 || ^2.0.0 || ^3.0.0")
-        self.assertEqual(result.anchors, ("1.0.0", "2.0.0"))
-        self.assertEqual(result.forward_anchor, "3.0.0")
 
-    def test_stack_invariance(self):
-        """Range result does not depend on build stack version."""
-        manifests = {
-            "pkg": {
-                "1.0.0": _manifest("^8.0.0"),
-                "2.0.0": _manifest("^9.0.0"),
-            }
-        }
-        first = find_compatible_version_range("pkg", manifests)
-        second = find_compatible_version_range("pkg", manifests)
-        self.assertEqual(first, second)
+        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"):
+            stack_8 = find_compatible_version_range("pkg", manifests)
+        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.1.0"):
+            stack_9 = find_compatible_version_range("pkg", manifests)
 
-    def test_single_major_appends_forward_anchor(self):
-        """A single integration major still appends the forward-looking anchor."""
-        manifests = {"pkg": {"9.0.0": _manifest("^9.0.0")}}
-        result = find_compatible_version_range("pkg", manifests)
-        self.assertEqual(result.range, "^9.0.0 || ^10.0.0")
-        self.assertEqual(result.anchors, ("9.0.0",))
-        self.assertEqual(result.forward_anchor, "10.0.0")
-
-    def test_three_majors_endpoint_shape(self):
-        """Synthetic endpoint-like majors on shipped stack lines (8.x and 9.x)."""
-        manifests = {
-            "endpoint": {
-                "7.17.0": _manifest("^7.17.0"),
-                "8.2.0": _manifest("^8.2.0"),
-                "9.0.0": _manifest("^9.0.0"),
-            }
-        }
-        result = find_compatible_version_range("endpoint", manifests)
-        self.assertEqual(result.range, "^8.2.0 || ^9.0.0 || ^10.0.0")
-        self.assertEqual(result.anchors, ("8.2.0", "9.0.0"))
-        self.assertEqual(result.forward_anchor, "10.0.0")
-
-    def test_skips_majors_with_no_overlap(self):
-        """Majors without stack overlap are omitted from anchors."""
-        manifests = {
-            "pkg": {
-                "7.10.0": _manifest("^7.10.0"),
-                "9.4.0": _manifest("=9.4.0"),
-            }
-        }
-        result = find_compatible_version_range("pkg", manifests)
-        self.assertEqual(result.range, "^9.4.0 || ^10.0.0")
-        self.assertEqual(result.anchors, ("9.4.0",))
-
-    def test_raises_when_no_compatible_major(self):
-        """When no stack line can be resolved, raise."""
-        manifests = {
-            "pkg": {
-                "1.0.0": _manifest(">=99.0.0 <99.0.0"),
-            }
-        }
-        with self.assertRaises(ValueError):
-            find_compatible_version_range("pkg", manifests)
-
-    def test_returns_anchor_list_for_policy_template_lookup(self):
-        """Anchors and forward anchor are exposed for policy template union."""
-        manifests = {
-            "pkg": {
-                "1.0.0": _manifest("^8.0.0"),
-                "2.0.0": _manifest("^9.0.0"),
-            }
-        }
-        result = find_compatible_version_range("pkg", manifests)
-        self.assertEqual(result.anchors, ("1.0.0", "2.0.0"))
-        self.assertEqual(result.forward_anchor, "3.0.0")
-
-    def test_unbounded_kibana_range_collects_multiple_stack_majors(self):
-        """``>=8.12.0`` (unbounded upper) must collect every overlapping stack major."""
-        manifests = {"pkg": {"1.0.0": _manifest(">=8.12.0")}}
-        stack_majors = _stack_majors_supported_by_package(manifests["pkg"])
-        lo_major = 8
-        expected = set(range(lo_major, lo_major + _MAX_UNBOUNDED_STACK_MAJOR_SPAN + 1))
-        self.assertEqual(stack_majors, expected)
-
-    def test_bounded_kibana_range_includes_upper_major(self):
-        """``>=8.12.0 <9.1.0`` overlaps stack major 9 (9.0.x) and must include it."""
-        majors = _majors_overlapping_kibana_clause(
-            Version(8, 12, 0),
-            Version(9, 1, 0),
-            ">=8.12.0 <9.1.0",
-        )
-        self.assertIn(8, majors)
-        self.assertIn(9, majors)
-        self.assertNotIn(10, majors)
-
-    def test_non_aligned_package_covers_shipped_stack_majors(self):
-        """Non-aligned packages emit one anchor per shipped backport stack major."""
-        manifests = {
-            "pkg": {
-                "1.0.0": _manifest("^8.12.0"),
-                "1.1.0": _manifest("^9.0.0"),
-                "1.2.0": _manifest("^10.0.0"),
-            }
-        }
-        result = find_compatible_version_range("pkg", manifests)
-        # Stack 10 is not a shipped backport line; only 8.x and 9.x majors from stack-schema-map.
-        self.assertEqual(result.anchors, ("1.0.0", "1.1.0"))
-        self.assertEqual(result.range, "^1.0.0 || ^1.1.0 || ^2.0.0")
-
-    def test_excludes_unshipped_stack_majors(self):
-        """Manifest stack lines outside shipped backports (e.g. Kibana 7.x) are not walked."""
-        manifests = {
-            "pkg": {
-                "0.0.2": _manifest("^7.9.0"),
-                "1.0.0": _manifest("^8.0.0"),
-                "1.22.0": _manifest("^9.0.0"),
-            }
-        }
-        result = find_compatible_version_range("pkg", manifests)
-        self.assertEqual(result.anchors, ("1.0.0", "1.22.0"))
-        self.assertNotIn("0.0.2", result.anchors)
-        self.assertEqual(result.range, "^1.0.0 || ^1.22.0 || ^2.0.0")
+        self.assertEqual(stack_8.range, "^1.0.0")
+        self.assertEqual(stack_8.anchors, ("1.0.0",))
+        self.assertEqual(stack_9.range, "^2.0.0")
+        self.assertEqual(stack_9.anchors, ("2.0.0",))
 
     def test_keeps_zero_major_when_only_stable_option_missing(self):
         """Keep 0.x anchors when no major >= 1 anchor exists."""
         manifests = {"pkg": {"0.5.0": _manifest("^8.0.0")}}
-        result = find_compatible_version_range("pkg", manifests)
+        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"):
+            result = find_compatible_version_range("pkg", manifests)
         self.assertEqual(result.anchors, ("0.5.0",))
 
-    def test_anchors_cover_each_shipped_stack_export(self):
-        """Each per-stack least-compatible anchor must appear in the OR range (Kibana semver.satisfies)."""
-        manifests = {
-            "pkg": {
-                "1.0.0": _manifest("^8.0.0"),
-                "2.0.0": _manifest("^9.2.0"),
-                "3.0.0": _manifest("^9.4.0"),
-            }
-        }
-        result = find_compatible_version_range("pkg", manifests)
-        for stack_version_str in get_stack_versions():
-            stack_version = Version.parse(stack_version_str)
-            expected = _find_least_compatible_for_stack(stack_version, manifests["pkg"])
-            if expected is None:
-                continue
-            self.assertIn(
-                expected,
-                result.anchors,
-                f"stack {stack_version_str} exported ^{expected} but anchors are {result.anchors}",
-            )
-
-    def test_aws_range_includes_late_stack_anchors(self):
-        """AWS 5.x/6.x require Kibana ^9.2+; walking 9.0.0 per major missed them."""
-        from detection_rules.integrations import load_integrations_manifests
-
-        manifests = load_integrations_manifests()
-        result = find_compatible_version_range("aws", manifests)
-        self.assertIn("5.0.0", result.anchors)
-        self.assertIn("6.0.0", result.anchors)
-        self.assertNotIn("1.5.0", result.anchors)
-        for stack_version_str in get_stack_versions():
-            stack_version = Version.parse(stack_version_str)
-            expected = _find_least_compatible_for_stack(stack_version, manifests["aws"])
-            self.assertIsNotNone(expected)
-            self.assertIn(expected, result.anchors, stack_version_str)
+    def test_raises_when_current_stack_is_incompatible(self):
+        """Raises when the current package stack cannot use any manifest version."""
+        manifests = {"pkg": {"1.0.0": _manifest("^9.4.0")}}
+        with (
+            unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"),
+            self.assertRaises(ValueError),
+        ):
+            find_compatible_version_range("pkg", manifests)
 
 
 class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
@@ -500,7 +361,10 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
                 "1.9.0": {"existing_ds": {}, "new_ds": {}},
             }
         }
-        with unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas):
+        with (
+            unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.12.0"),
+            unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
+        ):
             new_ds = find_compatible_version_range("pkg", manifests, integration="new_ds")
             self.assertIn("1.9.0", new_ds.anchors)
             self.assertNotIn("1.0.0", new_ds.anchors)
@@ -512,7 +376,10 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
     def test_no_schema_data_falls_back_to_kibana_only(self):
         """Versions without schema data are not filtered; kibana compatibility alone decides."""
         manifests = {"pkg": {"1.0.0": _manifest("^8.12.0"), "1.5.0": _manifest("^8.12.0")}}
-        with unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value={}):
+        with (
+            unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.12.0"),
+            unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value={}),
+        ):
             result = find_compatible_version_range("pkg", manifests, integration="new_ds")
             self.assertEqual(result.anchors, ("1.0.0",))
 
@@ -521,13 +388,14 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
         manifests = {"pkg": {"1.0.0": _manifest("^8.12.0"), "1.5.0": _manifest("^8.12.0")}}
         schemas = {"pkg": {"1.0.0": {"existing_ds": {}}, "1.5.0": {"existing_ds": {}}}}
         with (
+            unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.12.0"),
             unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
             self.assertRaises(ValueError),
         ):
             find_compatible_version_range("pkg", manifests, integration="new_ds")
 
-    def test_schema_floor_excludes_legacy_zero_major(self):
-        """Schema-floor fallback must not retain 0.x anchors from the package baseline."""
+    def test_schema_filter_excludes_legacy_zero_major(self):
+        """Schema filtering must not retain older versions without the requested integration."""
         manifests = {
             "pkg": {
                 "0.0.2": _manifest("^7.9.0"),
@@ -542,23 +410,35 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
                 "1.37.0": {"aadgraphactivitylogs": {}},
             }
         }
-        with unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas):
+        with (
+            unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.0.0"),
+            unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
+        ):
             result = find_compatible_version_range("pkg", manifests, integration="aadgraphactivitylogs")
             self.assertEqual(result.anchors, ("1.37.0",))
-            self.assertEqual(result.range, "^1.37.0 || ^2.0.0")
+            self.assertEqual(result.range, "^1.37.0")
 
-    def test_azure_aadgraphactivitylogs_schema_floor(self):
-        """aadgraphactivitylogs floor is azure 1.37.0 (bundled integration-schemas.json.gz)."""
+    def test_azure_aadgraphactivitylogs_schema_filter(self):
+        """aadgraphactivitylogs resolution matches current-stack compatibility plus bundled schemas."""
         from detection_rules.integrations import load_integrations_manifests, load_integrations_schemas
 
         schemas = load_integrations_schemas()
         manifests = load_integrations_manifests()
+        current_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
+        expected = _find_least_compatible_for_stack(
+            current_version,
+            manifests["azure"],
+            "aadgraphactivitylogs",
+            schemas["azure"],
+        )
+        if expected is None:
+            with self.assertRaises(ValueError):
+                find_compatible_version_range("azure", manifests, integration="aadgraphactivitylogs")
+            return
+
         result = find_compatible_version_range("azure", manifests, integration="aadgraphactivitylogs")
-        self.assertIn("1.37.0", result.anchors)
-        self.assertNotIn("1.0.0", result.anchors)
-        self.assertNotIn("0.0.2", result.anchors)
-        self.assertIn("^1.37.0", result.range)
-        self.assertEqual(result.range, "^1.37.0 || ^2.0.0")
+        self.assertEqual(result.anchors, (expected,))
+        self.assertEqual(result.range, f"^{expected}")
         floor_versions = [
             version
             for version in sorted(schemas["azure"], key=Version.parse)
@@ -600,8 +480,10 @@ class TestMetadataPackageRowDedupe(unittest.TestCase):
         windows_rows = [row for row in api["related_integrations"] if row["package"] == "windows"]
         self.assertEqual(len(endpoint_rows), 1)
         self.assertEqual(len(windows_rows), 1)
-        self.assertEqual(endpoint_rows[0]["version"], "^8.7.0 || ^9.0.0 || ^10.0.0")
-        self.assertEqual(windows_rows[0]["version"], "^1.0.0 || ^3.0.0 || ^4.0.0")
+        self.assertTrue(endpoint_rows[0]["version"].startswith("^"))
+        self.assertTrue(windows_rows[0]["version"].startswith("^"))
+        self.assertNotIn(" || ", endpoint_rows[0]["version"])
+        self.assertNotIn(" || ", windows_rows[0]["version"])
 
 
 class TestEsqlPackagedIntegrations(unittest.TestCase):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -13,6 +13,7 @@ from semver import Version
 
 from detection_rules.config import load_current_package_version
 from detection_rules.integrations import (
+    IntegrationVersionNotFoundError,
     _find_least_compatible_for_stack,
     _parse_clause,
     _parse_kibana_range,
@@ -107,6 +108,16 @@ class TestParseKibanaRange(unittest.TestCase):
         self.assertEqual(
             _parse_kibana_range("^9.1.0"),
             [(Version(9, 1, 0), Version(10, 0, 0))],
+        )
+
+    def test_or_clauses(self):
+        """OR'd clauses are parsed independently."""
+        self.assertEqual(
+            _parse_kibana_range("^8.0.0 || ^9.1.0"),
+            [
+                (Version(8, 0, 0), Version(9, 0, 0)),
+                (Version(9, 1, 0), Version(10, 0, 0)),
+            ],
         )
 
 
@@ -356,7 +367,7 @@ class TestResolveRelatedIntegrationVersion(unittest.TestCase):
         manifests = {"pkg": {"1.0.0": _manifest("^9.4.0")}}
         with (
             unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"),
-            self.assertRaises(ValueError),
+            self.assertRaises(IntegrationVersionNotFoundError),
         ):
             resolve_related_integration_version("pkg", manifests)
 
@@ -409,7 +420,7 @@ class TestResolveRelatedIntegrationVersionSchemaAware(unittest.TestCase):
         with (
             unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.12.0"),
             unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
-            self.assertRaises(ValueError),
+            self.assertRaises(IntegrationVersionNotFoundError),
         ):
             resolve_related_integration_version("pkg", manifests, integration="new_ds")
 
@@ -451,7 +462,7 @@ class TestResolveRelatedIntegrationVersionSchemaAware(unittest.TestCase):
             schemas["azure"],
         )
         if expected is None:
-            with self.assertRaises(ValueError):
+            with self.assertRaises(IntegrationVersionNotFoundError):
                 resolve_related_integration_version("azure", manifests, integration="aadgraphactivitylogs")
             return
 
@@ -517,7 +528,7 @@ class TestMetadataPackageRowDedupe(unittest.TestCase):
 
         def compatible_side_effect(package, packages_manifest, integration=None):
             if package == "unsupported":
-                raise ValueError(f"no compatible version for integration {package}:{integration}")
+                raise IntegrationVersionNotFoundError(f"no compatible version for integration {package}:{integration}")
             return RelatedIntegrationVersionStub()
 
         packages_manifest = {"endpoint": {"1.0.0": {"policy_templates": ["endpoint"]}}}

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -18,10 +18,10 @@ from detection_rules.integrations import (
     _parse_kibana_range,
     _related_integration_version_operator,
     _satisfies_kibana_range,
-    find_compatible_version_range,
     find_latest_compatible_version,
     find_latest_integration_patch_for_minor,
     get_integration_schema_data,
+    resolve_related_integration_version,
 )
 from detection_rules.rule_validators import KQLValidator
 
@@ -307,11 +307,11 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         self.assertEqual(schema_data[0]["stack_version"], "9.2.0")
 
 
-class TestFindCompatibleVersionRange(unittest.TestCase):
-    """Behavior coverage for ``find_compatible_version_range``."""
+class TestResolveRelatedIntegrationVersion(unittest.TestCase):
+    """Behavior coverage for ``resolve_related_integration_version``."""
 
-    def test_uses_current_stack_single_anchor(self):
-        """Returns only the least compatible anchor for the current package stack."""
+    def test_uses_current_stack_single_manifest_version(self):
+        """Returns only the least compatible manifest version for the current package stack."""
         manifests = {
             "pkg": {
                 "1.0.0": _manifest("^8.0.0"),
@@ -323,33 +323,33 @@ class TestFindCompatibleVersionRange(unittest.TestCase):
         }
 
         with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"):
-            stack_8 = find_compatible_version_range("pkg", manifests)
+            stack_8 = resolve_related_integration_version("pkg", manifests)
         with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.1.0"):
-            stack_9 = find_compatible_version_range("pkg", manifests)
+            stack_9 = resolve_related_integration_version("pkg", manifests)
         with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.5.0"):
-            stack_95 = find_compatible_version_range("pkg", manifests)
+            stack_95 = resolve_related_integration_version("pkg", manifests)
         with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.6.0"):
-            stack_96 = find_compatible_version_range("pkg", manifests)
+            stack_96 = resolve_related_integration_version("pkg", manifests)
         with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="10.0.0"):
-            stack_10 = find_compatible_version_range("pkg", manifests)
+            stack_10 = resolve_related_integration_version("pkg", manifests)
 
-        self.assertEqual(stack_8.range, "^1.0.0")
-        self.assertEqual(stack_8.anchors, ("1.0.0",))
-        self.assertEqual(stack_9.range, "^2.0.0")
-        self.assertEqual(stack_9.anchors, ("2.0.0",))
-        self.assertEqual(stack_95.range, ">=2.0.0")
-        self.assertEqual(stack_95.anchors, ("2.0.0",))
-        self.assertEqual(stack_96.range, ">=2.0.0")
-        self.assertEqual(stack_96.anchors, ("2.0.0",))
-        self.assertEqual(stack_10.range, ">=3.0.0")
-        self.assertEqual(stack_10.anchors, ("3.0.0",))
+        self.assertEqual(stack_8.expression, "^1.0.0")
+        self.assertEqual(stack_8.manifest_versions, ("1.0.0",))
+        self.assertEqual(stack_9.expression, "^2.0.0")
+        self.assertEqual(stack_9.manifest_versions, ("2.0.0",))
+        self.assertEqual(stack_95.expression, ">=2.0.0")
+        self.assertEqual(stack_95.manifest_versions, ("2.0.0",))
+        self.assertEqual(stack_96.expression, ">=2.0.0")
+        self.assertEqual(stack_96.manifest_versions, ("2.0.0",))
+        self.assertEqual(stack_10.expression, ">=3.0.0")
+        self.assertEqual(stack_10.manifest_versions, ("3.0.0",))
 
     def test_keeps_zero_major_when_only_stable_option_missing(self):
-        """Keep 0.x anchors when no major >= 1 anchor exists."""
+        """Keep 0.x manifest versions when no major >= 1 option exists."""
         manifests = {"pkg": {"0.5.0": _manifest("^8.0.0")}}
         with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"):
-            result = find_compatible_version_range("pkg", manifests)
-        self.assertEqual(result.anchors, ("0.5.0",))
+            result = resolve_related_integration_version("pkg", manifests)
+        self.assertEqual(result.manifest_versions, ("0.5.0",))
 
     def test_raises_when_current_stack_is_incompatible(self):
         """Raises when the current package stack cannot use any manifest version."""
@@ -358,11 +358,11 @@ class TestFindCompatibleVersionRange(unittest.TestCase):
             unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"),
             self.assertRaises(ValueError),
         ):
-            find_compatible_version_range("pkg", manifests)
+            resolve_related_integration_version("pkg", manifests)
 
 
-class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
-    """Schema-aware data stream filtering ported from #6251 into OR-range export."""
+class TestResolveRelatedIntegrationVersionSchemaAware(unittest.TestCase):
+    """Schema-aware data stream filtering for related integration version resolution."""
 
     def test_skips_versions_missing_integration(self):
         """Kibana-compatible versions whose schema lacks the integration are skipped for a later one."""
@@ -384,13 +384,13 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
             unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.12.0"),
             unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
         ):
-            new_ds = find_compatible_version_range("pkg", manifests, integration="new_ds")
-            self.assertIn("1.9.0", new_ds.anchors)
-            self.assertNotIn("1.0.0", new_ds.anchors)
-            self.assertNotIn("1.5.0", new_ds.anchors)
+            new_ds = resolve_related_integration_version("pkg", manifests, integration="new_ds")
+            self.assertIn("1.9.0", new_ds.manifest_versions)
+            self.assertNotIn("1.0.0", new_ds.manifest_versions)
+            self.assertNotIn("1.5.0", new_ds.manifest_versions)
 
-            existing_ds = find_compatible_version_range("pkg", manifests, integration="existing_ds")
-            self.assertEqual(existing_ds.anchors, ("1.0.0",))
+            existing_ds = resolve_related_integration_version("pkg", manifests, integration="existing_ds")
+            self.assertEqual(existing_ds.manifest_versions, ("1.0.0",))
 
     def test_no_schema_data_falls_back_to_kibana_only(self):
         """Versions without schema data are not filtered; kibana compatibility alone decides."""
@@ -399,8 +399,8 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
             unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.12.0"),
             unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value={}),
         ):
-            result = find_compatible_version_range("pkg", manifests, integration="new_ds")
-            self.assertEqual(result.anchors, ("1.0.0",))
+            result = resolve_related_integration_version("pkg", manifests, integration="new_ds")
+            self.assertEqual(result.manifest_versions, ("1.0.0",))
 
     def test_all_compatible_versions_missing_integration_raises(self):
         """Raise when every kibana-compatible version's schema lacks the requested integration."""
@@ -411,7 +411,7 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
             unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
             self.assertRaises(ValueError),
         ):
-            find_compatible_version_range("pkg", manifests, integration="new_ds")
+            resolve_related_integration_version("pkg", manifests, integration="new_ds")
 
     def test_schema_filter_excludes_legacy_zero_major(self):
         """Schema filtering must not retain older versions without the requested integration."""
@@ -433,9 +433,9 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
             unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.0.0"),
             unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
         ):
-            result = find_compatible_version_range("pkg", manifests, integration="aadgraphactivitylogs")
-            self.assertEqual(result.anchors, ("1.37.0",))
-            self.assertEqual(result.range, "^1.37.0")
+            result = resolve_related_integration_version("pkg", manifests, integration="aadgraphactivitylogs")
+            self.assertEqual(result.manifest_versions, ("1.37.0",))
+            self.assertEqual(result.expression, "^1.37.0")
 
     def test_azure_aadgraphactivitylogs_schema_filter(self):
         """aadgraphactivitylogs resolution matches current-stack compatibility plus bundled schemas."""
@@ -452,13 +452,13 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
         )
         if expected is None:
             with self.assertRaises(ValueError):
-                find_compatible_version_range("azure", manifests, integration="aadgraphactivitylogs")
+                resolve_related_integration_version("azure", manifests, integration="aadgraphactivitylogs")
             return
 
         operator = _related_integration_version_operator(current_version)
-        result = find_compatible_version_range("azure", manifests, integration="aadgraphactivitylogs")
-        self.assertEqual(result.anchors, (expected,))
-        self.assertEqual(result.range, f"{operator}{expected}")
+        result = resolve_related_integration_version("azure", manifests, integration="aadgraphactivitylogs")
+        self.assertEqual(result.manifest_versions, (expected,))
+        self.assertEqual(result.expression, f"{operator}{expected}")
         floor_versions = [
             version
             for version in sorted(schemas["azure"], key=Version.parse)
@@ -511,14 +511,14 @@ class TestMetadataPackageRowDedupe(unittest.TestCase):
 
         from detection_rules.rule_loader import RuleCollection
 
-        class VersionRange:
-            range = ">=1.0.0"
-            anchors = ("1.0.0",)
+        class RelatedIntegrationVersionStub:
+            expression = ">=1.0.0"
+            manifest_versions = ("1.0.0",)
 
         def compatible_side_effect(package, packages_manifest, integration=None):
             if package == "unsupported":
                 raise ValueError(f"no compatible version for integration {package}:{integration}")
-            return VersionRange()
+            return RelatedIntegrationVersionStub()
 
         packages_manifest = {"endpoint": {"1.0.0": {"policy_templates": ["endpoint"]}}}
         packaged_integrations = [
@@ -534,7 +534,7 @@ class TestMetadataPackageRowDedupe(unittest.TestCase):
                 return_value=packaged_integrations,
             ),
             unittest.mock.patch(
-                "detection_rules.rule.find_compatible_version_range",
+                "detection_rules.rule.resolve_related_integration_version",
                 side_effect=compatible_side_effect,
             ),
             unittest.mock.patch("detection_rules.rule.QueryRuleData.get_required_fields", return_value=[]),

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -14,8 +14,8 @@ from semver import Version
 
 from detection_rules.config import load_current_package_version
 from detection_rules.integrations import (
-    IntegrationVersionNotFoundError,
     RELATED_INTEGRATION_GTE_OPERATOR_ENV,
+    IntegrationVersionNotFoundError,
     _find_least_compatible_for_stack,
     _parse_clause,
     _parse_kibana_range,
@@ -336,7 +336,9 @@ class TestResolveRelatedIntegrationVersion(unittest.TestCase):
         }
 
         with unittest.mock.patch.dict(os.environ, {RELATED_INTEGRATION_GTE_OPERATOR_ENV: ""}):
-            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"):
+            with unittest.mock.patch(
+                "detection_rules.integrations.load_current_package_version", return_value="8.19.0"
+            ):
                 stack_8 = resolve_related_integration_version("pkg", manifests)
             with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.1.0"):
                 stack_9 = resolve_related_integration_version("pkg", manifests)
@@ -344,7 +346,9 @@ class TestResolveRelatedIntegrationVersion(unittest.TestCase):
                 stack_95 = resolve_related_integration_version("pkg", manifests)
             with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.6.0"):
                 stack_96 = resolve_related_integration_version("pkg", manifests)
-            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="10.0.0"):
+            with unittest.mock.patch(
+                "detection_rules.integrations.load_current_package_version", return_value="10.0.0"
+            ):
                 stack_10 = resolve_related_integration_version("pkg", manifests)
 
         self.assertEqual(stack_8.expression, "^1.0.0")
@@ -372,7 +376,9 @@ class TestResolveRelatedIntegrationVersion(unittest.TestCase):
                 stack_94 = resolve_related_integration_version("pkg", manifests)
             with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.5.0"):
                 stack_95 = resolve_related_integration_version("pkg", manifests)
-            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="10.0.0"):
+            with unittest.mock.patch(
+                "detection_rules.integrations.load_current_package_version", return_value="10.0.0"
+            ):
                 stack_10 = resolve_related_integration_version("pkg", manifests)
 
         self.assertEqual(stack_94.expression, "^2.0.0")

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -541,7 +541,9 @@ class TestMetadataPackageRowDedupe(unittest.TestCase):
         ):
             related_integrations = rule.contents.to_api_format()["related_integrations"]
 
-        self.assertEqual(related_integrations, [{"package": "endpoint", "integration": "endpoint", "version": ">=1.0.0"}])
+        self.assertEqual(
+            related_integrations, [{"package": "endpoint", "integration": "endpoint", "version": ">=1.0.0"}]
+        )
 
 
 class TestEsqlPackagedIntegrations(unittest.TestCase):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -5,6 +5,7 @@
 
 """Test integration version resolution against EPR manifest ranges."""
 
+import os
 import unittest
 import unittest.mock
 from types import SimpleNamespace
@@ -14,6 +15,7 @@ from semver import Version
 from detection_rules.config import load_current_package_version
 from detection_rules.integrations import (
     IntegrationVersionNotFoundError,
+    RELATED_INTEGRATION_GTE_OPERATOR_ENV,
     _find_least_compatible_for_stack,
     _parse_clause,
     _parse_kibana_range,
@@ -333,27 +335,49 @@ class TestResolveRelatedIntegrationVersion(unittest.TestCase):
             }
         }
 
-        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"):
-            stack_8 = resolve_related_integration_version("pkg", manifests)
-        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.1.0"):
-            stack_9 = resolve_related_integration_version("pkg", manifests)
-        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.5.0"):
-            stack_95 = resolve_related_integration_version("pkg", manifests)
-        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.6.0"):
-            stack_96 = resolve_related_integration_version("pkg", manifests)
-        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="10.0.0"):
-            stack_10 = resolve_related_integration_version("pkg", manifests)
+        with unittest.mock.patch.dict(os.environ, {RELATED_INTEGRATION_GTE_OPERATOR_ENV: ""}):
+            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="8.19.0"):
+                stack_8 = resolve_related_integration_version("pkg", manifests)
+            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.1.0"):
+                stack_9 = resolve_related_integration_version("pkg", manifests)
+            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.5.0"):
+                stack_95 = resolve_related_integration_version("pkg", manifests)
+            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.6.0"):
+                stack_96 = resolve_related_integration_version("pkg", manifests)
+            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="10.0.0"):
+                stack_10 = resolve_related_integration_version("pkg", manifests)
 
         self.assertEqual(stack_8.expression, "^1.0.0")
         self.assertEqual(stack_8.manifest_versions, ("1.0.0",))
         self.assertEqual(stack_9.expression, "^2.0.0")
         self.assertEqual(stack_9.manifest_versions, ("2.0.0",))
-        self.assertEqual(stack_95.expression, ">=2.0.0")
+        self.assertEqual(stack_95.expression, "^2.0.0")
         self.assertEqual(stack_95.manifest_versions, ("2.0.0",))
-        self.assertEqual(stack_96.expression, ">=2.0.0")
+        self.assertEqual(stack_96.expression, "^2.0.0")
         self.assertEqual(stack_96.manifest_versions, ("2.0.0",))
-        self.assertEqual(stack_10.expression, ">=3.0.0")
+        self.assertEqual(stack_10.expression, "^3.0.0")
         self.assertEqual(stack_10.manifest_versions, ("3.0.0",))
+
+    def test_env_override_allows_gte_on_min_stack(self):
+        """The >= operator is opt-in for package/unit-test workflows."""
+        manifests = {
+            "pkg": {
+                "2.0.0": _manifest("^9.0.0"),
+                "3.0.0": _manifest("^10.0.0"),
+            }
+        }
+
+        with unittest.mock.patch.dict(os.environ, {RELATED_INTEGRATION_GTE_OPERATOR_ENV: "True"}):
+            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.4.0"):
+                stack_94 = resolve_related_integration_version("pkg", manifests)
+            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.5.0"):
+                stack_95 = resolve_related_integration_version("pkg", manifests)
+            with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="10.0.0"):
+                stack_10 = resolve_related_integration_version("pkg", manifests)
+
+        self.assertEqual(stack_94.expression, "^2.0.0")
+        self.assertEqual(stack_95.expression, ">=2.0.0")
+        self.assertEqual(stack_10.expression, ">=3.0.0")
 
     def test_keeps_zero_major_when_only_stable_option_missing(self):
         """Keep 0.x manifest versions when no major >= 1 option exists."""

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -7,6 +7,7 @@
 
 import unittest
 import unittest.mock
+from types import SimpleNamespace
 
 from semver import Version
 
@@ -20,8 +21,9 @@ from detection_rules.integrations import (
     find_compatible_version_range,
     find_latest_compatible_version,
     find_latest_integration_patch_for_minor,
+    get_integration_schema_data,
 )
-from detection_rules.rule_validators import KQLValidator
+from detection_rules.rule_validators import ESQLValidator, KQLValidator
 
 
 def _manifest(kibana_version: str) -> dict:
@@ -107,26 +109,6 @@ class TestParseKibanaRange(unittest.TestCase):
             [(Version(9, 1, 0), Version(10, 0, 0))],
         )
 
-    def test_or_clauses(self):
-        """Clauses separated by ``||`` are returned as a list of OR'd ranges."""
-        self.assertEqual(
-            _parse_kibana_range("^8.12.0 || ^9.0.0"),
-            [
-                (Version(8, 12, 0), Version(9, 0, 0)),
-                (Version(9, 0, 0), Version(10, 0, 0)),
-            ],
-        )
-
-    def test_mixed_and_or(self):
-        """AND'd tokens inside each clause and OR'd clauses compose correctly."""
-        self.assertEqual(
-            _parse_kibana_range(">=8.12.0 <9.0.0 || ^9.1.0"),
-            [
-                (Version(8, 12, 0), Version(9, 0, 0)),
-                (Version(9, 1, 0), Version(10, 0, 0)),
-            ],
-        )
-
 
 class TestSatisfiesKibanaRange(unittest.TestCase):
     """Test range satisfaction for a given stack version."""
@@ -147,12 +129,6 @@ class TestSatisfiesKibanaRange(unittest.TestCase):
     def test_caret_rejects_prior_major(self):
         """Regression: 9.1 must NOT satisfy ^9.4.0 (drove 46 rule failures)."""
         self.assertFalse(_satisfies_kibana_range(Version(9, 1, 0), "^9.4.0"))
-
-    def test_or_union(self):
-        """OR'd clauses accept stacks inside either clause and reject otherwise."""
-        self.assertTrue(_satisfies_kibana_range(Version(8, 12, 5), "^8.12.0 || ^9.0.0"))
-        self.assertTrue(_satisfies_kibana_range(Version(9, 0, 1), "^8.12.0 || ^9.0.0"))
-        self.assertFalse(_satisfies_kibana_range(Version(10, 0, 0), "^8.12.0 || ^9.0.0"))
 
     def test_anded_bounds(self):
         """AND'd bounds produce a half-open interval [lo, hi)."""
@@ -197,12 +173,6 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         self.assertEqual(version, "1.0.0")
         self.assertEqual(notice, [""])
 
-    def test_or_clause_match(self):
-        """A stack that falls in any OR'd sub-range is considered compatible."""
-        manifests = {"pkg": {"1.0.0": _manifest("^8.12.0 || ^9.0.0")}}
-        version, _ = find_latest_compatible_version("pkg", "pkg", Version(8, 15, 0), manifests)
-        self.assertEqual(version, "1.0.0")
-
     def test_no_compatible_version_raises(self):
         """``ValueError`` when no manifest is compatible with the rule stack."""
         manifests = {"pkg": {"1.0.0": _manifest("^9.4.0")}}
@@ -231,10 +201,7 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         manifests = {
             package: {
                 older_version: _manifest(f"^{current_version.major}.0.0"),
-                newer_version: _manifest(
-                    f"~{current_version.major}.{current_version.minor}.{required_patch} || "
-                    f"^{current_version.major}.{current_version.minor + 1}.0"
-                ),
+                newer_version: _manifest(f"~{current_version.major}.{current_version.minor}.{required_patch}"),
             }
         }
         schemas = {
@@ -278,10 +245,7 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
         manifests = {
             package: {
                 "1.0.0": _manifest(f"^{current_version.major}.0.0"),
-                "1.1.0": _manifest(
-                    f"~{current_version.major}.{current_version.minor}.{required_patch} || "
-                    f"^{current_version.major}.{current_version.minor + 1}.0"
-                ),
+                "1.1.0": _manifest(f"~{current_version.major}.{current_version.minor}.{required_patch}"),
             }
         }
         schemas = {
@@ -300,6 +264,94 @@ class TestFindLatestCompatibleVersion(unittest.TestCase):
             required_fields = validator.get_required_fields([])
 
         self.assertIn({"name": field_name, "type": "keyword", "ecs": False}, required_fields)
+
+    def test_non_esql_validation_uses_patch_floor_for_integration_schema(self):
+        """Non-ES|QL schema validation resolves integration schemas using the inferred patch floor."""
+        package = "pkg"
+        integration = "new_ds"
+        field_name = "pkg.new_ds.some_field"
+        manifests = {
+            package: {
+                "1.0.0": _manifest("^9.0.0"),
+                "1.1.0": _manifest("~9.2.4"),
+            }
+        }
+        schemas = {
+            package: {
+                "1.0.0": {"old_ds": {}},
+                "1.1.0": {integration: {field_name: "keyword"}},
+            }
+        }
+        data = SimpleNamespace(language="kuery", get=lambda key, default=None: False if key == "notify" else default)
+        meta = SimpleNamespace(
+            maturity="production",
+            get_validation_stack_versions=lambda: {"9.2.0": {"ecs": "test-ecs", "endgame": "test-endgame"}},
+        )
+
+        with (
+            unittest.mock.patch("detection_rules.integrations.load_integrations_manifests", return_value=manifests),
+            unittest.mock.patch("detection_rules.integrations.load_integrations_schemas", return_value=schemas),
+            unittest.mock.patch("detection_rules.integrations.ecs.get_schema", return_value={}),
+            unittest.mock.patch("detection_rules.integrations.ecs.flatten_multi_fields", return_value={}),
+        ):
+            schema_data = list(
+                get_integration_schema_data(
+                    data,
+                    meta,
+                    [{"package": package, "integration": integration}],
+                )
+            )
+
+        self.assertEqual(len(schema_data), 1)
+        self.assertEqual(schema_data[0]["package_version"], "1.1.0")
+        self.assertEqual(schema_data[0]["stack_version"], "9.2.0")
+
+    def test_esql_remote_validation_uses_patch_floor_for_prepare_mappings(self):
+        """ES|QL remote validation prepares mappings with patch-adjusted stack versions."""
+        query = """
+        FROM logs-pkg.new_ds-* metadata _id, _version, _index
+        | WHERE data_stream.dataset == "pkg.new_ds"
+        | KEEP _id, _version, _index
+        """
+        metadata = SimpleNamespace(integration=["pkg"])
+        prepared_stack_versions: list[str] = []
+
+        def prepare_mappings_side_effect(*args):
+            prepared_stack_versions.append(args[4])
+            return {}, {}, {}
+
+        def patch_floor_side_effect(packages, major, minor):
+            self.assertIn("pkg", packages)
+            return 4 if (major, minor) == (9, 2) else 0
+
+        validator = ESQLValidator(query)
+        with (
+            unittest.mock.patch("detection_rules.rule_validators.get_latest_stack_version", return_value="9.2.0"),
+            unittest.mock.patch("detection_rules.rule_validators.get_stack_versions", return_value=["9.2.0", "9.3.0"]),
+            unittest.mock.patch(
+                "detection_rules.rule_validators.find_latest_integration_patch_for_minor",
+                side_effect=patch_floor_side_effect,
+            ),
+            unittest.mock.patch("detection_rules.rule_validators.prepare_mappings", side_effect=prepare_mappings_side_effect),
+            unittest.mock.patch("detection_rules.rule_validators.create_remote_indices", return_value="test-index"),
+            unittest.mock.patch(
+                "detection_rules.rule_validators.execute_query_against_indices",
+                return_value=([{"name": "data_stream.dataset", "type": "keyword"}], {"ok": True}),
+            ),
+            unittest.mock.patch.object(ESQLValidator, "validate_columns_index_mapping", return_value=True),
+        ):
+            response = validator.remote_validate_rule(
+                kibana_client=SimpleNamespace(get=lambda *_args, **_kwargs: {"version": {"number": "9.2.0"}}),
+                elastic_client=object(),
+                query=query,
+                metadata=metadata,
+                rule_id="test-rule",
+            )
+
+        self.assertEqual(response, {"ok": True})
+        self.assertIn("9.2.0", prepared_stack_versions)
+        self.assertIn("9.2.4", prepared_stack_versions)
+        self.assertIn("9.3.0", prepared_stack_versions)
 
 
 class TestFindCompatibleVersionRange(unittest.TestCase):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -15,6 +15,7 @@ from detection_rules.integrations import (
     _find_least_compatible_for_stack,
     _parse_clause,
     _parse_kibana_range,
+    _related_integration_version_operator,
     _satisfies_kibana_range,
     find_compatible_version_range,
     find_latest_compatible_version,
@@ -312,6 +313,7 @@ class TestFindCompatibleVersionRange(unittest.TestCase):
                 "1.5.0": _manifest("^8.0.0"),
                 "2.0.0": _manifest("^9.0.0"),
                 "2.5.0": _manifest("^9.1.0"),
+                "3.0.0": _manifest("^10.0.0"),
             }
         }
 
@@ -319,11 +321,23 @@ class TestFindCompatibleVersionRange(unittest.TestCase):
             stack_8 = find_compatible_version_range("pkg", manifests)
         with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.1.0"):
             stack_9 = find_compatible_version_range("pkg", manifests)
+        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.5.0"):
+            stack_95 = find_compatible_version_range("pkg", manifests)
+        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="9.6.0"):
+            stack_96 = find_compatible_version_range("pkg", manifests)
+        with unittest.mock.patch("detection_rules.integrations.load_current_package_version", return_value="10.0.0"):
+            stack_10 = find_compatible_version_range("pkg", manifests)
 
         self.assertEqual(stack_8.range, "^1.0.0")
         self.assertEqual(stack_8.anchors, ("1.0.0",))
         self.assertEqual(stack_9.range, "^2.0.0")
         self.assertEqual(stack_9.anchors, ("2.0.0",))
+        self.assertEqual(stack_95.range, ">=2.0.0")
+        self.assertEqual(stack_95.anchors, ("2.0.0",))
+        self.assertEqual(stack_96.range, ">=2.0.0")
+        self.assertEqual(stack_96.anchors, ("2.0.0",))
+        self.assertEqual(stack_10.range, ">=3.0.0")
+        self.assertEqual(stack_10.anchors, ("3.0.0",))
 
     def test_keeps_zero_major_when_only_stable_option_missing(self):
         """Keep 0.x anchors when no major >= 1 anchor exists."""
@@ -436,9 +450,10 @@ class TestFindCompatibleVersionRangeSchemaAware(unittest.TestCase):
                 find_compatible_version_range("azure", manifests, integration="aadgraphactivitylogs")
             return
 
+        operator = _related_integration_version_operator(current_version)
         result = find_compatible_version_range("azure", manifests, integration="aadgraphactivitylogs")
         self.assertEqual(result.anchors, (expected,))
-        self.assertEqual(result.range, f"^{expected}")
+        self.assertEqual(result.range, f"{operator}{expected}")
         floor_versions = [
             version
             for version in sorted(schemas["azure"], key=Version.parse)
@@ -480,8 +495,8 @@ class TestMetadataPackageRowDedupe(unittest.TestCase):
         windows_rows = [row for row in api["related_integrations"] if row["package"] == "windows"]
         self.assertEqual(len(endpoint_rows), 1)
         self.assertEqual(len(windows_rows), 1)
-        self.assertTrue(endpoint_rows[0]["version"].startswith("^"))
-        self.assertTrue(windows_rows[0]["version"].startswith("^"))
+        self.assertRegex(endpoint_rows[0]["version"], r"^(?:\^|>=)")
+        self.assertRegex(windows_rows[0]["version"], r"^(?:\^|>=)")
         self.assertNotIn(" || ", endpoint_rows[0]["version"])
         self.assertNotIn(" || ", windows_rows[0]["version"])
 

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -42,8 +42,15 @@ class TestESQLRemoteValidation(unittest.TestCase):
         metadata = SimpleNamespace(integration=["pkg"])
         prepared_stack_versions: list[str] = []
 
-        def prepare_mappings_side_effect(*args):
-            prepared_stack_versions.append(args[4])
+        def prepare_mappings_side_effect(
+            _elastic_client,
+            _indices,
+            _event_dataset_integrations,
+            _metadata,
+            stack_version,
+            _log,
+        ):
+            prepared_stack_versions.append(stack_version)
             return {}, {}, {}
 
         def patch_floor_side_effect(packages, major, minor):

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -58,7 +58,9 @@ class TestESQLRemoteValidation(unittest.TestCase):
                 "detection_rules.rule_validators.find_latest_integration_patch_for_minor",
                 side_effect=patch_floor_side_effect,
             ),
-            unittest.mock.patch("detection_rules.rule_validators.prepare_mappings", side_effect=prepare_mappings_side_effect),
+            unittest.mock.patch(
+                "detection_rules.rule_validators.prepare_mappings", side_effect=prepare_mappings_side_effect
+            ),
             unittest.mock.patch("detection_rules.rule_validators.create_remote_indices", return_value="test-index"),
             unittest.mock.patch(
                 "detection_rules.rule_validators.execute_query_against_indices",

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -5,6 +5,7 @@
 
 import unittest
 from copy import deepcopy
+from types import SimpleNamespace
 
 import pytest
 
@@ -21,10 +22,62 @@ from detection_rules.misc import (
 )
 from detection_rules.rule import ESQLRuleData
 from detection_rules.rule_loader import RuleCollection
+from detection_rules.rule_validators import ESQLValidator
 from detection_rules.schemas.definitions import ESQL_DYNAMIC_FIELD_PREFIXES
 from detection_rules.utils import get_path, load_rule_contents
 
 from .base import BaseRuleTest
+
+
+class TestESQLRemoteValidation(unittest.TestCase):
+    """Unit tests for ES|QL remote validation behavior that mock remote services."""
+
+    def test_remote_validation_uses_patch_floor_for_prepare_mappings(self):
+        """ES|QL remote validation prepares mappings with patch-adjusted stack versions."""
+        query = """
+        FROM logs-pkg.new_ds-* metadata _id, _version, _index
+        | WHERE data_stream.dataset == "pkg.new_ds"
+        | KEEP _id, _version, _index
+        """
+        metadata = SimpleNamespace(integration=["pkg"])
+        prepared_stack_versions: list[str] = []
+
+        def prepare_mappings_side_effect(*args):
+            prepared_stack_versions.append(args[4])
+            return {}, {}, {}
+
+        def patch_floor_side_effect(packages, major, minor):
+            self.assertIn("pkg", packages)
+            return 4 if (major, minor) == (9, 2) else 0
+
+        validator = ESQLValidator(query)
+        with (
+            unittest.mock.patch("detection_rules.rule_validators.get_latest_stack_version", return_value="9.2.0"),
+            unittest.mock.patch("detection_rules.rule_validators.get_stack_versions", return_value=["9.2.0", "9.3.0"]),
+            unittest.mock.patch(
+                "detection_rules.rule_validators.find_latest_integration_patch_for_minor",
+                side_effect=patch_floor_side_effect,
+            ),
+            unittest.mock.patch("detection_rules.rule_validators.prepare_mappings", side_effect=prepare_mappings_side_effect),
+            unittest.mock.patch("detection_rules.rule_validators.create_remote_indices", return_value="test-index"),
+            unittest.mock.patch(
+                "detection_rules.rule_validators.execute_query_against_indices",
+                return_value=([{"name": "data_stream.dataset", "type": "keyword"}], {"ok": True}),
+            ),
+            unittest.mock.patch.object(ESQLValidator, "validate_columns_index_mapping", return_value=True),
+        ):
+            response = validator.remote_validate_rule(
+                kibana_client=SimpleNamespace(get=lambda *_args, **_kwargs: {"version": {"number": "9.2.0"}}),
+                elastic_client=object(),
+                query=query,
+                metadata=metadata,
+                rule_id="test-rule",
+            )
+
+        self.assertEqual(response, {"ok": True})
+        self.assertIn("9.2.0", prepared_stack_versions)
+        self.assertIn("9.2.4", prepared_stack_versions)
+        self.assertIn("9.3.0", prepared_stack_versions)
 
 
 @unittest.skipIf(get_default_config() is None, "Skipping remote validation due to missing config")

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -96,7 +96,7 @@ class TestRemoteRules(BaseRuleTest):
         production_rule = deepcopy(original_production_rule)[0]
         # Non-aggregate queries must include _id, _version, _index in keep when keep is not exactly "*"
         base = "from logs-aws.cloudtrail* metadata _id, _version, _index\n"
-        base += '| where event.action == "start"\n | eval Esql.entity_type = cloud.target.entity.type\n | keep '
+        base += '| where event.action == "start"\n | eval Esql.entity_type = cloud.target.machine.type\n | keep '
         keep_star_queries = [
             base + "*",
             base + "Esql.*, _id, _version, _index",


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to: https://github.com/elastic/detection-rules/pull/6251, https://github.com/elastic/detection-rules/pull/6289, https://github.com/elastic/detection-rules/pull/6208, https://github.com/elastic/detection-rules/pull/5962

## Summary - What I changed

PR to remove the `||` based semantic version handling, and replace this with stack specific version parsing using `^` for stacks older than `9.5`. For stacks `9.5` and onward we can use `>=` instead of the caret for indicating supported related integrations. 

> [!NOTE]
> Extensive testing is required for each release branch, all view-rule and related validation commands, all ES|QL validation/remote valdation routes, and all DaC routes.


Also, additional DaC testing should be done once `>=` is available in Kibana. See [ref](https://github.com/elastic/detection-rules/pull/6323#issuecomment-4780542121). Fix in https://github.com/elastic/detection-rules/pull/6323/commits/b748616f1b32517fe433557f7604019ea266fc67.

This PR also addresses an unrelated fix where the latest stack schema map entry would be used when building a new custom rules directory regardless of whether or not the packages.yaml supported this version. This is fix is addressed in https://github.com/elastic/detection-rules/pull/6323/commits/703b211ad4237402d556469a29092d60613d6e4b.

## How To Test

On main, related integrations should be similar to:
```
  "related_integrations": [
    {
      "integration": "cloudtrail",
      "package": "aws",
      "version": ">=6.0.0"
    }
  ],
```

On release branches <9.5 it should be similar to the following:
```
  "related_integrations": [
    {
      "integration": "cloudtrail",
      "package": "aws",
      "version": "^6.0.0"
    }
  ],

```

Also, need to test on branches like 8.19 are the appropriate stack patch versions taken into account for certain integrations like `aadgraph`.  (note if unit tests pass on 8.19, this will already be handled since the rule has already back-ported to 8.19) 

```
  "related_integrations": [
    {
      "package": "azure",
      "version": "^1.22.0"
    },
    {
      "integration": "aadgraphactivitylogs",
      "package": "azure",
      "version": "^1.37.0"
    }
  ],
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
