### PR TITLE
Fix dict_filter crashing on a missing key and ignoring all but the first criterion

### DIFF
--- a/detection_rules/rule_loader.py
+++ b/detection_rules/rule_loader.py
@@ -44,7 +44,7 @@ def path_getter(value: str) -> Callable[[dict[str, Any]], Any]:
 
     def callback(obj: dict[str, Any]) -> Any:
         for p in path:
-            if p in path:
+            if isinstance(obj, dict) and p in obj:
                 obj = obj[p]
             else:
                 return None
@@ -76,9 +76,10 @@ def dict_filter(_obj: dict[str, Any] | None = None, **criteria: Any) -> Callable
                 else {target_values}
             )
 
-            return bool(expected.intersection(target_values))  # type: ignore[reportUnknownArgumentType]
+            if not expected.intersection(target_values):  # type: ignore[reportUnknownArgumentType]
+                return False
 
-        return False
+        return True
 
     return callback
 

--- a/tests/test_rule_loader.py
+++ b/tests/test_rule_loader.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from detection_rules.kbwrap import kibana_export_rules
 from detection_rules.main import import_rules_into_repo
-from detection_rules.rule_loader import RawRuleCollection
+from detection_rules.rule_loader import RawRuleCollection, dict_filter, path_getter
 
 DUPLICATE_NAME = "Duplicate Name Rule"
 ACTIVE_RULE_ID = "11111111-1111-4111-8111-111111111111"
@@ -84,6 +84,27 @@ class TestRawRuleCollectionDeprecatedSplit(unittest.TestCase):
 
             self.assertEqual(len(collection.rules), 1)
             self.assertEqual(len(collection.deprecated.rules), 1)
+
+
+class TestDictFilter(unittest.TestCase):
+    """path_getter/dict_filter must not crash on a missing key and must AND all criteria."""
+
+    def test_path_getter_missing_key_returns_none(self) -> None:
+        """A dotted path whose final key is absent should resolve to None, not raise KeyError."""
+        getter = path_getter("metadata__integration")
+        self.assertIsNone(getter({"metadata": {"maturity": "production"}}))
+
+    def test_dict_filter_requires_every_criterion_to_match(self) -> None:
+        """dict_filter must reject an object that fails any one of several criteria."""
+        flt = dict_filter(maturity="production", integration="okta")
+        self.assertTrue(flt({"maturity": "production", "integration": "okta"}))
+        self.assertFalse(flt({"maturity": "production", "integration": "aws"}))
+        self.assertFalse(flt({"maturity": "development", "integration": "okta"}))
+
+    def test_dict_filter_missing_optional_field_does_not_match(self) -> None:
+        """A criterion on a field the object doesn't have should fail closed, not raise."""
+        flt = dict_filter(maturity="production", integration="okta")
+        self.assertFalse(flt({"maturity": "production"}))
 
 
 class TestLoadRuleLoadingFlagBackwardsCompatibility(unittest.TestCase):


### PR DESCRIPTION
Two problems in the same block, both in `rule_loader.py`.

`path_getter`'s missing-key guard is `if p in path`, but `p` came from `path` a line earlier, so it's always true and the `else: return None` branch can never run. A path segment that isn't actually in the object falls through to `obj[p]` and raises `KeyError` instead of resolving to `None`.

`dict_filter`'s callback returns inside its loop over `checkers`, so it answers on the first criterion and never looks at the rest. Any second or later kwarg is silently ignored.

Neither bites today's callers, because they all pass a single criterion for a field every rule has — `production_filter` is `metadata_filter(maturity="production")`, and `cli_utils` passes `dict_filter(rule__rule_id=...)`. It breaks as soon as you filter on an optional metadata field or pass more than one kwarg, which is what `**criteria` is for.

Against the real collection on `main`:

```pycon
>>> rule = next(r for r in RuleCollection.default() if "integration" not in r.contents.metadata.to_dict())
>>> metadata_filter(integration="okta")(rule)
KeyError: 'integration'

>>> metadata_filter(maturity="production", integration="not-a-real-integration")(some_production_rule)
True    # the integration criterion never ran
```

56 rules in the current collection have no `integration` key, so that first case isn't hypothetical.

The fix checks `p in obj` instead of `p in path`, and moves the no-match return inside the loop so it only fires when a criterion actually fails, falling through to `True` once they've all passed.

Checked for regressions with the fix applied: the full collection still loads (2026 rules, 117 deprecated) and `production_filter` still matches all 2026, so single-criterion behaviour is unchanged. `metadata_filter(integration="okta")` on a rule without that key now returns `False` instead of raising, and a two-criteria filter where the second one fails correctly returns `False`.

Added `TestDictFilter` in `tests/test_rule_loader.py` covering the missing-key case, the multi-criteria AND case, and a criterion on a field the object doesn't have. All three fail on `main` (the first with `KeyError`, the others returning `True`) and pass with this change.
