### PR TITLE
[New Rule] Potential SIP REGISTER Brute Force

### DIFF
--- a/rules/network/credential_access_potential_sip_register_brute_force.toml
+++ b/rules/network/credential_access_potential_sip_register_brute_force.toml
@@ -92,7 +92,7 @@ from logs-network_traffic.sip-*, packetbeat-*
 | where
     Esql.method == "REGISTER" and
     Esql.sip_type == "response" and
-    sip.code in (401, 403, 407) and
+    sip.code in (401::long, 403::long, 407::long) and
     Esql.client_ip is not null and
     Esql.server_ip is not null and
     Esql.extension is not null

--- a/rules/network/credential_access_potential_sip_register_brute_force.toml
+++ b/rules/network/credential_access_potential_sip_register_brute_force.toml
@@ -84,15 +84,17 @@ type = "esql"
 query = '''
 from logs-network_traffic.sip-*, packetbeat-*
 | eval
-    Esql.method = TO_UPPER(COALESCE(sip.cseq.method, sip.method)),
-    Esql.sip_type = TO_LOWER(sip.type),
+    Esql.method = TO_UPPER(COALESCE(network_traffic.sip.cseq.method, sip.cseq.method,
+      network_traffic.sip.method, sip.method)),
+    Esql.sip_type = TO_LOWER(COALESCE(network_traffic.sip.type, sip.type)),
+    Esql.code = COALESCE(network_traffic.sip.code, sip.code),
     Esql.client_ip = COALESCE(client.ip, destination.ip),
     Esql.server_ip = COALESCE(server.ip, source.ip),
-    Esql.extension = sip.to.uri.username
+    Esql.extension = COALESCE(network_traffic.sip.to.uri.username, sip.to.uri.username)
 | where
     Esql.method == "REGISTER" and
     Esql.sip_type == "response" and
-    sip.code in (401::long, 403::long, 407::long) and
+    Esql.code in (401::long, 403::long, 407::long) and
     Esql.client_ip is not null and
     Esql.server_ip is not null and
     Esql.extension is not null

--- a/rules/network/credential_access_potential_sip_register_brute_force.toml
+++ b/rules/network/credential_access_potential_sip_register_brute_force.toml
@@ -1,5 +1,5 @@
 [metadata]
-creation_date = "2026/07/27"
+creation_date = "2026/07/31"
 integration = ["network_traffic"]
 maturity = "production"
 min_stack_comments = "Requires ES|QL JSON_EXTRACT on _source to read SIP fields across current and legacy schemas."

--- a/rules/network/credential_access_potential_sip_register_brute_force.toml
+++ b/rules/network/credential_access_potential_sip_register_brute_force.toml
@@ -1,0 +1,134 @@
+[metadata]
+creation_date = "2026/06/25"
+integration = ["network_traffic"]
+maturity = "production"
+updated_date = "2026/07/27"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies repeated SIP REGISTER authentication rejection responses for one or more extensions from a client to a VoIP
+server within five minutes. The rule distinguishes repeated failures from the single 401 or 407 challenge expected in a
+normal digest-authentication flow. Attackers brute-force extension credentials to register rogue endpoints for toll
+fraud, call interception, or registration hijacking.
+"""
+false_positives = [
+    """
+    Misconfigured phones, expired credentials, or provisioning errors can generate repeated REGISTER failures from a
+    single device. Validate the client, affected extensions, and registration state before escalating.
+    """,
+]
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+max_signals = 5
+name = "Potential SIP REGISTER Brute Force"
+note = """## Triage and analysis
+
+### Investigating Potential SIP REGISTER Brute Force
+
+SIP REGISTER authenticates endpoints to a PBX or SBC. Attackers iterate extensions and passwords, producing many 401
+Unauthorized, 403 Forbidden, or 407 Proxy Authentication Required responses from one external or internal client. A
+single 401 or 407 challenge is expected during normal digest authentication, so this rule requires either ten failures
+for one extension or a broader spray affecting at least five repeatedly challenged extensions.
+
+### Possible investigation steps
+
+- Determine whether `Esql.client_ip` is an expected phone, gateway, proxy, or external attacker address and confirm that
+  `Esql.server_ip` is the intended PBX or SBC.
+- Review `Esql.sample_extensions`, `Esql.total_failures`, and `Esql.max_failures_per_extension` to distinguish a targeted
+  password attack from a broader extension spray.
+- Review REGISTER requests corresponding to the rejection responses and confirm whether credentials were supplied after
+  the initial digest challenge.
+- Check for a successful REGISTER (2xx response) from the same client and extension shortly after the burst. Multiple
+  failures followed by success should be escalated as possible credential compromise.
+- Inspect CDR/billing records for anomalous outbound calls if a registration succeeded.
+
+### False positive analysis
+
+- A single misconfigured phone repeatedly attempting REGISTER with a stale password can trigger the targeted-failure
+  branch. Lower severity when only one extension is affected and the client maps to a known device.
+- NAT gateways and SIP proxies can represent many legitimate phones behind one address. The rule requires repeated
+  challenges per extension to reduce alerts caused by one normal digest challenge from each phone.
+
+### Response and remediation
+
+- Block or rate-limit the offending `Esql.client_ip` at the SBC and enforce strong SIP credentials.
+- Rotate compromised extension passwords and audit active registrations for rogue contact bindings.
+- Enable geo-blocking or IP allowlists for REGISTER if the PBX is internal-only.
+"""
+references = ["https://attack.mitre.org/techniques/T1110/"]
+risk_score = 47
+rule_id = "1ca59146-7386-4033-a010-1c32717e9321"
+setup = """## Setup
+
+This rule requires the Elastic **network_traffic** integration with the **SIP** protocol module enabled on a sensor that
+observes VoIP REGISTER signaling to or from the PBX/SBC.
+
+The rule requires decoded SIP headers and responses. SIP over TLS (commonly TCP 5061) is not visible unless the sensor
+receives decrypted traffic or observes plaintext SIP after TLS termination. SRTP encryption does not affect this rule
+when SIP signaling remains visible.
+"""
+severity = "medium"
+tags = [
+    "Domain: Network",
+    "Use Case: Threat Detection",
+    "Use Case: Network Security Monitoring",
+    "Tactic: Credential Access",
+    "Data Source: Network Packet Capture",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+from logs-network_traffic.sip-*, packetbeat-*
+| eval
+    Esql.method = TO_UPPER(COALESCE(sip.cseq.method, sip.method)),
+    Esql.sip_type = TO_LOWER(sip.type),
+    Esql.client_ip = COALESCE(client.ip, destination.ip),
+    Esql.server_ip = COALESCE(server.ip, source.ip),
+    Esql.extension = sip.to.uri.username
+| where
+    Esql.method == "REGISTER" and
+    Esql.sip_type == "response" and
+    sip.code in (401, 403, 407) and
+    Esql.client_ip is not null and
+    Esql.server_ip is not null and
+    Esql.extension is not null
+| eval Esql.time_window = DATE_TRUNC(5 minutes, @timestamp)
+| stats
+    Esql.failures_per_extension = COUNT(*)
+  by Esql.time_window, Esql.client_ip, Esql.server_ip, Esql.extension
+| eval Esql.repeated_extension = CASE(Esql.failures_per_extension >= 2, 1, 0)
+| stats
+    Esql.total_failures = SUM(Esql.failures_per_extension),
+    Esql.max_failures_per_extension = MAX(Esql.failures_per_extension),
+    Esql.distinct_extensions = COUNT(*),
+    Esql.repeated_extensions = SUM(Esql.repeated_extension),
+    Esql.sample_extensions = MV_SLICE(VALUES(Esql.extension), 0, 20)
+  by Esql.time_window, Esql.client_ip, Esql.server_ip
+| where
+    Esql.max_failures_per_extension >= 10 or
+    (
+      Esql.total_failures >= 25 and
+      Esql.distinct_extensions >= 5 and
+      Esql.repeated_extensions >= 5
+    )
+| keep Esql.*
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+

--- a/rules/network/credential_access_potential_sip_register_brute_force.toml
+++ b/rules/network/credential_access_potential_sip_register_brute_force.toml
@@ -1,8 +1,10 @@
 [metadata]
-creation_date = "2026/06/25"
+creation_date = "2026/07/27"
 integration = ["network_traffic"]
 maturity = "production"
-updated_date = "2026/07/27"
+min_stack_comments = "Requires ES|QL JSON_EXTRACT on _source to read SIP fields across current and legacy schemas."
+min_stack_version = "9.4.0"
+updated_date = "2026/07/31"
 
 [rule]
 author = ["Elastic"]
@@ -27,29 +29,20 @@ note = """## Triage and analysis
 
 ### Investigating Potential SIP REGISTER Brute Force
 
-SIP REGISTER authenticates endpoints to a PBX or SBC. Attackers iterate extensions and passwords, producing many 401
-Unauthorized, 403 Forbidden, or 407 Proxy Authentication Required responses from one external or internal client. A
-single 401 or 407 challenge is expected during normal digest authentication, so this rule requires either ten failures
-for one extension or a broader spray affecting at least five repeatedly challenged extensions.
+SIP REGISTER authenticates endpoints to a PBX or SBC. Attackers iterate extensions and passwords, producing many 401 Unauthorized, 403 Forbidden, or 407 Proxy Authentication Required responses from one external or internal client. A single 401 or 407 challenge is expected during normal digest authentication, so this rule requires either ten failures for one extension or a broader spray affecting at least five repeatedly challenged extensions.
 
 ### Possible investigation steps
 
-- Determine whether `Esql.client_ip` is an expected phone, gateway, proxy, or external attacker address and confirm that
-  `Esql.server_ip` is the intended PBX or SBC.
-- Review `Esql.sample_extensions`, `Esql.total_failures`, and `Esql.max_failures_per_extension` to distinguish a targeted
-  password attack from a broader extension spray.
-- Review REGISTER requests corresponding to the rejection responses and confirm whether credentials were supplied after
-  the initial digest challenge.
-- Check for a successful REGISTER (2xx response) from the same client and extension shortly after the burst. Multiple
-  failures followed by success should be escalated as possible credential compromise.
+- Determine whether `Esql.client_ip` is an expected phone, gateway, proxy, or external attacker address and confirm that `Esql.server_ip` is the intended PBX or SBC.
+- Review `Esql.sample_extensions`, `Esql.total_failures`, and `Esql.max_failures_per_extension` to distinguish a targeted password attack from a broader extension spray.
+- Review REGISTER requests corresponding to the rejection responses and confirm whether credentials were supplied after the initial digest challenge.
+- Check for a successful REGISTER (2xx response) from the same client and extension shortly after the burst. Multiple failures followed by success should be escalated as possible credential compromise.
 - Inspect CDR/billing records for anomalous outbound calls if a registration succeeded.
 
 ### False positive analysis
 
-- A single misconfigured phone repeatedly attempting REGISTER with a stale password can trigger the targeted-failure
-  branch. Lower severity when only one extension is affected and the client maps to a known device.
-- NAT gateways and SIP proxies can represent many legitimate phones behind one address. The rule requires repeated
-  challenges per extension to reduce alerts caused by one normal digest challenge from each phone.
+- A single misconfigured phone repeatedly attempting REGISTER with a stale password can trigger the targeted-failure branch. Lower severity when only one extension is affected and the client maps to a known device.
+- NAT gateways and SIP proxies can represent many legitimate phones behind one address. The rule requires repeated challenges per extension to reduce alerts caused by one normal digest challenge from each phone.
 
 ### Response and remediation
 
@@ -82,19 +75,32 @@ timestamp_override = "event.ingested"
 type = "esql"
 
 query = '''
-from logs-network_traffic.sip-*, packetbeat-*
+from logs-network_traffic.sip-*, packetbeat-* metadata _source
 | eval
-    Esql.method = TO_UPPER(COALESCE(network_traffic.sip.cseq.method, sip.cseq.method,
-      network_traffic.sip.method, sip.method)),
-    Esql.sip_type = TO_LOWER(COALESCE(network_traffic.sip.type, sip.type)),
-    Esql.code = COALESCE(network_traffic.sip.code, sip.code),
+    Esql.method = TO_UPPER(COALESCE(
+        JSON_EXTRACT(_source, "network_traffic.sip.cseq.method"),
+        JSON_EXTRACT(_source, "sip.cseq.method"),
+        JSON_EXTRACT(_source, "network_traffic.sip.method"),
+        JSON_EXTRACT(_source, "sip.method")
+    )),
+    Esql.sip_type = TO_LOWER(COALESCE(
+        JSON_EXTRACT(_source, "network_traffic.sip.type"),
+        JSON_EXTRACT(_source, "sip.type")
+    )),
+    Esql.code = COALESCE(
+        JSON_EXTRACT(_source, "network_traffic.sip.code"),
+        JSON_EXTRACT(_source, "sip.code")
+    ),
     Esql.client_ip = COALESCE(client.ip, destination.ip),
     Esql.server_ip = COALESCE(server.ip, source.ip),
-    Esql.extension = COALESCE(network_traffic.sip.to.uri.username, sip.to.uri.username)
+    Esql.extension = COALESCE(
+        JSON_EXTRACT(_source, "network_traffic.sip.to.uri.username"),
+        JSON_EXTRACT(_source, "sip.to.uri.username")
+    )
 | where
     Esql.method == "REGISTER" and
     Esql.sip_type == "response" and
-    Esql.code in (401::long, 403::long, 407::long) and
+    Esql.code in ("401", "403", "407") and
     Esql.client_ip is not null and
     Esql.server_ip is not null and
     Esql.extension is not null
@@ -106,7 +112,7 @@ from logs-network_traffic.sip-*, packetbeat-*
 | stats
     Esql.total_failures = SUM(Esql.failures_per_extension),
     Esql.max_failures_per_extension = MAX(Esql.failures_per_extension),
-    Esql.distinct_extensions = COUNT(*),
+    Esql.distinct_extensions = COUNT_DISTINCT(Esql.extension),
     Esql.repeated_extensions = SUM(Esql.repeated_extension),
     Esql.sample_extensions = MV_SLICE(VALUES(Esql.extension), 0, 20)
   by Esql.time_window, Esql.client_ip, Esql.server_ip
@@ -127,10 +133,28 @@ framework = "MITRE ATT&CK"
 id = "T1110"
 name = "Brute Force"
 reference = "https://attack.mitre.org/techniques/T1110/"
+[[rule.threat.technique.subtechnique]]
+id = "T1110.001"
+name = "Password Guessing"
+reference = "https://attack.mitre.org/techniques/T1110/001/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.003"
+name = "Password Spraying"
+reference = "https://attack.mitre.org/techniques/T1110/003/"
+
 
 
 [rule.threat.tactic]
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.alert_suppression]
+group_by = ["Esql.client_ip", "Esql.server_ip"]
+missing_fields_strategy = "suppress"
+
+[rule.alert_suppression.duration]
+unit = "h"
+value = 1
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to https://github.com/elastic/ia-trade-team/issues/961

## Summary - What I changed

Adds the `Potential SIP REGISTER Brute Force` rule to expand `network_traffic.sip` protocol coverage.

The medium-severity ES|QL rule identifies repeated SIP REGISTER authentication rejection responses (`401`, `403`, or`407`) from one client to a PBX or SBC within a five-minute window. It detects either a targeted attack producing at least 10 failures for one extension or a broader spray producing at least 25 failures across five or more extensions, with each affected extension challenged repeatedly.

Requiring repeated failures per extension distinguishes brute-force activity from the single `401` or `407` challenge expected during normal SIP digest authentication. The investigation guide covers misconfigured phones, expired credentials, NAT gateways, and SIP proxies, plus correlation with subsequent successful registrations and anomalous call activity.

> [!NOTE]
> `sip.code` is mapped as long, while 401, 403, and 407 are inferred as integer. ES|QL’s IN requires matching types so these are cast directly so that they are matching.

## How To Test

TRADE Stack or [RTA](https://github.com/elastic/cortado/pull/34/commits/d1aa9ed77adac3545c10cb83c6b6fd6c8dabb678)

<img width="1823" height="829" alt="image" src="https://github.com/user-attachments/assets/e4b86441-fea8-4bd5-96f7-162a3c760108" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
