### PR TITLE
[Rule Tuning] Rewriting execution through perl rule due to impossible condition

### DIFF
--- a/rules/linux/execution_perl_tty_shell.toml
+++ b/rules/linux/execution_perl_tty_shell.toml
@@ -113,12 +113,22 @@ type = "eql"
 query = '''
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
-process.name == "perl" and process.args == "exec" and
-process.args in (
-  "\"sh\";", "\"dash\";", "\"bash\";", "\"zsh\";",
-  "\"/bin/sh\";", "\"/bin/dash\";", "\"/bin/bash\";", "\"/bin/zsh\";",
-  "\"/usr/bin/sh\";", "\"/usr/bin/dash\";", "\"/usr/bin/bash\";", "\"/usr/bin/zsh\";",
-  "\"/usr/local/bin/sh\";", "\"/usr/local/bin/dash\";", "\"/usr/local/bin/bash\";", "\"/usr/local/bin/zsh\";"
+  (
+    (
+    process.name like~ "perl*" and
+    process.command_line like~ ("*exec*", "*system*") and
+    process.command_line like~ (
+      "*/bin/sh*", "*/bin/bash*", "*/bin/dash*", "*/bin/zsh*", "*/bin/ash*",
+      "*/usr/bin/sh*", "*/usr/bin/bash*", "*/usr/bin/dash*", "*/usr/bin/zsh*",
+      "*\"sh\"*", "*\"bash\"*", "*\"dash\"*", "*\"zsh\"*", "*\"ash\"*",
+      "*'sh'*", "*'bash'*", "*'dash'*", "*'zsh'*", "*'ash'*"
+    )
+  ) or
+  (
+    process.parent.name like~ "perl*" and
+    process.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+    process.args_count == 1
+  )
 )
 '''
 


### PR DESCRIPTION
# Pull Request

*Issue*:

The previous query included a condition on `process.args` that may not have matched.

```
process.name == "perl" and process.args == "exec" and
process.args in ("\"sh\";", "\"/bin/sh\";", ...)

```


## Summary - What I changed

I have rewritten the rule based on Python’s sibling rule. This query may have an impact on the cluster because of the multiple `*` wildcards, so I’m open to suggestions for further improvements.
