### PR TITLE
[Rule Tuning] Exclude Kea DHCP from CAP_NET_RAW building block

### DIFF
--- a/rules_building_block/discovery_capnetraw_capability.toml
+++ b/rules_building_block/discovery_capnetraw_capability.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/01/10"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2024/12/24"
+updated_date = "2026/07/19"
 
 [rule]
 author = ["Elastic"]
@@ -63,7 +63,7 @@ type = "new_terms"
 query = '''
 event.category:"process" and host.os.type:"linux" and event.type:"start" and event.action:"exec" and process.name:* and
 (process.thread.capabilities.effective:"CAP_NET_RAW" or process.thread.capabilities.permitted:"CAP_NET_RAW") and
-not user.id:"0"
+not user.id:"0" and not process.executable:"/usr/sbin/kea-dhcp4"
 '''
 
 [[rule.threat]]

--- a/tests/test_specific_rules.py
+++ b/tests/test_specific_rules.py
@@ -169,6 +169,32 @@ class TestNewTerms(BaseRuleTest):
                 )
 
 
+class TestCAPNetRawBuildingBlock(BaseRuleTest):
+    """Test the CAP_NET_RAW building block's known benign exclusion."""
+
+    def test_kea_dhcp4_is_excluded_but_other_non_root_processes_match(self):
+        """Exclude the reported Kea DHCP binary without suppressing CAP_NET_RAW detections broadly."""
+        rule = self.all_rules.id_map["e28b8093-833b-4eda-b877-0873d134cf3c"]
+        evaluator = kql.get_evaluator(rule.contents.data.query, optimize=False)
+        kea_dhcp4_event = {
+            "event": {"action": ["exec"], "category": ["process"], "type": ["start"]},
+            "host": {"os": {"type": "linux"}},
+            "process": {
+                "executable": "/usr/sbin/kea-dhcp4",
+                "name": "kea-dhcp4",
+                "thread": {"capabilities": {"effective": ["CAP_NET_RAW"]}},
+            },
+            "user": {"id": "973"},
+        }
+
+        self.assertFalse(evaluator(kea_dhcp4_event))
+
+        other_cap_net_raw_event = deepcopy(kea_dhcp4_event)
+        other_cap_net_raw_event["process"]["executable"] = "/opt/packet-sniffer"
+        other_cap_net_raw_event["process"]["name"] = "packet-sniffer"
+        self.assertTrue(evaluator(other_cap_net_raw_event))
+
+
 class TestESQLRules(BaseRuleTest):
     """Test ESQL Rules."""
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: Closes #5826

## Problem

The `Network Traffic Capture via CAP_NET_RAW` building block alerts on the reported Elastic Defend process-start event for the legitimate Kea DHCP server at `/usr/sbin/kea-dhcp4`. The service runs as a non-root account and legitimately has `CAP_NET_RAW`, so it satisfies the current query and creates false-positive noise.

## Solution

Exclude only `process.executable:"/usr/sbin/kea-dhcp4"` and update the rule metadata date. This does not exclude the Kea account, every `kea-dhcp4` binary, or other non-root `CAP_NET_RAW` processes.

Added a regression test that evaluates the actual rule query against the reported event shape and asserts it no longer matches. The same test asserts that an otherwise equivalent non-root `CAP_NET_RAW` process at `/opt/packet-sniffer` still matches.

## How To Test

```bash
source env/detection-rules-build/bin/activate
python -m pytest tests/test_specific_rules.py::TestCAPNetRawBuildingBlock -vv
python -m ruff check tests/test_specific_rules.py
python -m ruff format --check tests/test_specific_rules.py
python -m pytest tests/kuery/test_evaluator.py -q
python -m detection_rules test
```

Local results:

- Focused behavioral regression: `1 passed`.
- Ruff check and format check: passed.
- KQL evaluator suite: `13 passed`.
- Full repository suite: `306 passed, 19 skipped, 2 warnings, 2 subtests passed`.

The skipped tests require remote Elasticsearch/Kibana ESQL validation and are unrelated to this KQL rule tune.

## Checklist

- [ ] Add the `Rule: Tuning` PR label (maintainer action required for external contributors).
- [x] No secrets or sensitive host data are included; the test uses only relevant normalized fields from the issue report.
- [x] Added a behavioral regression test and preserved positive detection coverage.
- [x] Rule metadata `updated_date` is updated for this tuning.
- [x] The query remains inclusive outside the single reported executable path.

## Contributor checklist

- [ ] I have signed the Elastic Contributor License Agreement.
- [x] I followed the repository contribution and rule-tuning guidelines.
