### PR TITLE
[New Rule] Postgresql COPY PROGRAM Command Execution

### DIFF
--- a/rules/network/execution_postgresql_copy_program_command.toml
+++ b/rules/network/execution_postgresql_copy_program_command.toml
@@ -7,8 +7,8 @@ updated_date = "2026/07/30"
 [rule]
 author = ["Elastic"]
 description = """
-Identifies PostgreSQL `COPY` statements that invoke an operating-system command through the `PROGRAM` option. A
-superuser or role with `pg_execute_server_program` can use this feature to execute arbitrary commands as the PostgreSQL
+Identifies PostgreSQL "COPY" statements that invoke an operating-system command through the "PROGRAM" option. A
+superuser or role with "pg_execute_server_program" can use this feature to execute arbitrary commands as the PostgreSQL
 service account, a technique used after credential compromise and by cryptomining campaigns.
 """
 false_positives = [
@@ -20,34 +20,27 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["logs-network_traffic.pgsql-*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "PostgreSQL COPY PROGRAM Command Execution"
 note = """## Triage and analysis
 
 ### Investigating PostgreSQL COPY PROGRAM Command Execution
 
-PostgreSQL supports `COPY ... FROM PROGRAM` and `COPY ... TO PROGRAM` for server-side process execution. Attackers who
-obtain a privileged database identity can use this feature to launch shells, download payloads, establish persistence,
-or deploy cryptominers from the PostgreSQL process context.
+PostgreSQL supports `COPY ... FROM PROGRAM` and `COPY ... TO PROGRAM` for server-side process execution. Attackers who obtain a privileged database identity can use this feature to launch shells, download payloads, establish persistence, or deploy cryptominers from the PostgreSQL process context.
 
 ### Possible investigation steps
 
 - Review `client.ip`, `server.ip`, `network.community_id`, `network_traffic.pgsql.query`, and PostgreSQL error fields.
-- Extract the command passed to `PROGRAM` and identify referenced shells, interpreters, downloaders, files, or network
-  destinations.
-- Confirm the database role and whether it has superuser or `pg_execute_server_program` privileges using PostgreSQL
-  audit and server logs.
-- Correlate the event with endpoint telemetry for `postgres` spawning `sh`, `bash`, `curl`, `wget`, `python`, `perl`,
-  `nc`, miners, or other unusual child processes.
-- Search earlier events from the client for authentication failures, role changes, extension creation, or database
-  enumeration.
+- Extract the command passed to `PROGRAM` and identify referenced shells, interpreters, downloaders, files, or network destinations.
+- Confirm the database role and whether it has superuser or `pg_execute_server_program` privileges using PostgreSQL audit and server logs.
+- Correlate the event with endpoint telemetry for `postgres` spawning `sh`, `bash`, `curl`, `wget`, `python`, `perl`, `nc`, miners, or other unusual child processes.
+- Search earlier events from the client for authentication failures, role changes, extension creation, or database enumeration.
 
 ### False positive analysis
 
 - Approved ETL, backup, and administrative automation can use COPY PROGRAM.
-- Scope exceptions to a documented client, command family, and maintenance context; do not globally exclude the
-  `PROGRAM` keyword.
+- Scope exceptions to a documented client, command family, and maintenance context; do not globally exclude the `PROGRAM` keyword.
 
 ### Response and remediation
 
@@ -80,11 +73,14 @@ tags = [
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-data_stream.dataset:network_traffic.pgsql and
-network_traffic.pgsql.query:(*COPY* and *PROGRAM* or *copy* and *program*)
+any where data_stream.dataset == "network_traffic.pgsql" and
+    (
+        network_traffic.pgsql.query like~ "*copy*from*program*" or
+        network_traffic.pgsql.query like~ "*copy*to*program*"
+    )
 '''
 
 

--- a/rules/network/execution_postgresql_copy_program_command.toml
+++ b/rules/network/execution_postgresql_copy_program_command.toml
@@ -86,12 +86,12 @@ query = '''
 data_stream.dataset:network_traffic.pgsql and
 (
   (
-    network_traffic.pgsql.query:"*COPY*" and
-    network_traffic.pgsql.query:"*PROGRAM*"
+    network_traffic.pgsql.query:*COPY* and
+    network_traffic.pgsql.query:*PROGRAM*
   ) or
   (
-    network_traffic.pgsql.query:"*copy*" and
-    network_traffic.pgsql.query:"*program*"
+    network_traffic.pgsql.query:*copy* and
+    network_traffic.pgsql.query:*program*
   )
 )
 '''

--- a/rules/network/execution_postgresql_copy_program_command.toml
+++ b/rules/network/execution_postgresql_copy_program_command.toml
@@ -59,7 +59,7 @@ references = [
     "https://www.postgresql.org/docs/current/sql-copy.html",
     "https://www.aquasec.com/blog/pg_mem-a-malware-hidden-in-the-postgres-processes/",
     "https://www.wiz.io/blog/postgresql-cryptomining",
-    "https://attack.mitre.org/techniques/T1059/004/",
+    "https://attack.mitre.org/techniques/T1059/",
 ]
 risk_score = 73
 rule_id = "8ab64631-17ee-46b9-9800-9acacbeee1b3"
@@ -84,16 +84,7 @@ type = "query"
 
 query = '''
 data_stream.dataset:network_traffic.pgsql and
-(
-  (
-    network_traffic.pgsql.query:*COPY* and
-    network_traffic.pgsql.query:*PROGRAM*
-  ) or
-  (
-    network_traffic.pgsql.query:*copy* and
-    network_traffic.pgsql.query:*program*
-  )
-)
+network_traffic.pgsql.query:(*COPY* and *PROGRAM* or *copy* and *program*)
 '''
 
 
@@ -103,11 +94,6 @@ framework = "MITRE ATT&CK"
 id = "T1059"
 name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
-[[rule.threat.technique.subtechnique]]
-id = "T1059.004"
-name = "Unix Shell"
-reference = "https://attack.mitre.org/techniques/T1059/004/"
-
 
 
 [rule.threat.tactic]

--- a/rules/network/execution_postgresql_copy_program_command.toml
+++ b/rules/network/execution_postgresql_copy_program_command.toml
@@ -1,0 +1,117 @@
+[metadata]
+creation_date = "2026/07/30"
+integration = ["network_traffic"]
+maturity = "production"
+updated_date = "2026/07/30"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies PostgreSQL `COPY` statements that invoke an operating-system command through the `PROGRAM` option. A
+superuser or role with `pg_execute_server_program` can use this feature to execute arbitrary commands as the PostgreSQL
+service account, a technique used after credential compromise and by cryptomining campaigns.
+"""
+false_positives = [
+    """
+    Database administrators and scheduled data-processing jobs may legitimately use COPY PROGRAM for import or export
+    workflows. Confirm the command, client address, database role, maintenance context, and resulting process activity
+    before escalating.
+    """,
+]
+from = "now-9m"
+index = ["logs-network_traffic.pgsql-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "PostgreSQL COPY PROGRAM Command Execution"
+note = """## Triage and analysis
+
+### Investigating PostgreSQL COPY PROGRAM Command Execution
+
+PostgreSQL supports `COPY ... FROM PROGRAM` and `COPY ... TO PROGRAM` for server-side process execution. Attackers who
+obtain a privileged database identity can use this feature to launch shells, download payloads, establish persistence,
+or deploy cryptominers from the PostgreSQL process context.
+
+### Possible investigation steps
+
+- Review `client.ip`, `server.ip`, `network.community_id`, `network_traffic.pgsql.query`, and PostgreSQL error fields.
+- Extract the command passed to `PROGRAM` and identify referenced shells, interpreters, downloaders, files, or network
+  destinations.
+- Confirm the database role and whether it has superuser or `pg_execute_server_program` privileges using PostgreSQL
+  audit and server logs.
+- Correlate the event with endpoint telemetry for `postgres` spawning `sh`, `bash`, `curl`, `wget`, `python`, `perl`,
+  `nc`, miners, or other unusual child processes.
+- Search earlier events from the client for authentication failures, role changes, extension creation, or database
+  enumeration.
+
+### False positive analysis
+
+- Approved ETL, backup, and administrative automation can use COPY PROGRAM.
+- Scope exceptions to a documented client, command family, and maintenance context; do not globally exclude the
+  `PROGRAM` keyword.
+
+### Response and remediation
+
+- Terminate the database session and isolate the server if unauthorized process execution is confirmed.
+- Preserve PostgreSQL, endpoint, and network evidence and remove malicious processes or persistence.
+- Rotate affected credentials and revoke unnecessary superuser and `pg_execute_server_program` privileges.
+"""
+references = [
+    "https://www.postgresql.org/docs/current/sql-copy.html",
+    "https://www.aquasec.com/blog/pg_mem-a-malware-hidden-in-the-postgres-processes/",
+    "https://www.wiz.io/blog/postgresql-cryptomining",
+    "https://attack.mitre.org/techniques/T1059/004/",
+]
+risk_score = 73
+rule_id = "8ab64631-17ee-46b9-9800-9acacbeee1b3"
+setup = """## Setup
+
+This rule requires the Elastic Network Packet Capture integration with the PostgreSQL protocol analyzer enabled and
+cleartext visibility into PostgreSQL query traffic. TLS-encrypted sessions, prepared statements, packet loss, and
+asymmetric capture can hide or fragment query text. Use PostgreSQL audit logs and endpoint process telemetry to confirm
+the database identity and command execution outcome.
+"""
+severity = "high"
+tags = [
+    "Domain: Network",
+    "Use Case: Network Security Monitoring",
+    "Use Case: Threat Detection",
+    "Tactic: Execution",
+    "Data Source: Network Packet Capture",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:network_traffic.pgsql and
+(
+  (
+    network_traffic.pgsql.query:"*COPY*" and
+    network_traffic.pgsql.query:"*PROGRAM*"
+  ) or
+  (
+    network_traffic.pgsql.query:"*copy*" and
+    network_traffic.pgsql.query:"*program*"
+  )
+)
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.004"
+name = "Unix Shell"
+reference = "https://attack.mitre.org/techniques/T1059/004/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

Related to https://github.com/elastic/ia-trade-team/issues/961

## Summary - What I changed

Adds the `PostgreSQL COPY PROGRAM Command Execution` rule to expand `network_traffic.pgsql` protocol coverage.

The high-severity KQL rule identifies PostgreSQL `COPY ... FROM PROGRAM` and `COPY ... TO PROGRAM` statements. A superuser or role with `pg_execute_server_program` can abuse this functionality to execute arbitrary operating-system commands as the PostgreSQL service account following database credential compromise.

> [!NOTE]
> This rule requires visibility into plaintext PostgreSQL query traffic. Similar to the other paintext based rules, this is to gauge customer interest in these protections. 

## How To Test

[RTA](https://github.com/elastic/cortado/pull/34/commits/66cec4f8b72ccd90e37ffbb6997aeea4adbeb935) or TRADE stack

<img width="1823" height="525" alt="image" src="https://github.com/user-attachments/assets/871f0871-8db2-4ba0-8f53-ff1ca65fcf0c" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
