### PR TITLE
[Rule Tuning] Suspicious Inter-Process Communication via Outlook

### DIFF
--- a/rules/windows/collection_email_outlook_mailbox_via_com.toml
+++ b/rules/windows/collection_email_outlook_mailbox_via_com.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/01/11"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/15"
 
 [rule]
 author = ["Elastic"]
@@ -43,7 +43,8 @@ sequence with maxspan=1m
       (process.code_signature.trusted == false or process.code_signature.exists == false) and
       (process.Ext.relative_file_creation_time <= 500 or process.Ext.relative_file_name_modify_time <= 500)
     )
-  )
+  ) and
+  not process.parent.name : "cybercnsagent.exe"
 ] by process.entity_id
 [process where host.os.type == "windows" and event.action == "start" and process.name : "OUTLOOK.EXE" and
   process.Ext.effective_parent.name != null] by process.Ext.effective_parent.entity_id


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1027

Reduces false positives from the CyberCNS IT management agent, which periodically spawns PowerShell to check Outlook version via COM across 20 clusters. Adds a parent process exclusion for cybercnsagent.exe in the first sequence event to filter this benign IT inventory activity.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
