### PR TITLE
Fix KQL wildcard literal failing to lex escaped specials with spaces

### DIFF
--- a/lib/kql/kql/kql.g
+++ b/lib/kql/kql/kql.g
@@ -43,14 +43,19 @@ RANGE_OPERATOR: "<="
 // MUST contain at least one space to differentiate from field names like common.*
 // Must not start with not/or/and so "not /tmp/go-build*" is not matched (value is UNQUOTED_LITERAL)
 // All patterns end with (?=\s|$|[()":{}]) to prevent capturing trailing whitespace
+// Each "safe unit" below is either a backslash-escape pair (mirrors UNQUOTED_CHAR's
+// escapes, e.g. \: \( \" \\) or a single raw character outside the reserved set. Without
+// the escape alternative, a value like `*\: no such file` would fail to lex at all because
+// the escaped colon isn't a "safe" raw char, even though it's not being used as the
+// field:value separator (see #6282).
 // Pattern 1: Starts with * (e.g., *S3 Browser, *S3 Browser*)
 // Pattern 2: Ends with * but doesn't start with * (e.g., S3 Browser*)
 // Pattern 3a: Middle * - star appears AFTER a space (e.g., S3 B*owser)
 // Pattern 3b: Middle * - star appears BEFORE a space (e.g., S3* Browser)
-WILDCARD_LITERAL.3: /\*[^\s\r\n()"':{}]*(?:\s+(?!(?:or|and|not)\b)[^\s\r\n()"':{}]+)+\*?(?=\s|$|[()":{}])/i
-                  | /(?!(?:not|or|and)\b)[^\s\r\n()"':{}][^\s\r\n()"':{}]*(?:\s+(?!(?:or|and|not)\b)[^\s\r\n()"':{}]+)+\*(?=\s|$|[()":{}])/i
-                  | /(?!(?:not|or|and)\b)[^\s\r\n()"'*:{}][^\s\r\n()"':{}]*\s+(?!(?:or|and|not)\b)[^\s\r\n()"':{}]*\*[^\s\r\n()"':{}]+(?:\s+(?!(?:or|and|not)\b)[^\s\r\n()"':{}]+)*(?<!\*)(?=\s|$|[()":{}])/i
-                  | /(?!(?:not|or|and)\b)[^\s\r\n()"'*:{}][^\s\r\n()"':{}]*\*[^\s\r\n()"':{}]*\s+(?!(?:or|and|not)\b)[^\s\r\n()"':{}]+(?:\s+(?!(?:or|and|not)\b)[^\s\r\n()"':{}]+)*(?<!\*)(?=\s|$|[()":{}])/i
+WILDCARD_LITERAL.3: /\*(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])*(?:\s+(?!(?:or|and|not)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])+)+\*?(?=\s|$|[()":{}])/i
+                  | /(?!(?:not|or|and)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])*(?:\s+(?!(?:or|and|not)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])+)+\*(?=\s|$|[()":{}])/i
+                  | /(?!(?:not|or|and)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"'*:{}])(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])*\s+(?!(?:or|and|not)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])*\*(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])+(?:\s+(?!(?:or|and|not)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])+)*(?<!\*)(?=\s|$|[()":{}])/i
+                  | /(?!(?:not|or|and)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"'*:{}])(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])*\*(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])*\s+(?!(?:or|and|not)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])+(?:\s+(?!(?:or|and|not)\b)(?:\\[trn\\():<>"*{}]|[^\s\r\n()"':{}])+)*(?<!\*)(?=\s|$|[()":{}])/i
 
 UNQUOTED_LITERAL: UNQUOTED_CHAR+
 UNQUOTED_CHAR: "\\" /[trn]/              // escaped whitespace

--- a/tests/kuery/test_parser.py
+++ b/tests/kuery/test_parser.py
@@ -172,6 +172,21 @@ class ParserTests(unittest.TestCase):
             FieldComparison(Field("process.args"), Wildcard("/lockscreenurl:http*")),
         )
 
+    def test_wildcard_with_spaces_and_escaped_special_chars(self):
+        """Regression test for #6282: a wildcard value with unquoted spaces that also
+        contains an escaped special char (e.g. `\\:`) must still lex as a single
+        WILDCARD_LITERAL instead of failing to parse outright."""
+        self.validate(
+            r"app_message:*\: no such file present",
+            FieldComparison(Field("app_message"), Wildcard("*: no such file present")),
+        )
+
+        # other escaped specials besides `:` must also be allowed inside a spaced wildcard
+        self.validate(
+            r"field:*\( something",
+            FieldComparison(Field("field"), Wildcard("*( something")),
+        )
+
     def test_escaped_wildcard_is_literal(self):
         """Test that an escaped `\\*` is treated as a literal asterisk, not a wildcard."""
         # Regression test for the literal-`*` -> match-all-wildcard bug: since wildcard


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

Resolves #6282

## Summary - What I changed

`export-rules` fails on a KQL rule when its query has a wildcard value that mixes unquoted spaces with an escaped special character, like `app_message : *\: No such file or directory`. Kibana accepts this query fine, but the KQL grammar here can't lex it, so export throws a syntax error and skips the rule (matches the screenshots in the issue).

The cause is in `WILDCARD_LITERAL` in `lib/kql/kql/kql.g`. It has four patterns for wildcard values containing spaces, and each one only allows a fixed set of raw characters as "safe" - anything backslash-escaped (`\:`, `\(`, `\"`, etc.) falls outside that set and breaks the match, even though `UNQUOTED_CHAR` already knows how to handle those same escapes for the no-space case.

I extended each pattern so a "safe unit" is either one of those escape pairs or a raw safe character, matching what `UNQUOTED_CHAR` already does. No other behavior changes.

One thing worth flagging: if the wildcard value contains a bare `or`/`and`/`not` as a full word (like "No such file **or** directory" in the original report), the grammar still splits the query there - that's pre-existing behavior unrelated to this bug (I confirmed it happens on current `main` too, with or without an escaped char involved), so I left it alone to keep this change scoped to the actual reported failure.

## How To Test

```pycon
>>> import kql
>>> kql.parse(r"app_message: *\: no such file present")
FieldComparison(field=Field(name='app_message'), value=Wildcard(value='*: no such file present'))
```

Before this change, that raises `kql.errors.KqlParseError`.

Added `test_wildcard_with_spaces_and_escaped_special_chars` to `tests/kuery/test_parser.py`. Ran the full `tests/kuery` suite locally (72 tests, all passing) and `ruff check` / `ruff format --check` on the changed test file.

## Checklist

- [x] Added a label for the type of pr: `bug`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
