### PR TITLE
[Rule Tuning] Temporarily Scheduled Task Creation

### DIFF
--- a/rules/windows/persistence_temp_scheduled_task.toml
+++ b/rules/windows/persistence_temp_scheduled_task.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/20"
 
 [rule]
 author = ["Elastic"]
@@ -67,7 +67,24 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
-   [iam where host.os.type == "windows" and event.action == "scheduled-task-created" and not user.name : "*$"]
+   [iam where host.os.type == "windows" and event.action == "scheduled-task-created" and not user.name : "*$" and
+     not winlog.event_data.TaskName : (
+       "\\GoogleUserPEH\\*",
+       "\\PRTG *",
+       "*\\HP Support Assistant\\*",
+       "\\OneDrive Standalone Update Task*",
+       "*Firefox Default Browser Agent*",
+       "*\\DeviceLicensingService\\*",
+       "\\PowerToys\\Autorun*",
+       "\\Cortex-Local-Server-*",
+       "\\AMDLinkUpdate",
+       "\\RunAADCHTestConnectivityAsSystem",
+       "\\ZoomUpdateTaskUser-*",
+       "*ansible-ansible.windows.win_updates*",
+       "\\CreateExplorerShellUnelevatedTask",
+       "\\SoftLanding\\*"
+     )
+   ]
    [iam where host.os.type == "windows" and event.action == "scheduled-task-deleted" and not user.name : "*$"]
 '''
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1033

Reduces noise from well-known software that routinely creates and immediately deletes scheduled tasks as part of normal operation. Adds task-name exclusions in the first sequence event for Google Chrome Platform Experience Helper, PRTG Network Monitor, Microsoft OneDrive and PowerToys, Mozilla Firefox Default Browser Agent, HP Support Assistant, Palo Alto Cortex XDR, Windows DeviceLicensingService, 1E SoftLanding, AMD Link Update, Azure AD Connect Health, Zoom client updates, Ansible win_updates, and the Windows Explorer shell unelevated task. Red-team testing patterns such as ATOMIC and T1053_005 tasks are preserved.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
