### PR TITLE
[New Rule] Azure AKS Pod Exec Cloud Instance Metadata Access

### DIFF
--- a/rules/integrations/azure/credential_access_azure_aks_pod_exec_cloud_instance_metadata.toml
+++ b/rules/integrations/azure/credential_access_azure_aks_pod_exec_cloud_instance_metadata.toml
@@ -1,0 +1,148 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+    Detects an AKS (Azure Kubernetes Service) identity establishing a pods/exec session whose command line targets the
+    Azure Instance Metadata Service (IMDS) at 169.254.169.254 or related metadata paths. Exec into a pod and querying
+    IMDS is a common credential-theft step used to steal the node or pod managed identity token for lateral movement
+    into Azure ARM. Node, control-plane, and kube-system service account identities are excluded.
+"""
+false_positives = [
+    """
+    Legitimate troubleshooting that curls IMDS from inside a pod is rare and should be ticketed. Platform health probes
+    that need IMDS should run as kube-system service accounts, which are already excluded.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Pod Exec Cloud Instance Metadata Access"
+note = """## Triage and analysis
+
+### Investigating Azure AKS Pod Exec Cloud Instance Metadata Access
+
+AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree and share the ARM
+operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. This rule alerts when a
+`pods/exec` request embeds IMDS indicators in `requestURI` (the exec command arguments are query parameters), such as
+`169.254.169.254`, `metadata`, or `instance/compute`. Successful IMDS access from a pod can yield the node or workload
+managed identity token, which adversaries reuse against Azure Resource Manager.
+
+### Possible investigation steps
+
+- Identify the acting identity in `azure.platformlogs.properties.log.user.username` and groups in
+  `azure.platformlogs.properties.log.user.groups`, and the target pod in
+  `azure.platformlogs.properties.log.objectRef.namespace` / `objectRef.name`.
+- Decode the exec command from `azure.platformlogs.properties.log.requestURI` (URL-decoded `command=` parameters) to
+  confirm IMDS access and note which identity endpoint was queried (`/metadata/identity/oauth2/token` is highest risk).
+- Evaluate `azure.platformlogs.properties.log.sourceIPs` and `userAgent` (interactive `kubectl` vs scripted client).
+- Correlate with subsequent Azure activity logs for the node or pod managed identity (token use, role assignments,
+  resource enumeration) and with nearby secret reads or RBAC changes in kube-audit.
+
+### False positive analysis
+
+- Break-glass debugging that intentionally queries IMDS from a pod should be rare; exclude the specific operator
+  identity after review rather than removing IMDS patterns.
+- Automated node-agent or cloud-provider components typically do not exec into workload pods to reach IMDS and should
+  not match once kube-system identities remain excluded.
+
+### Response and remediation
+
+- If unauthorized, terminate the exec session, revoke the acting identity's credentials/kubeconfig, and rotate any
+  managed identity credentials that may have been issued.
+- Inspect the target node and pod for persistence, and review Azure activity performed with the stolen identity.
+- Collect kube-audit and Azure activity artifacts per incident response procedures.
+"""
+references = [
+    "https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service",
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+    "https://unit42.paloaltonetworks.com/hildegard-malware-teamtnt/",
+    "https://www.aquasec.com/blog/illusive-attacks-in-aks/",
+]
+risk_score = 73
+rule_id = "7952ab6b-1aba-4143-ad61-ac5341e76662"
+setup = """
+The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
+into the `azure.platformlogs` data stream is required for this rule. Pod exec command arguments appear in
+`requestURI`; `kube-audit-admin` alone is insufficient if exec metadata is filtered in your diagnostic configuration.
+"""
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Tactic: Execution",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.objectRef.resource:"pods" and
+  azure.platformlogs.properties.log.objectRef.subresource:"exec" and
+  azure.platformlogs.properties.log.verb:("create" or "get") and
+  azure.platformlogs.properties.log.requestURI:(*169.254.169.254* or *metadata* or *instance/compute*) and
+  not azure.platformlogs.properties.log.user.username:(
+    system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
+    system\:serviceaccount\:kube-system\:* or "system:apiserver" or
+    "system:kube-controller-manager" or "system:kube-scheduler"
+  )
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.005"
+name = "Cloud Instance Metadata API"
+reference = "https://attack.mitre.org/techniques/T1552/005/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1609"
+name = "Container Administration Command"
+reference = "https://attack.mitre.org/techniques/T1609/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.subresource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.objectRef.name",
+    "azure.platformlogs.properties.log.requestURI",
+    "azure.platformlogs.properties.log.responseStatus.code",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds a detection for AKS pods/exec sessions whose command line targets the Azure Instance Metadata Service (169.254.169.254 / metadata paths), indicating attempted theft of node or workload managed identity credentials.

Validated on sandkube-fi-aks (emulation tag `aks-cred-0f8252`) with trade-lab `logs-azure.platformlogs-*` kube-audit telemetry; exec requestURI contained IMDS indicators and matched the query.

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit).

## Checklist

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
