### PR TITLE
[Bug] Fix MITRE v19 testing harness

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.0.0"
+version = "2.0.1"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_threat_mappings.py
+++ b/tests/test_threat_mappings.py
@@ -10,6 +10,7 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, ClassVar
+from unittest import mock
 
 from marshmallow import ValidationError
 
@@ -18,6 +19,7 @@ from detection_rules.config import (
     THREAT_MAPPING_VERSION_ENV,
 )
 from detection_rules.rule_loader import RuleCollection
+from detection_rules.stack_emit import MITRE_V19_MIN_STACK
 
 TACTIC = {
     "id": "TA0001",
@@ -57,6 +59,14 @@ def _rule(threat_mappings: list[dict[str, Any]] | None = None) -> dict[str, Any]
     if threat_mappings is not None:
         rule["threat_mappings"] = threat_mappings
     return rule
+
+
+def _pin_v19_stack() -> Any:
+    """Pin the emit stack to the v19 gate so stack-gated transforms apply on release branches (< 9.5)."""
+    return mock.patch(
+        "detection_rules.rule.load_current_package_version",
+        return_value=f"{MITRE_V19_MIN_STACK.major}.{MITRE_V19_MIN_STACK.minor}",
+    )
 
 
 def _v19_block(technique: dict[str, Any] = TECH_V19) -> dict[str, Any]:
@@ -160,7 +170,7 @@ class TestVersionedThreatMappingSchema(unittest.TestCase):
     def test_selects_v19_when_configured(self) -> None:
         """Assert that v19 output emits the v19 threat block when configured."""
         rule = self._load(_rule(threat_mappings=[_v19_block()]))
-        with ThreatMappingEnv("19"):
+        with ThreatMappingEnv("19"), _pin_v19_stack():
             api = rule.contents.to_api_format()
         self.assertNotIn("threat_mappings", api)
         self.assertEqual(api["threat"][0]["technique"][0]["name"], "Valid Accounts (v19)")
@@ -181,7 +191,7 @@ class TestVersionedThreatMappingSchema(unittest.TestCase):
     def test_auto_converts_when_no_threat_mappings_block(self) -> None:
         """Assert that v19 output auto-converts from baseline when no threat_mappings exist."""
         rule = self._load(_rule())
-        with ThreatMappingEnv("19"):
+        with ThreatMappingEnv("19"), _pin_v19_stack():
             api = rule.contents.to_api_format(apply_emit_transforms=True)
         self.assertNotIn("threat_mappings", api)
         self.assertTrue(api.get("threat"))
@@ -218,7 +228,7 @@ class TestVersionedThreatMappingSchema(unittest.TestCase):
             "threat": [{"framework": "MITRE ATT&CK", "tactic": custom_tactic, "technique": [custom_tech]}],
         }
         rule = self._load(_rule(threat_mappings=[override_block]))
-        with ThreatMappingEnv("19"):
+        with ThreatMappingEnv("19"), _pin_v19_stack():
             api = rule.contents.to_api_format()
         self.assertEqual(api["threat"][0]["tactic"]["name"], "Custom Name Override")
         self.assertEqual(api["threat"][0]["technique"][0]["name"], "Custom Tech Name")

--- a/tests/test_threat_mappings.py
+++ b/tests/test_threat_mappings.py
@@ -65,7 +65,7 @@ def _pin_v19_stack() -> Any:
     """Pin the emit stack to the v19 gate so stack-gated transforms apply on release branches (< 9.5)."""
     return mock.patch(
         "detection_rules.rule.load_current_package_version",
-        return_value=f"{MITRE_V19_MIN_STACK.major}.{MITRE_V19_MIN_STACK.minor}",
+        return_value=str(MITRE_V19_MIN_STACK),
     )
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:


Related to https://github.com/elastic/detection-rules/pull/6367

Example failing run: https://github.com/elastic/detection-rules/actions/runs/29612541794/job/87990291790


## Summary - What I changed


Fixes the unit test failures on the `8.19`, `9.2`, `9.3`, and `9.4` branches introduced by the
backport of #6367 (`tests/test_threat_mappings.py::TestVersionedThreatMappingSchema::test_selects_v19_when_configured`
and `::test_explicit_threat_mappings_overrides_auto_conversion`).

**Root cause**

The failing tests set `DR_THREAT_MAPPING_VERSION=19` and assert that `to_api_format()` emits the v19 threat mapping. However, v19 emission happens inside the `mitre_attack_v19` emit, which is gated on `min_stack=MITRE_V19_MIN_STACK` (9.5.0) in `stack_emit.py`. `to_api_format()` applies transforms with `stack=load_current_package_version()` (from `packages.yaml`), so on release branches packaging < 9.5 the transform is filtered out by `transforms_for_stack()` before the env var is ever consulted. 

Therefore, the baseline v18 `threat` is emitted and the assertions fail. The tests only passed on `main` because its package version is `9.5`.

The transform gate itself is correct (a 9.4 package must not ship v19 mappings); the tests were
implicitly coupled to the branch's package version.

**Fix**

- Add a `_pin_v19_stack()` helper to `tests/test_threat_mappings.py` that patches `detection_rules.rule.load_current_package_version` to return the v19 gate stack (`9.5`).
- Wrap the three v19-dependent tests with it.

The emit behavior per stack is unchanged.

> [!IMPORTANT]
> Given that unit tests are failing on the release branches, this PR will need to be merged where we bypass stack protections.

## How To Test


Reproduce the branch failures locally on `main` by pointing the package at a pre-9.5 stack, then
verify the fix passes on all package versions:

```bash
# before fix: fails with AssertionError: 'Valid Accounts' != 'Valid Accounts (v19)'
git checkout origin/9.4 -- detection_rules/etc/packages.yaml
pytest tests/test_threat_mappings.py -q
```

After the fix, all 39 tests in the file pass with the package version set to `9.5`, `9.4`, and
`8.19`:

```
git checkout origin/9.4 -- detection_rules/etc/packages.yaml
python -m detection_rules test
```

<img width="1194" height="1066" alt="image" src="https://github.com/user-attachments/assets/ad04c94f-4e06-440c-b8c5-a1de97e73277" />



## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
