### PR TITLE
[Rule Tuning] Potential AWS S3 Bucket Ransomware Note Uploaded

### DIFF
--- a/rules/integrations/aws/impact_s3_bucket_object_uploaded_with_ransom_keyword.toml
+++ b/rules/integrations/aws/impact_s3_bucket_object_uploaded_with_ransom_keyword.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/04/17"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/07/13"
 
 [rule]
 author = ["Elastic"]
@@ -121,7 +121,7 @@ file where
   event.outcome == "success" and
   /* Apply regex to match patterns only after the bucket name */
   /* common ransom note file name keywords */
-  aws.cloudtrail.resources.arn regex~ "arn:aws:s3:::[^/]+/.*?(how|decrypt|restor|help|instruct|read|get|recov|save|encrypt|info|ransom).*"
+  aws.cloudtrail.resources.arn regex~ "arn:aws:s3:::[^/]+/.*?(how|decrypt|restor|help|instruct|read|get|recov|save|encrypt|delet|info|ransom).*"
   and not aws.cloudtrail.resources.arn regex~ ".*(AWSLogs|CloudTrail|access-logs).*"
   and not aws.cloudtrail.user_identity.type == "AWSService"
 '''


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/921
* https://github.com/elastic/ia-trade-team/issues/1012

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

Added `delet` to the ransom-note keyword regex (`...encrypt|delet|info|ransom...`).

## Why it matters

Found while live-testing Stratus Red Team's `s3-ransomware-batch-deletion`/`s3-ransomware-individual-deletion` techniques, the uploaded ransom note used a deletion-themed filename that the original keyword list didn't match, so the rule silently missed it.

<!--
  Summarize your PR. Animated gifs are 💯. Code snippets are ⚡️. Examples & screenshots are 🔥
-->

## How To Test

Query can be used in TRADE stack and other telemetry stacks.

<!--
  Some examples of what you could include here are:
  * Links to GitHub action results for CI test improvements
  * Sample data before/after screenshots (or short videos showing how something works)
  * Copy/pasted commands and output from the testing you did in your local terminal window
  * If tests run in GitHub, you can 🪁or 🔱, respectively, to indicate tests will run in CI
  * Query used in your stack to verify the change
-->

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?