### PR TITLE
[Bug] Fix import-rules error handling: KeyError on errors without rule_id; unread exceptions/connector error arrays

### DIFF
--- a/detection_rules/kbwrap.py
+++ b/detection_rules/kbwrap.py
@@ -126,16 +126,26 @@ def kibana_import_rules(  # noqa: PLR0915
         flattened_exceptions: list[dict[str, Any]] = [e for sublist in exception_dicts for e in sublist]
         all_exception_list_ids: set[str] = {exception["list_id"] for exception in flattened_exceptions}
 
-        click.echo(f"{len(response['errors'])} rule(s) failed to import!")
+        if response["errors"]:
+            click.echo(f"{len(response['errors'])} rule(s) failed to import!")
+        if response.get("exceptions_errors"):
+            click.echo(f"{len(response['exceptions_errors'])} exception list(s) failed to import!")
+        if response.get("action_connectors_errors"):
+            click.echo(f"{len(response['action_connectors_errors'])} action connector(s) failed to import!")
 
+        all_errors: list[dict[str, Any]] = (
+            response["errors"]
+            + response.get("exceptions_errors", [])
+            + response.get("action_connectors_errors", [])
+        )
         action_connector_validation_error = "Error validating create data"
         action_connector_type_error = "expected value of type [string] but got [undefined]"
-        for error in response["errors"]:
+        for error in all_errors:
             error_details = error.get("error", {})
             error_message = error_details.get("message", "<missing error message>")
             status_code = error_details.get("status_code", "unknown status")
             rule_id = error.get("rule_id")
-            display_rule_id = rule_id or "<unknown rule_id>"
+            display_rule_id = rule_id or error.get("id") or "<unknown rule_id>"
             click.echo(f" - {display_rule_id}: ({status_code}) {error_message}")
 
             if "references a non existent exception list" in error_message:
@@ -202,7 +212,7 @@ def kibana_import_rules(  # noqa: PLR0915
         click.echo(f"{len(successful_rule_ids)} rule(s) successfully imported")  # type: ignore[reportUnknownArgumentType]
         rule_str = "\n - ".join(successful_rule_ids)  # type: ignore[reportUnknownArgumentType]
         click.echo(f" - {rule_str}")
-    if response["errors"]:
+    if response["errors"] or response.get("exceptions_errors") or response.get("action_connectors_errors"):
         _handle_response_errors(response)  # type: ignore[reportUnknownArgumentType]
     else:
         _process_imported_items(exception_dicts, "exception list(s)", "list_id")  # type: ignore[reportUnknownArgumentType]

--- a/lib/kibana/kibana/resources.py
+++ b/lib/kibana/kibana/resources.py
@@ -249,7 +249,10 @@ class RuleResource(BaseResource):
         )
         response = Kibana.current().post(url, headers=headers, params=params, raw_data=raw_data)
         errors = response.get("errors", [])
-        error_rule_ids = [e['rule_id'] for e in errors]
+        # Error entries are not guaranteed to carry a rule_id: ndjson schema-parse
+        # failures come back with only an `error` object, and action-connector
+        # errors are keyed by `id` instead.
+        error_rule_ids = [e.get('rule_id') or e.get('id') for e in errors]
 
         # successful rule_ids are not returned, so they must be implicitly inferred from errored rule_ids
         successful_rule_ids = [r for r in rule_ids if r not in error_rule_ids]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: none — happy to open a companion issue if preferred; context below is self-contained.

## Summary - What I changed

Two related defects in the `kibana import-rules` error handling, both hit in production during a detection-as-code CI deploy against a serverless Kibana project:

**1. `KeyError: 'rule_id'` crash that swallows the real Kibana error.**
`RuleResource.import_rules` (`lib/kibana/kibana/resources.py`) does `error_rule_ids = [e['rule_id'] for e in errors]`, but Kibana's `_import` API returns some error entries **without** a `rule_id` key:

- ndjson schema-parse failures carry only an `error` object — acknowledged as a TODO in Kibana's [`create_rules_stream_from_ndjson.ts`](https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/lib/detection_engine/rule_management/logic/import/create_rules_stream_from_ndjson.ts) ("Capture both the line number and the rule_id if you have that information for the error message");
- action-connector errors are keyed by `id` instead of `rule_id`.

Any such entry crashes the CLI with a traceback **before the actual Kibana error message is printed**, turning a one-line schema reject (in our case `actions.0.frequency.throttle: Required`) into an undiagnosable failure. Fixed with `e.get('rule_id') or e.get('id')`, mirroring the defensive `error.get("rule_id")` pattern `kbwrap._handle_response_errors` already uses.

**2. Exception-list / action-connector rejections import "green".**
Kibana reports exception and connector ndjson rejections in the separate `exceptions_errors` / `action_connectors_errors` response arrays, which `kibana_import_rules` never read — only `response["errors"]`. A rejected exception list therefore exits 0 with no failure output, and the operator believes it deployed. `_handle_response_errors` now folds both arrays into the error report (with per-type counts), and the call site triggers on any of the three arrays. Connector error entries display their `id` instead of `<unknown rule_id>`.

## How To Test

Reproduce defect 1 (no stack needed): mock the `_import` response and call `RuleResource.import_rules`:

```python
resp = {"errors": [{"error": {"message": "actions.0.frequency.throttle: Required", "status_code": 400}}],
        "success": False, "success_count": 0}
```

- Before: `KeyError: 'rule_id'` at `resources.py` (`error_rule_ids = [e['rule_id'] for e in errors]`).
- After: the import completes and `import-rules` prints ` - <unknown rule_id>: (400) actions.0.frequency.throttle: Required`.

Live repro: import any rule whose `actions[].frequency` omits the (required-but-nullable) `throttle` key into 8.16+/serverless — Kibana returns HTTP 200 with the errors body above.

For defect 2: import a rule with an exceptions container that Kibana rejects (e.g. bad `list_id` reference) — before, exit 0 and no error output despite `exceptions_errors` being non-empty in the response; after, `N exception list(s) failed to import!` plus the per-item detail.

## Checklist

- [ ] Added a label for the type of pr: `bug`
