### PR TITLE
[Rule Tuning] Potential Lateral Tool Transfer via SMB Share

### DIFF
--- a/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
+++ b/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/10"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/23"
 
 [rule]
 author = ["Elastic"]
@@ -88,8 +88,18 @@ sequence by host.id with maxspan=30s
    network.transport == "tcp" and source.ip != "127.0.0.1" and source.ip != "::1"
   ] by process.entity_id
   /* add more executable / script extensions here if they are not noisy in your environment */
-  [file where host.os.type == "windows" and event.type in ("creation", "change") and process.pid == 4 and user.id like ("S-1-5-21*", "S-1-12-*") and 
-   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl"))] by process.entity_id
+  [file where host.os.type == "windows" and event.type in ("creation", "change") and process.pid == 4 and user.id like ("S-1-5-21*", "S-1-12-*") and
+   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl")) and
+   not file.path : (
+     "?:\\Windows\\AdminArsenal\\*",
+     "?:\\Windows\\VeeamVssSupport\\*",
+     "?:\\Windows\\VeeamLogShipper\\*",
+     "?:\\Windows\\Veeam\\Backup\\*",
+     "?:\\Sysmon\\*",
+     "?:\\Windows\\Temp\\KAV Remote Installations\\*",
+     "?:\\Windows\\SysWOW64\\Qualys\\*",
+     "?:\\Windows\\SysWOW64\\NwxExeSvc\\*"
+   )] by process.entity_id
 '''
 
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1037

Reduces noise from legitimate IT management and backup tools being deployed over SMB shares. Adds file path exclusions in the file event leg of the sequence for PDQ Deploy/Inventory (AdminArsenal), Veeam backup components (VssSupport, LogShipper, Backup agent), Sysmon deployment artifacts, Kaspersky remote installations, Qualys agent updates, and NetWrix agent binaries. These are all well-known enterprise tools that routinely transfer executables and DLLs via SMB and account for approximately 85% of observed alert volume across dozens of clusters.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
