### PR TITLE
[Rule Tuning] Unusual Parent-Child Relationship

### DIFF
--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2026/07/07"
+updated_date = "2026/07/08"
 
 [transform]
 [[transform.osquery]]
@@ -152,7 +152,7 @@ not process.parent.name like "S-1-*" and
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
    (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe", "svchost.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "RuntimeBroker.exe", "TiWorker.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "TiWorker.exe", "RuntimeBroker.exe", "consent.exe")) or
    (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
    (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
    (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
@@ -163,19 +163,18 @@ not process.parent.name like "S-1-*" and
    (process.name:("lsass.exe", "LsaIso.exe") and not process.parent.name:"wininit.exe") or
    (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe", "LogonUI.exe")) or
    (process.name:"services.exe" and not process.parent.name:"wininit.exe") or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnet.exe", "rpcnetp.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe")) or
    (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe", "spoolsv.exe")) or
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "ngentask.exe")) or
    (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
-   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:("svchost.exe", "wmiprvse.exe", "wsmprovhost.exe")) or
+   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
    /* suspicious child processes */
    (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
-   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
-     not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "cmd.exe", "powershell.exe"))
+   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe", "rundll32.exe")) or
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "cmd.exe", "powershell.exe", "pwsh.exe"))
   )
 '''
 

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2026/07/08"
+updated_date = "2026/07/15"
 
 [transform]
 [[transform.osquery]]
@@ -152,9 +152,9 @@ not process.parent.name like "S-1-*" and
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
    (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "consent.exe", "RuntimeBroker.exe", "TiWorker.exe", "ThreatLockerConsent.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "consent.exe", "RuntimeBroker.exe", "TiWorker.exe")) or
    (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
-   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
+   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe")) or
    (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
    (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe")) or
    (process.name:"csrss.exe" and not process.parent.name:("smss.exe", "svchost.exe")) or
@@ -172,10 +172,10 @@ not process.parent.name like "S-1-*" and
    /* suspicious child processes */
    (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
-   (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe", "QcSkExt8380.exe")) or
+   (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
    (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
      not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "powershell.exe", "cmd.exe"))
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "cmd.exe", "powershell.exe"))
   )
 '''
 

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -151,8 +151,8 @@ not process.parent.name like "S-1-*" and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
-   (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe", "svchost.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "TiWorker.exe", "RuntimeBroker.exe", "consent.exe")) or
+   (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "consent.exe", "RuntimeBroker.exe", "TiWorker.exe", "ThreatLockerConsent.exe")) or
    (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
    (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
    (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
@@ -168,13 +168,14 @@ not process.parent.name like "S-1-*" and
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "ngentask.exe")) or
    (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
-   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
+   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:("svchost.exe", "wmiprvse.exe")) or
    /* suspicious child processes */
    (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
-   (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
-   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe", "rundll32.exe")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "cmd.exe", "powershell.exe", "pwsh.exe"))
+   (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe", "QcSkExt8380.exe")) or
+   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
+     not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "powershell.exe", "cmd.exe"))
   )
 '''
 

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -146,14 +146,13 @@ type = "eql"
 
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and not process.parent.name like~ "S-1-*" and
-process.parent.executable like ("?:\\*", "\\Device\\*") and
+process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
+not process.parent.name like "S-1-*" and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
-   (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "RuntimeBroker.exe")) or
-   (process.name:"TiWorker.exe" and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "TrustedInstaller.exe")) or
+   (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe", "svchost.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "RuntimeBroker.exe", "TiWorker.exe")) or
    (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
    (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
    (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
@@ -164,7 +163,7 @@ process.parent.executable like ("?:\\*", "\\Device\\*") and
    (process.name:("lsass.exe", "LsaIso.exe") and not process.parent.name:"wininit.exe") or
    (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe", "LogonUI.exe")) or
    (process.name:"services.exe" and not process.parent.name:"wininit.exe") or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnetp.exe", "rpcnet.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnet.exe", "rpcnetp.exe")) or
    (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe", "spoolsv.exe")) or
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "ngentask.exe")) or
    (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -146,23 +146,25 @@ type = "eql"
 
 query = '''
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
+process.parent.name != null and not process.parent.name like~ "S-1-*" and
+process.parent.executable like ("?:\\*", "\\Device\\*") and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
    (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "consent.exe", "RuntimeBroker.exe", "TiWorker.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "RuntimeBroker.exe")) or
+   (process.name:"TiWorker.exe" and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "TrustedInstaller.exe")) or
    (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
    (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
    (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
-   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe", "ntoskrnl.exe")) or
+   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe")) or
    (process.name:"csrss.exe" and not process.parent.name:("smss.exe", "svchost.exe")) or
    (process.name:"wininit.exe" and not process.parent.name:"smss.exe") or
    (process.name:"winlogon.exe" and not process.parent.name:"smss.exe") or
    (process.name:("lsass.exe", "LsaIso.exe") and not process.parent.name:"wininit.exe") or
    (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe", "LogonUI.exe")) or
    (process.name:"services.exe" and not process.parent.name:"wininit.exe") or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnet.exe", "rpcnetp.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnetp.exe", "rpcnet.exe")) or
    (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe", "spoolsv.exe")) or
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "ngentask.exe")) or
    (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or
@@ -174,7 +176,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
    (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
      not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "powershell.exe", "cmd.exe"))
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "cmd.exe", "powershell.exe"))
   )
 '''
 

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["endpoint", "windows", "system", "m365_defender", "sentinel_one_cloud_funnel", "crowdstrike"]
 maturity = "production"
-updated_date = "2026/07/06"
+updated_date = "2026/07/07"
 
 [transform]
 [[transform.osquery]]

--- a/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
+++ b/rules/windows/privilege_escalation_unusual_parentchild_relationship.toml
@@ -151,30 +151,30 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
    (process.name:("fontdrvhost.exe", "dwm.exe") and not process.parent.name:("wininit.exe", "winlogon.exe", "dwm.exe")) or
-   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe")) or
-   (process.name:"SearchIndexer.exe" and not process.parent.name:"services.exe") or
-   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe")) or
-   (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
-   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe")) or
+   (process.name:("consent.exe", "RuntimeBroker.exe", "TiWorker.exe") and not process.parent.name:("svchost.exe", "Workplace Container Helper.exe", "consent.exe", "RuntimeBroker.exe", "TiWorker.exe")) or
+   (process.name:"SearchIndexer.exe" and not process.parent.name:("services.exe", "SearchIndexer.exe")) or
+   (process.name:"SearchProtocolHost.exe" and not process.parent.name:("SearchIndexer.exe", "dllhost.exe", "SearchProtocolHost.exe")) or
+   (process.name:"dllhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "dllhost.exe")) or
+   (process.name:"smss.exe" and not process.parent.name:("System", "smss.exe", "ntoskrnl.exe")) or
    (process.name:"csrss.exe" and not process.parent.name:("smss.exe", "svchost.exe")) or
    (process.name:"wininit.exe" and not process.parent.name:"smss.exe") or
    (process.name:"winlogon.exe" and not process.parent.name:"smss.exe") or
    (process.name:("lsass.exe", "LsaIso.exe") and not process.parent.name:"wininit.exe") or
-   (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe")) or
+   (process.name:"LogonUI.exe" and not process.parent.name:("wininit.exe", "winlogon.exe", "LogonUI.exe")) or
    (process.name:"services.exe" and not process.parent.name:"wininit.exe") or
-   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe")) or
-   (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe")) or
+   (process.name:"svchost.exe" and not process.parent.name:("MsMpEng.exe", "services.exe", "svchost.exe", "rpcnet.exe", "rpcnetp.exe")) or
+   (process.name:"spoolsv.exe" and not process.parent.name:("services.exe", "Workplace Starter.exe", "spoolsv.exe")) or
    (process.name:"taskhost.exe" and not process.parent.name:("services.exe", "svchost.exe", "ngentask.exe")) or
-   (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe")) or
+   (process.name:"taskhostw.exe" and not process.parent.name:("services.exe", "svchost.exe", "taskhostw.exe")) or
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
-   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
+   (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:("svchost.exe", "wmiprvse.exe", "wsmprovhost.exe")) or
    /* suspicious child processes */
    (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
    (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
      not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe", "powershell.exe", "cmd.exe"))
   )
 '''
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#991

Reduces noise from SID-as-parent data quality issues, legitimate Windows self-spawn pairs, and headless conhost spawning cmd/powershell. Adds a top-level S-1-* parent filter, expands allowed-parent lists for system processes to cover self-spawning, adds svchost.exe as an allowed parent for dwm.exe, broadens the wermgr.exe child exception for rundll32.exe, and adds cmd.exe/powershell.exe/pwsh.exe to the conhost.exe allowed-child list.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*