### PR TITLE
[Rule Tuning] remove URL/IP filtering from interactive curl/wget rule

### DIFF
--- a/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
+++ b/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
@@ -4,7 +4,7 @@ integration = ["cloud_defend"]
 maturity = "production"
 min_stack_comments = "Defend for Containers integration was re-introduced in 9.3.0"
 min_stack_version = "9.3.0"
-updated_date = "2026/03/24"
+updated_date = "2026/06/30"
 
 [rule]
 author = ["Elastic"]

--- a/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
+++ b/rules/integrations/cloud_defend/command_and_control_interactive_file_download_from_internet.toml
@@ -86,10 +86,8 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     (process.name == "wget" or process.args in ("wget", "/bin/wget", "/usr/bin/wget", "/usr/local/bin/wget")) and
     process.args like ("-*O*", "--output-document=*", "--output-file=*")
   )
-) and (
- process.args like~ "*http*" or
- process.args regex~ ".*[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}[:/]{1}.*"
-) and container.id like "?*"
+) 
+and container.id like "?*"
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
# Pull Request
_Issue link(s)_: N/A

## Summary - What I changed
Broadens the interactive `curl`/`wget` download detection rule by removing the `process.args like~ "*http*" or IP regex` condition. This makes the detection protocol-agnostic and eliminates false negatives caused by argument splitting, environment variable injection, or non-HTTP protocols (FTP, SFTP, local paths, etc.).

## How To Test
- Deploy in a Linux container environment with process telemetry capturing `process.name`, `process.args`, `process.interactive`, and `container.id`.
- Execute interactive commands with output flags:
  - `curl -o /tmp/x ftp://server/file`
  - `wget -O out ssh://user@host/payload`
  - `curl -O example.com/data`
- Verify the rule triggers on all specified output flags (`-o`, `-O`, `--output-*`, `--remote-name`, `--output-dir`, `--output-document`, `--output-file`) regardless of the protocol or target in the arguments.
- Confirm non-interactive executions (scripts, cron, CI/CD) and host-level processes are correctly excluded.
- Validated against target SIEM/EDR engine syntax for proper `contains`/`like` behavior.

## Checklist
- [x] Added a label for the type of pr: `Rule: Tuning`

## Contributor checklist
- [x] Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- [x] Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?