### PR TITLE
[Rule Tuning] Component Object Model Hijacking

### DIFF
--- a/rules/windows/persistence_suspicious_com_hijack_registry.toml
+++ b/rules/windows/persistence_suspicious_com_hijack_registry.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/18"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/14"
 
 [rule]
 author = ["Elastic"]
@@ -127,7 +127,9 @@ registry where host.os.type == "windows" and event.type == "change" and
         "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
         "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
         "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
-        "Vivaldi Technologies AS"
+        "Vivaldi Technologies AS", "WPS SOFTWARE PTE. LTD.", "Anysphere, Inc.", "ASUSTeK COMPUTER INC.", "Proton AG",
+        "ALE International", "ELEMENT CREATIONS LIMITED", "SteelSeries France SASU", "A-Volute SAS",
+        "nordvpn s.a.", "INCA Internet Co.,Ltd.", "London Stock Exchange Group plc"
     )
   ) and 
 
@@ -136,9 +138,10 @@ registry where host.os.type == "windows" and event.type == "change" and
   (
     process.name : (
       "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
-      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe", "powershell.exe",
+      "Code.exe", "mighost.exe"
     ) and
-    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation", "Microsoft Windows Publisher")
   ) and
   
   not process.executable : (


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1021

Reduces false positives from trusted-signed desktop and utility applications registering COM objects during normal operation. Expands the code-signature exclusion list with ten additional vendors including WPS Office, Cursor, ASUS, Proton, Nahimic/A-Volute, ALE International, INCA Internet, NordVPN, Element, and London Stock Exchange Group. Adds powershell.exe, Code.exe, and mighost.exe to the Microsoft-signed process exclusion block to suppress benign ToastActivated COM registrations, VS Code LocalServer32 updates, and Windows migration host TypeLib writes.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
