### PR TITLE
[Bug] Pin ruff version to fix failing CI

### DIFF
--- a/detection_rules/action_connector.py
+++ b/detection_rules/action_connector.py
@@ -138,7 +138,7 @@ def parse_action_connector_results_from_api(
     return action_results, non_action_results
 
 
-def build_action_connector_objects(  # noqa: PLR0913
+def build_action_connector_objects(  # noqa: PLR0913, PLR0917
     action_connectors: list[dict[str, Any]],
     action_connector_rule_table: dict[str, Any],
     action_connectors_directory: Path | None,

--- a/detection_rules/attack.py
+++ b/detection_rules/attack.py
@@ -588,7 +588,7 @@ def convert_threat_to_version(  # noqa: PLR0912, PLR0913, PLR0915
     framework: str,
     *,
     vmap: AttackVersionMap | None = None,
-    target_lookups: AttackLookups | None | object = _LOOKUPS_AUTO,
+    target_lookups: AttackLookups | object | None = _LOOKUPS_AUTO,
     dropped: list[str] | None = None,
     moved: list[str] | None = None,
 ) -> list[dict[str, Any]]:

--- a/detection_rules/cli_utils.py
+++ b/detection_rules/cli_utils.py
@@ -238,7 +238,7 @@ def multi_collection(f: Callable[..., Any]) -> Callable[..., Any]:
     return get_collection
 
 
-def rule_prompt(  # noqa: PLR0912, PLR0913, PLR0915
+def rule_prompt(  # noqa: PLR0912, PLR0913, PLR0915, PLR0917
     path: Path | None = None,
     rule_type: str | None = None,
     required_only: bool = True,

--- a/detection_rules/devtools.py
+++ b/detection_rules/devtools.py
@@ -128,7 +128,7 @@ def dev_group() -> None:
 @click.option("--generate-docs", is_flag=True, default=False, help="Generate markdown documentation")
 @click.option("--update-message", type=str, help="Update message for new package")
 @click.pass_context
-def build_release(  # noqa: PLR0913
+def build_release(  # noqa: PLR0913, PLR0917
     ctx: click.Context,
     config_file: Path,
     update_version_lock: bool,
@@ -251,7 +251,7 @@ def get_release_diff(
 @click.option("--remote", "-r", default="origin", help='Override the remote from "origin"')
 @click.option("--update-message", default="Rule Updates.", type=str, help="Update message for new package")
 @click.pass_context
-def build_integration_docs(  # noqa: PLR0913
+def build_integration_docs(  # noqa: PLR0913, PLR0917
     ctx: click.Context,
     registry_version: str,
     pre: str,
@@ -379,7 +379,7 @@ def bump_versions(
 @click.option("--comment", is_flag=True, help="If set, enables commenting on the PR (requires --pr-number)")
 @click.option("--save-double-bumps", type=Path, help="Optional path to save the double bumps to a file")
 @click.pass_context
-def check_version_lock(  # noqa: PLR0913
+def check_version_lock(  # noqa: PLR0913, PLR0917
     ctx: click.Context,
     pr_number: int,
     local_file: str,
@@ -652,7 +652,7 @@ def kibana_diff(rule_id: list[str], repo: str, branch: str, threads: int) -> dic
 @click.option("--draft", is_flag=True, help="Open the PR as a draft")
 @click.option("--remote", help="Override the remote from 'origin'", default="origin")
 @click.pass_context
-def integrations_pr(  # noqa: PLR0913, PLR0915
+def integrations_pr(  # noqa: PLR0913, PLR0915, PLR0917
     ctx: click.Context,
     local_repo: Path,
     token: str,
@@ -919,7 +919,7 @@ def package_stats(ctx: click.Context, token: str | None, threads: int) -> None:
 @click.option("--token", "-t", help="GitHub token to search API authenticated (may exceed threshold without auth)")
 @click.option("--threads", default=50, help="Number of threads to download rules from GitHub")
 @click.pass_context
-def search_rule_prs(  # noqa: PLR0913
+def search_rule_prs(  # noqa: PLR0913, PLR0917
     ctx: click.Context,
     no_loop: bool,
     query: str | None,
@@ -1333,7 +1333,7 @@ def test_group() -> None:
 )
 @click.option("--verbose", "-v", is_flag=True, default=True)
 @add_client(["elasticsearch"])
-def event_search(  # noqa: PLR0913
+def event_search(  # noqa: PLR0913, PLR0917
     query: str,
     index: list[str],
     language: str | None,
@@ -1378,7 +1378,7 @@ def event_search(  # noqa: PLR0913
 @click.option("--verbose", "-v", is_flag=True)
 @click.pass_context
 @add_client(["elasticsearch"])
-def rule_event_search(  # noqa: PLR0913
+def rule_event_search(  # noqa: PLR0913, PLR0917
     ctx: click.Context,
     rule: Any,
     date_range: tuple[str, str],
@@ -1498,7 +1498,7 @@ def esql_remote_validation(
 @click.option("--hide-errors", "-e", is_flag=True, help="Exclude rules with errors from printing")
 @click.pass_context
 @add_client(["elasticsearch", "kibana"], add_to_ctx=True)
-def rule_survey(  # noqa: PLR0913
+def rule_survey(  # noqa: PLR0913, PLR0917
     ctx: click.Context,
     query: str,
     date_range: tuple[str, str],
@@ -1819,7 +1819,7 @@ def update_attack_in_rules() -> list[TOMLRule]:
     return new_rules
 
 
-def _remap_threat_entries(  # noqa: PLR0913
+def _remap_threat_entries(  # noqa: PLR0913, PLR0917
     entries: list[ThreatMapping],
     vmap: "attack.AttackVersionMap",
     framework: str,
@@ -1988,7 +1988,7 @@ def _get_source_threat(rule: TOMLRule, framework: str, source_version: str) -> l
     help="Replace an existing target-version block on a rule (otherwise the rule is skipped)",
 )
 @multi_collection
-def convert_threat_mappings(  # noqa: PLR0912, PLR0913, PLR0915
+def convert_threat_mappings(  # noqa: PLR0912, PLR0913, PLR0915, PLR0917
     rules: RuleCollection,
     target_version: str,
     source_version: str,

--- a/detection_rules/docs.py
+++ b/detection_rules/docs.py
@@ -320,7 +320,7 @@ class KibanaSecurityDocs:
 class IntegrationSecurityDocs:
     """Generate docs for prebuilt rules in Elastic documentation."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         registry_version: str,
         directory: Path,
@@ -841,7 +841,7 @@ class MDX:
 class IntegrationSecurityDocsMDX:
     """Generate docs for prebuilt rules in Elastic documentation using MDX."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         release_version: str,
         directory: Path,

--- a/detection_rules/endgame.py
+++ b/detection_rules/endgame.py
@@ -69,7 +69,7 @@ class EndgameSchema(eql.Schema):
         self.endgame_schema = endgame_schema
         eql.Schema.__init__(self, {}, allow_any=True, allow_generic=False, allow_missing=False)  # type: ignore[reportUnknownMemberType]
 
-    def get_event_type_hint(self, _: str, path: list[str]) -> None | tuple[Any, None]:  # type: ignore[reportIncompatibleMethodOverride]
+    def get_event_type_hint(self, _: str, path: list[str]) -> tuple[Any, None] | None:  # type: ignore[reportIncompatibleMethodOverride]
         from kql.parser import elasticsearch_type_family  # type: ignore[reportMissingTypeStubs]
 
         dotted = ".".join(str(p) for p in path)

--- a/detection_rules/eswrap.py
+++ b/detection_rules/eswrap.py
@@ -159,7 +159,7 @@ class CollectEvents:
         mappings = self.client.indices.get_mapping(index=index)
         return {n: m["mappings"].get("properties", {}).get("@timestamp", {}) for n, m in mappings.items()}
 
-    def _get_last_event_time(self, index: str, dsl: dict[str, Any] | None = None) -> None | str:
+    def _get_last_event_time(self, index: str, dsl: dict[str, Any] | None = None) -> str | None:
         """Get timestamp of most recent event."""
         last_event = self.client.search(query=dsl, index=index, size=1, sort="@timestamp:desc")["hits"]["hits"]
         if not last_event:
@@ -217,7 +217,7 @@ class CollectEvents:
 
         return index_str, formatted_dsl, lucene_query
 
-    def search(  # noqa: PLR0913
+    def search(  # noqa: PLR0913, PLR0917
         self,
         query: str | dict[str, Any],
         language: str,
@@ -490,7 +490,7 @@ def es_group(ctx: click.Context, **kwargs: Any) -> None:
 @click.option("--rule-id", help="Updates rule mapping in rule-mapping.yaml file (requires --rta-name)")
 @click.option("--view-events", is_flag=True, help="Print events after saving")
 @click.pass_context
-def collect_events(  # noqa: PLR0913
+def collect_events(  # noqa: PLR0913, PLR0917
     ctx: click.Context,
     host_id: str,
     query: str,

--- a/detection_rules/exception.py
+++ b/detection_rules/exception.py
@@ -74,7 +74,7 @@ class ExceptionItemEntry(BaseExceptionItemEntry, MarshmallowDataclassMixin):
 
     operator: definitions.ExceptionEntryOperator
     list_vals: ListObject | None = field(default=None, metadata={"data_key": "list"})
-    value: str | None | list[str] = None
+    value: str | list[str] | None = None
 
     @validates_schema
     def validate_entry(self, data: dict[str, Any], **_: Any) -> None:
@@ -306,7 +306,7 @@ def parse_exceptions_results_from_api(
     return exceptions_containers, exceptions_items, [], unparsed_results
 
 
-def build_exception_objects(  # noqa: PLR0913
+def build_exception_objects(  # noqa: PLR0913, PLR0917
     exceptions_containers: dict[str, Any],
     exceptions_items: dict[str, Any],
     exception_list_rule_table: dict[str, Any],

--- a/detection_rules/ghwrap.py
+++ b/detection_rules/ghwrap.py
@@ -90,7 +90,7 @@ def download_gh_asset(url: str, path: str, overwrite: bool = False) -> None:
     z.close()
 
 
-def update_gist(  # noqa: PLR0913
+def update_gist(  # noqa: PLR0913, PLR0917
     token: str,
     file_map: dict[Path, str],
     description: str,

--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -190,7 +190,7 @@ def prune_mappings_of_unsupported_types(
     return stream_mappings
 
 
-def prepare_integration_mappings(  # noqa: PLR0913
+def prepare_integration_mappings(  # noqa: PLR0913, PLR0917
     rule_integrations: list[str],
     event_dataset_integrations: list[EventDataset],
     package_manifests: Any,
@@ -254,7 +254,7 @@ def get_index_to_package_lookup(indices: list[str], index_lookup: dict[str, Any]
     return index_lookup_indices
 
 
-def get_filtered_index_schema(  # noqa: PLR0913
+def get_filtered_index_schema(  # noqa: PLR0913, PLR0917
     indices: list[str],
     index_lookup: dict[str, Any],
     ecs_schema: dict[str, Any],
@@ -458,7 +458,7 @@ def get_ecs_schema_mappings(current_version: Version) -> dict[str, Any]:
     return ecs_schema
 
 
-def prepare_mappings(  # noqa: PLR0913
+def prepare_mappings(  # noqa: PLR0913, PLR0917
     elastic_client: Elasticsearch,
     indices: list[str],
     event_dataset_integrations: list[EventDataset],

--- a/detection_rules/integrations.py
+++ b/detection_rules/integrations.py
@@ -420,8 +420,10 @@ def find_latest_compatible_version(
                 integration_label = f" {integration.strip()}" if integration else ""
                 notice = [
                     f"There is a new integration {package}{integration_label} version {skipped_version} available!",
-                    f"Update the rule min_stack version from {rule_stack_version} to "
-                    f"{skipped_floor} if using new features in this latest version.",
+                    (
+                        f"Update the rule min_stack version from {rule_stack_version} to "
+                        f"{skipped_floor} if using new features in this latest version."
+                    ),
                 ]
             return version, notice
 
@@ -538,7 +540,7 @@ def get_integration_schema_data(
                 }
 
 
-def get_integration_schema_fields(  # noqa: PLR0913
+def get_integration_schema_fields(  # noqa: PLR0913, PLR0917
     integrations_schemas: dict[str, Any],
     package: str,
     integration: str,

--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -270,7 +270,7 @@ def kibana_import_rules(  # noqa: PLR0915
     ),
 )
 @click.pass_context
-def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
+def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915, PLR0917
     ctx: click.Context,
     directory: Path,
     action_connectors_directory: Path | None,
@@ -553,7 +553,7 @@ def kibana_export_rules(  # noqa: PLR0912, PLR0913, PLR0915
 @click.option("--extend", "-e", is_flag=True, help="If columns are specified, extend the original columns")
 @click.option("--max-count", "-m", default=100, help="The max number of alerts to return")
 @click.pass_context
-def search_alerts(  # noqa: PLR0913
+def search_alerts(  # noqa: PLR0913, PLR0917
     ctx: click.Context,
     query: str,
     date_range: tuple[str, str],

--- a/detection_rules/main.py
+++ b/detection_rules/main.py
@@ -183,7 +183,7 @@ def generate_rules_index(
         "for backwards compatibility."
     ),
 )
-def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915
+def import_rules_into_repo(  # noqa: PLR0912, PLR0913, PLR0915, PLR0917
     input_file: tuple[Path, ...] | None,
     required_only: bool,
     action_connector_import: bool,
@@ -519,7 +519,7 @@ def view_rule(
     return rule
 
 
-def _export_rules_as_yaml(  # noqa: PLR0913
+def _export_rules_as_yaml(  # noqa: PLR0913, PLR0917
     rules: RuleCollection,
     yaml_directory: Path,
     downgrade_version: definitions.SemVer | None = None,
@@ -573,7 +573,7 @@ def _export_rules_as_yaml(  # noqa: PLR0913
             click.echo(f"Skipped {len(unsupported)} unsupported rules: \n- {unsupported_str}")
 
 
-def _export_rules(  # noqa: PLR0913
+def _export_rules(  # noqa: PLR0913, PLR0917
     rules: RuleCollection,
     outfile: Path,
     downgrade_version: definitions.SemVer | None = None,
@@ -679,7 +679,7 @@ def _export_rules(  # noqa: PLR0913
     required=False,
     help="Optional directory to export individual YAML files instead of NDJSON",
 )
-def export_rules_from_repo(  # noqa: PLR0913
+def export_rules_from_repo(  # noqa: PLR0913, PLR0917
     rules: RuleCollection,
     outfile: Path,
     replace_id: bool,
@@ -753,7 +753,7 @@ def validate_all() -> None:
 @click.option("--columns", "-c", multiple=True, help="Specify columns to add the table")
 @click.option("--language", type=click.Choice(["eql", "kql"]), default="kql")
 @click.option("--count", is_flag=True, help="Return a count rather than table")
-def search_rules(  # noqa: PLR0913
+def search_rules(  # noqa: PLR0913, PLR0917
     query: str | None,
     columns: list[str],
     language: Literal["eql", "kql"],

--- a/detection_rules/misc.py
+++ b/detection_rules/misc.py
@@ -53,7 +53,7 @@ class ClientError(click.ClickException):
         click.echo(msg, err=err, file=file)
 
 
-def raise_client_error(  # noqa: PLR0913
+def raise_client_error(  # noqa: PLR0913, PLR0917
     message: str,
     exc: Exception | None = None,
     debug: bool | None = False,
@@ -245,7 +245,7 @@ def getdefault(name: str) -> Callable[[], Any]:
     return lambda: os.environ.get(envvar, config.get(name))
 
 
-def get_elasticsearch_client(  # noqa: PLR0913
+def get_elasticsearch_client(  # noqa: PLR0913, PLR0917
     cloud_id: str | None = None,
     elasticsearch_url: str | None = None,
     es_user: str | None = None,

--- a/detection_rules/navigator.py
+++ b/detection_rules/navigator.py
@@ -191,7 +191,7 @@ class NavigatorBuilder:
             layer_key = tag.replace(" ", "-").lower()  # type: ignore[reportUnknownVariableType]
             self.add_rule_to_technique(rule, "tags", tactic, technique_id, value, layer_key=layer_key)  # type: ignore[reportUnknownArgumentType]
 
-    def add_rule_to_technique(  # noqa: PLR0913
+    def add_rule_to_technique(  # noqa: PLR0913, PLR0917
         self,
         rule: TOMLRule,
         layer_name: str,

--- a/detection_rules/packaging.py
+++ b/detection_rules/packaging.py
@@ -132,7 +132,7 @@ CURRENT_RELEASE_PATH = RELEASE_DIR / load_current_package_version()
 class Package:
     """Packaging object for siem rules and releases."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         rules: RuleCollection,
         name: str,

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -568,7 +568,7 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
 class DataValidator:
     """Additional validation beyond base marshmallow schema validation."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         name: definitions.RuleName,
         is_elastic_rule: bool,

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -644,7 +644,7 @@ class EQLValidator(QueryValidator):
 
         raise ValueError(f"Maximum validation attempts exceeded for {data.rule_id} - {data.name}")
 
-    def validate_query_text_with_schema(  # noqa: PLR0913
+    def validate_query_text_with_schema(  # noqa: PLR0913, PLR0917
         self,
         query_text: str,
         schema: ecs.KqlSchema2Eql | endgame.EndgameSchema,
@@ -878,7 +878,7 @@ class ESQLValidator(QueryValidator):
             verbosity=verbosity,
         )
 
-    def remote_validate_rule(  # noqa: PLR0913
+    def remote_validate_rule(  # noqa: PLR0913, PLR0917
         self,
         kibana_client: Kibana,
         elastic_client: Elasticsearch,

--- a/detection_rules/version_lock.py
+++ b/detection_rules/version_lock.py
@@ -141,7 +141,7 @@ def add_rule_types_to_lock(lock_contents: dict[str, Any], rule_map: dict[str, An
 class VersionLock:
     """Version handling for rule files and collections."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         version_lock_file: Path | None = None,
         deprecated_lock_file: Path | None = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.0.4"
+version = "2.0.5"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -52,7 +52,7 @@ dev = [
   "pytest>=8.1.1",
   "nodeenv==1.9.1",
   "pre-commit==4.6.0",
-  "ruff>=0.11",
+  "ruff>=0.16",
   "pyright==1.1.409",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
   "pytest>=8.1.1",
   "nodeenv==1.9.1",
   "pre-commit==4.6.0",
-  "ruff>=0.16",
+  "ruff==0.16.0",
   "pyright==1.1.409",
 ]
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

The `code-checks` workflow installs ruff unpinned (`ruff>=0.11`), so when ruff 0.16.0 was released it was picked up by CI immediately and the Linting check on `main` started failing with 42 errors. 

Failing run on `main`: https://github.com/elastic/detection-rules/actions/runs/29998361267/job/89315195287. 

For fixing, I went for simply ignoring the errors and updating formatting to keep in line with the current logic, but also keeping ruff updated so we could use the updated format.

- **PLR0917** `too-many-positional-arguments` (37 errors) — fires on the same functions that already carry `# noqa: PLR0913` (too-many-arguments). PLR0913 counts all parameters while PLR0917 counts positional-capable ones, so every suppressed function tripped the newly stabilized sibling rule.
- **RUF036** `none-not-at-end-of-union` (4 errors) — `None` appearing before other members in type unions.
- **ISC004** `implicit-string-concatenation-in-collection-literal` (1 error) — adjacent f-strings inside a list literal.

## How To Test
With ruff 0.16.0 (what CI now resolves), all four steps of the `code-checks` job pass:

```console
pip install .[dev]
ruff check
ruff format --check
```

And unit tests should pass.

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
