### PR TITLE
Fix KQL to EQL conversion treating an escaped/quoted asterisk as a wildcard

### DIFF
--- a/lib/kql/kql/kql2eql.py
+++ b/lib/kql/kql/kql2eql.py
@@ -128,6 +128,8 @@ class KqlToEQL(BaseKqlParser):
         if self.get_field_types(field_name) == {"ip"} and "/" in value:
             return eql.ast.FunctionCall("cidrMatch", [field, value_ast])
 
+        # For values with a literal `*`, this `==` Comparison is exact-match at the AST Level
+        # If re-parsing its string output with py eql, the value folds `== "foo*bar"` back into wildcard()
         return eql.ast.Comparison(field, "==", value_ast)
 
     def literal(self, tree):

--- a/lib/kql/kql/kql2eql.py
+++ b/lib/kql/kql/kql2eql.py
@@ -108,8 +108,12 @@ class KqlToEQL(BaseKqlParser):
         field_name = self.scoped_field
         field = self.to_eql_field(field_name)
 
-        # Handle wildcard literals (may contain spaces) and unquoted literals with wildcards
-        if token.type == "WILDCARD_LITERAL" or (token.type == "UNQUOTED_LITERAL" and "*" in str(token.value)):
+        # Handle wildcard literals (may contain spaces) and unquoted literals with an
+        # *unescaped* wildcard. A quoted string, or an unquoted literal whose only `*`
+        # are escaped (`\*`), is a literal asterisk and must not be treated as a glob -
+        # mirrors kql.parser.BaseKqlParser.value (see issue #441).
+        if token.type == "WILDCARD_LITERAL" or (token.type == "UNQUOTED_LITERAL"
+                                                and self.has_unescaped_wildcard(token.value)):
             if eql.utils.is_string(value) and value.replace("*", "").strip() == "":
                 return eql.ast.IsNotNull(field)
             value_ast = eql.ast.Literal.from_python(value)
@@ -120,12 +124,6 @@ class KqlToEQL(BaseKqlParser):
 
         if value is None:
             return eql.ast.IsNull(field)
-
-        if eql.utils.is_string(value) and value.replace("*", "") == "":
-            return eql.ast.IsNotNull(field)
-
-        if eql.utils.is_string(value) and "*" in value:
-            return eql.ast.FunctionCall("wildcard", [field, value_ast])
 
         if self.get_field_types(field_name) == {"ip"} and "/" in value:
             return eql.ast.FunctionCall("cidrMatch", [field, value_ast])

--- a/lib/kql/pyproject.toml
+++ b/lib/kql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection-rules-kql"
-version = "0.1.11"
+version = "0.1.12"
 description = "Kibana Query Language parser for Elastic Detection Rules"
 license = {text = "Elastic License v2"}
 keywords = ["Elastic", "sour", "Detection Rules", "Security", "Elasticsearch", "kql"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.0.5"
+version = "2.0.6"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/kuery/test_kql2eql.py
+++ b/tests/kuery/test_kql2eql.py
@@ -22,6 +22,16 @@ class TestKql2Eql(unittest.TestCase):
         self.validate("not field:*", "field == null")
         self.validate("field:*", "field != null")
 
+    def test_quoted_and_escaped_asterisk_is_literal(self):
+        # A quoted `*`, or an escaped `\*`, is a literal asterisk and must convert to
+        # an exact `==` comparison, not a wildcard() glob match - this already matches
+        # kql.parse()/kql.to_dsl() for the same input (see issue #441).
+        for kql_source in ['field:"foo*bar"', r"field:foo\*bar"]:
+            converted = kql.to_eql(kql_source)
+            self.assertIsInstance(converted, eql.ast.Comparison)
+            self.assertEqual(converted.comparator, "==")
+            self.assertEqual(converted.right.value, "foo*bar")
+
     def test_field_inequality(self):
         self.validate("field < value", "field < 'value'")
         self.validate("field > -1", "field > -1")


### PR DESCRIPTION
`kql.to_eql()` doesn't agree with `kql.parse()`/`kql.to_dsl()` on what a literal asterisk means. `field: "foo*bar"` (quoted, so literal per KQL) and `field: foo\*bar` (backslash-escaped) both resolve to an exact match on the native parse path, but through `kql2eql.py` they compile into an EQL `wildcard()` call. The resulting EQL then matches `fooXYZbar`, `foo123bar`, `foobar` — anything of that shape — instead of the literal string.

The cause is that `kql2eql.py`'s `value()` still uses the old `"*" in token.value` check that `parser.py` moved away from in #6001. That PR added `has_unescaped_wildcard()` so an escaped `\*` isn't treated as a glob, and fixed the native parse path, but `kql2eql.py` never got the same treatment. It also had a second, redundant `"*" in value` check further down that would misfire even after fixing the first one.

Both spots now reuse `has_unescaped_wildcard()` from the shared base class, so the EQL path agrees with `parser.py`.

```pycon
>>> import kql
>>> kql.to_eql('field:"foo*bar"')
field == "foo*bar"
```

Before this change that came back as `wildcard(field, "foo*bar")`. A genuine unescaped wildcard like `field:foo*bar` still converts to `wildcard()`, and `field:*` / `not field:*` still map to the null checks.

Added `test_quoted_and_escaped_asterisk_is_literal` and ran the `tests/kuery` suite.
