### PR TITLE
[Rule Tuning] Suspicious Windows Powershell Arguments

### DIFF
--- a/rules/windows/execution_windows_powershell_susp_args.toml
+++ b/rules/windows/execution_windows_powershell_susp_args.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/09/06"
 integration = ["endpoint", "windows", "system", "sentinel_one_cloud_funnel", "m365_defender", "crowdstrike"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/13"
 
 [rule]
 author = ["Elastic"]
@@ -168,8 +168,6 @@ process where host.os.type == "windows" and event.type == "start" and
 
     process.args : "$*$*;set-alias" or
 
-    process.args == "-e" or
-
     // ATHPowerShellCommandLineParameter
     process.args : ("-EncodedCommandParamVariation", "-UseEncodedArguments", "-CommandParamVariation") or
 
@@ -179,7 +177,9 @@ process where host.os.type == "windows" and event.type == "start" and
     ) and
     not process.command_line : (
       "*Use-Icinga -Minimal*",
-      "*& {$j = sajb {Add-Type -AssemblyName*"
+      "*& {$j = sajb {Add-Type -AssemblyName*",
+      "*ConvertTo-Csv*",
+      "*Get-Counter*"
     )
 '''
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1018

Removes the overly broad standalone process.args == "-e" condition which is redundant with the existing command_line pattern "* -e *" and generates false positives on data sources with incomplete command_line telemetry. Adds exclusions for benign monitoring tool patterns where ConvertTo-Csv paired with .Replace and Get-Counter paired with replace trigger the rule's broad .replace command_line match.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
