### PR TITLE
[Testing] Unusual Parent-Child Relationship

### DIFF
--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -146,23 +146,25 @@ type = "eql"
 
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
+process.parent.name != null and not process.parent.name like~ "S-1-*" and
+process.parent.executable like ("?:\\*", "\\Device\\*") and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
    (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "consent.exe", "RuntimeBroker.exe", "TiWorker.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "RuntimeBroker.exe")) or
+   (process.name:"TiWorker.exe" and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "TrustedInstaller.exe")) or
    (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
    (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
    (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
-   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe", "ntoskrnl.exe")) or
+   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe")) or
    (process.name:"csrss.exe" and not process.parent.name:("smss.exe", "svchost.exe")) or
    (process.name:"wininit.exe" and not process.parent.name:"smss.exe") or
    (process.name:"winlogon.exe" and not process.parent.name:"smss.exe") or
    (process.name:("lsass.exe", "LsaIso.exe") and not process.parent.name:"wininit.exe") or
    (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe", "LogonUI.exe")) or
    (process.name:"services.exe" and not process.parent.name:"wininit.exe") or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnet.exe", "rpcnetp.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnetp.exe", "rpcnet.exe")) or
    (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe", "spoolsv.exe")) or
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "ngentask.exe")) or
    (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or
@@ -174,7 +176,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
    (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
      not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "powershell.exe", "cmd.exe"))
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "cmd.exe", "powershell.exe"))
   )
 '''
 

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -151,30 +151,30 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
    (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe")) or
-   (process.name:"SearchIndexer.exe" and not process.parent.name:"services.exe") or
-   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe")) or
-   (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
-   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "consent.exe", "RuntimeBroker.exe", "TiWorker.exe")) or
+   (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
+   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
+   (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
+   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe", "ntoskrnl.exe")) or
    (process.name:"csrss.exe" and not process.parent.name:("smss.exe", "svchost.exe")) or
    (process.name:"wininit.exe" and not process.parent.name:"smss.exe") or
    (process.name:"winlogon.exe" and not process.parent.name:"smss.exe") or
    (process.name:("lsass.exe", "LsaIso.exe") and not process.parent.name:"wininit.exe") or
-   (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe")) or
+   (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe", "LogonUI.exe")) or
    (process.name:"services.exe" and not process.parent.name:"wininit.exe") or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe")) or
-   (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnet.exe", "rpcnetp.exe")) or
+   (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe", "spoolsv.exe")) or
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "ngentask.exe")) or
-   (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
+   (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
-   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
+   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:("svchost.exe", "wmiprvse.exe", "wsmprovhost.exe")) or
    /* suspicious child processes */
    (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
    (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
      not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "powershell.exe", "cmd.exe"))
   )
 '''
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#990

"## Summary

This rule generates ~2.9M alerts across 1,115 clusters over 30 days, driven primarily by three FP categories: (1) SID-as-parent-name data quality issues from Windows forwarded logs where integrity level SIDs (e.g. `S-1-16-16384`) appear in `process.parent.name` instead of actual process names, (2) legitimate self-spawning Windows system processes (wmiprvse, wsmprovhost, dllhost, conhost, taskhostw, SearchIndexer, SearchProtocolHost, spoolsv, LogonUI, RuntimeBroker), and (3) known legitimate parent-child pairs (conhostâcmd/powershell via headless console host, TrustedInstallerâTiWorker, Dameware rpcnetp/rpcnetâsvchost). The tuning adds a top-level filter for SID parent names, expands allowed-parent lists for self-spawning processes, and adds known-good parents for svchost and TiWorker.

## Query diff

Key changes to the EQL query:

```diff
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
+process.parent.name != null and not process.parent.name like~ "S-1-*" and
+process.parent.executable like ("?:\\*", "\\Device\\*") and
  (
    /* suspicious parent processes */
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "RuntimeBroker.exe")) or
+   (process.name:"TiWorker.exe" and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "TrustedInstaller.exe")) or
-   (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
+   (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnetp.exe", "rpcnet.exe")) or
-   (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe")) or
+   (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe", "spoolsv.exe")) or
-   (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
+   (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or
-   (process.name:"SearchIndexer.exe" and not process.parent.name:"services.exe") or
+   (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
-   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe")) or
+   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
-   (process.name:("LogonUI.exe") and not process.parent.name:("wininit.exe", "winlogon.exe")) or
+   (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe", "LogonUI.exe")) or
-   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
+   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:("svchost.exe", "wmiprvse.exe", "wsmprovhost.exe")) or
    /* suspicious child processes */
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "cmd.exe", "powershell.exe"))
```

## Simulation (30-day, versions 319 + 321)

| Metric | Before | After | Î |
|---|---|---|---|
| Alerts | 2,889,084 | 173,901 | â94.0% |
| Clusters | 1,115 | 780 | â30.0% |
| Agents | 23,978 | 5,548 | â76.9% |

## Detection gap risk

**Low** â all exclusions target well-documented Windows self-spawn patterns, data quality issues (SID-as-parent-name from forwarded logs), and known legitimate software (Dameware, TrustedInstaller, headless conhost).
"

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
