### PR TITLE
[Rule Tuning] RPC (Remote Procedure Call) to the Internet

### DIFF
--- a/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
+++ b/rules/network/initial_access_rpc_remote_procedure_call_to_the_internet.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/02/18"
 integration = ["network_traffic", "panw", "pfsense", "zeek", "corelight"]
 maturity = "production"
-updated_date = "2026/06/24"
+updated_date = "2026/08/01"
 
 [rule]
 author = ["Elastic"]
@@ -69,8 +69,19 @@ query = '''
     240.0.0.0/4 or
     "::1" or
     "FE80::/10" or
-    "FF00::/8"
-  )
+    "FF00::/8" or
+    "8.8.8.8" or
+    "8.8.4.4" or
+    "1.1.1.1" or
+    "1.0.0.1" or
+    "208.67.222.222" or
+    "208.67.220.220" or
+    "4.2.2.2" or
+    "4.2.2.1" or
+    "9.9.9.9"
+  ) and
+  not event.outcome:"failure" and
+  not network.application:("incomplete" or "not-applicable")
 '''
 note = """## Triage and analysis
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1051

Reduces noise from well-known public DNS resolver IPs appearing as RPC destinations due to firewall NAT or ephemeral port artifacts, firewall-blocked connections that were already mitigated, and PAN-OS flows where app-id determined the traffic was not actually RPC. Adds destination IP exclusions for common DNS resolvers, filters out event.outcome failure (denied/dropped flows), and excludes PAN-OS network.application values of "incomplete" and "not-applicable" which indicate non-RPC traffic on port 135.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
