### PR TITLE
[New Rule] Azure AKS Pod Exec Sensitive File or Credential Path Access

### DIFF
--- a/rules/integrations/azure/credential_access_azure_aks_pod_exec_sensitive_file_access.toml
+++ b/rules/integrations/azure/credential_access_azure_aks_pod_exec_sensitive_file_access.toml
@@ -1,0 +1,145 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+    Detects an AKS (Azure Kubernetes Service) identity establishing a pods/exec session whose command line targets
+    sensitive credential paths such as service account tokens, cloud credential files, kubeconfig, SSH keys, or
+    /etc/shadow. Adversaries exec into pods to harvest mounted tokens and host credentials for persistence and lateral
+    movement. Node, control-plane, and kube-system service account identities are excluded.
+"""
+false_positives = [
+    """
+    Break-glass debugging that cats service account tokens or credential files should be rare and ticketed. Exclude
+    specific operator identities after review rather than dropping path patterns.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Pod Exec Sensitive File or Credential Path Access"
+note = """## Triage and analysis
+
+### Investigating Azure AKS Pod Exec Sensitive File or Credential Path Access
+
+AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree and share the ARM
+operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. Exec command arguments are
+recorded as `command=` query parameters on `pods/exec` in `requestURI`. This rule matches when those arguments reference
+common credential locations (`serviceaccount`, `shadow`, `.aws`, `.azure`, `kubeconfig`, `id_rsa`).
+
+### Possible investigation steps
+
+- Identify the acting identity in `azure.platformlogs.properties.log.user.username` and the target pod in
+  `objectRef.namespace` / `objectRef.name`.
+- URL-decode `azure.platformlogs.properties.log.requestURI` to recover the exact commands and paths accessed.
+- Determine whether the pod mounts a privileged service account or cloud credentials, and whether hostPath or privileged
+  capabilities could expose host files such as `/etc/shadow`.
+- Evaluate `sourceIPs` and `userAgent`, then correlate with subsequent secret API reads, TokenRequest calls, or Azure
+  sign-ins that reuse stolen material.
+
+### False positive analysis
+
+- Approved incident-response or platform engineering workflows that inspect SA tokens may match; exclude the stable
+  operator identity after review.
+- Overlap with IMDS-focused exec detections is expected when a single shell command both reads the SA token and calls
+  metadata endpoints; triage as one credential-access chain.
+
+### Response and remediation
+
+- If unauthorized, terminate the exec session, revoke the acting identity, and rotate any tokens or keys that may have
+  been read from the pod or node.
+- Harden the workload (disable automountServiceAccountToken where unused, drop capabilities, avoid hostPath).
+- Collect kube-audit artifacts per incident response procedures.
+"""
+references = [
+    "https://kubernetes.io/docs/concepts/security/pod-security-standards/",
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+    "https://unit42.paloaltonetworks.com/hildegard-malware-teamtnt/",
+    "https://github.com/inguardians/peirates",
+]
+risk_score = 73
+rule_id = "3fb68caa-c41a-47bb-be9d-481915e7b1c8"
+setup = """
+The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
+into the `azure.platformlogs` data stream is required for this rule.
+"""
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Tactic: Execution",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.objectRef.resource:"pods" and
+  azure.platformlogs.properties.log.objectRef.subresource:"exec" and
+  azure.platformlogs.properties.log.verb:("create" or "get") and
+  azure.platformlogs.properties.log.requestURI:(*serviceaccount* or *shadow* or *.aws* or *.azure* or *kubeconfig* or *id_rsa*) and
+  not azure.platformlogs.properties.log.user.username:(
+    system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
+    system\:serviceaccount\:kube-system\:* or "system:apiserver" or
+    "system:kube-controller-manager" or "system:kube-scheduler"
+  )
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.001"
+name = "Credentials In Files"
+reference = "https://attack.mitre.org/techniques/T1552/001/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1609"
+name = "Container Administration Command"
+reference = "https://attack.mitre.org/techniques/T1609/"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.subresource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.objectRef.name",
+    "azure.platformlogs.properties.log.requestURI",
+    "azure.platformlogs.properties.log.responseStatus.code",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds a detection for AKS pods/exec sessions whose command line targets sensitive credential paths (service account tokens, cloud credential files, kubeconfig, SSH keys, or /etc/shadow).

Validated on sandkube-fi-aks (emulation tag `aks-cred-0f8252`) with trade-lab `logs-azure.platformlogs-*` kube-audit telemetry; query matched expected emulation events.

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit).

## Checklist

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
