### PR TITLE
[New Rule] Successful AMQP Multi-Queue Purge Burst

### DIFF
--- a/rules/network/impact_amqp_multi_queue_purge_burst.toml
+++ b/rules/network/impact_amqp_multi_queue_purge_burst.toml
@@ -51,7 +51,10 @@ The AMQP `queue.purge` method removes every ready message from the selected queu
 - Review RabbitMQ permissions and remove unnecessary queue-configuration rights from application accounts.
 - Investigate the client host and associated account for credential theft and additional destructive activity.
 """
-references = ["https://www.rabbitmq.com/amqp-0-9-1-reference", "https://attack.mitre.org/techniques/T1485/"]
+references = [
+    "https://www.rabbitmq.com/amqp-0-9-1-reference",
+    "https://attack.mitre.org/techniques/T1485/",
+]
 risk_score = 73
 rule_id = "286614ee-8b72-4ea5-a22d-e0d2ae59d0a9"
 setup = """## Setup

--- a/rules/network/impact_amqp_multi_queue_purge_burst.toml
+++ b/rules/network/impact_amqp_multi_queue_purge_burst.toml
@@ -1,0 +1,115 @@
+[metadata]
+creation_date = "2026/07/30"
+integration = ["network_traffic"]
+maturity = "production"
+updated_date = "2026/07/30"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies multiple successful AMQP queue purge operations issued by the same client to the same broker within a short
+period. The AMQP `queue.purge` method removes all messages from a queue that are not awaiting acknowledgment. Purging
+several distinct queues can indicate deliberate message destruction or disruption after broker credentials are
+compromised.
+"""
+false_positives = [
+    """
+    Authorized administrators or automation may purge multiple queues during maintenance, testing, disaster recovery, or
+    application resets. Confirm the client, authenticated RabbitMQ user, affected queues, and change window before
+    escalating. Add exceptions for verified administrative sources rather than reducing the queue-cardinality threshold.
+    """,
+]
+from = "now-9m"
+index = ["logs-network_traffic.amqp-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Successful AMQP Multi-Queue Purge Burst"
+note = """## Triage and analysis
+
+### Investigating Successful AMQP Multi-Queue Purge Burst
+
+The AMQP `queue.purge` method removes every ready message from the selected queue. This rule requires successful purge
+responses for at least three distinct queues from one client-to-broker pair, reducing noise from isolated administrative
+operations while identifying activity capable of causing broad message loss and application disruption.
+
+### Possible investigation steps
+
+- Review `client.ip`, `server.ip`, and the alert time range. Search the underlying
+  `logs-network_traffic.amqp-*` events for the affected `network_traffic.amqp.queue` values.
+- Confirm that each event has `network_traffic.amqp.method: "queue.purge"` and
+  `network_traffic.status: "OK"`, indicating that the broker accepted the operation.
+- Use RabbitMQ audit and application logs to identify the authenticated user associated with the client connection.
+  AMQP message properties are not authoritative authentication identities.
+- Determine whether the source is approved administration or maintenance automation and whether a documented change
+  authorized purging all affected queues.
+- Assess message loss and application impact. Review queue-depth metrics, dead-letter queues, publisher errors, consumer
+  lag, and service availability around the alert.
+- Correlate the client and account with `queue.delete`, `exchange.delete`, binding changes, unusual consumers,
+  authentication anomalies, and endpoint alerts.
+
+### False positive analysis
+
+- Queue maintenance, integration testing, disaster-recovery exercises, and application reset workflows may
+  intentionally purge several queues.
+- Treat confirmed recurring activity as a benign true positive and scope exceptions to approved client-to-broker pairs
+  or queue names. Broadly excluding `queue.purge` would conceal the destructive behavior this rule is intended to detect.
+
+### Response and remediation
+
+- Revoke or restrict unauthorized RabbitMQ credentials and block the client if the purge was not approved.
+- Preserve broker, network, and application evidence before restarting affected services.
+- Restore or replay messages from upstream systems, backups, or dead-letter infrastructure where possible.
+- Review RabbitMQ permissions and remove unnecessary queue-configuration rights from application accounts.
+- Investigate the client host and associated account for credential theft and additional destructive activity.
+"""
+references = ["https://www.rabbitmq.com/amqp-0-9-1-reference", "https://attack.mitre.org/techniques/T1485/"]
+risk_score = 73
+rule_id = "286614ee-8b72-4ea5-a22d-e0d2ae59d0a9"
+setup = """## Setup
+
+This rule requires the Elastic Network Packet Capture integration with the AMQP protocol analyzer enabled and cleartext
+AMQP 0.9.1 visibility. AMQP header and method-argument parsing must remain enabled so the method, queue, and transaction
+status are populated. AMQP over TLS is opaque to passive capture. RabbitMQ audit logs are required to map the observed
+client connection to an authenticated broker identity.
+"""
+severity = "high"
+tags = [
+    "Domain: Network",
+    "Use Case: Network Security Monitoring",
+    "Use Case: Threat Detection",
+    "Tactic: Impact",
+    "Data Source: Network Packet Capture",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "threshold"
+
+query = '''
+data_stream.dataset:"network_traffic.amqp" and
+network_traffic.amqp.method:"queue.purge" and
+network_traffic.status:"OK" and
+client.ip:* and server.ip:* and network_traffic.amqp.queue:*
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1485"
+name = "Data Destruction"
+reference = "https://attack.mitre.org/techniques/T1485/"
+
+
+[rule.threat.tactic]
+id = "TA0040"
+name = "Impact"
+reference = "https://attack.mitre.org/tactics/TA0040/"
+
+[rule.threshold]
+field = ["client.ip", "server.ip"]
+value = 3
+[[rule.threshold.cardinality]]
+field = "network_traffic.amqp.queue"
+value = 3
+
+

--- a/rules/network/impact_amqp_multi_queue_purge_burst.toml
+++ b/rules/network/impact_amqp_multi_queue_purge_burst.toml
@@ -8,7 +8,7 @@ updated_date = "2026/07/30"
 author = ["Elastic"]
 description = """
 Identifies multiple successful AMQP queue purge operations issued by the same client to the same broker within a short
-period. The AMQP `queue.purge` method removes all messages from a queue that are not awaiting acknowledgment. Purging
+period. The AMQP queue.purge method removes all messages from a queue that are not awaiting acknowledgment. Purging
 several distinct queues can indicate deliberate message destruction or disruption after broker credentials are
 compromised.
 """
@@ -20,39 +20,28 @@ false_positives = [
     """,
 ]
 from = "now-9m"
-index = ["logs-network_traffic.amqp-*"]
-language = "kuery"
+language = "esql"
 license = "Elastic License v2"
 name = "Successful AMQP Multi-Queue Purge Burst"
 note = """## Triage and analysis
 
 ### Investigating Successful AMQP Multi-Queue Purge Burst
 
-The AMQP `queue.purge` method removes every ready message from the selected queue. This rule requires successful purge
-responses for at least three distinct queues from one client-to-broker pair, reducing noise from isolated administrative
-operations while identifying activity capable of causing broad message loss and application disruption.
+The AMQP `queue.purge` method removes every ready message from the selected queue. This rule requires successful purge responses for at least three distinct queues from one client-to-broker pair, reducing noise from isolated administrative operations while identifying activity capable of causing broad message loss and application disruption.
 
 ### Possible investigation steps
 
-- Review `client.ip`, `server.ip`, and the alert time range. Search the underlying
-  `logs-network_traffic.amqp-*` events for the affected `network_traffic.amqp.queue` values.
-- Confirm that each event has `network_traffic.amqp.method: "queue.purge"` and
-  `network_traffic.status: "OK"`, indicating that the broker accepted the operation.
-- Use RabbitMQ audit and application logs to identify the authenticated user associated with the client connection.
-  AMQP message properties are not authoritative authentication identities.
-- Determine whether the source is approved administration or maintenance automation and whether a documented change
-  authorized purging all affected queues.
-- Assess message loss and application impact. Review queue-depth metrics, dead-letter queues, publisher errors, consumer
-  lag, and service availability around the alert.
-- Correlate the client and account with `queue.delete`, `exchange.delete`, binding changes, unusual consumers,
-  authentication anomalies, and endpoint alerts.
+- Review `client.ip`, `server.ip`, `Esql.purge_count`, `Esql.queue_count`, `Esql.queues`, `Esql.first_purge`, and `Esql.last_purge` to determine the scope and timing of the activity.
+- Search the underlying `logs-network_traffic.amqp-*` events and confirm that each transaction has `network_traffic.amqp.method: "queue.purge"`, `network_traffic.amqp.no-wait: false`, and `network_traffic.status: "OK"`. Together, these values indicate that Packetbeat observed the broker's `queue.purge-ok` response.
+- Use RabbitMQ audit and application logs to identify the authenticated user associated with the client connection. AMQP message properties are not authoritative authentication identities.
+- Determine whether the source is approved administration or maintenance automation and whether a documented change authorized purging all affected queues.
+- Assess message loss and application impact. Review queue-depth metrics, dead-letter queues, publisher errors, consumer lag, and service availability around the alert.
+- Correlate the client and account with `queue.delete`, `exchange.delete`, binding changes, unusual consumers, authentication anomalies, and endpoint alerts.
 
 ### False positive analysis
 
-- Queue maintenance, integration testing, disaster-recovery exercises, and application reset workflows may
-  intentionally purge several queues.
-- Treat confirmed recurring activity as a benign true positive and scope exceptions to approved client-to-broker pairs
-  or queue names. Broadly excluding `queue.purge` would conceal the destructive behavior this rule is intended to detect.
+- Queue maintenance, integration testing, disaster-recovery exercises, and application reset workflows may intentionally purge several queues.
+- Treat confirmed recurring activity as a benign true positive and scope exceptions to approved client-to-broker pairs or queue names. Broadly excluding `queue.purge` would conceal the destructive behavior this rule is intended to detect.
 
 ### Response and remediation
 
@@ -82,13 +71,28 @@ tags = [
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
-type = "threshold"
+type = "esql"
 
 query = '''
-data_stream.dataset:"network_traffic.amqp" and
-network_traffic.amqp.method:"queue.purge" and
-network_traffic.status:"OK" and
-client.ip:* and server.ip:* and network_traffic.amqp.queue:*
+FROM logs-network_traffic.amqp-*
+| WHERE
+    data_stream.dataset == "network_traffic.amqp" AND
+    network_traffic.amqp.method == "queue.purge" AND
+    network_traffic.amqp.`no-wait` == false AND
+    network_traffic.status == "OK" AND
+    client.ip IS NOT NULL AND
+    server.ip IS NOT NULL AND
+    network_traffic.amqp.queue IS NOT NULL
+| STATS
+    Esql.purge_count = COUNT(*),
+    Esql.queue_count = COUNT_DISTINCT(network_traffic.amqp.queue),
+    Esql.queues = VALUES(network_traffic.amqp.queue),
+    Esql.first_purge = MIN(@timestamp),
+    Esql.last_purge = MAX(@timestamp)
+  BY client.ip, server.ip
+| WHERE Esql.purge_count >= 3 AND Esql.queue_count >= 3
+| SORT Esql.queue_count DESC, Esql.purge_count DESC
+| KEEP client.ip, server.ip, Esql.purge_count, Esql.queue_count, Esql.queues, Esql.first_purge, Esql.last_purge
 '''
 
 
@@ -104,12 +108,4 @@ reference = "https://attack.mitre.org/techniques/T1485/"
 id = "TA0040"
 name = "Impact"
 reference = "https://attack.mitre.org/tactics/TA0040/"
-
-[rule.threshold]
-field = ["client.ip", "server.ip"]
-value = 3
-[[rule.threshold.cardinality]]
-field = "network_traffic.amqp.queue"
-value = 3
-
 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to https://github.com/elastic/ia-trade-team/issues/961

## Summary - What I changed

Adds the `Successful AMQP Multi-Queue Purge Burst` rule to expand `network_traffic.amqp` protocol coverage.

The high-severity threshold rule identifies at least three successful AMQP `queue.purge` operations affecting three distinct queues from the same client to the same broker. Purging multiple queues removes ready messages and can indicate
deliberate data destruction or application disruption after RabbitMQ credentials are compromised.

The query requires `network_traffic.status: "OK"` so only broker-accepted purge operations contribute to the threshold. Grouping by `client.ip` and `server.ip` associates the activity with one client-to-broker relationship.

> [!NOTE]
> This rule requires visibility into plaintext AMQP traffic. Similar to the other paintext based rules, this is to gauge customer interest in these protections. 

## How To Test

[RTA](https://github.com/elastic/cortado/pull/34/commits/ca75ab86cfa4f1e642677f7c9a060ce8043b0df8) or data in test stack

<img width="1823" height="569" alt="image" src="https://github.com/user-attachments/assets/60451260-9086-4729-b70c-e2ff706267e7" />


ES|QL Version

<img width="1829" height="883" alt="image" src="https://github.com/user-attachments/assets/a9140cb7-fa28-4faf-9dbe-9b0b7c4cd29c" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
