### PR TITLE
[New Rule/Tuning] PHP File Creation in WordPress Plugin Directory

### DIFF
--- a/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
+++ b/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
@@ -7,8 +7,8 @@ updated_date = "2026/07/20"
 [rule]
 author = ["Elastic"]
 description = """
-Detects the creation of a php file in the wordpress plugin directory, which is a common technique used
-by attackers to establish persistence on a compromised web server. Attackers may upload a malicious php
+Detects the creation of a PHP file in the WordPress plugin directory, which is a common technique used
+by attackers to establish persistence on a compromised web server. Attackers may upload a malicious PHP
 file and call it from a web browser to gain remote access to the server.
 """
 false_positives = [

--- a/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
+++ b/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
@@ -1,0 +1,120 @@
+[metadata]
+creation_date = "2026/07/20"
+integration = ["endpoint"]
+maturity = "production"
+updated_date = "2026/07/20"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects the creation of a php file in the wordpress plugin directory, which is a common technique used
+by attackers to establish persistence on a compromised web server. Attackers may upload a malicious php
+file and call it from a web browser to gain remote access to the server.
+"""
+false_positives = [
+    """
+    Web servers or administrators may create php files in the wordpress plugin directory during maintenance.
+    """,
+]
+from = "now-9m"
+index = ["logs-endpoint.events.file*"]
+language = "eql"
+license = "Elastic License v2"
+name = "PHP File Creation in WordPress Plugin Directory"
+references = [
+    "https://github.com/Icex0/wp2shell-poc",
+]
+risk_score = 21
+rule_id = "fb76c80b-3eb2-4c56-9ed1-e4c529425d0f"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "low"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Persistence",
+    "Tactic: Initial Access",
+    "Use Case: Vulnerability",
+    "Resources: Investigation Guide",
+    "Data Source: Elastic Defend"
+]
+timestamp_override = "event.ingested"
+type = "eql"
+query = '''
+file where host.os.type == "linux" and event.type in ("creation", "change") and (
+  process.name in (
+    "nginx", "apache2", "httpd", "php-cgi", "php-fcgi", "php-cgi.cagefs",  "sw-engine-fpm",
+    "wget", "curl", "bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh", "busybox"
+  ) or
+  process.name like ("php-fpm*", "lsphp*", "*.cgi", "*.fcgi")
+) and
+file.path like~ "*/wp-content/plugins/*.php*"
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1505"
+name = "Server Software Component"
+reference = "https://attack.mitre.org/techniques/T1505/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1505.003"
+name = "Web Shell"
+reference = "https://attack.mitre.org/techniques/T1505/003/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1190"
+name = "Exploit Public-Facing Application"
+reference = "https://attack.mitre.org/techniques/T1190/"
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"

--- a/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
+++ b/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
@@ -13,7 +13,7 @@ file and call it from a web browser to gain remote access to the server.
 """
 false_positives = [
     """
-    Web servers or administrators may create php files in the wordpress plugin directory during maintenance.
+    Web servers or administrators may create PHP files in the WordPress plugin directory during maintenance.
     """,
 ]
 from = "now-9m"

--- a/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
+++ b/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
@@ -59,7 +59,6 @@ tags = [
     "Tactic: Persistence",
     "Tactic: Initial Access",
     "Use Case: Vulnerability",
-    "Resources: Investigation Guide",
     "Data Source: Elastic Defend"
 ]
 timestamp_override = "event.ingested"

--- a/rules/linux/persistence_webserver_suspicious_child_execution.toml
+++ b/rules/linux/persistence_webserver_suspicious_child_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2023/03/04"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/07/02"
+updated_date = "2026/07/20"
 
 [transform]
 [[transform.osquery]]
@@ -147,7 +147,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     "php-cgi", "php-fcgi", "php-cgi.cagefs", "lswsctrl", "varnishd", "uvicorn", "waitress-serve", "starman",
     "frankenphp", "zabbix_server", "asterisk", "sw-engine-fpm"
   ) or
-  process.parent.name like ("php-fpm*", "gunicorn*", "*.cgi", "*.fcgi") or
+  process.parent.name like ("php-fpm*", "lsphp*", "gunicorn*", "*.cgi", "*.fcgi") or
   (
     process.parent.name like "ruby*" and
     process.parent.command_line like~ ("*puma*", "*rails*", "*passenger*")

--- a/rules/linux/persistence_webserver_suspicious_command_execution.toml
+++ b/rules/linux/persistence_webserver_suspicious_command_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/06/01"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/06/18"
+updated_date = "2026/07/20"
 
 [rule]
 author = ["Elastic"]
@@ -100,7 +100,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     "php-cgi", "php-fcgi", "php-cgi.cagefs", "lswsctrl", "varnishd", "uvicorn", "waitress-serve", "starman",
     "frankenphp", "zabbix_server", "asterisk", "sw-engine-fpm"
   ) or
-  process.parent.name like ("php-fpm*", "gunicorn*", "*.cgi", "*.fcgi") or
+  process.parent.name like ("php-fpm*", "lsphp*", "gunicorn*", "*.cgi", "*.fcgi") or
   (
     process.parent.name like "ruby*" and
     process.parent.command_line like~ ("*puma*", "*rails*", "*passenger*")

--- a/rules/linux/persistence_webserver_unusual_child_execution.toml
+++ b/rules/linux/persistence_webserver_unusual_child_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/06/01"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/06/04"
+updated_date = "2026/07/20"
 
 [rule]
 author = ["Elastic"]
@@ -70,7 +70,7 @@ event.category:process and host.os.type:linux and event.type:start and event.act
     apache2 or asterisk or caddy or daphne or flask or frankenphp or httpd or httpd.worker or
     lswsctrl or mongrel_rails or nginx or php-cgi or php-cgi.cagefs or php-fcgi or starman or
     sw-engine-fpm or uvicorn or uwsgi or varnishd or waitress-serve or zabbix_server or *.cgi
-    or *.fcgi or gunicorn* or php-fpm*
+    or *.fcgi or gunicorn* or php-fpm* or lsphp*
   ) or
   process.parent.name:ruby* and process.parent.command_line:(*passenger* or *puma* or *rails*) or
   process.parent.name:python* and process.parent.command_line:(

--- a/rules/linux/persistence_webserver_unusual_command_execution.toml
+++ b/rules/linux/persistence_webserver_unusual_command_execution.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/12/02"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/06/04"
+updated_date = "2026/07/20"
 
 [rule]
 author = ["Elastic"]
@@ -69,7 +69,7 @@ event.category:process and host.os.type:linux and event.type:start and event.act
     apache2 or asterisk or caddy or daphne or flask or frankenphp or httpd or httpd.worker or
     lswsctrl or mongrel_rails or nginx or php-cgi or php-cgi.cagefs or php-fcgi or starman or
     sw-engine-fpm or uvicorn or uwsgi or varnishd or waitress-serve or zabbix_server or *.cgi
-    or *.fcgi or gunicorn* or php-fpm*
+    or *.fcgi or gunicorn* or php-fpm* or lsphp*
   ) or
   process.parent.name:ruby* and process.parent.command_line:(*passenger* or *puma* or *rails*) or
   process.parent.name:python* and process.parent.command_line:(


### PR DESCRIPTION
## Summary
Detects the creation of a PHP file in the WordPress plugin directory, which is a common technique used by attackers to establish persistence on a compromised web server. Attackers may upload a malicious PHP file and call it from a web browser to gain remote access to the server.

