### PR TITLE
[FR] Offline ES|QL validation via esql-detection-rules-py

### DIFF
--- a/detection_rules/esql.py
+++ b/detection_rules/esql.py
@@ -3,10 +3,27 @@
 # 2.0; you may not use this file except in compliance with the Elastic License
 # 2.0.
 
-"""ESQL Query Parsing Classes."""
+"""ES|QL query helpers and EventDataset extraction."""
 
+from __future__ import annotations
+
+import fnmatch
 import re
 from dataclasses import dataclass
+from typing import Any
+
+import esql
+
+from . import ecs
+from .config import CUSTOM_RULES_DIR
+
+# Legacy / alternate dataset package prefixes → Fleet package names.
+DATASET_PACKAGE_ALIASES: dict[str, str] = {
+    "googlecloud": "gcp",
+}
+
+# logs-<package>.… / metrics-<package>.… / traces-<package>.…
+_INDEX_PACKAGE_RE = re.compile(r"^(?:logs|metrics|traces)-([a-zA-Z0-9_]+)", re.IGNORECASE)
 
 
 @dataclass
@@ -16,45 +33,131 @@ class EventDataset:
     package: str
     integration: str
 
+    def __post_init__(self) -> None:
+        self.package = DATASET_PACKAGE_ALIASES.get(self.package, self.package)
+
     def __str__(self) -> str:
         return f"{self.package}.{self.integration}"
 
 
-def get_esql_query_event_dataset_integrations(query: str) -> list[EventDataset]:
-    """Extract event.dataset and data_stream.dataset integrations from an ES|QL query."""
-    number_of_parts = 2
-    # Regex patterns for event.dataset, and data_stream.dataset
-    # This mimics the logic in get_datasets_and_modules but for ES|QL as we do not have an ast
+def normalize_dataset_package(package: str) -> str:
+    """Map alternate dataset package names to Fleet package names."""
+    return DATASET_PACKAGE_ALIASES.get(package, package)
 
-    regex_patterns = {
-        "in": [
-            re.compile(r"event\.dataset\s+in\s*\(\s*([^)]+)\s*\)"),
-            re.compile(r"data_stream\.dataset\s+in\s*\(\s*([^)]+)\s*\)"),
-        ],
-        "eq": [
-            re.compile(r'event\.dataset\s*==\s*"([^"]+)"'),
-            re.compile(r'data_stream\.dataset\s*==\s*"([^"]+)"'),
-        ],
-    }
 
-    # Extract datasets
-    datasets: list[str] = []
-    for regex_list in regex_patterns.values():
-        for regex in regex_list:
-            matches = regex.findall(query)
-            if matches:
-                for match in matches:
-                    if "," in match:
-                        # Handle `in` case with multiple values
-                        datasets.extend([ds.strip().strip('"') for ds in match.split(",")])
-                    else:
-                        # Handle `==` case
-                        datasets.append(match.strip().strip('"'))
-
+def get_esql_query_event_dataset_integrations(query: str, tree: Any | None = None) -> list[EventDataset]:
+    """Extract event.dataset / data_stream.dataset integrations from an ES|QL query."""
+    parsed = tree if tree is not None else esql.parse_query(query)
+    seen: set[tuple[str, str]] = set()
     event_datasets: list[EventDataset] = []
-    for dataset in datasets:
-        parts = dataset.split(".")
-        if len(parts) == number_of_parts:  # Ensure there are exactly two parts
-            event_datasets.append(EventDataset(package=parts[0], integration=parts[1]))
-
+    for ds in esql.get_event_datasets(parsed):
+        item = EventDataset(package=ds.package, integration=ds.integration)
+        key = (item.package, item.integration)
+        if key not in seen:
+            seen.add(key)
+            event_datasets.append(item)
     return event_datasets
+
+
+def index_patterns_match(left: str, right: str) -> bool:
+    """Return True when two index patterns refer to overlapping names."""
+    if left == right:
+        return True
+    return bool(fnmatch.fnmatch(left, right) or fnmatch.fnmatch(right, left))
+
+
+def infer_packages_from_indices(indices: list[str]) -> list[str]:
+    """Infer Fleet package names from ES|QL FROM index patterns."""
+    packages: list[str] = []
+    seen: set[str] = set()
+    for index in indices:
+        cleaned = index.replace("::", ":").split(":")[-1].strip()
+        match = _INDEX_PACKAGE_RE.match(cleaned)
+        if match:
+            package = normalize_dataset_package(match.group(1).lower())
+        elif cleaned.startswith("metrics-") or cleaned == "metrics-*":
+            # Broad metrics-* datastreams commonly include Elastic Agent system metrics.
+            package = "system"
+        else:
+            continue
+        if package not in seen:
+            seen.add(package)
+            packages.append(package)
+    return packages
+
+
+def collect_index_field_schemas(indices: list[str]) -> dict[str, Any]:
+    """Merge non-ECS / custom field schemas for the given FROM indices.
+
+    Mirrors remote ``prepare_mappings`` so offline validation includes alert fields
+    (``kibana.alert.*``), integration gaps tracked in ``non-ecs-schema.json``, and
+    custom index schemas.
+    """
+    fields: dict[str, Any] = {}
+    non_ecs = ecs.get_non_ecs_schema()
+    for index in indices:
+        fields.update(**ecs.flatten(ecs.get_index_schema(index)))
+        for key, index_fields in non_ecs.items():
+            if index_patterns_match(index, key):
+                fields.update(index_fields)
+        if CUSTOM_RULES_DIR:
+            fields.update(**ecs.flatten(ecs.get_custom_index_schema(index)))
+    fields.update(**ecs.flatten(ecs.get_endpoint_schemas()))
+    return fields
+
+
+def stream_matches_indices(package: str, dataset: str, indices: list[str]) -> bool:
+    """Return True when a Fleet package stream could back any FROM index pattern."""
+    if not indices:
+        return True
+    candidates = (
+        f"logs-{package}.{dataset}*",
+        f"logs-{package}.{dataset}-*",
+        f"metrics-{package}.{dataset}*",
+        f"metrics-{package}.{dataset}-*",
+        f"traces-{package}.{dataset}*",
+        f"traces-{package}.{dataset}-*",
+        # endpoint events use logs-endpoint.events.<dataset>-*
+        f"logs-{package}.events.{dataset}*",
+        f"logs-{package}.events.{dataset}-*",
+    )
+    return any(index_patterns_match(index, candidate) for index in indices for candidate in candidates)
+
+
+def collect_package_fields_for_indices(
+    package_schema: dict[str, Any],
+    package: str,
+    indices: list[str],
+    integration: str | None = None,
+) -> dict[str, Any]:
+    """Collect package fields, restricted to streams that match FROM indices.
+
+    When *integration* is set, returns that stream only if it matches. When unset,
+    unions matching streams. If no stream matches (should be rare), falls back to
+    all streams so broad patterns are not under-validated.
+    """
+    if integration is not None:
+        if integration not in package_schema:
+            return {}
+        if stream_matches_indices(package, integration, indices):
+            return dict(package_schema[integration])
+        return {}
+
+    fields: dict[str, Any] = {}
+    matched = False
+    for dataset, dataset_fields in package_schema.items():
+        if dataset == "jobs" or not isinstance(dataset_fields, dict):
+            continue
+        if stream_matches_indices(package, dataset, indices):
+            matched = True
+            fields.update(dataset_fields)
+    if matched:
+        return fields
+    # Fallback: no stream key matched (e.g. unusual index shape) — keep prior
+    # whole-package behavior rather than validating against an empty schema.
+    return {
+        field: value
+        for dataset, dataset_fields in package_schema.items()
+        if dataset != "jobs" and isinstance(dataset_fields, dict)
+        for field, value in dataset_fields.items()
+    }

--- a/detection_rules/esql.py
+++ b/detection_rules/esql.py
@@ -89,8 +89,8 @@ def infer_packages_from_indices(indices: list[str]) -> list[str]:
 def collect_index_field_schemas(indices: list[str]) -> dict[str, Any]:
     """Merge non-ECS / custom field schemas for the given FROM indices.
 
-    Mirrors remote ``prepare_mappings`` so offline validation includes alert fields
-    (``kibana.alert.*``), integration gaps tracked in ``non-ecs-schema.json``, and
+    Mirrors remote `prepare_mappings` so offline validation includes alert fields
+    (`kibana.alert.*`), integration gaps tracked in `non-ecs-schema.json`, and
     custom index schemas.
     """
     fields: dict[str, Any] = {}

--- a/detection_rules/esql_errors.py
+++ b/detection_rules/esql_errors.py
@@ -36,19 +36,20 @@ def cleanup_empty_indices(
 
 
 class EsqlKibanaBaseError(ClientError):
-    """Base class for ESQL exceptions with cleanup logic."""
+    """Base class for ESQL exceptions with optional remote cleanup logic."""
 
     def __init__(
         self,
         message: str,
-        elastic_client: Elasticsearch,
+        elastic_client: Elasticsearch | None = None,
     ) -> None:
-        cleanup_empty_indices(elastic_client)
+        if elastic_client is not None:
+            cleanup_empty_indices(elastic_client)
         super().__init__(message, original_error=self)
 
 
 class EsqlSchemaError(EsqlKibanaBaseError):
-    """Error in ESQL schema. Validated via Kibana until AST is available."""
+    """Error in ESQL schema (local python-esql or remote stack)."""
 
 
 class EsqlUnsupportedTypeError(EsqlKibanaBaseError):
@@ -56,7 +57,7 @@ class EsqlUnsupportedTypeError(EsqlKibanaBaseError):
 
 
 class EsqlSyntaxError(EsqlKibanaBaseError):
-    """Error with ESQL syntax."""
+    """Error with ESQL syntax (local python-esql or remote stack)."""
 
 
 class EsqlTypeMismatchError(ClientError):

--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -159,6 +159,82 @@ def get_simulated_index_template_mappings(elastic_client: Elasticsearch, name: s
     return template["template"]["mappings"]["properties"]
 
 
+_SCALAR_MAPPING_TYPES = frozenset(
+    {
+        "keyword",
+        "text",
+        "match_only_text",
+        "wildcard",
+        "constant_keyword",
+        "long",
+        "integer",
+        "short",
+        "byte",
+        "double",
+        "float",
+        "half_float",
+        "scaled_float",
+        "boolean",
+        "date",
+        "date_nanos",
+        "ip",
+        "version",
+        "binary",
+        "geo_point",
+        "geo_shape",
+        "flattened",
+    }
+)
+
+
+def combine_index_mappings(dest: dict[str, Any], src: dict[str, Any]) -> None:
+    """Merge nested index mappings without creating invalid scalar+properties shapes."""
+    for key, value in src.items():
+        existing = dest.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            src_type = value.get("type") if isinstance(value.get("type"), str) else None
+            dest_type = existing.get("type") if isinstance(existing.get("type"), str) else None
+            src_has_props = isinstance(value.get("properties"), dict)
+            dest_has_props = isinstance(existing.get("properties"), dict)
+
+            # Prefer object shapes over scalars (e.g. ECS keyword vs integration object).
+            if src_has_props and not dest_has_props:
+                dest[key] = value
+            elif (
+                dest_has_props
+                and not src_has_props
+                and src_type in _SCALAR_MAPPING_TYPES
+            ):
+                # Keep the richer object mapping already present.
+                continue
+            elif src_type in _SCALAR_MAPPING_TYPES and not src_has_props:
+                dest[key] = value
+            elif dest_type in _SCALAR_MAPPING_TYPES and src_has_props:
+                dest[key] = value
+            else:
+                combine_index_mappings(existing, value)
+        else:
+            dest[key] = value
+
+
+def prune_scalar_fields_with_subfields(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Drop ``properties``/``fields`` under scalar types (invalid ES mappings)."""
+    for value in mapping.values():
+        if not isinstance(value, dict):
+            continue
+        field_type = value.get("type")
+        if isinstance(field_type, str) and field_type in _SCALAR_MAPPING_TYPES:
+            value.pop("properties", None)
+            # Keep multi-fields on scalars; only drop nested object properties above.
+        nested = value.get("properties")
+        if isinstance(nested, dict):
+            prune_scalar_fields_with_subfields(nested)
+        fields = value.get("fields")
+        if isinstance(fields, dict):
+            prune_scalar_fields_with_subfields(fields)
+    return mapping
+
+
 def prune_mappings_of_unsupported_types(
     debug_str_data_source: str, stream_mappings: dict[str, Any], log: Callable[[str], None]
 ) -> dict[str, Any]:
@@ -199,18 +275,32 @@ def prepare_integration_mappings(  # noqa: PLR0913, PLR0917
     log: Callable[[str], None],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Prepare integration mappings for the given rule integrations."""
+    from .esql import normalize_dataset_package
+
     integration_mappings: dict[str, Any] = {}
     index_lookup: dict[str, Any] = {}
     dataset_restriction: dict[str, list[str]] = {}
 
+    # Normalize alternate dataset package names (e.g. googlecloud → gcp) before Fleet lookup.
+    rule_integrations = [normalize_dataset_package(pkg) for pkg in rule_integrations]
     # Process restrictions, note we need this for loops to be separate
     for event_dataset in event_dataset_integrations:
-        # Ensure the integration is in rule_integrations
-        if event_dataset.package not in rule_integrations:
-            dataset_restriction.setdefault(event_dataset.package, []).append(event_dataset.integration)
+        package = normalize_dataset_package(event_dataset.package)
+        if package not in rule_integrations:
+            dataset_restriction.setdefault(package, []).append(event_dataset.integration)
     for event_dataset in event_dataset_integrations:
-        if event_dataset.package not in rule_integrations:
-            rule_integrations.append(event_dataset.package)
+        package = normalize_dataset_package(event_dataset.package)
+        if package not in rule_integrations:
+            rule_integrations.append(package)
+
+    # Preserve order, drop duplicates after aliasing
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for package in rule_integrations:
+        if package not in seen:
+            seen.add(package)
+            deduped.append(package)
+    rule_integrations = deduped
 
     for integration in rule_integrations:
         package = integration
@@ -254,6 +344,79 @@ def get_index_to_package_lookup(indices: list[str], index_lookup: dict[str, Any]
     return index_lookup_indices
 
 
+def collect_known_esql_index_patterns(index_lookup: dict[str, Any], indices: list[str]) -> set[str]:
+    """Build the set of known ES|QL index patterns from Fleet streams + non-ECS/custom."""
+    # Assumes valid index format is logs-<integration>.<package>* or logs-<integration>.<package>-*
+    filtered_keys = {"logs-" + key.replace("-", ".") + "*" for key in index_lookup if key not in indices}
+    filtered_keys.update({"logs-" + key.replace("-", ".") + "-*" for key in index_lookup if key not in indices})
+    # Replace "logs-endpoint." with "logs-endpoint.events."
+    filtered_keys = {
+        key.replace("logs-endpoint.", "logs-endpoint.events.") if "logs-endpoint." in key else key
+        for key in filtered_keys
+    }
+    filtered_keys.update(ecs.get_non_ecs_schema().keys())
+    filtered_keys.update(ecs.get_custom_schemas().keys())
+    filtered_keys.add("logs-endpoint.alerts-*")
+    return filtered_keys
+
+
+def assert_known_esql_indices(indices: list[str], index_lookup: dict[str, Any]) -> list[str]:
+    """Return known patterns matching FROM indices; raise if none match."""
+    filtered_keys = collect_known_esql_index_patterns(index_lookup, indices)
+    matches: list[str] = []
+    for index in indices:
+        pattern = re.compile(index.replace(".", r"\.").replace("*", ".*").rstrip("-"))
+        matches.extend([key for key in filtered_keys if pattern.fullmatch(key)])
+
+    if not matches:
+        raise EsqlUnknownIndexError(
+            f"Unknown index pattern(s): {', '.join(indices)}. Known patterns: {', '.join(sorted(filtered_keys))}"
+        )
+
+    if "logs-endpoint.alerts-*" in matches and "logs-endpoint.events.alerts-*" not in matches:
+        matches.append("logs-endpoint.events.alerts-*")
+    return matches
+
+
+_OFFLINE_INDEX_LOOKUP_CACHE: dict[tuple[Any, ...], dict[str, Any]] = {}
+
+
+def validate_offline_esql_from_indices(
+    indices: list[str],
+    metadata: RuleMeta,
+    event_dataset_integrations: list[EventDataset],
+    stack_version: str,
+) -> list[str]:
+    """Offline parity with remote prepare_mappings unknown-index checks."""
+    from .esql import infer_packages_from_indices
+
+    rule_integrations = get_rule_integrations(metadata)
+    for package in infer_packages_from_indices(indices):
+        if package not in rule_integrations:
+            rule_integrations.append(package)
+
+    package_manifests = load_integrations_manifests()
+    integration_schemas = load_integrations_schemas()
+    known_packages = [p for p in rule_integrations if p in integration_schemas and p in package_manifests]
+    datasets_key = tuple(sorted((ds.package, ds.integration) for ds in event_dataset_integrations))
+    cache_key = (tuple(sorted(known_packages)), datasets_key, str(stack_version))
+    index_lookup = _OFFLINE_INDEX_LOOKUP_CACHE.get(cache_key)
+    if index_lookup is None:
+        index_lookup = {}
+        if known_packages:
+            _, index_lookup = prepare_integration_mappings(
+                known_packages,
+                event_dataset_integrations,
+                package_manifests,
+                integration_schemas,
+                stack_version,
+                lambda _msg: None,
+            )
+        _OFFLINE_INDEX_LOOKUP_CACHE[cache_key] = index_lookup
+
+    return assert_known_esql_indices(indices, index_lookup)
+
+
 def get_filtered_index_schema(  # noqa: PLR0913, PLR0917
     indices: list[str],
     index_lookup: dict[str, Any],
@@ -264,33 +427,7 @@ def get_filtered_index_schema(  # noqa: PLR0913, PLR0917
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Check if the provided indices are known based on the integration format. Returns the combined schema."""
 
-    non_ecs_indices = ecs.get_non_ecs_schema()
-    custom_indices = ecs.get_custom_schemas()
-
-    # Assumes valid index format is logs-<integration>.<package>* or logs-<integration>.<package>-*
-    filtered_keys = {"logs-" + key.replace("-", ".") + "*" for key in index_lookup if key not in indices}
-    filtered_keys.update({"logs-" + key.replace("-", ".") + "-*" for key in index_lookup if key not in indices})
-    # Replace "logs-endpoint." with "logs-endpoint.events."
-    filtered_keys = {
-        key.replace("logs-endpoint.", "logs-endpoint.events.") if "logs-endpoint." in key else key
-        for key in filtered_keys
-    }
-    filtered_keys.update(non_ecs_indices.keys())
-    filtered_keys.update(custom_indices.keys())
-    filtered_keys.add("logs-endpoint.alerts-*")
-
-    matches: list[str] = []
-    for index in indices:
-        pattern = re.compile(index.replace(".", r"\.").replace("*", ".*").rstrip("-"))
-        matches.extend([key for key in filtered_keys if pattern.fullmatch(key)])
-
-    if not matches:
-        raise EsqlUnknownIndexError(
-            f"Unknown index pattern(s): {', '.join(indices)}. Known patterns: {', '.join(filtered_keys)}"
-        )
-
-    if "logs-endpoint.alerts-*" in matches and "logs-endpoint.events.alerts-*" not in matches:
-        matches.append("logs-endpoint.events.alerts-*")
+    matches = assert_known_esql_indices(indices, index_lookup)
 
     # Now that we have the matched indices, we need to filter the index lookup to only include those indices
     filtered_index_lookup = {
@@ -470,7 +607,12 @@ def prepare_mappings(  # noqa: PLR0913, PLR0917
     existing_mappings, index_lookup = get_existing_mappings(elastic_client, indices)
 
     # Collect mappings for the integrations
+    from .esql import index_patterns_match, infer_packages_from_indices
+
     rule_integrations = get_rule_integrations(metadata)
+    for package in infer_packages_from_indices(indices):
+        if package not in rule_integrations:
+            rule_integrations.append(package)
 
     # Collect mappings for all relevant integrations for the given stack version
     package_manifests = load_integrations_manifests()
@@ -489,11 +631,15 @@ def prepare_mappings(  # noqa: PLR0913, PLR0917
     non_ecs_mapping: dict[str, Any] = {}
     non_ecs = ecs.get_non_ecs_schema()
     for index in indices:
-        index_mapping = non_ecs.get(index, {})
-        non_ecs_schema.update(index_mapping)
-        index_mapping = ecs.flatten(index_mapping)
-        index_mapping = utils.convert_to_nested_schema(index_mapping)
-        non_ecs_mapping.update({index: index_mapping})
+        matched_fields: dict[str, Any] = dict(non_ecs.get(index, {}))
+        for key, fields in non_ecs.items():
+            if key == index:
+                continue
+            if index_patterns_match(index, key):
+                matched_fields.update(fields)
+        non_ecs_schema.update(matched_fields)
+        nested = utils.convert_to_nested_schema(ecs.flatten(matched_fields))
+        non_ecs_mapping.update({index: nested})
 
     # These need to be handled separately as we need to be able to validate non-ecs fields as a whole
     # and also at a per index level as custom schemas can override non-ecs fields and/or indices
@@ -519,11 +665,23 @@ def prepare_mappings(  # noqa: PLR0913, PLR0917
         indices, index_lookup, ecs_schema, non_ecs_mapping, custom_mapping, log
     )
 
-    index_lookup.update({"rule-ecs-index": ecs_schema})
+    index_lookup.update({"rule-ecs-index": prune_scalar_fields_with_subfields(deepcopy(ecs_schema))})
 
     if (not integration_mappings or existing_mappings) and not non_ecs_schema and not ecs_schema:
         raise ValueError("No mappings found")
-    index_lookup.update({"rule-non-ecs-index": non_ecs_schema})
+    index_lookup.update({"rule-non-ecs-index": prune_scalar_fields_with_subfields(deepcopy(non_ecs_schema))})
     utils.combine_dicts(combined_mappings, deepcopy(non_ecs_schema))
+
+    # ES|QL verifies fields against each index in FROM. Merge ECS into every
+    # integration test-index mapping so remote validation matches offline
+    # (integration schema ∪ ECS), not integration-only fields.
+    for key, properties in list(index_lookup.items()):
+        if key in {"rule-ecs-index", "rule-non-ecs-index"}:
+            continue
+        if not isinstance(properties, dict):
+            continue
+        merged = deepcopy(ecs_schema)
+        combine_index_mappings(merged, deepcopy(properties))
+        index_lookup[key] = prune_scalar_fields_with_subfields(merged)
 
     return existing_mappings, index_lookup, combined_mappings

--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -200,16 +200,12 @@ def combine_index_mappings(dest: dict[str, Any], src: dict[str, Any]) -> None:
             # Prefer object shapes over scalars (e.g. ECS keyword vs integration object).
             if src_has_props and not dest_has_props:
                 dest[key] = value
-            elif (
-                dest_has_props
-                and not src_has_props
-                and src_type in _SCALAR_MAPPING_TYPES
-            ):
+            elif dest_has_props and not src_has_props and src_type in _SCALAR_MAPPING_TYPES:
                 # Keep the richer object mapping already present.
                 continue
-            elif src_type in _SCALAR_MAPPING_TYPES and not src_has_props:
-                dest[key] = value
-            elif dest_type in _SCALAR_MAPPING_TYPES and src_has_props:
+            elif (src_type in _SCALAR_MAPPING_TYPES and not src_has_props) or (
+                dest_type in _SCALAR_MAPPING_TYPES and src_has_props
+            ):
                 dest[key] = value
             else:
                 combine_index_mappings(existing, value)
@@ -266,7 +262,7 @@ def prune_mappings_of_unsupported_types(
     return stream_mappings
 
 
-def prepare_integration_mappings(  # noqa: PLR0913, PLR0917
+def prepare_integration_mappings(  # noqa: PLR0913
     rule_integrations: list[str],
     event_dataset_integrations: list[EventDataset],
     package_manifests: Any,
@@ -417,7 +413,7 @@ def validate_offline_esql_from_indices(
     return assert_known_esql_indices(indices, index_lookup)
 
 
-def get_filtered_index_schema(  # noqa: PLR0913, PLR0917
+def get_filtered_index_schema(  # noqa: PLR0913
     indices: list[str],
     index_lookup: dict[str, Any],
     ecs_schema: dict[str, Any],
@@ -595,7 +591,7 @@ def get_ecs_schema_mappings(current_version: Version) -> dict[str, Any]:
     return ecs_schema
 
 
-def prepare_mappings(  # noqa: PLR0913, PLR0917
+def prepare_mappings(  # noqa: PLR0913
     elastic_client: Elasticsearch,
     indices: list[str],
     event_dataset_integrations: list[EventDataset],
@@ -674,7 +670,7 @@ def prepare_mappings(  # noqa: PLR0913, PLR0917
 
     # ES|QL verifies fields against each index in FROM. Merge ECS into every
     # integration test-index mapping so remote validation matches offline
-    # (integration schema ∪ ECS), not integration-only fields.
+    # (integration schema union ECS), not integration-only fields.
     for key, properties in list(index_lookup.items()):
         if key in {"rule-ecs-index", "rule-non-ecs-index"}:
             continue

--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -218,7 +218,7 @@ def combine_index_mappings(dest: dict[str, Any], src: dict[str, Any]) -> None:
 
 
 def prune_scalar_fields_with_subfields(mapping: dict[str, Any]) -> dict[str, Any]:
-    """Drop ``properties``/``fields`` under scalar types (invalid ES mappings)."""
+    """Drop `properties`/`fields` under scalar types (invalid ES mappings)."""
     for value in mapping.values():
         if not isinstance(value, dict):
             continue

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -568,7 +568,7 @@ class BaseRuleData(MarshmallowDataclassMixin, StackCompatMixin):
 class DataValidator:
     """Additional validation beyond base marshmallow schema validation."""
 
-    def __init__(  # noqa: PLR0913, PLR0917
+    def __init__(  # noqa: PLR0913
         self,
         name: definitions.RuleName,
         is_elastic_rule: bool,
@@ -1051,7 +1051,7 @@ class ESQLRuleData(QueryRuleData):
     alert_suppression: AlertSuppressionMapping | None = field(metadata={"metadata": {"min_compat": "8.15"}})
 
     @validates_schema
-    def validates_esql_data(self, data: dict[str, Any], **_: Any) -> None:
+    def validates_esql_data(self, data: dict[str, Any], **_: Any) -> None:  # noqa: PLR0912
         """Custom validation for query rule type and subclasses."""
         import esql  # local import: avoid cycle with rule_validators at module import
 
@@ -1075,20 +1075,20 @@ class ESQLRuleData(QueryRuleData):
                 if not esql.is_aggregate_query(tree):
                     metadata = set(esql.get_metadata_fields(tree))
                     if not {"_id", "_version", "_index"}.issubset(metadata):
-                        raise esql.EsqlSemanticError(
+                        raise esql.EsqlSemanticError(  # noqa: TRY301
                             f"Rule: {data['name']} contains a non-aggregate query without metadata fields "
                             f"'_id', '_version', and '_index' -> Add 'metadata _id, _version, _index' "
                             f"to the from command or add an aggregate function."
                         )
             elif not bypass_keep:
                 if not esql.has_keep(tree):
-                    raise esql.EsqlSemanticError(
+                    raise esql.EsqlSemanticError(  # noqa: TRY301
                         f"Rule: {data['name']} does not contain a 'keep' command -> Add a 'keep' command to the query."
                     )
                 if not esql.is_aggregate_query(tree):
                     keep_columns = {c.strip() for c in esql.get_keep_columns(tree)}
                     if "*" not in keep_columns and not {"_id", "_version", "_index"}.issubset(keep_columns):
-                        raise esql.EsqlSemanticError(
+                        raise esql.EsqlSemanticError(  # noqa: TRY301
                             f"Rule: {data['name']} contains a keep clause without metadata fields "
                             f"'_id', '_version', and '_index' -> Add '_id', '_version', '_index' to the keep command."
                         )
@@ -1760,17 +1760,17 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         if isinstance(rule_integrations, str):
             rule_integrations = [rule_integrations]
         for integration in rule_integrations:
-            integration = normalize_dataset_package(integration)
+            package = normalize_dataset_package(integration)
             ml_packages_lower = set(map(str.lower, definitions.MACHINE_LEARNING_PACKAGES))
             if isinstance(data, MachineLearningRuleData):
-                packaged_integrations.append({"package": integration, "integration": None})
-            elif integration in definitions.NON_DATASET_PACKAGES:
-                if _metadata_package_row_needed(integration, datasets):
-                    packaged_integrations.append({"package": integration, "integration": None})
-            elif integration.lower() in ml_packages_lower or (
-                isinstance(data, ESQLRuleData) and _metadata_package_row_needed(integration, datasets)
+                packaged_integrations.append({"package": package, "integration": None})
+            elif package in definitions.NON_DATASET_PACKAGES:
+                if _metadata_package_row_needed(package, datasets):
+                    packaged_integrations.append({"package": package, "integration": None})
+            elif package.lower() in ml_packages_lower or (
+                isinstance(data, ESQLRuleData) and _metadata_package_row_needed(package, datasets)
             ):
-                packaged_integrations.append({"package": integration, "integration": None})
+                packaged_integrations.append({"package": package, "integration": None})
 
         packaged_integrations.extend(parse_datasets(list(datasets), package_manifest))
 

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -29,7 +29,7 @@ from semver import Version
 
 from . import beats, ecs, endgame, utils
 from .config import CUSTOM_RULES_DIR, load_current_package_version, parse_rules_config
-from .esql import get_esql_query_event_dataset_integrations
+from .esql import get_esql_query_event_dataset_integrations, normalize_dataset_package
 from .esql_errors import EsqlSemanticError
 from .integrations import (
     UNKNOWN_PACKAGE_INTEGRATION,
@@ -1053,67 +1053,57 @@ class ESQLRuleData(QueryRuleData):
     @validates_schema
     def validates_esql_data(self, data: dict[str, Any], **_: Any) -> None:
         """Custom validation for query rule type and subclasses."""
+        import esql  # local import: avoid cycle with rule_validators at module import
+
         if data.get("index"):
             raise EsqlSemanticError("Index is not a valid field for ES|QL rule type.")
 
-        # Convert the query string to lowercase to handle case insensitivity
-        query_lower = data["query"].lower()
+        bypass_metadata = os.environ.get("DR_BYPASS_ESQL_METADATA_VALIDATION") is not None
+        bypass_keep = os.environ.get("DR_BYPASS_ESQL_KEEP_VALIDATION") is not None
+        if bypass_metadata and bypass_keep:
+            return
 
-        # Combine both patterns using an OR operator and compile the regex.
-        # The first part matches the metadata fields in the from clause by allowing one or
-        # multiple indices and any order of the metadata fields
-        # The second part matches the stats command with the by clause
-        combined_pattern = re.compile(
-            r"(from\s+(?:\S+\s*,\s*)*\S+\s+metadata\s+"
-            r"(?:_id|_version|_index)(?:,\s*(?:_id|_version|_index)){2})"
-            r"|(\bstats\b.*?\bby\b)",
-            re.DOTALL,
-        )
+        cfg = set_esql_config(load_current_package_version())
+        with cfg, esql.Schema({}, allow_missing=True):
+            tree = esql.parse_query(data["query"])
 
-        # Ensure that non-aggregate queries have metadata
-        if os.environ.get("DR_BYPASS_ESQL_METADATA_VALIDATION") is None:
-            bypass_metadata_hint = (
-                " To bypass ES|QL `FROM` metadata validation, set the environment variable "
-                "`DR_BYPASS_ESQL_METADATA_VALIDATION`."
-            )
-            if not combined_pattern.search(query_lower):
-                raise EsqlSemanticError(
-                    f"Rule: {data['name']} contains a non-aggregate query without"
-                    f" metadata fields '_id', '_version', and '_index' ->"
-                    f" Add 'metadata _id, _version, _index' to the from command or add an aggregate function."
-                    + bypass_metadata_hint
+        try:
+            if not bypass_metadata and not bypass_keep:
+                esql.validate_detection_rule_query(tree, name=data["name"])
+            elif not bypass_metadata:
+                # KEEP bypassed: still enforce METADATA / aggregate shape.
+                if not esql.is_aggregate_query(tree):
+                    metadata = set(esql.get_metadata_fields(tree))
+                    if not {"_id", "_version", "_index"}.issubset(metadata):
+                        raise esql.EsqlSemanticError(
+                            f"Rule: {data['name']} contains a non-aggregate query without metadata fields "
+                            f"'_id', '_version', and '_index' -> Add 'metadata _id, _version, _index' "
+                            f"to the from command or add an aggregate function."
+                        )
+            elif not bypass_keep:
+                if not esql.has_keep(tree):
+                    raise esql.EsqlSemanticError(
+                        f"Rule: {data['name']} does not contain a 'keep' command -> Add a 'keep' command to the query."
+                    )
+                if not esql.is_aggregate_query(tree):
+                    keep_columns = {c.strip() for c in esql.get_keep_columns(tree)}
+                    if "*" not in keep_columns and not {"_id", "_version", "_index"}.issubset(keep_columns):
+                        raise esql.EsqlSemanticError(
+                            f"Rule: {data['name']} contains a keep clause without metadata fields "
+                            f"'_id', '_version', and '_index' -> Add '_id', '_version', '_index' to the keep command."
+                        )
+        except esql.EsqlSemanticError as exc:
+            hint = ""
+            if "metadata" in str(exc).lower():
+                hint = (
+                    " To bypass ES|QL `FROM` metadata validation, set the environment variable "
+                    "`DR_BYPASS_ESQL_METADATA_VALIDATION`."
                 )
-
-        # Enforce KEEP command for ESQL rules and that METADATA fields are present in non-aggregate queries
-        if os.environ.get("DR_BYPASS_ESQL_KEEP_VALIDATION") is None:
-            bypass_keep_hint = (
-                " To bypass ES|QL `keep` validation, set the environment variable `DR_BYPASS_ESQL_KEEP_VALIDATION`."
-            )
-            # Match | followed by optional whitespace/newlines and then 'keep'
-            keep_pattern = re.compile(r"\|\s*keep\b\s+([^\|]+)", re.IGNORECASE | re.DOTALL)
-            keep_matches = list(keep_pattern.finditer(query_lower))
-            if not keep_matches:
-                raise EsqlSemanticError(
-                    f"Rule: {data['name']} does not contain a 'keep' command -> Add a 'keep' command to the query."
-                    + bypass_keep_hint
+            elif "keep" in str(exc).lower():
+                hint = (
+                    " To bypass ES|QL `keep` validation, set the environment variable `DR_BYPASS_ESQL_KEEP_VALIDATION`."
                 )
-
-            # Ensure that keep clause includes metadata fields on non-aggregate queries
-            aggregate_pattern = re.compile(
-                r"\|\s*stats\b(?:\s+([^\|]+?))?(?:\s+by\s+([^\|]+))?", re.IGNORECASE | re.DOTALL
-            )
-            if not aggregate_pattern.search(query_lower):
-                for keep_match in keep_matches:
-                    raw_keep = re.sub(r"//.*", "", keep_match.group(1))
-                    keep_fields = [field.strip() for field in raw_keep.split(",") if field.strip()]
-                    if "*" not in keep_fields:
-                        required_metadata = {"_id", "_version", "_index"}
-                        if not required_metadata.issubset(set(map(str.strip, keep_fields))):
-                            raise EsqlSemanticError(
-                                f"Rule: {data['name']} contains a keep clause without"
-                                f" metadata fields '_id', '_version', and '_index' ->"
-                                f" Add '_id', '_version', '_index' to the keep command." + bypass_keep_hint
-                            )
+            raise EsqlSemanticError(f"{exc}{hint}") from exc
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -1770,6 +1760,7 @@ class TOMLRuleContents(BaseRuleContents, MarshmallowDataclassMixin):
         if isinstance(rule_integrations, str):
             rule_integrations = [rule_integrations]
         for integration in rule_integrations:
+            integration = normalize_dataset_package(integration)
             ml_packages_lower = set(map(str.lower, definitions.MACHINE_LEARNING_PACKAGES))
             if isinstance(data, MachineLearningRuleData):
                 packaged_integrations.append({"package": integration, "integration": None})
@@ -2068,19 +2059,58 @@ def set_eql_config(min_stack_version_val: str) -> eql.parser.ParserConfig:
     return config
 
 
+def set_esql_config(min_stack_version_val: str) -> Any:
+    """Enable ES|QL features for this stack version (python-esql + DR overrides)."""
+    import esql  # local import: rule.py loads validators at module end
+
+    if min_stack_version_val:
+        min_stack_version = Version.parse(min_stack_version_val, optional_minor_and_patch=True)
+    else:
+        min_stack_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
+
+    features = {**esql.ESQL_FEATURES, **(definitions.ELASTICSEARCH_ESQL_FEATURES or {})}
+    cfg = esql.ParserConfig(min_stack_version=str(min_stack_version))
+    for name, version_range in features.items():
+        lo, hi = version_range
+        lo_v = Version.parse(str(lo), optional_minor_and_patch=True) if not isinstance(lo, Version) else lo
+        hi_v = (
+            None
+            if hi is None
+            else (Version.parse(str(hi), optional_minor_and_patch=True) if not isinstance(hi, Version) else hi)
+        )
+        if lo_v <= min_stack_version <= (hi_v or min_stack_version):
+            cfg.context[name] = True
+        else:
+            cfg.context[name] = False
+
+    def _kql_parse(text: str) -> Any:
+        return kql.parse(text, normalize_kql_keywords=RULES_CONFIG.normalize_kql_keywords)
+
+    cfg.context["kql_parse"] = _kql_parse
+    return cfg
+
+
 def get_unique_query_fields(rule: TOMLRule) -> list[str] | None:
     """Get a list of unique fields used in a rule query from rule contents."""
     contents = rule.contents.to_api_format()
     language = contents.get("language")
     query = contents.get("query")
-    if language not in ("kuery", "eql"):
+    if language not in ("kuery", "eql", "esql"):
         return None
-
-    # remove once py-eql supports ipv6 for cidrmatch
 
     min_stack_version = rule.contents.metadata.get("min_stack_version")
     if not min_stack_version:
         raise ValueError("Min stack version not found")
+
+    if language == "esql":
+        import esql  # local import: avoid cycle with rule_validators
+
+        cfg = set_esql_config(min_stack_version)
+        with cfg, esql.Schema({}, allow_missing=True):
+            tree = esql.parse_query(query)
+        return sorted(esql.get_unique_fields(tree))
+
+    # remove once py-eql supports ipv6 for cidrmatch
     cfg = set_eql_config(min_stack_version)
     with eql.parser.elasticsearch_syntax, eql.parser.ignore_missing_functions, eql.parser.skip_optimizations, cfg:
         parsed = (  # type: ignore[reportUnknownVariableType]

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -14,6 +14,7 @@ from functools import cached_property, wraps
 from typing import Any
 
 import eql  # type: ignore[reportMissingTypeStubs]
+import esql
 import kql  # type: ignore[reportMissingTypeStubs]
 from elastic_transport import ObjectApiResponse
 from elasticsearch import Elasticsearch  # type: ignore[reportMissingTypeStubs]
@@ -32,21 +33,47 @@ from . import ecs, endgame, misc, utils
 from .beats import get_datasets_and_modules, parse_beats_from_index
 from .config import CUSTOM_RULES_DIR, load_current_package_version, parse_rules_config
 from .custom_schemas import update_auto_generated_schema
-from .esql import get_esql_query_event_dataset_integrations
+from .esql import (
+    collect_index_field_schemas,
+    collect_package_fields_for_indices,
+    get_esql_query_event_dataset_integrations,
+    infer_packages_from_indices,
+    normalize_dataset_package,
+)
+from .esql_errors import (
+    EsqlSchemaError as DrEsqlSchemaError,
+)
+from .esql_errors import (
+    EsqlSemanticError as DrEsqlSemanticError,
+)
+from .esql_errors import (
+    EsqlSyntaxError as DrEsqlSyntaxError,
+)
 from .esql_errors import EsqlTypeMismatchError
 from .index_mappings import (
     create_remote_indices,
     execute_query_against_indices,
     get_rule_integrations,
     prepare_mappings,
+    validate_offline_esql_from_indices,
 )
 from .integrations import (
+    find_latest_compatible_version,
     find_latest_integration_patch_for_minor,
     get_integration_schema_data,
     load_integrations_manifests,
+    load_integrations_schemas,
     parse_datasets,
 )
-from .rule import EQLRuleData, QueryRuleData, QueryValidator, RuleMeta, TOMLRuleContents, set_eql_config
+from .rule import (
+    EQLRuleData,
+    QueryRuleData,
+    QueryValidator,
+    RuleMeta,
+    TOMLRuleContents,
+    set_eql_config,
+    set_esql_config,
+)
 from .schemas import get_latest_stack_version, get_stack_schemas, get_stack_versions
 from .schemas.definitions import ESQL_DYNAMIC_FIELD_PREFIXES, FROM_SOURCES_REGEX
 
@@ -733,47 +760,77 @@ class EQLValidator(QueryValidator):
         return configured, any(f not in schema for f in configured)
 
 
+# Cross-rule caches for offline ES|QL validation (M6).
+_ESQL_SCHEMA_DICT_CACHE: dict[tuple[Any, ...], dict[str, Any]] = {}
+_ESQL_WARMED = False
+
+
+def _warm_esql_offline_caches() -> None:
+    """Load heavy integration/ECS artifacts once per process."""
+    global _ESQL_WARMED
+    if _ESQL_WARMED:
+        return
+    load_integrations_manifests()
+    load_integrations_schemas()
+    _ESQL_WARMED = True
+
+
 class ESQLValidator(QueryValidator):
-    """Validate specific fields for ESQL query event types."""
+    """Validate ES|QL queries offline via python-esql (optional remote fidelity)."""
 
     kibana_client: Kibana
     elastic_client: Elasticsearch
     metadata: RuleMeta
     rule_id: str
-    verbosity: int
-    esql_unique_fields: list[dict[str, str]]
+    verbosity: int = 0
+    esql_unique_fields: list[dict[str, str]] = None  # type: ignore[assignment]
+    _parsed_tree: Any | None = None
 
     def log(self, val: str) -> None:
         """Log if verbosity is 1 or greater (1 corresponds to `-v` in pytest)"""
         unit_test_verbose_level = 1
-        if self.verbosity >= unit_test_verbose_level:
-            print(f"{self.rule_id}:", val)
+        if getattr(self, "verbosity", 0) >= unit_test_verbose_level:
+            print(f"{getattr(self, 'rule_id', '')}:", val)
 
-    @property
+    def _ensure_fields(self) -> None:
+        if self.esql_unique_fields is None:
+            self.esql_unique_fields = []
+
+    def _parse_tree(self, min_stack_version: str | None = None) -> Any:
+        """Parse query with python-esql under the given stack config."""
+        stack = min_stack_version or load_current_package_version()
+        cfg = set_esql_config(stack)
+        # Empty schema for AST-only parse; field checks run in validate() with plan schemas.
+        with cfg, esql.Schema({}, allow_missing=True):
+            return esql.parse_query(self.query)
+
+    @cached_property
     def ast(self) -> Any:
-        """Return the AST of the ESQL query. Dependant on an ESQL parser, which is not implemented"""
-        # Needs to return none to prevent not implemented error
-        return None
+        """Return the AST of the ES|QL query."""
+        if self._parsed_tree is None:
+            self._parsed_tree = self._parse_tree()
+        return self._parsed_tree
 
     @cached_property
     def unique_fields(self) -> list[str]:  # type: ignore[reportIncompatibleMethodOverride]
-        """Return a list of unique fields in the query. Requires remote validation to have occurred."""
-        esql_unique_fields = getattr(self, "esql_unique_fields", None)
-        if esql_unique_fields:
-            return [field["name"] for field in self.esql_unique_fields]
-        return []
+        """Return unique field names from the AST (or remote columns when present)."""
+        remote = getattr(self, "esql_unique_fields", None)
+        if remote:
+            return [field["name"] for field in remote]
+        return list(esql.get_unique_fields(self.ast))
 
     def get_esql_query_indices(self, query: str) -> tuple[str, list[str]]:
-        """Extract indices from an ES|QL query."""
-        match = FROM_SOURCES_REGEX.search(query)
-        if not match:
-            return "", []
+        """Extract indices from an ES|QL query.
 
-        sources_str = match.group("sources")
-        # Truncate cross cluster search indices to local indices
-        sources_list: list[str] = [
-            source.split(":", 1)[-1].strip() if ":" in source else source.strip() for source in sources_str.split(",")
-        ]
+        Returns the exact FROM-sources substring (for remote index replacement) and a
+        normalized list of patterns from the AST.
+        """
+        tree = self.ast if query == self.query else esql.parse_query(query)
+        sources = esql.get_from_sources(tree)
+        sources_list = [source.split(":", 1)[-1].strip() if ":" in source else source.strip() for source in sources]
+        # Preserve original formatting so remote validation can ``query.replace(sources_str, …)``.
+        match = FROM_SOURCES_REGEX.search(query)
+        sources_str = match.group("sources") if match else ", ".join(sources)
         return sources_str, sources_list
 
     def get_unique_field_type(self, field_name: str) -> str | None:  # type: ignore[reportIncompatibleMethodOverride]
@@ -784,6 +841,201 @@ class ESQLValidator(QueryValidator):
                 return field["type"]
         return None
 
+    def build_validation_plan(self, data: "QueryRuleData", meta: RuleMeta) -> list[ValidationTarget]:
+        """Build offline validation targets across the release-window stack map."""
+        _warm_esql_offline_caches()
+        targets: list[ValidationTarget] = []
+        packages_manifest = load_integrations_manifests()
+        integrations_schemas = load_integrations_schemas()
+        package_integrations = TOMLRuleContents.get_packaged_integrations(data, meta, packages_manifest) or []
+
+        event_datasets = get_esql_query_event_dataset_integrations(self.query, tree=self.ast)
+        if not package_integrations and event_datasets:
+            package_integrations = [
+                {"package": ds.package, "integration": ds.integration} for ds in event_datasets
+            ]
+
+        _, from_indices = self.get_esql_query_indices(self.query)
+        # Infer Fleet packages from FROM patterns when metadata/datasets are absent
+        # (e.g. metrics-* → system) so offline schemas match remote mapping prep.
+        known_packages = {str(p.get("package")) for p in package_integrations if p.get("package")}
+        for package in infer_packages_from_indices(from_indices):
+            if package not in known_packages:
+                package_integrations.append({"package": package, "integration": None})
+                known_packages.add(package)
+        index_fields = collect_index_field_schemas(from_indices)
+        pkg_key = tuple(
+            sorted(
+                (normalize_dataset_package(str(p["package"])), p.get("integration"))
+                for p in package_integrations
+                if p.get("package")
+            )
+        )
+        indices_key = tuple(sorted(from_indices))
+
+        stack_versions = meta.get_validation_stack_versions()
+        if package_integrations:
+            # Combine packages per stack, but only Fleet streams that match FROM indices
+            # (parity with remote prepare_mappings / get_filtered_index_schema).
+            combined_by_stack: dict[str, dict[str, Any]] = {}
+            ecs_by_stack: dict[str, str] = {}
+            packages_by_stack: dict[str, set[str]] = {}
+
+            for stack_version, mapping in stack_versions.items():
+                ecs_version = mapping["ecs"]
+                ecs_by_stack[stack_version] = ecs_version
+                cache_key = (pkg_key, indices_key, str(stack_version), str(ecs_version))
+                cached_schema = _ESQL_SCHEMA_DICT_CACHE.get(cache_key)
+                if cached_schema is not None:
+                    combined_by_stack[stack_version] = cached_schema
+                    packages_by_stack[stack_version] = {
+                        normalize_dataset_package(str(p["package"]))
+                        for p in package_integrations
+                        if p.get("package")
+                    }
+                    continue
+
+                parsed_stack = Version.parse(stack_version)
+                patch_floor = find_latest_integration_patch_for_minor(
+                    {normalize_dataset_package(str(p["package"])) for p in package_integrations if p.get("package")},
+                    parsed_stack.major,
+                    parsed_stack.minor,
+                )
+                min_stack = Version(parsed_stack.major, parsed_stack.minor, max(parsed_stack.patch, patch_floor))
+                ecs_flat = ecs.flatten_multi_fields(ecs.get_schema(ecs_version, name="ecs_flat"))
+                schema_dict = dict(ecs_flat)
+                schema_dict.update(index_fields)
+
+                for pk_int in package_integrations:
+                    package = normalize_dataset_package(str(pk_int["package"]))
+                    integration = pk_int.get("integration")
+                    package_schemas = integrations_schemas.get(package, {})
+                    try:
+                        package_version, _ = find_latest_compatible_version(
+                            package,
+                            integration or "",
+                            min_stack,
+                            packages_manifest,
+                            package_schemas=package_schemas if integration else None,
+                        )
+                    except ValueError:
+                        continue
+                    if package not in integrations_schemas or package_version not in integrations_schemas[package]:
+                        continue
+                    package_schema = integrations_schemas[package][package_version]
+                    stream_fields = collect_package_fields_for_indices(
+                        package_schema, package, from_indices, integration
+                    )
+                    for field_name, field_type in stream_fields.items():
+                        schema_dict[field_name] = kql.parser.elasticsearch_type_family(field_type)
+                    packages_by_stack.setdefault(stack_version, set()).add(package)
+
+                combined_by_stack[stack_version] = schema_dict
+                _ESQL_SCHEMA_DICT_CACHE[cache_key] = schema_dict
+
+            for stack_version, schema_dict in combined_by_stack.items():
+                ecs_version = ecs_by_stack.get(stack_version, "unknown")
+                pkgs = ", ".join(sorted(p for p in packages_by_stack.get(stack_version, set()) if p))
+                err_trailer = (
+                    "Try adding event.module or event.dataset to specify integration module\n\n"
+                    f"Checked against packages [{pkgs}]; stack: {stack_version}; ecs: {ecs_version}\n"
+                    f"rule: {data.name} - {data.rule_id}"
+                )
+                targets.append(
+                    ValidationTarget(
+                        query_text=self.query,
+                        schema=esql.Schema(schema_dict, allow_missing=False),
+                        err_trailer=err_trailer,
+                        min_stack_version=stack_version,
+                        kind="integration",
+                        integration_types=sorted(packages_by_stack.get(stack_version, set())),
+                    )
+                )
+
+        if not targets:
+            for stack_version, mapping in stack_versions.items():
+                ecs_version = mapping["ecs"]
+                cache_key = (("__stack__",), indices_key, str(stack_version), str(ecs_version))
+                schema_dict = _ESQL_SCHEMA_DICT_CACHE.get(cache_key)
+                if schema_dict is None:
+                    raw_schema = ecs.get_schema(ecs_version)
+                    schema_dict = {
+                        k: (v.get("type") if isinstance(v, dict) else v) for k, v in raw_schema.items()
+                    }
+                    schema_dict.update(index_fields)
+                    _ESQL_SCHEMA_DICT_CACHE[cache_key] = schema_dict
+                err_trailer = (
+                    f"stack: {stack_version}, ecs: {ecs_version}\n" f"rule: {data.name} - {data.rule_id}"
+                )
+                targets.append(
+                    ValidationTarget(
+                        query_text=self.query,
+                        schema=esql.Schema(schema_dict, allow_missing=False),
+                        err_trailer=err_trailer,
+                        min_stack_version=str(stack_version),
+                        kind="stack",
+                    )
+                )
+
+        return targets
+
+    def validate_query_text_with_schema(  # noqa: PLR0913
+        self,
+        query_text: str,
+        schema: Any,
+        err_trailer: str,
+        min_stack_version: str,
+        beat_types: list[str] | None = None,
+        integration_types: list[str] | None = None,
+        tree: Any | None = None,
+    ) -> tuple[Exception | None, str | None]:
+        """Validate ES|QL query text with python-esql under Schema + ParserConfig."""
+        try:
+            cfg = set_esql_config(min_stack_version)
+            schema_ctx = (
+                schema
+                if isinstance(schema, esql.Schema)
+                else esql.Schema(schema or {}, allow_missing=False)
+            )
+            if tree is not None:
+                # Reuse a parse from the same grammar; re-check features + schema.
+                with cfg:
+                    esql.verify_features(tree, min_stack_version)
+                    esql.analyze(tree, schema_ctx)
+                self._parsed_tree = tree
+            else:
+                with cfg, schema_ctx:
+                    tree = esql.parse_query(query_text)
+                self._parsed_tree = tree
+            return None, None
+        except esql.EsqlSyntaxError as exc:
+            msg = str(exc)
+            if err_trailer:
+                msg = f"{msg}\n\n{err_trailer}"
+            return DrEsqlSyntaxError(msg), None
+        except esql.EsqlNestedQueryError as exc:
+            msg = str(exc)
+            if err_trailer:
+                msg = f"{msg}\n\n{err_trailer}"
+            return DrEsqlSemanticError(msg), None
+        except esql.EsqlSchemaError as exc:
+            msg = str(exc)
+            if err_trailer:
+                msg = f"{msg}\n\n{err_trailer}"
+            return DrEsqlSchemaError(msg), None
+        except esql.EsqlTypeMismatchError as exc:
+            msg = str(exc)
+            if err_trailer:
+                msg = f"{msg}\n\n{err_trailer}"
+            return EsqlTypeMismatchError(msg), None
+        except esql.EsqlSemanticError as exc:
+            msg = str(exc)
+            if err_trailer:
+                msg = f"{msg}\n\n{err_trailer}"
+            return DrEsqlSemanticError(msg), None
+        except Exception as exc:  # noqa: BLE001
+            return exc, None
+
     def validate_columns_index_mapping(
         self, query_columns: list[dict[str, str]], combined_mappings: dict[str, Any], version: str = "", query: str = ""
     ) -> bool:
@@ -792,30 +1044,22 @@ class ESQLValidator(QueryValidator):
 
         for column in query_columns:
             column_name = column["name"]
-            # Skip Dynamic fields
             if column_name.startswith(ESQL_DYNAMIC_FIELD_PREFIXES):
                 continue
-            # Skip internal fields
             if column_name in ("_id", "_version", "_index"):
                 continue
-            # Skip implicit fields
             if column_name not in query:
                 continue
             column_type = column["type"]
 
-            # Check if the column exists in combined_mappings or a valid field generated from a function or operator
             keys = column_name.split(".")
             schema_type = utils.get_column_from_index_mapping_schema(keys, combined_mappings)
             schema_type = kql.parser.elasticsearch_type_family(schema_type) if schema_type else None
 
-            # If it is in the schema, but Kibana returns unsupported
             if schema_type and column_type == "unsupported":
                 continue
 
-            # Validate the type
             if not schema_type or column_type != schema_type:
-                # Attempt reverse mapping as for our purposes they are equivalent.
-                # We are generally concerned about the operators for the types not the values themselves.
                 reverse_col_type = kql.parser.elasticsearch_type_family(column_type) if column_type else None
                 if reverse_col_type is not None and schema_type is not None and reverse_col_type == schema_type:
                     continue
@@ -834,7 +1078,53 @@ class ESQLValidator(QueryValidator):
         return True
 
     def validate(self, data: "QueryRuleData", rule_meta: RuleMeta, force_remote_validation: bool = False) -> None:  # type: ignore[reportIncompatibleMethodOverride]
-        """Validate an ESQL query while checking TOMLRule."""
+        """Validate an ESQL query: local python-esql by default; optional remote fidelity."""
+        if rule_meta.query_schema_validation is False or rule_meta.maturity == "deprecated":
+            return
+
+        _warm_esql_offline_caches()
+
+        # Unknown FROM patterns must fail offline (parity with remote prepare_mappings).
+        _, from_indices = self.get_esql_query_indices(self.query)
+        event_datasets = get_esql_query_event_dataset_integrations(self.query, tree=self.ast)
+        stack_versions = rule_meta.get_validation_stack_versions()
+        stack_version = (
+            max(stack_versions.keys(), key=lambda v: Version.parse(str(v), optional_minor_and_patch=True))
+            if stack_versions
+            else load_current_package_version()
+        )
+        validate_offline_esql_from_indices(from_indices, rule_meta, event_datasets, str(stack_version))
+
+        # Always run offline plan (syntax + nested KQL + version gates)
+        plan = self.build_validation_plan(data, rule_meta)
+        if not plan:
+            # Still parse once for AST / unique_fields
+            _ = self.ast
+
+        # Parse once per grammar snapshot; reuse AST for schema/feature checks (M6).
+        from esql.grammar_registry import resolve_grammar_key
+
+        trees_by_grammar: dict[str, Any] = {}
+        for target in plan:
+            gkey = resolve_grammar_key(target.min_stack_version)
+            tree = trees_by_grammar.get(gkey)
+            if tree is None:
+                cfg = set_esql_config(target.min_stack_version)
+                with cfg, esql.Schema({}, allow_missing=True):
+                    tree = esql.parse_query(target.query_text)
+                trees_by_grammar[gkey] = tree
+            exc, _ = self.validate_query_text_with_schema(
+                target.query_text,
+                target.schema,
+                err_trailer=target.err_trailer,
+                min_stack_version=target.min_stack_version,
+                beat_types=target.beat_types,
+                integration_types=target.integration_types,
+                tree=tree,
+            )
+            if exc is not None:
+                raise exc
+
         if misc.getdefault("remote_esql_validation")() or force_remote_validation:
             resolved_kibana_options = {
                 str(option.name): option.default() if callable(option.default) else option.default
@@ -853,7 +1143,6 @@ class ESQLValidator(QueryValidator):
                 misc.get_elasticsearch_client(**resolved_elastic_options) as elastic_client,  # type: ignore[reportUnknownVariableType]
             ):
                 query = data.query
-                # QueryRuleData permits None for custom filter-only KQL rules; ES|QL still requires a query.
                 if query is None:
                     raise ValueError("ES|QL remote validation requires a query.")
 
@@ -892,8 +1181,6 @@ class ESQLValidator(QueryValidator):
         self.rule_id = rule_id
         self.verbosity = verbosity
 
-        # Validate that all fields (columns) are either dynamic fields or correctly mapped
-        # against the combined mapping of all the indices
         kibana_details: dict[str, Any] = kibana_client.get("/api/status", {})  # type: ignore[reportUnknownVariableType]
         if "version" not in kibana_details:
             raise ValueError("Failed to retrieve Kibana details.")
@@ -909,32 +1196,21 @@ class ESQLValidator(QueryValidator):
             f"{', '.join(str(integration) for integration in event_dataset_integrations)}"
         )
 
-        # Get mappings for all matching existing index templates
         existing_mappings, index_lookup, combined_mappings = prepare_mappings(
             elastic_client, indices, event_dataset_integrations, metadata, stack_version, self.log
         )
         self.log(f"Collected mappings: {len(existing_mappings)}")
         self.log(f"Combined mappings prepared: {len(combined_mappings)}")
 
-        # Create remote indices
         full_index_str = create_remote_indices(elastic_client, existing_mappings, index_lookup, self.log)
 
-        # Replace all sources with the test indices
         query = query.replace(indices_str, full_index_str)  # type: ignore[reportUnknownVariableType]
 
         query_columns, response = execute_query_against_indices(elastic_client, query, full_index_str, self.log)  # type: ignore[reportUnknownVariableType]
         self.esql_unique_fields = query_columns
 
-        # Build a mapping lookup for all stack versions to validate against.
-        # We only need to check against the schemas locally for the type
-        # mismatch error, as the EsqlSchemaError and EsqlSyntaxError errors from the stack
-        # will not be impacted by the difference in schema type mapping.
         mappings_lookup: dict[str, dict[str, Any]] = {stack_version: combined_mappings}
 
-        # The schema-map keys stacks at MAJOR.MINOR.0, but an integration may gate its data stream
-        # behind a later patch (e.g. azure ~8.19.10). Validating at the literal .0 resolves an older
-        # package that predates the stream, so for each minor use the latest patch the rule's own
-        # integrations gate on. Only the rule's packages are inspected, not the full manifest.
         rule_packages = set(get_rule_integrations(metadata))
         rule_packages.update(integration.package for integration in event_dataset_integrations)
 

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -671,7 +671,7 @@ class EQLValidator(QueryValidator):
 
         raise ValueError(f"Maximum validation attempts exceeded for {data.rule_id} - {data.name}")
 
-    def validate_query_text_with_schema(  # noqa: PLR0913, PLR0917
+    def validate_query_text_with_schema(  # noqa: PLR0913
         self,
         query_text: str,
         schema: ecs.KqlSchema2Eql | endgame.EndgameSchema,
@@ -762,17 +762,16 @@ class EQLValidator(QueryValidator):
 
 # Cross-rule caches for offline ES|QL validation (M6).
 _ESQL_SCHEMA_DICT_CACHE: dict[tuple[Any, ...], dict[str, Any]] = {}
-_ESQL_WARMED = False
+_ESQL_WARM_STATE = {"warmed": False}
 
 
 def _warm_esql_offline_caches() -> None:
     """Load heavy integration/ECS artifacts once per process."""
-    global _ESQL_WARMED
-    if _ESQL_WARMED:
+    if _ESQL_WARM_STATE["warmed"]:
         return
     load_integrations_manifests()
     load_integrations_schemas()
-    _ESQL_WARMED = True
+    _ESQL_WARM_STATE["warmed"] = True
 
 
 class ESQLValidator(QueryValidator):
@@ -791,10 +790,6 @@ class ESQLValidator(QueryValidator):
         unit_test_verbose_level = 1
         if getattr(self, "verbosity", 0) >= unit_test_verbose_level:
             print(f"{getattr(self, 'rule_id', '')}:", val)
-
-    def _ensure_fields(self) -> None:
-        if self.esql_unique_fields is None:
-            self.esql_unique_fields = []
 
     def _parse_tree(self, min_stack_version: str | None = None) -> Any:
         """Parse query with python-esql under the given stack config."""
@@ -841,7 +836,9 @@ class ESQLValidator(QueryValidator):
                 return field["type"]
         return None
 
-    def build_validation_plan(self, data: "QueryRuleData", meta: RuleMeta) -> list[ValidationTarget]:
+    def build_validation_plan(  # noqa: PLR0912, PLR0915
+        self, data: "QueryRuleData", meta: RuleMeta
+    ) -> list[ValidationTarget]:
         """Build offline validation targets across the release-window stack map."""
         _warm_esql_offline_caches()
         targets: list[ValidationTarget] = []
@@ -851,9 +848,7 @@ class ESQLValidator(QueryValidator):
 
         event_datasets = get_esql_query_event_dataset_integrations(self.query, tree=self.ast)
         if not package_integrations and event_datasets:
-            package_integrations = [
-                {"package": ds.package, "integration": ds.integration} for ds in event_datasets
-            ]
+            package_integrations = [{"package": ds.package, "integration": ds.integration} for ds in event_datasets]
 
         _, from_indices = self.get_esql_query_indices(self.query)
         # Infer Fleet packages from FROM patterns when metadata/datasets are absent
@@ -889,9 +884,7 @@ class ESQLValidator(QueryValidator):
                 if cached_schema is not None:
                     combined_by_stack[stack_version] = cached_schema
                     packages_by_stack[stack_version] = {
-                        normalize_dataset_package(str(p["package"]))
-                        for p in package_integrations
-                        if p.get("package")
+                        normalize_dataset_package(str(p["package"])) for p in package_integrations if p.get("package")
                     }
                     continue
 
@@ -959,14 +952,10 @@ class ESQLValidator(QueryValidator):
                 schema_dict = _ESQL_SCHEMA_DICT_CACHE.get(cache_key)
                 if schema_dict is None:
                     raw_schema = ecs.get_schema(ecs_version)
-                    schema_dict = {
-                        k: (v.get("type") if isinstance(v, dict) else v) for k, v in raw_schema.items()
-                    }
+                    schema_dict = {k: (v.get("type") if isinstance(v, dict) else v) for k, v in raw_schema.items()}
                     schema_dict.update(index_fields)
                     _ESQL_SCHEMA_DICT_CACHE[cache_key] = schema_dict
-                err_trailer = (
-                    f"stack: {stack_version}, ecs: {ecs_version}\n" f"rule: {data.name} - {data.rule_id}"
-                )
+                err_trailer = f"stack: {stack_version}, ecs: {ecs_version}\nrule: {data.name} - {data.rule_id}"
                 targets.append(
                     ValidationTarget(
                         query_text=self.query,
@@ -979,24 +968,20 @@ class ESQLValidator(QueryValidator):
 
         return targets
 
-    def validate_query_text_with_schema(  # noqa: PLR0913
+    def validate_query_text_with_schema(  # noqa: PLR0911, PLR0912, PLR0913
         self,
         query_text: str,
         schema: Any,
         err_trailer: str,
         min_stack_version: str,
-        beat_types: list[str] | None = None,
-        integration_types: list[str] | None = None,
+        beat_types: list[str] | None = None,  # noqa: ARG002
+        integration_types: list[str] | None = None,  # noqa: ARG002
         tree: Any | None = None,
     ) -> tuple[Exception | None, str | None]:
         """Validate ES|QL query text with python-esql under Schema + ParserConfig."""
         try:
             cfg = set_esql_config(min_stack_version)
-            schema_ctx = (
-                schema
-                if isinstance(schema, esql.Schema)
-                else esql.Schema(schema or {}, allow_missing=False)
-            )
+            schema_ctx = schema if isinstance(schema, esql.Schema) else esql.Schema(schema or {}, allow_missing=False)
             if tree is not None:
                 # Reuse a parse from the same grammar; re-check features + schema.
                 with cfg:
@@ -1007,7 +992,6 @@ class ESQLValidator(QueryValidator):
                 with cfg, schema_ctx:
                     tree = esql.parse_query(query_text)
                 self._parsed_tree = tree
-            return None, None
         except esql.EsqlSyntaxError as exc:
             msg = str(exc)
             if err_trailer:
@@ -1035,6 +1019,8 @@ class ESQLValidator(QueryValidator):
             return DrEsqlSemanticError(msg), None
         except Exception as exc:  # noqa: BLE001
             return exc, None
+        else:
+            return None, None
 
     def validate_columns_index_mapping(
         self, query_columns: list[dict[str, str]], combined_mappings: dict[str, Any], version: str = "", query: str = ""
@@ -1167,7 +1153,7 @@ class ESQLValidator(QueryValidator):
             verbosity=verbosity,
         )
 
-    def remote_validate_rule(  # noqa: PLR0913, PLR0917
+    def remote_validate_rule(  # noqa: PLR0913
         self,
         kibana_client: Kibana,
         elastic_client: Elasticsearch,

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -828,7 +828,7 @@ class ESQLValidator(QueryValidator):
         tree = self.ast if query == self.query else esql.parse_query(query)
         sources = esql.get_from_sources(tree)
         sources_list = [source.split(":", 1)[-1].strip() if ":" in source else source.strip() for source in sources]
-        # Preserve original formatting so remote validation can ``query.replace(sources_str, …)``.
+        # Preserve original formatting so remote validation can `query.replace(sources_str, …)`.
         match = FROM_SOURCES_REGEX.search(query)
         sources_str = match.group("sources") if match else ", ".join(sources)
         return sources_str, sources_list

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -87,6 +87,9 @@ ELASTICSEARCH_EQL_FEATURES = {
     "allow_sample": (Version.parse("8.6.0"), None),
     "elasticsearch_validate_optional_fields": (Version.parse("7.16.0"), None),
 }
+# Optional overrides for python-esql feature gates (merged on top of esql.ESQL_FEATURES).
+# Shape: feature_name -> (introduced Version, removed Version | None)
+ELASTICSEARCH_ESQL_FEATURES: dict[str, tuple[Version, Version | None]] = {}
 NON_DATASET_PACKAGES = [
     "apm",
     "auditd_manager",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "Click~=8.3.0",
   "elasticsearch~=8.12.1",
   "eql==0.9.19",
-  "python-esql @ git+https://github.com/elastic/python-esql.git@main",
+  "python-esql==0.1.0",
   "jsl==0.2.4",
   "jsonschema>=4.21.1",
   "marko==2.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "Click~=8.3.0",
   "elasticsearch~=8.12.1",
   "eql==0.9.19",
+  "python-esql @ git+https://github.com/elastic/python-esql.git@main",
   "jsl==0.2.4",
   "jsonschema>=4.21.1",
   "marko==2.2.1",

--- a/rules/cross-platform/multiple_alerts_llm_by_user_entity.toml
+++ b/rules/cross-platform/multiple_alerts_llm_by_user_entity.toml
@@ -1,7 +1,9 @@
 [metadata]
 creation_date = "2026/02/12"
 maturity = "production"
-updated_date = "2026/04/07"
+min_stack_comments = "ES|QL COMPLETION command requires Elastic Managed LLM (gp-llm-v2) available in 9.3.0+"
+min_stack_version = "9.3.0"
+updated_date = "2026/07/25"
 
 [rule]
 author = ["Elastic"]

--- a/tests/test_esql_offline.py
+++ b/tests/test_esql_offline.py
@@ -1,0 +1,149 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+
+"""Offline ES|QL validation unit tests (no remote cluster)."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from detection_rules.esql import (
+    collect_index_field_schemas,
+    infer_packages_from_indices,
+    normalize_dataset_package,
+)
+from detection_rules.esql_errors import EsqlSchemaError, EsqlUnknownIndexError
+from detection_rules.index_mappings import combine_index_mappings, prune_scalar_fields_with_subfields
+from detection_rules.rule_loader import RuleCollection
+from detection_rules.utils import get_path, load_rule_contents
+
+
+def _sample_rule() -> dict:
+    file_path = get_path(["tests", "data", "command_control_dummy_production_rule.toml"])
+    return deepcopy(load_rule_contents(file_path)[0])
+
+
+class TestEsqlOfflineSchemaFailures:
+    """Queries that must fail offline validation with allow_missing=False."""
+
+    def test_unknown_index_raises_offline(self) -> None:
+        """Parity with remote test_esql_endpoint_unknown_index."""
+        rule = _sample_rule()
+        rule["metadata"]["integration"] = ["endpoint"]
+        rule["rule"]["query"] = """
+        FROM logs-endpoint.fake-* METADATA _id, _version, _index
+        | WHERE event.code in ("malicious_file", "memory_signature", "shellcode_thread")
+        | KEEP host.id, rule.name, event.code, _id, _version, _index
+        """
+        with pytest.raises(EsqlUnknownIndexError, match="logs-endpoint.fake"):
+            RuleCollection().load_dict(rule)
+
+    def test_unknown_field_raises_schema_error(self) -> None:
+        rule = _sample_rule()
+        rule["metadata"]["integration"] = ["endpoint"]
+        rule["rule"]["query"] = """
+        FROM logs-endpoint.events.process-* METADATA _id, _version, _index
+        | WHERE totally.made_up.field == "x"
+        | KEEP totally.made_up.field, _id, _version, _index
+        """
+        with pytest.raises(EsqlSchemaError, match="totally.made_up.field"):
+            RuleCollection().load_dict(rule)
+
+    def test_keep_only_unknown_field_raises_schema_error(self) -> None:
+        rule = _sample_rule()
+        rule["metadata"]["integration"] = ["endpoint"]
+        rule["rule"]["query"] = """
+        FROM logs-endpoint.events.process-* METADATA _id, _version, _index
+        | KEEP totally_unknown_keep_field, _id, _version, _index
+        """
+        with pytest.raises(EsqlSchemaError, match="totally_unknown_keep_field"):
+            RuleCollection().load_dict(rule)
+
+    def test_field_from_unrelated_package_raises_schema_error(self) -> None:
+        """Endpoint-only package plan must reject azure-only fields."""
+        rule = _sample_rule()
+        rule["metadata"]["integration"] = ["endpoint"]
+        rule["rule"]["query"] = """
+        FROM logs-endpoint.events.process-* METADATA _id, _version, _index
+        | WHERE azure.signinlogs.properties.session_id == "abc"
+        | KEEP azure.signinlogs.properties.session_id, _id, _version, _index
+        """
+        with pytest.raises(EsqlSchemaError, match="azure.signinlogs.properties.session_id"):
+            RuleCollection().load_dict(rule)
+
+    def test_field_outside_index_stream_raises_schema_error(self) -> None:
+        """billing index must not validate cloudtrail-only fields (stream filter)."""
+        rule = _sample_rule()
+        rule["metadata"]["integration"] = ["aws"]
+        rule["rule"]["query"] = """
+        FROM logs-aws.billing-* METADATA _id, _version, _index
+        | WHERE aws.cloudtrail.user_identity.type == "IAMUser"
+        | KEEP aws.cloudtrail.user_identity.type, _id, _version, _index
+        """
+        with pytest.raises(EsqlSchemaError):
+            RuleCollection().load_dict(rule)
+
+
+class TestEsqlOfflineSchemaPasses:
+    """Queries that must pass once schemas / defined columns are correct."""
+
+    def test_alert_index_kibana_alert_fields_pass(self) -> None:
+        rule = _sample_rule()
+        del rule["metadata"]["integration"]
+        rule["rule"]["query"] = """
+        FROM .alerts-security.* METADATA _id, _version, _index
+        | WHERE kibana.alert.rule.name IS NOT NULL AND kibana.alert.risk_score > 21
+        | KEEP kibana.alert.rule.name, kibana.alert.risk_score, _id, _version, _index
+        """
+        loaded = RuleCollection().load_dict(rule)
+        assert loaded.contents.data.language == "esql"
+
+    def test_grok_named_capture_field_passes(self) -> None:
+        rule = _sample_rule()
+        rule["metadata"]["integration"] = ["aws"]
+        rule["rule"]["query"] = """
+        FROM logs-aws.cloudtrail-* METADATA _id, _version, _index
+        | WHERE event.dataset == "aws.cloudtrail"
+        | GROK aws.cloudtrail.request_parameters "[Cc]ontent=(?<script_b64>[A-Za-z0-9+/=]+)"
+        | WHERE script_b64 IS NOT NULL
+        | KEEP script_b64, _id, _version, _index
+        """
+        loaded = RuleCollection().load_dict(rule)
+        assert "script_b64" in loaded.contents.data.query
+
+
+class TestEsqlSchemaHelpers:
+    def test_googlecloud_aliases_to_gcp(self) -> None:
+        assert normalize_dataset_package("googlecloud") == "gcp"
+        assert normalize_dataset_package("gcp") == "gcp"
+
+    def test_infer_packages_from_indices(self) -> None:
+        packages = infer_packages_from_indices(
+            ["logs-aws.cloudtrail-*", "metrics-*", ".alerts-security.*", "logs-googlecloud.audit-*"]
+        )
+        assert "aws" in packages
+        assert "system" in packages
+        assert "gcp" in packages
+        assert ".alerts-security.*" not in packages
+
+    def test_collect_index_field_schemas_includes_alert_fields(self) -> None:
+        fields = collect_index_field_schemas([".alerts-security.*"])
+        assert fields.get("kibana.alert.rule.name") == "keyword"
+        assert fields.get("kibana.alert.risk_score") == "long"
+
+    def test_combine_index_mappings_prefers_object_over_scalar(self) -> None:
+        dest = {"model": {"type": "keyword"}}
+        src = {"model": {"properties": {"id": {"type": "keyword"}}}}
+        combine_index_mappings(dest, src)
+        assert "properties" in dest["model"]
+        assert dest["model"]["properties"]["id"]["type"] == "keyword"
+
+    def test_prune_scalar_fields_with_subfields(self) -> None:
+        mapping = {"data": {"type": "keyword", "properties": {"nested": {"type": "keyword"}}}}
+        pruned = prune_scalar_fields_with_subfields(mapping)
+        assert pruned["data"]["type"] == "keyword"
+        assert "properties" not in pruned["data"]

--- a/tests/test_esql_offline.py
+++ b/tests/test_esql_offline.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import re
 from copy import deepcopy
 
 import pytest
@@ -39,7 +40,7 @@ class TestEsqlOfflineSchemaFailures:
         | WHERE event.code in ("malicious_file", "memory_signature", "shellcode_thread")
         | KEEP host.id, rule.name, event.code, _id, _version, _index
         """
-        with pytest.raises(EsqlUnknownIndexError, match="logs-endpoint.fake"):
+        with pytest.raises(EsqlUnknownIndexError, match=re.escape("logs-endpoint.fake")):
             RuleCollection().load_dict(rule)
 
     def test_unknown_field_raises_schema_error(self) -> None:
@@ -50,7 +51,7 @@ class TestEsqlOfflineSchemaFailures:
         | WHERE totally.made_up.field == "x"
         | KEEP totally.made_up.field, _id, _version, _index
         """
-        with pytest.raises(EsqlSchemaError, match="totally.made_up.field"):
+        with pytest.raises(EsqlSchemaError, match=re.escape("totally.made_up.field")):
             RuleCollection().load_dict(rule)
 
     def test_keep_only_unknown_field_raises_schema_error(self) -> None:
@@ -72,7 +73,7 @@ class TestEsqlOfflineSchemaFailures:
         | WHERE azure.signinlogs.properties.session_id == "abc"
         | KEEP azure.signinlogs.properties.session_id, _id, _version, _index
         """
-        with pytest.raises(EsqlSchemaError, match="azure.signinlogs.properties.session_id"):
+        with pytest.raises(EsqlSchemaError, match=re.escape("azure.signinlogs.properties.session_id")):
             RuleCollection().load_dict(rule)
 
     def test_field_outside_index_stream_raises_schema_error(self) -> None:


### PR DESCRIPTION
# Pull Request

_Issue link(s)_:
- Related to elastic/security-team#11554

## Summary - What I changed

* Offline ES|QL parse/schema validation via `esql-detection-rules-py` (`import esql`)
* Remote validation remains optional
* Vendor staging copy at `lib/esql` (`esql-detection-rules-py @ file:./lib/esql`) until PyPI publish
* `set_esql_config` now passes a `features` bool map that `verify_features()` actually reads
* Nested `KQL()` always normalizes keywords (uppercase `NOT`/`AND`/`OR`) and schema-checks against the same validation target
* Hunt validation uses `Schema({}, allow_missing=True)` so KEEP/ENRICH column visibility still runs
* Okta hunt KEEP restored to `source.user.full_name` (typo `ource.user…` could not survive KEEP projection)
* Merged `origin/main` (includes #6823 hunt query fixes)

## How To Test

* `pip install .[dev]`
* `pytest tests/test_esql_offline.py tests/test_hunt_data.py -q`
* Full corpus: from python-esql staging, `DETECTION_RULES_ROOT=../detection-rules python scripts/e2e_detection_rules_corpus.py`
* Release branches: `DETECTION_RULES_ROOT=../detection-rules python scripts/validate_release_branches.py`

## Local validation (2026-09-17)

| Check | Result |
| --- | --- |
| `pytest tests/test_esql_offline.py tests/test_hunt_data.py` | 31 passed |
| Full ES\|QL corpus | 228/228 |
| origin/8.19 | 198/198, 0 hygiene (#6829 dropped COMPLETION from 8.19) |
| origin/9.3 | 214/214 |
| origin/9.4 | 220/220 |
| origin/9.5 | 224/224 |

## Checklist

- [x] Added a label for the type of pr: `enhancement` + `minor`
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [x] Secret and sensitive material has been managed correctly
- [x] Automated testing was updated or added to match the most common scenarios
- [x] Documentation and comments were added for features that require explanation

## Notes

* Public package name is `esql-detection-rules-py` (staging GitHub: `elastic/python-esql`). Official repo `elastic/esql-detection-rules-py` is a later one-commit cutover.
* Grammar versions live inside the parser package (`esql/_antlr/…`).
* COMPLETION `WITH { map }` requires `min_stack_version` 9.3+; 8.19 tech-preview identifier syntax is not treated as supported detection-rules syntax.