### PR TITLE
[Rule Tuning] A scheduled task was created

### DIFF
--- a/rules/windows/persistence_scheduled_task_creation_winlog.toml
+++ b/rules/windows/persistence_scheduled_task_creation_winlog.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/10"
 
 [rule]
 author = ["Elastic"]
@@ -74,12 +74,12 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
  not winlog.event_data.TaskName : (
               "\\CreateExplorerShellUnelevatedTask",
               "\\Hewlett-Packard\\HPDeviceCheck",
-              "\\Hewlett-Packard\\HP Support Assistant\\WarrantyChecker",
-              "\\Hewlett-Packard\\HP Support Assistant\\WarrantyChecker_backup",
+              "\\Hewlett-Packard\\HP Support Assistant\\WarrantyChecker*",
               "\\Hewlett-Packard\\HP Web Products Detection",
               "\\Microsoft\\VisualStudio\\Updates\\BackgroundDownload",
               "\\OneDrive Standalone Update Task-S-1-5-21*",
               "\\OneDrive Standalone Update Task-S-1-12-1-*",
+              "\\OneDrive Per-Machine Standalone Update Task",
               "\\SoftLanding\\S-1-5-21-*\\SoftLanding*",
               "\\SoftLanding\\S-1-12-*\\SoftLanding*",
               "\\OneDrive Reporting Task-S-1-5-21-*",
@@ -87,7 +87,19 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
               "\\GoogleUserPEH\\RunPlatformExperienceHelper*",
               "\\Mozilla\\Firefox Default Browser Agent*",
               "\\Microsoft\\Office\\Office Background Push Maintenance",
-              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate"
+              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate",
+              "\\Microsoft\\Windows\\DeviceLicensingService\\*",
+              "\\Microsoft\\Windows\\RemovalTools\\MRT_ERROR_HB",
+              "\\PRTG Windows Update Sensor",
+              "\\AMDLinkUpdate",
+              "\\AMDInstallLauncher",
+              "\\PowerToys\\Autorun for *",
+              "\\Lenovo\\LenovoMachineFixUser*",
+              "\\Barco ClickShare Update Task",
+              "\\npcapwatchdog",
+              "\\BlazerBrowserStartupTask",
+              "\\BlazerBrowserUpdateTask",
+              "\\ZoomVDIMGMTTaskUser"
  )
 '''
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1004

Reduces noise from widespread benign scheduled task creation by expanding the TaskName exclusion list. Adds filters for PRTG monitoring sensors, AMD driver updates, Microsoft PowerToys autorun tasks, Windows DeviceLicensingService and MRT tasks, OneDrive per-machine updates, Lenovo OEM tasks, Barco ClickShare, Blazer Browser, Zoom VDI management, and Npcap watchdog tasks. Also widens the HP WarrantyChecker exclusion to cover machine-specific task name suffixes.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
