### PR TITLE
[New Rule] Cassandra JavaScript UDF Creation

### DIFF
--- a/rules/network/execution_cassandra_javascript_udf_creation.toml
+++ b/rules/network/execution_cassandra_javascript_udf_creation.toml
@@ -99,7 +99,7 @@ name = "Command and Scripting Interpreter"
 reference = "https://attack.mitre.org/techniques/T1059/"
 [[rule.threat.technique.subtechnique]]
 id = "T1059.007"
-name = "JavaScript/JScript"
+name = "JavaScript"
 reference = "https://attack.mitre.org/techniques/T1059/007/"
 
 

--- a/rules/network/execution_cassandra_javascript_udf_creation.toml
+++ b/rules/network/execution_cassandra_javascript_udf_creation.toml
@@ -20,34 +20,27 @@ false_positives = [
 ]
 from = "now-9m"
 index = ["logs-network_traffic.cassandra-*"]
-language = "kuery"
+language = "eql"
 license = "Elastic License v2"
 name = "Cassandra JavaScript UDF Creation"
 note = """## Triage and analysis
 
 ### Investigating Cassandra JavaScript UDF Creation
 
-CVE-2021-44521 allows a JavaScript UDF to escape the Nashorn sandbox when Cassandra is vulnerable and scripted UDFs
-are enabled with unsafe thread settings. Even on patched systems, JavaScript UDF creation is a sensitive control-plane
-operation that should be rare and restricted to approved administrators.
+CVE-2021-44521 allows a JavaScript UDF to escape the Nashorn sandbox when Cassandra is vulnerable and scripted UDFs are enabled with unsafe thread settings. Even on patched systems, JavaScript UDF creation is a sensitive control-plane operation that should be rare and restricted to approved administrators.
 
 ### Possible investigation steps
 
-- Review `client.ip`, `server.ip`, `network.community_id`, and
-  `network_traffic.cassandra.request.query`.
+- Review `client.ip`, `server.ip`, `network.community_id`, and `network_traffic.cassandra.request.query`.
 - Extract the function name, keyspace, declared language, and function body.
-- Look for Java interoperability, reflection, process execution, class loading, file access, or network-access strings
-  in the UDF body.
-- Confirm the Cassandra version and the values of `enable_user_defined_functions`,
-  `enable_scripted_user_defined_functions`, and `enable_user_defined_functions_threads`.
-- Correlate with Cassandra audit logs and endpoint telemetry for child processes, file creation, or outbound
-  connections from the Cassandra service.
+- Look for Java interoperability, reflection, process execution, class loading, file access, or network-access strings in the UDF body.
+- Confirm the Cassandra version and the values of `enable_user_defined_functions`, `enable_scripted_user_defined_functions`, and `enable_user_defined_functions_threads`.
+- Correlate with Cassandra audit logs and endpoint telemetry for child processes, file creation, or outbound connections from the Cassandra service.
 
 ### False positive analysis
 
 - Approved application deployments may create JavaScript UDFs, though this should be uncommon.
-- Scope exceptions to known deployment clients and reviewed function definitions rather than excluding UDF creation
-  globally.
+- Scope exceptions to known deployment clients and reviewed function definitions rather than excluding UDF creation globally.
 
 ### Response and remediation
 
@@ -80,14 +73,12 @@ tags = [
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
-type = "query"
+type = "eql"
 
 query = '''
-data_stream.dataset:network_traffic.cassandra and
-network_traffic.cassandra.request.query:(
-  (*CREATE* and *FUNCTION* and *LANGUAGE* and *JAVASCRIPT*) or
-  (*create* and *function* and *language* and *javascript*)
-)
+any where data_stream.dataset == "network_traffic.cassandra" and
+    network_traffic.cassandra.request.query like~ "*create*function*" and
+    network_traffic.cassandra.request.query like~ "*language*javascript*"
 '''
 
 

--- a/rules/network/execution_cassandra_javascript_udf_creation.toml
+++ b/rules/network/execution_cassandra_javascript_udf_creation.toml
@@ -1,0 +1,117 @@
+[metadata]
+creation_date = "2026/07/30"
+integration = ["network_traffic"]
+maturity = "production"
+updated_date = "2026/07/30"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies Cassandra Query Language statements that create a JavaScript user-defined function. On vulnerable and
+dangerously configured Cassandra servers, adversaries can abuse scripted UDF creation to escape the JavaScript sandbox
+and execute operating-system commands, including through CVE-2021-44521.
+"""
+false_positives = [
+    """
+    Developers or database administrators may deploy approved JavaScript UDFs in environments where scripted functions
+    are intentionally enabled. Validate the function body, client address, Cassandra version, configuration, and change
+    window before escalating.
+    """,
+]
+from = "now-9m"
+index = ["logs-network_traffic.cassandra-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Cassandra JavaScript UDF Creation"
+note = """## Triage and analysis
+
+### Investigating Cassandra JavaScript UDF Creation
+
+CVE-2021-44521 allows a JavaScript UDF to escape the Nashorn sandbox when Cassandra is vulnerable and scripted UDFs
+are enabled with unsafe thread settings. Even on patched systems, JavaScript UDF creation is a sensitive control-plane
+operation that should be rare and restricted to approved administrators.
+
+### Possible investigation steps
+
+- Review `client.ip`, `server.ip`, `network.community_id`, and
+  `network_traffic.cassandra.request.query`.
+- Extract the function name, keyspace, declared language, and function body.
+- Look for Java interoperability, reflection, process execution, class loading, file access, or network-access strings
+  in the UDF body.
+- Confirm the Cassandra version and the values of `enable_user_defined_functions`,
+  `enable_scripted_user_defined_functions`, and `enable_user_defined_functions_threads`.
+- Correlate with Cassandra audit logs and endpoint telemetry for child processes, file creation, or outbound
+  connections from the Cassandra service.
+
+### False positive analysis
+
+- Approved application deployments may create JavaScript UDFs, though this should be uncommon.
+- Scope exceptions to known deployment clients and reviewed function definitions rather than excluding UDF creation
+  globally.
+
+### Response and remediation
+
+- Terminate unauthorized sessions and isolate the Cassandra node if code execution is suspected.
+- Disable scripted UDFs where they are not required and upgrade Cassandra to a version that fixes CVE-2021-44521.
+- Remove unauthorized functions, rotate affected credentials, and review role permissions and cluster-wide activity.
+"""
+references = [
+    "https://jfrog.com/blog/cve-2021-44521-exploiting-apache-cassandra-user-defined-functions-for-remote-code-execution/",
+    "https://nvd.nist.gov/vuln/detail/CVE-2021-44521",
+    "https://attack.mitre.org/techniques/T1059/007/",
+]
+risk_score = 73
+rule_id = "b3e2c2ad-9a81-4638-bf12-7ca2feed66a2"
+setup = """## Setup
+
+This rule requires the Elastic Network Packet Capture integration with the Cassandra protocol analyzer enabled and
+cleartext visibility into native CQL traffic. Prepared statements expose query text during `PREPARE`, while later
+`EXECUTE` frames may not repeat it. TLS-encrypted traffic is opaque. Use Cassandra audit logs and endpoint telemetry to
+confirm the database identity and execution outcome.
+"""
+severity = "high"
+tags = [
+    "Domain: Network",
+    "Use Case: Network Security Monitoring",
+    "Use Case: Threat Detection",
+    "Use Case: Vulnerability",
+    "Tactic: Execution",
+    "Data Source: Network Packet Capture",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:network_traffic.cassandra and
+(
+  (
+    network_traffic.cassandra.request.query:"*CREATE FUNCTION*" and
+    network_traffic.cassandra.request.query:"*LANGUAGE JAVASCRIPT*"
+  ) or
+  (
+    network_traffic.cassandra.request.query:"*create function*" and
+    network_traffic.cassandra.request.query:"*language javascript*"
+  )
+)
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.007"
+name = "JavaScript/JScript"
+reference = "https://attack.mitre.org/techniques/T1059/007/"
+
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+

--- a/rules/network/execution_cassandra_javascript_udf_creation.toml
+++ b/rules/network/execution_cassandra_javascript_udf_creation.toml
@@ -84,15 +84,9 @@ type = "query"
 
 query = '''
 data_stream.dataset:network_traffic.cassandra and
-(
-  (
-    network_traffic.cassandra.request.query:"*CREATE FUNCTION*" and
-    network_traffic.cassandra.request.query:"*LANGUAGE JAVASCRIPT*"
-  ) or
-  (
-    network_traffic.cassandra.request.query:"*create function*" and
-    network_traffic.cassandra.request.query:"*language javascript*"
-  )
+network_traffic.cassandra.request.query:(
+  (*CREATE* and *FUNCTION* and *LANGUAGE* and *JAVASCRIPT*) or
+  (*create* and *function* and *language* and *javascript*)
 )
 '''
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to https://github.com/elastic/ia-trade-team/issues/961

## Summary - What I changed

Adds the `Cassandra JavaScript UDF Creation` rule to expand `network_traffic.cassandra` protocol coverage.

The high-severity KQL rule identifies Cassandra Query Language statements that create a user-defined function with `LANGUAGE JAVASCRIPT`. On vulnerable and dangerously configured Cassandra servers, an adversary can abuse scripted UDF creation to escape the JavaScript sandbox and execute operating-system commands, including through CVE-2021-44521.

> [!NOTE]
> This rule requires visibility into plaintext Cassandra native protocol traffic. Similar to the other paintext based rules, this is to gauge customer interest in these protections. 

## How To Test

[RTA](https://github.com/elastic/cortado/pull/34/commits/95e136ba830a2f5f806cb5eef232411571bcad54) or test data in stack.

<img width="1823" height="525" alt="image" src="https://github.com/user-attachments/assets/cf13c795-0e06-4c69-a64d-aea16da4b3de" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
