### PR TITLE
[FR] Add Safeguard for Kibana Rule Exception Race Condition

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -275,8 +275,7 @@ Options:
   -e, --overwrite-exceptions      Overwrite exceptions in existing rules
   -ac, --overwrite-action-connectors
                                   Overwrite action connectors in existing rules
-  -ed, --enable-delay INTEGER RANGE
-                                  Import rules as disabled, wait the given number of seconds, then enable the rules
+  -ed, --enable-delay SECONDS     Import rules as disabled, wait the given number of seconds, then enable the rules
                                   that were originally enabled. Guards against a race condition where rules can run
                                   before their exceptions and action connectors are fully applied.  [x>=0]
   -h, --help                      Show this message and exit.

--- a/CLI.md
+++ b/CLI.md
@@ -275,7 +275,20 @@ Options:
   -e, --overwrite-exceptions      Overwrite exceptions in existing rules
   -ac, --overwrite-action-connectors
                                   Overwrite action connectors in existing rules
+  -ed, --enable-delay INTEGER RANGE
+                                  Import rules as disabled, wait the given number of seconds, then enable the rules
+                                  that were originally enabled. Guards against a race condition where rules can run
+                                  before their exceptions and action connectors are fully applied.  [x>=0]
   -h, --help                      Show this message and exit.
+```
+
+When importing rules that have exceptions or action connectors attached, a rule can start running before its
+exceptions are fully applied, which can generate false positive alerts. Use the `--enable-delay` option to guard
+against this: rules are imported as disabled, and after the given delay, the rules that were originally enabled
+(`enabled = true`) are enabled via the bulk action API. Rules that were not originally enabled remain disabled.
+
+```
+python -m detection_rules kibana import-rules -d test-export-rules -o --enable-delay 30
 ```
 
 Example usage of a successful upload:

--- a/CLI.md
+++ b/CLI.md
@@ -281,12 +281,14 @@ Options:
   -h, --help                      Show this message and exit.
 ```
 
-When importing rules that have exceptions or action connectors attached, a rule can start running before its
-exceptions are fully applied, which can generate false positive alerts. Use the `--enable-delay` option to guard
-against this: rules are imported as disabled, and after the given delay, the rules that were originally enabled
-(`enabled = true`) are enabled via the bulk action API. Rules that omit `enabled` retain their current state when
-overwritten, and new rules use Kibana's enabled-by-default behavior. Rules that were not originally enabled remain
-disabled. The delay must be at least one second.
+A rule with attached exceptions or action connectors can start running before those are fully applied, which can
+generate false positive alerts. `--enable-delay SECONDS` (minimum `1`) guards against this by importing every rule
+as disabled, waiting out the delay, then enabling the rules that were meant to be enabled:
+
+- `enabled = true` in the rule file: enabled after the delay.
+- `enabled = false`: left disabled.
+- `enabled` omitted (the common case for DaC rules): the state Kibana would have applied on import — the currently
+  deployed state when overwriting an existing rule, or enabled for a new rule.
 
 ```
 python -m detection_rules kibana import-rules -d test-export-rules -o --enable-delay 30

--- a/CLI.md
+++ b/CLI.md
@@ -275,16 +275,18 @@ Options:
   -e, --overwrite-exceptions      Overwrite exceptions in existing rules
   -ac, --overwrite-action-connectors
                                   Overwrite action connectors in existing rules
-  -ed, --enable-delay SECONDS     Import rules as disabled, wait the given number of seconds, then enable the rules
+  --enable-delay SECONDS          Import rules as disabled, wait the given number of seconds, then enable the rules
                                   that were originally enabled. Guards against a race condition where rules can run
-                                  before their exceptions and action connectors are fully applied.  [x>=0]
+                                  before their exceptions and action connectors are fully applied.  [x>=1]
   -h, --help                      Show this message and exit.
 ```
 
 When importing rules that have exceptions or action connectors attached, a rule can start running before its
 exceptions are fully applied, which can generate false positive alerts. Use the `--enable-delay` option to guard
 against this: rules are imported as disabled, and after the given delay, the rules that were originally enabled
-(`enabled = true`) are enabled via the bulk action API. Rules that were not originally enabled remain disabled.
+(`enabled = true`) are enabled via the bulk action API. Rules that omit `enabled` retain their current state when
+overwritten, and new rules use Kibana's enabled-by-default behavior. Rules that were not originally enabled remain
+disabled. The delay must be at least one second.
 
 ```
 python -m detection_rules kibana import-rules -d test-export-rules -o --enable-delay 30

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -7,6 +7,7 @@
 
 import re
 import sys
+import time
 from pathlib import Path
 from typing import Any, cast
 
@@ -101,13 +102,22 @@ def upload_rule(ctx: click.Context, rules: RuleCollection, replace_id: bool) -> 
     is_flag=True,
     help="Overwrite action connectors in existing rules",
 )
+@click.option(
+    "--enable-delay",
+    "-ed",
+    type=click.IntRange(min=0),
+    help="Import rules as disabled, wait the given number of seconds, then enable the rules that were "
+    "originally enabled. Guards against a race condition where rules can run before their exceptions "
+    "and action connectors are fully applied.",
+)
 @click.pass_context
-def kibana_import_rules(  # noqa: PLR0915
+def kibana_import_rules(  # noqa: PLR0913, PLR0915
     ctx: click.Context,
     rules: RuleCollection,
     overwrite: bool = False,
     overwrite_exceptions: bool = False,
     overwrite_action_connectors: bool = False,
+    enable_delay: int | None = None,
 ) -> tuple[dict[str, Any], list[RuleResource]]:
     """Import rules into Kibana."""
 
@@ -179,6 +189,14 @@ def kibana_import_rules(  # noqa: PLR0915
     kibana = ctx.obj["kibana"]
     rule_dicts = [r.contents.to_api_format() for r in rules]
     rule_ids = {rule["rule_id"] for rule in rule_dicts}
+
+    enabled_rule_ids: set[str] = set()
+    if enable_delay is not None:
+        for rule_dict in rule_dicts:
+            if rule_dict.get("enabled", False):
+                enabled_rule_ids.add(rule_dict["rule_id"])
+            rule_dict["enabled"] = False
+
     with kibana:
         cl = GenericCollection.default()
         exception_dicts: list[list[dict[str, Any]]] = [
@@ -207,6 +225,24 @@ def kibana_import_rules(  # noqa: PLR0915
     else:
         _process_imported_items(exception_dicts, "exception list(s)", "list_id")  # type: ignore[reportUnknownArgumentType]
         _process_imported_items(action_connectors_dicts, "action connector(s)", "id")  # type: ignore[reportUnknownArgumentType]
+
+    if enable_delay is not None and enabled_rule_ids:
+        # Rules were imported as disabled; re-enable the originally enabled ones after the delay using the
+        # Kibana object ids of the successfully imported rules
+        ids_to_enable: list[str] = [r["id"] for r in results if r.get("rule_id") in enabled_rule_ids]  # type: ignore[reportUnknownMemberType]
+        if ids_to_enable:
+            click.echo(f"Waiting {enable_delay} second(s) before enabling {len(ids_to_enable)} imported rule(s)")
+            time.sleep(enable_delay)
+            with kibana:
+                # error=False: a partial failure returns a 500 with per-rule details, which is reported below
+                enable_response: dict[str, Any] = RuleResource.bulk_action(  # type: ignore[reportAssignmentType]
+                    "enable", rule_ids=ids_to_enable, error=False
+                )
+            summary: dict[str, Any] = enable_response.get("attributes", {}).get("summary", {})
+            click.echo(f"{summary.get('succeeded', 0)} rule(s) enabled, {summary.get('failed', 0)} failed to enable")
+            for enable_error in enable_response.get("attributes", {}).get("errors", []):
+                failed_rules = ", ".join(str(r.get("id")) for r in enable_error.get("rules", []))
+                click.echo(f" - ({enable_error.get('status_code')}) {enable_error.get('message')}: {failed_rules}")
 
     return response, results  # type: ignore[reportUnknownVariableType]
 

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -106,6 +106,7 @@ def upload_rule(ctx: click.Context, rules: RuleCollection, replace_id: bool) -> 
     "--enable-delay",
     "-ed",
     type=click.IntRange(min=0),
+    metavar="SECONDS",
     help="Import rules as disabled, wait the given number of seconds, then enable the rules that were "
     "originally enabled. Guards against a race condition where rules can run before their exceptions "
     "and action connectors are fully applied.",

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -192,14 +192,21 @@ def kibana_import_rules(  # noqa: PLR0913, PLR0915
 
     enabled_rule_ids: set[str] = set()
     with kibana:
-        if enable_delay is not None:
+        existing_rule_enabled_by_id: dict[str, bool] = {}
+        if enable_delay is not None and any("enabled" not in rule_dict for rule_dict in rule_dicts):
             # Most DaC rules omit `enabled`. For overwrites, retain the currently deployed state;
             # new Kibana rules default to enabled when the field is omitted.
-            existing_rule_enabled_by_id = {
-                rule["rule_id"]: rule["enabled"]
-                for rule in RuleResource.export_rules(list(rule_ids))  # type: ignore[reportUnknownMemberType]
-                if "rule_id" in rule and "enabled" in rule
-            }
+            existing_rules = cast(
+                list[dict[str, Any]],
+                RuleResource.export_rules(list(rule_ids)),  # type: ignore[reportUnknownMemberType]
+            )
+            for existing_rule in existing_rules:
+                rule_id = existing_rule.get("rule_id")
+                enabled = existing_rule.get("enabled")
+                if isinstance(rule_id, str) and isinstance(enabled, bool):
+                    existing_rule_enabled_by_id[rule_id] = enabled
+
+        if enable_delay is not None:
             for rule_dict in rule_dicts:
                 if rule_dict.get("enabled", existing_rule_enabled_by_id.get(rule_dict["rule_id"], True)):
                     enabled_rule_ids.add(rule_dict["rule_id"])

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -35,6 +35,55 @@ from .utils import CUSTOM_RULES_KQL, format_command_options, rulename_to_filenam
 RULES_CONFIG = parse_rules_config()
 
 
+def _force_disabled_import(rule_dicts: list[dict[str, Any]]) -> set[str]:
+    """Rewrite rules to import as disabled and return the rule_ids that should be enabled afterwards."""
+    # Most DaC rules omit `enabled`, in which case the intended state is whatever Kibana would have applied on
+    # import: the currently deployed state when overwriting an existing rule, or enabled for a brand new rule.
+    deployed_state: dict[str, bool] = {}
+    if any("enabled" not in rule_dict for rule_dict in rule_dicts):
+        exported = cast(
+            "list[dict[str, Any]]",
+            RuleResource.export_rules([r["rule_id"] for r in rule_dicts]),  # type: ignore[reportUnknownMemberType]
+        )
+        # Rule ids that do not exist yet come back as per-object errors rather than rules, so they are simply
+        # absent here and fall through to the enabled-by-default behavior for new rules.
+        deployed_state = {r["rule_id"]: r["enabled"] for r in exported if "rule_id" in r and "enabled" in r}
+
+    rule_ids_to_enable: set[str] = set()
+    for rule_dict in rule_dicts:
+        rule_id = rule_dict["rule_id"]
+        if rule_dict.get("enabled", deployed_state.get(rule_id, True)):
+            rule_ids_to_enable.add(rule_id)
+        rule_dict["enabled"] = False
+
+    return rule_ids_to_enable
+
+
+def _enable_after_delay(ctx: click.Context, kibana: Any, ids_to_enable: list[str], delay: int) -> None:
+    """Wait out the delay, then bulk enable the given Kibana rule object ids."""
+    click.echo(f"Waiting {delay} second(s) before enabling {len(ids_to_enable)} imported rule(s)")
+    time.sleep(delay)
+
+    with kibana:
+        # error=False: a partial failure returns a 500 with per-rule details, which is reported below
+        response = cast(
+            "dict[str, Any]",
+            RuleResource.bulk_action("enable", rule_ids=ids_to_enable, error=False),  # type: ignore[reportUnknownMemberType]
+        )
+
+    attributes: dict[str, Any] = response.get("attributes", {})
+    summary: dict[str, Any] = attributes.get("summary", {})
+    failed = summary.get("failed", 0)
+    click.echo(f"{summary.get('succeeded', 0)} rule(s) enabled, {failed} failed to enable")
+
+    for error in attributes.get("errors", []):
+        failed_rules = ", ".join(str(r.get("id")) for r in error.get("rules", []))
+        click.echo(f" - ({error.get('status_code')}) {error.get('message')}: {failed_rules}")
+
+    if failed:
+        raise_client_error(f"{failed} imported rule(s) failed to enable after waiting {delay} second(s)", ctx=ctx)
+
+
 @root.group("kibana")
 @add_params(*kibana_options)
 @click.pass_context
@@ -190,27 +239,10 @@ def kibana_import_rules(  # noqa: PLR0913, PLR0915
     rule_dicts = [r.contents.to_api_format() for r in rules]
     rule_ids = {rule["rule_id"] for rule in rule_dicts}
 
-    enabled_rule_ids: set[str] = set()
+    rule_ids_to_enable: set[str] = set()
     with kibana:
-        existing_rule_enabled_by_id: dict[str, bool] = {}
-        if enable_delay is not None and any("enabled" not in rule_dict for rule_dict in rule_dicts):
-            # Most DaC rules omit `enabled`. For overwrites, retain the currently deployed state;
-            # new Kibana rules default to enabled when the field is omitted.
-            existing_rules = cast(
-                list[dict[str, Any]],
-                RuleResource.export_rules(list(rule_ids)),  # type: ignore[reportUnknownMemberType]
-            )
-            for existing_rule in existing_rules:
-                rule_id = existing_rule.get("rule_id")
-                enabled = existing_rule.get("enabled")
-                if isinstance(rule_id, str) and isinstance(enabled, bool):
-                    existing_rule_enabled_by_id[rule_id] = enabled
-
         if enable_delay is not None:
-            for rule_dict in rule_dicts:
-                if rule_dict.get("enabled", existing_rule_enabled_by_id.get(rule_dict["rule_id"], True)):
-                    enabled_rule_ids.add(rule_dict["rule_id"])
-                rule_dict["enabled"] = False
+            rule_ids_to_enable = _force_disabled_import(rule_dicts)
 
         cl = GenericCollection.default()
         exception_dicts: list[list[dict[str, Any]]] = [
@@ -240,28 +272,11 @@ def kibana_import_rules(  # noqa: PLR0913, PLR0915
         _process_imported_items(exception_dicts, "exception list(s)", "list_id")  # type: ignore[reportUnknownArgumentType]
         _process_imported_items(action_connectors_dicts, "action connector(s)", "id")  # type: ignore[reportUnknownArgumentType]
 
-    if enable_delay is not None and enabled_rule_ids:
-        # Rules were imported as disabled; re-enable the originally enabled ones after the delay using the
-        # Kibana object ids of the successfully imported rules
-        ids_to_enable: list[str] = [r["id"] for r in results if r.get("rule_id") in enabled_rule_ids]  # type: ignore[reportUnknownMemberType]
+    if enable_delay is not None and rule_ids_to_enable:
+        # Rules were imported as disabled; re-enable the intended ones by their Kibana object ids
+        ids_to_enable: list[str] = [r["id"] for r in results if r.get("rule_id") in rule_ids_to_enable]  # type: ignore[reportUnknownMemberType]
         if ids_to_enable:
-            click.echo(f"Waiting {enable_delay} second(s) before enabling {len(ids_to_enable)} imported rule(s)")
-            time.sleep(enable_delay)
-            with kibana:
-                # error=False: a partial failure returns a 500 with per-rule details, which is reported below
-                enable_response: dict[str, Any] = RuleResource.bulk_action(  # type: ignore[reportAssignmentType]
-                    "enable", rule_ids=ids_to_enable, error=False
-                )
-            summary: dict[str, Any] = enable_response.get("attributes", {}).get("summary", {})
-            click.echo(f"{summary.get('succeeded', 0)} rule(s) enabled, {summary.get('failed', 0)} failed to enable")
-            for enable_error in enable_response.get("attributes", {}).get("errors", []):
-                failed_rules = ", ".join(str(r.get("id")) for r in enable_error.get("rules", []))
-                click.echo(f" - ({enable_error.get('status_code')}) {enable_error.get('message')}: {failed_rules}")
-            if summary.get("failed", 0):
-                raise_client_error(
-                    f"{summary['failed']} imported rule(s) failed to enable after waiting {enable_delay} second(s)",
-                    ctx=ctx,
-                )
+            _enable_after_delay(ctx, kibana, ids_to_enable, enable_delay)
 
     return response, results  # type: ignore[reportUnknownVariableType]
 

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -104,8 +104,7 @@ def upload_rule(ctx: click.Context, rules: RuleCollection, replace_id: bool) -> 
 )
 @click.option(
     "--enable-delay",
-    "-ed",
-    type=click.IntRange(min=0),
+    type=click.IntRange(min=1),
     metavar="SECONDS",
     help="Import rules as disabled, wait the given number of seconds, then enable the rules that were "
     "originally enabled. Guards against a race condition where rules can run before their exceptions "
@@ -192,13 +191,20 @@ def kibana_import_rules(  # noqa: PLR0913, PLR0915
     rule_ids = {rule["rule_id"] for rule in rule_dicts}
 
     enabled_rule_ids: set[str] = set()
-    if enable_delay is not None:
-        for rule_dict in rule_dicts:
-            if rule_dict.get("enabled", False):
-                enabled_rule_ids.add(rule_dict["rule_id"])
-            rule_dict["enabled"] = False
-
     with kibana:
+        if enable_delay is not None:
+            # Most DaC rules omit `enabled`. For overwrites, retain the currently deployed state;
+            # new Kibana rules default to enabled when the field is omitted.
+            existing_rule_enabled_by_id = {
+                rule["rule_id"]: rule["enabled"]
+                for rule in RuleResource.export_rules(list(rule_ids))  # type: ignore[reportUnknownMemberType]
+                if "rule_id" in rule and "enabled" in rule
+            }
+            for rule_dict in rule_dicts:
+                if rule_dict.get("enabled", existing_rule_enabled_by_id.get(rule_dict["rule_id"], True)):
+                    enabled_rule_ids.add(rule_dict["rule_id"])
+                rule_dict["enabled"] = False
+
         cl = GenericCollection.default()
         exception_dicts: list[list[dict[str, Any]]] = [
             d.contents.to_api_format()  # type: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
@@ -244,6 +250,11 @@ def kibana_import_rules(  # noqa: PLR0913, PLR0915
             for enable_error in enable_response.get("attributes", {}).get("errors", []):
                 failed_rules = ", ".join(str(r.get("id")) for r in enable_error.get("rules", []))
                 click.echo(f" - ({enable_error.get('status_code')}) {enable_error.get('message')}: {failed_rules}")
+            if summary.get("failed", 0):
+                raise_client_error(
+                    f"{summary['failed']} imported rule(s) failed to enable after waiting {enable_delay} second(s)",
+                    ctx=ctx,
+                )
 
     return response, results  # type: ignore[reportUnknownVariableType]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.0.4"
+version = "2.0.5"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_kbwrap.py
+++ b/tests/test_kbwrap.py
@@ -1,122 +1,140 @@
 """Tests for Kibana command wrappers."""
 
+import inspect
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import click
 
-from detection_rules.kbwrap import kibana_import_rules
+from detection_rules.kbwrap import _enable_after_delay, _force_disabled_import, kibana_import_rules
 from detection_rules.misc import ClientError
 
 
+class TestForceDisabledImport(unittest.TestCase):
+    """Resolving which rules to re-enable after a delayed import."""
+
+    def test_resolves_intended_state_from_payload_and_kibana(self) -> None:
+        """The intended state comes from `enabled` when set, otherwise from what Kibana would have applied."""
+        rule_dicts = [
+            {"rule_id": "explicit-enabled", "enabled": True},
+            {"rule_id": "explicit-disabled", "enabled": False},
+            {"rule_id": "omitted-deployed-enabled"},
+            {"rule_id": "omitted-deployed-disabled"},
+            {"rule_id": "omitted-new-rule"},
+        ]
+        deployed = [
+            {"rule_id": "omitted-deployed-enabled", "enabled": True},
+            {"rule_id": "omitted-deployed-disabled", "enabled": False},
+            # omitted-new-rule is absent: Kibana returns a per-object error for unknown rule_ids
+            {"error": {"status_code": 404, "message": "not found"}},
+        ]
+
+        with patch("detection_rules.kbwrap.RuleResource.export_rules", return_value=deployed) as export_rules:
+            rule_ids_to_enable = _force_disabled_import(rule_dicts)
+
+        self.assertCountEqual(export_rules.call_args.args[0], [rule_dict["rule_id"] for rule_dict in rule_dicts])
+        self.assertEqual(rule_ids_to_enable, {"explicit-enabled", "omitted-deployed-enabled", "omitted-new-rule"})
+        # Every rule is imported as disabled regardless of its intended state
+        self.assertTrue(all(rule_dict["enabled"] is False for rule_dict in rule_dicts))
+
+    def test_skips_kibana_lookup_when_every_rule_is_explicit(self) -> None:
+        """No deployed state is needed when all payloads set `enabled`."""
+        rule_dicts = [{"rule_id": "a", "enabled": True}, {"rule_id": "b", "enabled": False}]
+
+        with patch("detection_rules.kbwrap.RuleResource.export_rules") as export_rules:
+            rule_ids_to_enable = _force_disabled_import(rule_dicts)
+
+        export_rules.assert_not_called()
+        self.assertEqual(rule_ids_to_enable, {"a"})
+
+
+class TestEnableAfterDelay(unittest.TestCase):
+    """Waiting out the delay before bulk enabling."""
+
+    @staticmethod
+    def _kibana() -> MagicMock:
+        kibana = MagicMock()
+        kibana.__enter__.return_value = kibana
+        return kibana
+
+    def test_waits_then_bulk_enables(self) -> None:
+        """The delay is honored and the rules are enabled by their Kibana object ids."""
+        response = {"attributes": {"summary": {"succeeded": 2, "failed": 0}, "errors": []}}
+
+        with (
+            patch("detection_rules.kbwrap.RuleResource.bulk_action", return_value=response) as bulk_action,
+            patch("detection_rules.kbwrap.time.sleep") as sleep,
+        ):
+            _enable_after_delay(click.Context(kibana_import_rules), self._kibana(), ["1", "3"], 30)
+
+        sleep.assert_called_once_with(30)
+        bulk_action.assert_called_once_with("enable", rule_ids=["1", "3"], error=False)
+
+    def test_raises_when_any_rule_fails_to_enable(self) -> None:
+        """A partial enable failure surfaces as a client error rather than a silent success."""
+        response = {
+            "attributes": {
+                "summary": {"succeeded": 0, "failed": 1},
+                "errors": [{"status_code": 500, "message": "failed", "rules": [{"id": "1"}]}],
+            }
+        }
+
+        with (
+            patch("detection_rules.kbwrap.RuleResource.bulk_action", return_value=response),
+            patch("detection_rules.kbwrap.time.sleep"),
+            self.assertRaisesRegex(ClientError, r"1 imported rule\(s\) failed to enable"),
+        ):
+            _enable_after_delay(click.Context(kibana_import_rules), self._kibana(), ["1"], 30)
+
+
 class TestKibanaImportRulesEnableDelay(unittest.TestCase):
-    """The delayed enable safeguard preserves intended rule state."""
+    """`--enable-delay` wiring within the import command."""
 
-    @staticmethod
-    def _invoke_import_rules(
-        rules: list[SimpleNamespace],
-        kibana: MagicMock,
-        enable_delay: int = 30,
-    ) -> tuple[dict[str, object], list[dict[str, str]]]:
-        """Invoke the undecorated import command with test doubles."""
-        callback = kibana_import_rules.callback
-        assert callback is not None
-        implementation = callback.__wrapped__.__wrapped__
-        ctx = click.Context(kibana_import_rules, obj={"kibana": kibana})
-        return implementation(
-            ctx,
-            rules,
-            overwrite=False,
-            overwrite_exceptions=False,
-            overwrite_action_connectors=False,
-            enable_delay=enable_delay,
-        )
-
-    @staticmethod
-    def _rule(payload: dict[str, object]) -> SimpleNamespace:
-        """Create a minimal rule accepted by the import command."""
-        return SimpleNamespace(contents=SimpleNamespace(to_api_format=lambda: payload.copy()))
-
-    def test_enable_delay_preserves_explicit_and_existing_enabled_states(self) -> None:
-        """Only rules intended to be enabled are enabled after the delay."""
+    def test_imports_disabled_then_enables_by_object_id(self) -> None:
+        """Rules are imported disabled and re-enabled using the ids returned by the import."""
+        # Bypass the click option decorators; rules are passed in directly instead of loaded from disk
+        implementation = inspect.unwrap(kibana_import_rules.callback)
         kibana = MagicMock()
         kibana.__enter__.return_value = kibana
         rules = [
-            self._rule({"rule_id": "explicit-enabled", "enabled": True}),
-            self._rule({"rule_id": "explicit-disabled", "enabled": False}),
-            self._rule({"rule_id": "new-rule"}),
-            self._rule({"rule_id": "existing-disabled"}),
+            SimpleNamespace(contents=SimpleNamespace(to_api_format=lambda: {"rule_id": "wanted", "enabled": True})),
+            SimpleNamespace(contents=SimpleNamespace(to_api_format=lambda: {"rule_id": "unwanted", "enabled": False})),
         ]
         import_response = {"errors": []}
-        import_results = [
-            {"id": "1", "rule_id": "explicit-enabled"},
-            {"id": "2", "rule_id": "explicit-disabled"},
-            {"id": "3", "rule_id": "new-rule"},
-            {"id": "4", "rule_id": "existing-disabled"},
-        ]
+        import_results = [{"id": "1", "rule_id": "wanted"}, {"id": "2", "rule_id": "unwanted"}]
 
         with (
             patch("detection_rules.kbwrap.GenericCollection.default") as generic_collection,
             patch(
-                "detection_rules.kbwrap.RuleResource.export_rules",
-                return_value=[{"rule_id": "existing-disabled", "enabled": False}],
-            ) as export_rules,
-            patch(
                 "detection_rules.kbwrap.RuleResource.import_rules",
-                return_value=(import_response, [rule["rule_id"] for rule in import_results], import_results),
+                return_value=(import_response, ["wanted", "unwanted"], import_results),
             ) as import_rules,
             patch(
                 "detection_rules.kbwrap.RuleResource.bulk_action",
-                return_value={"attributes": {"summary": {"succeeded": 2, "failed": 0}, "errors": []}},
+                return_value={"attributes": {"summary": {"succeeded": 1, "failed": 0}, "errors": []}},
             ) as bulk_action,
             patch("detection_rules.kbwrap.time.sleep") as sleep,
         ):
             generic_collection.return_value.items_matching.return_value = []
-            result = self._invoke_import_rules(rules, kibana)
+            result = implementation(
+                click.Context(kibana_import_rules, obj={"kibana": kibana}),
+                rules,
+                overwrite=False,
+                overwrite_exceptions=False,
+                overwrite_action_connectors=False,
+                enable_delay=30,
+            )
 
         self.assertEqual(result, (import_response, import_results))
-        self.assertCountEqual(export_rules.call_args.args[0], [rule["rule_id"] for rule in import_results])
         self.assertEqual(
             import_rules.call_args.args[0],
-            [
-                {"rule_id": "explicit-enabled", "enabled": False},
-                {"rule_id": "explicit-disabled", "enabled": False},
-                {"rule_id": "new-rule", "enabled": False},
-                {"rule_id": "existing-disabled", "enabled": False},
-            ],
+            [{"rule_id": "wanted", "enabled": False}, {"rule_id": "unwanted", "enabled": False}],
         )
         sleep.assert_called_once_with(30)
-        bulk_action.assert_called_once_with("enable", rule_ids=["1", "3"], error=False)
+        bulk_action.assert_called_once_with("enable", rule_ids=["1"], error=False)
 
-    def test_enable_delay_fails_when_bulk_enable_has_failures(self) -> None:
-        """A partial enable failure causes a non-zero command result."""
-        kibana = MagicMock()
-        kibana.__enter__.return_value = kibana
-        rules = [self._rule({"rule_id": "explicit-enabled", "enabled": True})]
-
-        with (
-            patch("detection_rules.kbwrap.GenericCollection.default") as generic_collection,
-            patch(
-                "detection_rules.kbwrap.RuleResource.import_rules",
-                return_value=({"errors": []}, ["explicit-enabled"], [{"id": "1", "rule_id": "explicit-enabled"}]),
-            ),
-            patch(
-                "detection_rules.kbwrap.RuleResource.bulk_action",
-                return_value={
-                    "attributes": {
-                        "summary": {"succeeded": 0, "failed": 1},
-                        "errors": [{"status_code": 500, "message": "failed", "rules": [{"id": "1"}]}],
-                    }
-                },
-            ),
-            patch("detection_rules.kbwrap.time.sleep"),
-            self.assertRaisesRegex(ClientError, "1 imported rule\\(s\\) failed to enable"),
-        ):
-            generic_collection.return_value.items_matching.return_value = []
-            _ = self._invoke_import_rules(rules, kibana)
-
-    def test_enable_delay_requires_a_positive_delay(self) -> None:
+    def test_option_requires_a_positive_delay(self) -> None:
         """The safeguard cannot be invoked without a wait."""
         ctx = kibana_import_rules.make_context("import-rules", ["--enable-delay", "30"])
         self.assertEqual(ctx.params["enable_delay"], 30)

--- a/tests/test_kbwrap.py
+++ b/tests/test_kbwrap.py
@@ -1,0 +1,134 @@
+"""Tests for Kibana command wrappers."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import click
+
+from detection_rules.kbwrap import kibana_export_rules, kibana_import_rules
+from detection_rules.misc import ClientError
+
+
+class TestKibanaImportRulesEnableDelay(unittest.TestCase):
+    """The delayed enable safeguard preserves intended rule state."""
+
+    @staticmethod
+    def _invoke_import_rules(
+        rules: list[SimpleNamespace],
+        kibana: MagicMock,
+        enable_delay: int = 30,
+    ) -> tuple[dict[str, object], list[dict[str, str]]]:
+        """Invoke the undecorated import command with test doubles."""
+        callback = kibana_import_rules.callback
+        assert callback is not None
+        implementation = callback.__wrapped__.__wrapped__
+        ctx = click.Context(kibana_import_rules, obj={"kibana": kibana})
+        return implementation(
+            ctx,
+            rules,
+            overwrite=False,
+            overwrite_exceptions=False,
+            overwrite_action_connectors=False,
+            enable_delay=enable_delay,
+        )
+
+    @staticmethod
+    def _rule(payload: dict[str, object]) -> SimpleNamespace:
+        """Create a minimal rule accepted by the import command."""
+        return SimpleNamespace(contents=SimpleNamespace(to_api_format=lambda: payload.copy()))
+
+    def test_enable_delay_preserves_explicit_and_existing_enabled_states(self) -> None:
+        """Only rules intended to be enabled are enabled after the delay."""
+        kibana = MagicMock()
+        kibana.__enter__.return_value = kibana
+        rules = [
+            self._rule({"rule_id": "explicit-enabled", "enabled": True}),
+            self._rule({"rule_id": "explicit-disabled", "enabled": False}),
+            self._rule({"rule_id": "new-rule"}),
+            self._rule({"rule_id": "existing-disabled"}),
+        ]
+        import_response = {"errors": []}
+        import_results = [
+            {"id": "1", "rule_id": "explicit-enabled"},
+            {"id": "2", "rule_id": "explicit-disabled"},
+            {"id": "3", "rule_id": "new-rule"},
+            {"id": "4", "rule_id": "existing-disabled"},
+        ]
+
+        with (
+            patch("detection_rules.kbwrap.GenericCollection.default") as generic_collection,
+            patch(
+                "detection_rules.kbwrap.RuleResource.export_rules",
+                return_value=[{"rule_id": "existing-disabled", "enabled": False}],
+            ) as export_rules,
+            patch(
+                "detection_rules.kbwrap.RuleResource.import_rules",
+                return_value=(import_response, [rule["rule_id"] for rule in import_results], import_results),
+            ) as import_rules,
+            patch(
+                "detection_rules.kbwrap.RuleResource.bulk_action",
+                return_value={"attributes": {"summary": {"succeeded": 2, "failed": 0}, "errors": []}},
+            ) as bulk_action,
+            patch("detection_rules.kbwrap.time.sleep") as sleep,
+        ):
+            generic_collection.return_value.items_matching.return_value = []
+            result = self._invoke_import_rules(rules, kibana)
+
+        self.assertEqual(result, (import_response, import_results))
+        self.assertCountEqual(export_rules.call_args.args[0], [rule["rule_id"] for rule in import_results])
+        self.assertEqual(
+            import_rules.call_args.args[0],
+            [
+                {"rule_id": "explicit-enabled", "enabled": False},
+                {"rule_id": "explicit-disabled", "enabled": False},
+                {"rule_id": "new-rule", "enabled": False},
+                {"rule_id": "existing-disabled", "enabled": False},
+            ],
+        )
+        sleep.assert_called_once_with(30)
+        bulk_action.assert_called_once_with("enable", rule_ids=["1", "3"], error=False)
+
+    def test_enable_delay_fails_when_bulk_enable_has_failures(self) -> None:
+        """A partial enable failure causes a non-zero command result."""
+        kibana = MagicMock()
+        kibana.__enter__.return_value = kibana
+        rules = [self._rule({"rule_id": "explicit-enabled", "enabled": True})]
+
+        with (
+            patch("detection_rules.kbwrap.GenericCollection.default") as generic_collection,
+            patch(
+                "detection_rules.kbwrap.RuleResource.import_rules",
+                return_value=({"errors": []}, ["explicit-enabled"], [{"id": "1", "rule_id": "explicit-enabled"}]),
+            ),
+            patch(
+                "detection_rules.kbwrap.RuleResource.bulk_action",
+                return_value={
+                    "attributes": {
+                        "summary": {"succeeded": 0, "failed": 1},
+                        "errors": [{"status_code": 500, "message": "failed", "rules": [{"id": "1"}]}],
+                    }
+                },
+            ),
+            patch("detection_rules.kbwrap.time.sleep"),
+            self.assertRaisesRegex(ClientError, "1 imported rule\\(s\\) failed to enable"),
+        ):
+            generic_collection.return_value.items_matching.return_value = []
+            _ = self._invoke_import_rules(rules, kibana)
+
+    def test_enable_delay_requires_a_positive_delay_and_has_no_short_alias(self) -> None:
+        """The safeguard cannot be invoked without a wait or with export's -ed flag."""
+        ctx = kibana_import_rules.make_context("import-rules", ["--enable-delay", "30"])
+        self.assertEqual(ctx.params["enable_delay"], 30)
+
+        for value in ("0", "-5"):
+            with self.assertRaises(click.exceptions.UsageError):
+                _ = kibana_import_rules.make_context("import-rules", ["--enable-delay", value])
+
+        with self.assertRaises(click.exceptions.NoSuchOption):
+            _ = kibana_import_rules.make_context("import-rules", ["-ed", "30"])
+
+        export_context = kibana_export_rules.make_context(
+            "export-rules", ["--directory", "export-rules-test", "-ed", "exceptions"]
+        )
+        self.assertEqual(export_context.params["exceptions_directory"], "exceptions")

--- a/tests/test_kbwrap.py
+++ b/tests/test_kbwrap.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import click
 
-from detection_rules.kbwrap import kibana_export_rules, kibana_import_rules
+from detection_rules.kbwrap import kibana_import_rules
 from detection_rules.misc import ClientError
 
 
@@ -116,19 +116,11 @@ class TestKibanaImportRulesEnableDelay(unittest.TestCase):
             generic_collection.return_value.items_matching.return_value = []
             _ = self._invoke_import_rules(rules, kibana)
 
-    def test_enable_delay_requires_a_positive_delay_and_has_no_short_alias(self) -> None:
-        """The safeguard cannot be invoked without a wait or with export's -ed flag."""
+    def test_enable_delay_requires_a_positive_delay(self) -> None:
+        """The safeguard cannot be invoked without a wait."""
         ctx = kibana_import_rules.make_context("import-rules", ["--enable-delay", "30"])
         self.assertEqual(ctx.params["enable_delay"], 30)
 
         for value in ("0", "-5"):
             with self.assertRaises(click.exceptions.UsageError):
                 _ = kibana_import_rules.make_context("import-rules", ["--enable-delay", value])
-
-        with self.assertRaises(click.exceptions.NoSuchOption):
-            _ = kibana_import_rules.make_context("import-rules", ["-ed", "30"])
-
-        export_context = kibana_export_rules.make_context(
-            "export-rules", ["--directory", "export-rules-test", "-ed", "exceptions"]
-        )
-        self.assertEqual(export_context.params["exceptions_directory"], "exceptions")

--- a/tests/test_rule_loader.py
+++ b/tests/test_rule_loader.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-from detection_rules.kbwrap import kibana_export_rules
+import click
+
+from detection_rules.kbwrap import kibana_export_rules, kibana_import_rules
 from detection_rules.main import import_rules_into_repo
 from detection_rules.rule_loader import RawRuleCollection
 
@@ -107,3 +109,23 @@ class TestLoadRuleLoadingFlagBackwardsCompatibility(unittest.TestCase):
 
         ctx = kibana_export_rules.make_context("export-rules", base_args)
         self.assertFalse(ctx.params["use_existing_rule_dirs"])
+
+
+class TestKibanaImportRulesEnableDelay(unittest.TestCase):
+    """--enable-delay must parse as an optional non-negative integer."""
+
+    def test_enable_delay_flag_parsing(self) -> None:
+        """The --enable-delay and -ed flags must parse into the enable_delay param."""
+        ctx = kibana_import_rules.make_context("import-rules", ["--enable-delay", "30"])
+        self.assertEqual(ctx.params["enable_delay"], 30)
+
+        ctx = kibana_import_rules.make_context("import-rules", ["-ed", "0"])
+        self.assertEqual(ctx.params["enable_delay"], 0)
+
+        ctx = kibana_import_rules.make_context("import-rules", [])
+        self.assertIsNone(ctx.params["enable_delay"])
+
+    def test_enable_delay_rejects_negative(self) -> None:
+        """Negative values must be rejected by the IntRange validation."""
+        with self.assertRaises(click.exceptions.UsageError):
+            _ = kibana_import_rules.make_context("import-rules", ["--enable-delay", "-5"])

--- a/tests/test_rule_loader.py
+++ b/tests/test_rule_loader.py
@@ -10,9 +10,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
-import click
-
-from detection_rules.kbwrap import kibana_export_rules, kibana_import_rules
+from detection_rules.kbwrap import kibana_export_rules
 from detection_rules.main import import_rules_into_repo
 from detection_rules.rule_loader import RawRuleCollection
 
@@ -109,23 +107,3 @@ class TestLoadRuleLoadingFlagBackwardsCompatibility(unittest.TestCase):
 
         ctx = kibana_export_rules.make_context("export-rules", base_args)
         self.assertFalse(ctx.params["use_existing_rule_dirs"])
-
-
-class TestKibanaImportRulesEnableDelay(unittest.TestCase):
-    """--enable-delay must parse as an optional non-negative integer."""
-
-    def test_enable_delay_flag_parsing(self) -> None:
-        """The --enable-delay and -ed flags must parse into the enable_delay param."""
-        ctx = kibana_import_rules.make_context("import-rules", ["--enable-delay", "30"])
-        self.assertEqual(ctx.params["enable_delay"], 30)
-
-        ctx = kibana_import_rules.make_context("import-rules", ["-ed", "0"])
-        self.assertEqual(ctx.params["enable_delay"], 0)
-
-        ctx = kibana_import_rules.make_context("import-rules", [])
-        self.assertIsNone(ctx.params["enable_delay"])
-
-    def test_enable_delay_rejects_negative(self) -> None:
-        """Negative values must be rejected by the IntRange validation."""
-        with self.assertRaises(click.exceptions.UsageError):
-            _ = kibana_import_rules.make_context("import-rules", ["--enable-delay", "-5"])


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

- Resolves https://github.com/elastic/detection-rules/issues/6488
- Related to https://github.com/elastic/detection-rules/issues/5564

## Summary - What I changed

When importing rules with exceptions (or action connectors) via `kibana import-rules`, a rule can start running before its exceptions are fully applied, generating false positive alerts. Customers have been exploring scripting a `disable → import → sleep → enable` sequence around the CLI as a workaround. This PR adds  that safeguard as an option in the command.

New option on `kibana import-rules`:

```
  --enable-delay SECONDS     Import rules as disabled, wait the given
                                  number of seconds, then enable the rules
                                  that were originally enabled. Guards against
                                  a race condition where rules can run before
                                  their exceptions and action connectors are
                                  fully applied.  [x>=0]
```

> [!NOTE]
> If we add this feature there will be a companion PR to the DaC Reference guide. 

> [!IMPORTANT]
> While it may seem like this setting to should be a default setting instead of an optional field, we should also consider cases where a network drop could inadvertently cause rules to be unknowingly disabled, without a direct state recovery. As such, customers using this feature should be aware of the potential risk.  


## How To Test



Use two pre-built rules from the repo, one imported as enabled and one as disabled. Set `enabled = true` on `rules/apm/apm_sqlmap_user_agent.toml` and leave `rules/apm/apm_403_response_to_a_post.toml` unchanged (no `enabled` field, so it imports disabled):

```console
$ sed -i '/^\[rule\]$/a enabled = true' rules/apm/apm_sqlmap_user_agent.toml
$ python -m detection_rules kibana import-rules -f rules/apm/apm_sqlmap_user_agent.toml -f rules/apm/apm_403_response_to_a_post.toml -o --enable-delay 5
2 rule(s) successfully imported
 - d49cc73f-7a16-4def-89ce-9fc7127d7820
 - a87a4e42-1d82-44bd-b0bf-d9b7f91fb89e
Waiting 5 second(s) before enabling 1 imported rule(s)
1 rule(s) enabled, 0 failed to enable
```
Verify in Kibana that the originally-enabled rule ends up enabled and the originally-disabled rule stays disabled:

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
