### PR TITLE
chore: bump setup tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "jsonschema>=4.21.1",
   "marko==2.2.1",
   "marshmallow-dataclass==8.7.1",
-  "marshmallow-jsonschema~=0.13.0",
+  "marshmallow-jsonschema~=0.16.0",
   "marshmallow-union~=0.1.15",
   "marshmallow~=3.26.1",
   "pywin32 ; platform_system=='Windows'",
@@ -42,7 +42,7 @@ dependencies = [
   "PyGithub==2.9.1",
   "detection-rules-kql @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql",
   "detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana",
-  "setuptools==78.1.1"
+  "setuptools==83.0.0"
 ]
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ hunting = ["tabulate==0.10.0"]
 "Elastic" = "https://www.elastic.co"
 
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+requires = ["setuptools>=83.0.0", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.0.6"
+version = "2.0.7"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/pull/6495, https://github.com/elastic/detection-rules/security/dependabot/3

## Summary - What I changed

Bumps `setuptools` from 78.1.1 to 83.0.0 to resolve Dependabot alert #3 (GHSA-h35f-9h28-mq5c), and upgrades `marshmallow-jsonschema` from `~=0.13.0` to `~=0.16.0` as a required co-dependency fix to unblock the CI failure on the existing Dependabot PR #6495.

| Package | Old | New | Reason |
|---|---|---|---|
| `setuptools` | `==78.1.1` | `==83.0.0` | Fix GHSA-h35f-9h28-mq5c (MANIFEST.in Unicode normalization bypass) |
| `marshmallow-jsonschema` | `~=0.13.0` | `~=0.16.0` | Drop `pkg_resources` dependency; unblocks Python 3.13 CI |

### Historical context

A previous setuptools bump (75.2.0 → 78.1.1, PR #4730) had to simultaneously lock `marshmallow-dataclass[union]` to 8.6.1 due to a different marshmallow-dataclass 8.7.x behavior change that broke `AlertSuppressionMapping.__init__()`. That issue is unrelated to the current one. `marshmallow-dataclass` is now at 8.7.1 and working correctly. The current blocker is exclusively `marshmallow-jsonschema` 0.13.x's use of `pkg_resources`.

## How To Test

- `make deps` (clean environment build)
- `python -m detection_rules test`
- Confirm `import marshmallow_jsonschema` succeeds on Python 3.13


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
