### PR TITLE
[New Rule] AWS Bedrock Agent Credential Exfiltration Pattern in Invocation Content

### DIFF
--- a/rules/integrations/aws_bedrock/aws_bedrock_agent_credential_exfiltration_pattern_in_invocation.toml
+++ b/rules/integrations/aws_bedrock/aws_bedrock_agent_credential_exfiltration_pattern_in_invocation.toml
@@ -1,0 +1,131 @@
+[metadata]
+creation_date = "2026/06/28"
+integration = ["aws_bedrock"]
+maturity = "development"
+updated_date = "2026/06/28"
+
+[rule]
+author = ["Adam Lin"]
+description = """
+Identifies AWS Bedrock model invocations whose request content references multiple distinct, high-signal credential and
+secret-material targets within a single one-minute window for the same caller and account. Examples include the cloud
+instance metadata endpoint, on-disk credential stores such as the SSH or AWS credentials directories, and well-known
+secret token prefixes. When an agent's tool-call or message traffic reads these fixed-infrastructure locations, it is
+consistent with an attacker steering the agent toward credential discovery and exfiltration rather than a benign task.
+This is a behavioral detection over agent telemetry that keys off the structural targets of the request, not a single
+literal phrase, so it is not bypassed by rephrasing a prompt. The detection requires three or more distinct credential
+targets in the same window to suppress incidental one-off mentions.
+"""
+false_positives = [
+    """
+    Security tooling, infrastructure automation, or developer assistants that legitimately read instance metadata, SSH
+    or AWS credential files, or reference token formats as part of sanctioned workflows. Tune by caller identity,
+    account, or an allowlist of approved agents.
+    """,
+    """
+    Documentation, training, or evaluation prompts that discuss credential paths and token formats without a real read.
+    Raise the distinct-target threshold or exclude known evaluation accounts.
+    """,
+]
+from = "now-60m"
+interval = "10m"
+language = "esql"
+license = "Elastic License v2"
+name = "AWS Bedrock Agent Credential Exfiltration Pattern in Invocation Content"
+note = """## Triage and analysis
+
+### Investigating AWS Bedrock Agent Credential Exfiltration Pattern in Invocation Content
+
+AI agents backed by Bedrock can be steered, through prompt injection or a poisoned tool, into reading credential
+material and sending it outbound. The fixed targets of that behavior, the instance metadata endpoint, the SSH and AWS
+credential directories, and well-known secret token formats, are stable infrastructure that a benign task rarely
+touches in volume. This rule surfaces invocations whose content references three or more distinct credential targets
+for the same caller and account in a one-minute window.
+
+#### Possible investigation steps
+
+- Review Esql.matched_targets for the exact credential indicators that fired and whether they represent a real read or only a textual mention.
+- Identify the caller (user.id) and cloud.account.id and confirm whether this agent or workflow is expected to access credential material.
+- Examine the surrounding invocations for the same caller for an outbound or tool-call step that would complete an exfiltration chain.
+- Determine whether the request originated from an injected instruction or a tool description rather than the operator.
+
+### False positive analysis
+
+- Confirm the activity is not sanctioned security tooling, infrastructure automation, or a developer assistant operating within policy.
+- If the content only discusses credential paths without a real read, raise the distinct-target threshold or exclude the known evaluation account.
+
+### Response and remediation
+
+- If unexpected, suspend the caller's Bedrock access and review the agent's tool and permission scope.
+- Rotate any credentials whose stores were referenced and review recent use of the cloud instance metadata role.
+- Trace the originating instruction or tool to determine whether the agent was poisoned or injected.
+"""
+references = [
+    "https://github.com/Agent-Threat-Rule/agent-threat-rules",
+    "https://atlas.mitre.org/techniques/AML.T0098",
+    "https://atlas.mitre.org/techniques/AML.T0086",
+    "https://atlas.mitre.org/techniques/AML.T0055",
+    "https://genai.owasp.org/llmrisk/llm06-sensitive-information-disclosure/",
+    "https://www.elastic.co/security-labs/elastic-advances-llm-security",
+]
+risk_score = 47
+rule_id = "9a828943-bbc8-4774-9797-4053bdae30f7"
+severity = "medium"
+tags = [
+    "Domain: LLM",
+    "Data Source: AWS Bedrock",
+    "Use Case: Threat Detection",
+    "Resources: Investigation Guide",
+    "Mitre Atlas: T0098",
+    "Mitre Atlas: T0086",
+    "Mitre Atlas: T0055",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+from logs-aws_bedrock.invocation-* metadata _id, _version, _index
+| where user.id is not null
+| eval Esql.content = to_lower(concat(coalesce(gen_ai.prompt, ""), " ", coalesce(gen_ai.completion, "")))
+| eval Esql.time_window = date_trunc(1 minute, @timestamp)
+| eval Esql.target = case(
+    Esql.content like "*169.254.169.254*" or Esql.content like "*latest/meta-data/iam*" or Esql.content like "*metadata.google.internal*", "instance_metadata",
+    Esql.content like "*/.ssh/id_rsa*" or Esql.content like "*/.ssh/id_ed25519*" or Esql.content like "*begin*private key*", "ssh_private_key",
+    Esql.content like "*/.aws/credentials*" or Esql.content like "*aws_secret_access_key*", "aws_credentials_file",
+    Esql.content like "*/.env*" or Esql.content like "*client_secret*", "env_or_client_secret",
+    Esql.content like "*ghp_*" or Esql.content like "*github_pat_*" or Esql.content like "*xoxb-*" or Esql.content like "*aws_session_token*", "secret_token_prefix",
+    null)
+| where Esql.target is not null
+| keep @timestamp, Esql.time_window, user.id, cloud.account.id, Esql.target
+| stats
+    Esql.matched_targets = values(Esql.target),
+    Esql.distinct_targets = count_distinct(Esql.target)
+  by user.id, cloud.account.id, Esql.time_window
+| where Esql.distinct_targets >= 3
+| sort Esql.distinct_targets desc
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+[[rule.threat.technique.subtechnique]]
+id = "T1552.001"
+name = "Credentials In Files"
+reference = "https://attack.mitre.org/techniques/T1552/001/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.005"
+name = "Cloud Instance Metadata API"
+reference = "https://attack.mitre.org/techniques/T1552/005/"
+
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+


### PR DESCRIPTION
Resolves part of #6126. As discussed there, this is one behavioral ES|QL seed rule, not a content/phrase match.

What it does
Flags AWS Bedrock invocations whose request content references three or more distinct credential-exfiltration targets for the same caller and account within a one-minute window. Targets are fixed infrastructure: the cloud instance metadata endpoint, the SSH and AWS credential stores, and well-known secret token formats. The rule keys off the structural targets of the agent's tool-call and message traffic rather than a single literal phrase, so rephrasing a prompt does not bypass it. The 3-distinct-target threshold suppresses incidental one-off mentions.

Data source
aws_bedrock integration, invocation data stream (logs-aws_bedrock.invocation-*). Fields used (gen_ai.prompt, gen_ai.completion, user.id, cloud.account.id) are verified against the integration fields manifest. There is no aws_bedrock_agentcore or provider-neutral LLM integration in this repo today, so this targets the closest existing GenAI integration, consistent with the existing aws_bedrock LLM rules.

Maturity
Shipped at maturity = development for review. I have not been able to run remote ES|QL validation against a live stack, so I would value a maintainer running that and sanity-checking field and column types before this moves toward production. Threshold and window are starting points to tune against real volume.

Frameworks
MITRE ATT&CK T1552 (with sub-techniques .001 and .005) in the threat block. MITRE ATLAS T0098/T0086/T0055 in tags and references, per the thread.

Validation
detection_rules test passes locally (232 passed, 19 remote-only skipped). toml-lint clean.

CLA: I will sign the Elastic CLA.
