### PR TITLE
[Rule Tuning] Command Line Obfuscation via Whitespace Padding - ignore trailing-only padding from process-title rewrites

### DIFF
--- a/rules/cross-platform/defense_evasion_whitespace_padding_command_line.toml
+++ b/rules/cross-platform/defense_evasion_whitespace_padding_command_line.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/06/30"
 integration = ["endpoint", "system", "windows", "auditd_manager", "m365_defender", "crowdstrike", "sentinel_one_cloud_funnel"]
 maturity = "production"
-updated_date = "2026/03/24"
+updated_date = "2026/07/15"
 
 [rule]
 author = ["Elastic"]

--- a/rules/cross-platform/defense_evasion_whitespace_padding_command_line.toml
+++ b/rules/cross-platform/defense_evasion_whitespace_padding_command_line.toml
@@ -88,7 +88,9 @@ query = '''
 FROM logs-* metadata _id, _version, _index 
 | where event.category == "process" and event.type == "start" and event.action != "fork"
 // more than 100 spaces in process.command_line
-| eval multi_spaces = LOCATE(process.command_line, space(100)) 
+// trim first so trailing/leading padding from process-title rewrites (setproctitle) is ignored;
+// only internal runs of 100+ spaces — actual command obfuscation — will match
+| eval multi_spaces = LOCATE(TRIM(process.command_line), space(100))
 | where multi_spaces > 0 
 | keep user.name, host.id, host.name, process.command_line, process.executable, process.parent.executable, _id, _version, _index
 '''


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: N/A — summary below; labelled `Rule: Tuning`.

## Summary - What I changed

`Command Line Obfuscation via Whitespace Padding` (rule_id `5a876e0d-d39a-49b9-8ad8-19c9b622203b`)
fires on any `process.command_line` containing 100+ contiguous spaces. In practice, the
dominant match in our environment is a benign mechanism: **setproctitle-style process-title
rewrites on Linux/Unix hosts**. When a process overwrites its title in the argv buffer, the
remainder of the original (longer) buffer is left as trailing spaces, which telemetry sources
(notably Microsoft Defender for Endpoint `DeviceProcessEvents`) capture as part of
`ProcessCommandLine`. Common producers:

- Node.js worker pools rewriting titles, e.g. `"node (vitest)"` + ~100-250 trailing spaces
  (vitest, gulp, and similar dev tooling on developer workstations)
- OpenSSH ControlMaster multiplexing: `ssh: /root/.ansible/cp/<hash> [mux]` (Ansible connection reuse)
- sshd per-session titles: `sshd: user@notty`, `sshd: [accepted]`, `sshd: root [priv]`

All of these pad only at the **end** of the command line. Deliberate command obfuscation
(the behaviour this rule targets, T1027.010) pads **between** tokens to break signature
matching — trailing padding contributes nothing to evasion.

Change: trim the command line before searching for the 100-space run, so only internal
padding matches:

​```esql
| eval multi_spaces = LOCATE(TRIM(process.command_line), space(100))
​```

## How To Test

Measured on our production stack (MDE `DeviceProcessEvents` telemetry, ES|QL on 9.x):

​```esql
FROM logs-* metadata _id
| where event.category == "process" and event.type == "start" and event.action != "fork"
| eval original = case(locate(process.command_line, space(100)) > 0, 1, null),
       trimmed  = case(locate(trim(process.command_line), space(100)) > 0, 1, null)
| stats matches_original = count(original), matches_after_trim = count(trimmed)
​```

Results:

| Window | Matches (current logic) | Matches (with TRIM) |
|--------|------------------------|---------------------|
| 24h (~5.5M process starts) | 151 | 0 |
| 7d | 314 | 1 |

- 100% of the current-logic matches were trailing-only padding from the three process-title
  patterns above (all benign, verified).
- The single 7d survivor had genuine internal padding — exactly the behaviour the rule
  should keep flagging — demonstrating the tune preserves the intended detection.
- Synthetic check: a command line padded internally (e.g. `cmd.exe /c calc.exe<150 spaces>-flag`)
  still matches after TRIM; the same padding moved to the end no longer matches.

One observation for reviewers: filtering `host.os.type != "linux"` is not sufficient to
suppress this FP class, because some sources map Linux distros (e.g. RHEL via MDE) to
`host.os.type: "unix"`. TRIM addresses the mechanism regardless of OS mapping and keeps
Linux/macOS/Windows all in scope.

## Checklist

- [x] Added a label for the type of pr: `Rule: Tuning`
- [x] Secret and sensitive material has been managed correctly

## Contributor checklist

- [x] Signed the contributor license agreement
- [x] Followed the contributor guidelines