### PR TITLE
[Testing] Unusual Parent-Child Relationship

### DIFF
--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -151,30 +151,30 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
    (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe")) or
-   (process.name:"SearchIndexer.exe" and not process.parent.name:"services.exe") or
-   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe")) or
-   (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
-   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "consent.exe", "RuntimeBroker.exe", "TiWorker.exe")) or
+   (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
+   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
+   (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
+   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe", "ntoskrnl.exe")) or
    (process.name:"csrss.exe" and not process.parent.name:("smss.exe", "svchost.exe")) or
    (process.name:"wininit.exe" and not process.parent.name:"smss.exe") or
    (process.name:"winlogon.exe" and not process.parent.name:"smss.exe") or
    (process.name:("lsass.exe", "LsaIso.exe") and not process.parent.name:"wininit.exe") or
-   (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe")) or
+   (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe", "LogonUI.exe")) or
    (process.name:"services.exe" and not process.parent.name:"wininit.exe") or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe")) or
-   (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnet.exe", "rpcnetp.exe")) or
+   (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe", "spoolsv.exe")) or
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "ngentask.exe")) or
-   (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
+   (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
-   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
+   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:("svchost.exe", "wmiprvse.exe", "wsmprovhost.exe")) or
    /* suspicious child processes */
    (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
    (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
      not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "powershell.exe", "cmd.exe"))
   )
 '''
 


### PR DESCRIPTION
## Trigger context

| Field | Value |
|---|---|
| **Rule** | Unusual Parent-Child Relationship |
| **Rule ID** | `35df0dd8-092d-4a83-88c1-5151a804f31b` |
| **Rule type** | eql |
---

*Elastic Workflow — SIEM Rule Tuning PR (genai-tradecraft)*



---

## Summary

This tuning reduces false positive alerts for the **Unusual Parent-Child Relationship** rule by expanding parent process allowlists for known benign Windows system process behaviors observed broadly across production telemetry.

## Classification

| Category | Pattern | 30-day Alerts | Clusters | Assessment |
|---|---|---|---|---|
| Self-spawning system processes | `WmiPrvSE.exe` ← `WmiPrvSE.exe` | ~31K | 82 | FP — WMI provider host legitimate restart |
| Self-spawning system processes | `dllhost.exe` ← `dllhost.exe` | ~2.8K | 105 | FP — COM surrogate legitimate restart |
| Self-spawning system processes | `spoolsv.exe` ← `spoolsv.exe` | ~2.5K | 142 | FP — Print spooler service restart |
| Self-spawning system processes | `taskhostw.exe` ← `taskhostw.exe` | ~3.9K | 53 | FP — Task host worker restart |
| Self-spawning system processes | `SearchProtocolHost.exe`, `SearchIndexer.exe`, `LogonUI.exe`, `RuntimeBroker.exe`, `TiWorker.exe`, `consent.exe`, `wsmprovhost.exe` | ~4.5K combined | 41–85 each | FP — legitimate Windows service restarts |
| Console host children | `conhost.exe` → `powershell.exe` / `cmd.exe` | ~66K | 33–57 | FP — legitimate console host parent-child relationship across Elastic Defend, CrowdStrike, M365 Defender, Sysmon, and Windows Security data sources |
| Endpoint management | `svchost.exe` ← `rpcnet.exe` / `rpcnetp.exe` | ~15.7K | 17 | FP — Absolute Software Computrace/Persistence agent |
| Kernel boot | `smss.exe` ← `ntoskrnl.exe` | ~314 | 9 | FP — legitimate Windows kernel spawning Session Manager |

## Query Modifications

### Suspicious parent processes — self-spawning allowlists

Added the process's own name to the parent allowlist for the following system processes, as Windows legitimately restarts these services and the self-spawning pattern is observed broadly across 40–142 clusters:

- `consent.exe`, `RuntimeBroker.exe`, `TiWorker.exe` — added self-names to parent allowlist
- `SearchIndexer.exe` — added `SearchIndexer.exe` to parent allowlist
- `SearchProtocolHost.exe` — added `SearchProtocolHost.exe` to parent allowlist
- `dllhost.exe` — added `dllhost.exe` to parent allowlist
- `spoolsv.exe` — added `spoolsv.exe` to parent allowlist
- `taskhostw.exe` — added `taskhostw.exe` to parent allowlist
- `LogonUI.exe` — added `LogonUI.exe` to parent allowlist
- `wmiprvse.exe`, `wsmprovhost.exe` — added self-names to parent allowlist

**Note:** `lsass.exe` self-spawning was intentionally **not** excluded (19 clusters) as it may indicate credential dumping or process hollowing.

### Suspicious parent processes — additional legitimate parents

- `svchost.exe` — added `rpcnet.exe` and `rpcnetp.exe` (Absolute Software Computrace endpoint management agent, 17 clusters)
- `smss.exe` — added `ntoskrnl.exe` (legitimate Windows kernel boot process, 9 clusters)

### Suspicious child processes — conhost.exe children

- Added `powershell.exe` and `cmd.exe` to the `conhost.exe` child exclusion list. The Console Window Host (`conhost.exe`) legitimately appears as a parent of command-line interpreters across all major data sources (Elastic Defend, CrowdStrike, M365 Defender, Sysmon, Windows Security Event Logs) and 57+ clusters.

## Simulation

| Metric | Baseline | After Tuning | Change |
|---|---|---|---|
| Alerts (30-day, v≥319) | 133,962 | 9,419 | −93.0% |
| Clusters | 447 | 256 | −42.7% |
| Agents | 4,713 | 818 | −82.6% |

## Detection Gap Risk: Low

- All excluded patterns are well-documented benign Windows system behaviors
- Self-spawning exclusions require exact process name match (attacker would need to spoof both process and parent name identically)
- `conhost.exe` → `powershell.exe`/`cmd.exe` abuse is covered by other detection rules targeting PowerShell and command-line interpreter misuse
- `lsass.exe` self-spawning intentionally preserved as a detection surface
- Rule retains coverage across 256 clusters after tuning

## Verification

Baseline query:
```
kibana.alert.rule.name:"Unusual Parent-Child Relationship" AND kibana.alert.rule.version >= 319
```

Excluded patterns query:
```
kibana.alert.rule.name:"Unusual Parent-Child Relationship" AND kibana.alert.rule.version >= 319 AND ((process.name:process.parent.name AND process.name:("WmiPrvSE.exe" OR "dllhost.exe" OR "spoolsv.exe" OR "taskhostw.exe" OR "SearchProtocolHost.exe" OR "LogonUI.exe" OR "SearchIndexer.exe" OR "RuntimeBroker.exe" OR "TiWorker.exe" OR "consent.exe" OR "wsmprovhost.exe")) OR (process.parent.name:"conhost.exe" AND process.name:("powershell.exe" OR "cmd.exe")) OR (process.name:"svchost.exe" AND process.parent.name:("rpcnet.exe" OR "rpcnetp.exe")) OR (process.name:"smss.exe" AND process.parent.name:"ntoskrnl.exe"))
```

