### PR TITLE
[Bug] Use built-in `github.token` for Branch Version Status Checks

### DIFF
--- a/.github/workflows/branch-status-checks.yml
+++ b/.github/workflows/branch-status-checks.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   get-branches:
@@ -25,7 +26,7 @@ jobs:
       with:
         url: "https://api.github.com/repos/elastic/detection-rules/actions/workflows/pythonpackage.yml/runs?per_page=1&branch=${{matrix.target_branch}}"
         method: 'GET'
-        bearerToken: ${{ secrets.READ_ELASTIC_DETECTION_RULES_ORG_TOKEN }}
+        bearerToken: ${{ github.token }}
 
     - name: Check Backport Status
       uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to https://github.com/elastic/detection-rules/pull/6524

## Summary - What I changed

The `Branch Version Status Checks` workflow began failing with `401 Bad credentials` on the "Get Backport Status" step (example: [run 30542809302](https://github.com/elastic/detection-rules/actions/runs/30542809302/job/90875458975)).

The step authenticated with `secrets.READ_ELASTIC_DETECTION_RULES_ORG_TOKEN`, a PAT-backed secret that was retired as part of the ephemeral token migration in #6524. That PR missed `branch-status-checks.yml`, which was the last remaining reference to the secret.


The step only reads workflow-run status on this public repo, which the default `GITHUB_TOKEN` can do with `actions: read`. This workflow also triggers on `pull_request`, and OIDC id-tokens are not issued for `pull_request` events from forks (as noted in #6524)

## How To Test

CI should pass, if still fails, then this did not work. 

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
