### PR TITLE
Validate the field against the schema in KQL range expressions

### DIFF
--- a/lib/kql/kql/parser.py
+++ b/lib/kql/kql/parser.py
@@ -338,6 +338,8 @@ class KqlParser(BaseKqlParser):
     def field_range_expression(self, tree):
         field_tree, operator, literal = tree.children
         with self.scope(self.visit(field_tree)) as field:
+            # check the field against the schema
+            self.get_field_types(field.name, field_tree)
             value = self.convert_value(field.name, self.visit(literal), literal)
             return FieldRange(field, operator, Value.from_python(value))
 

--- a/lib/kql/pyproject.toml
+++ b/lib/kql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection-rules-kql"
-version = "0.1.11"
+version = "0.1.12"
 description = "Kibana Query Language parser for Elastic Detection Rules"
 license = {text = "Elastic License v2"}
 keywords = ["Elastic", "sour", "Detection Rules", "Security", "Elasticsearch", "kql"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.0.5"
+version = "2.0.6"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rules/windows/defense_evasion_posh_compressed.toml
+++ b/rules/windows/defense_evasion_posh_compressed.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/10/19"
 integration = ["windows"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/26"
 
 [rule]
 author = ["Elastic"]
@@ -12,7 +12,7 @@ Attackers use this pattern to deobfuscate and reconstruct payloads in memory to 
 """
 false_positives = ["Legitimate PowerShell scripts that reconstruct to a confirmed benign installer, updater, or administrative workflow for the same user and host scope."]
 from = "now-9m"
-index = ["logs-windows.powershell*", "winlogbeat-*"]
+index = ["logs-windows.powershell*"]
 language = "kuery"
 license = "Elastic License v2"
 name = "PowerShell Suspicious Payload Encoded and Compressed"

--- a/tests/kuery/test_parser.py
+++ b/tests/kuery/test_parser.py
@@ -90,6 +90,25 @@ class ParserTests(unittest.TestCase):
         with self.assertRaises(kql.KqlParseError):
             kql.parse("@time > 5", schema=schema)
 
+    def test_range_expression_unknown_field(self):
+        """Range comparisons must validate the field against the schema, like `:` does."""
+        schema = {"process.pid": "long"}
+
+        self.validate("process.pid > 5", FieldRange(Field("process.pid"), ">", Number(5)), schema=schema)
+
+        for query in ("typo.pid > 5", "typo.pid >= 5", "typo.pid < 5", "typo.pid <= 5"):
+            with self.assertRaises(kql.KqlParseError) as exc:
+                kql.parse(query, schema=schema)
+            self.assertEqual(exc.exception.error_msg, "Unknown field")
+
+        # a wildcard field that matches nothing used to raise AttributeError instead
+        with self.assertRaises(kql.KqlParseError) as exc:
+            kql.parse('"process.*.nope" > 5', schema=schema)
+        self.assertEqual(exc.exception.error_msg, "Unknown field")
+
+        # without a schema there is nothing to check against
+        self.validate("typo.pid > 5", FieldRange(Field("typo.pid"), ">", Number(5)))
+
     def test_optimization(self):
         query = 'host.name: test-* and not (destination.ip : "127.0.0.53" and destination.ip : "169.254.169.254")'
         dsl_str = str(kql.to_dsl(query))


### PR DESCRIPTION
`field_value_expression` checks the field against the schema before it does anything else, but `field_range_expression` never got the same call. So `some.typo.field : 5` is caught and `some.typo.field > 5` sails straight through.

Two things fall out of that. Unknown fields in a range comparison aren't reported at all, and a wildcard field that matches nothing blows up with `AttributeError: 'NoneType' object has no attribute 'line'` instead of a `KqlParseError` — `convert_value` calls `get_field_types` without a lark tree, so the "Unknown field" error gets built from `None`.

With a schema of `{"process.pid": "long"}`, on `main`:

```
'typo.pid > 5'          -> no error, returns FieldRange(...)
'"process.*.nope" > 5'  -> AttributeError: 'NoneType' object has no attribute 'line'
'typo.pid : 5'          -> KqlParseError: Unknown field     <- the ':' path gets it right
```

After the change all three raise `KqlParseError: Unknown field`, and queries parsed without a schema are unaffected.

Adding the one missing `get_field_types` call turned up a rule that's already wrong on `main`. `defense_evasion_posh_compressed.toml` lists `winlogbeat-*` in its index, but the query needs `powershell.file.script_block_entropy_bits`, which winlogbeat doesn't produce. I checked every schema in `etc/beats_schemas` — the only `script_block` fields anywhere are `script_block_hash`, `script_block_id` and `script_block_text` — and the `winlogbeat-*` block in `non-ecs-schema.json` declares just `powershell.file.script_block_text`, which is why the `:` clause passed and the `>=` one was never looked at. The entropy field comes from the Windows integration pipeline. Since the clause is ANDed, the rule can't match on winlogbeat data at all. `defense_evasion_posh_high_entropy.toml` uses the same fields and lists only `logs-windows.powershell*`, so I made this one match.

Happy to split the rule change out if you'd rather own that part — the parser fix can't merge green without it, but the call on which index list is right is yours.

Added a test in `tests/kuery/test_parser.py` covering the unknown-field, wildcard and no-schema cases.
