### PR TITLE
[Rule Tuning] PHP File Creation in WordPress Plugin Directory

### DIFF
--- a/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
+++ b/rules/linux/persistence_webserver_php_file_creation_in_wordpress_plugin_dir.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/07/20"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/07/20"
+updated_date = "2026/07/22"
 
 [rule]
 author = ["Elastic"]
@@ -71,7 +71,7 @@ file where host.os.type == "linux" and event.type in ("creation", "change") and 
   ) or
   process.name like ("php-fpm*", "lsphp*", "*.cgi", "*.fcgi")
 ) and
-file.path like~ "*/wp-content/plugins/*.php*"
+file.path like~ "*/wp-content/plugins/*"
 '''
 
 [[rule.threat]]


### PR DESCRIPTION
## Summary
Removing the enforcement of the `.php` extension.

<img width="1163" height="706" alt="{A77A6F0D-3C81-4BA4-8D0F-284285177D7D}" src="https://github.com/user-attachments/assets/8a55bfb6-0981-4a96-97a6-50c58efb6f55" />
