### PR TITLE
[New Rule] Azure AKS Rapid Secret GET Activity Against Multiple Objects

### DIFF
--- a/rules/integrations/azure/credential_access_azure_aks_rapid_secret_get_activity.toml
+++ b/rules/integrations/azure/credential_access_azure_aks_rapid_secret_get_activity.toml
@@ -7,18 +7,21 @@ updated_date = "2026/08/04"
 [rule]
 author = ["Elastic"]
 description = """
-    Detects a burst of successful Kubernetes Secret get operations by the same identity on AKS (Azure Kubernetes
-    Service). Rapid enumeration of many secret objects is a common credential-harvesting step after a token or
-    kubeconfig is stolen. Node, control-plane, and kube-system service account identities are excluded.
+    Detects an AKS (Azure Kubernetes Service) identity that successfully gets multiple distinct Kubernetes Secret
+    objects within a short window, grouped by username and user agent. This is the AKS counterpart to the Kubernetes
+    ES|QL rapid secret-get rule: breadth of distinct secret names (cardinality), not raw event count, indicates
+    credential harvesting. Node, control-plane, and kube-system service account identities are excluded, as are Helm
+    release secret objects.
 """
 false_positives = [
     """
-    Controllers, secret sync tools, backup agents, and deployments that mount many secrets can generate bursts above the
-    threshold. Baseline expected identities and raise the threshold or add targeted exclusions after review.
+    Controllers, secret sync tools, backup agents, and deployments that mount many secrets can exceed the cardinality
+    threshold. Baseline expected identities and raise the cardinality value or add targeted exclusions after review.
     """,
 ]
 from = "now-9m"
 index = ["logs-azure.platformlogs-*"]
+interval = "5m"
 language = "kuery"
 license = "Elastic License v2"
 name = "Azure AKS Rapid Secret GET Activity Against Multiple Objects"
@@ -28,25 +31,22 @@ note = """## Triage and analysis
 
 AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree and share the ARM
 operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. This threshold rule groups
-successful (`responseStatus.code:200`) Secret `get` operations by `user.username` and alerts when a single identity
-exceeds the threshold within the rule window — a pattern consistent with secret harvesting across multiple objects.
+successful Secret `get` operations by `user.username` and `userAgent`, and alerts when the same fingerprint touches
+several distinct `objectRef.name` values (cardinality ≥ 3). That matches the Kubernetes audit ES|QL rule's
+`count_distinct(secret name)` approach without requiring ES|QL over flattened platformlogs fields.
 
 ### Possible investigation steps
 
-- Identify the acting identity in `azure.platformlogs.properties.log.user.username` and whether it normally reads many
-  secrets (operators, external-secrets, CI deployers).
-- Review distinct `objectRef.namespace` / `objectRef.name` values in the threshold bucket and the client in `userAgent`
-  (`kubectl` vs scripting HTTP clients).
-- Evaluate `sourceIPs` for external or unusual origins, and correlate with nearby `list` on secrets, TokenRequest, pod
-  exec, or RBAC changes by the same identity.
-- Determine whether retrieved secrets include high-value material (cloud keys, registry pull secrets, TLS keys).
+- Identify the acting fingerprint (`user.username`, `userAgent`) and whether it normally reads many secrets.
+- Enumerate distinct `objectRef.namespace` / `objectRef.name` values in the threshold bucket for high-value targets.
+- Evaluate `sourceIPs` and correlate with nearby `list` on secrets, TokenRequest, pod exec, or RBAC changes.
+- Validate against expected automation (CI, GitOps, backup, in-cluster controllers) before treating as malicious.
 
 ### False positive analysis
 
 - GitOps/CI that reconciles many Secret-backed workloads, backup tools, and secret-management operators commonly exceed
-  low thresholds; exclude those service accounts or raise `threshold.value` after baselining.
-- A single `kubectl get secret -o yaml` against one object will not trip this rule; focus on identities spanning many
-  names.
+  low cardinality thresholds; exclude those service accounts after baselining.
+- Helm release secrets (`sh.helm.release.*`) are excluded by query; other package-manager secret naming may still match.
 
 ### Response and remediation
 
@@ -58,15 +58,16 @@ references = [
     "https://kubernetes.io/docs/concepts/configuration/secret/",
     "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
     "https://unit42.paloaltonetworks.com/modern-kubernetes-threats/",
+    "https://attack.mitre.org/techniques/T1552/007/",
 ]
-risk_score = 47
+risk_score = 73
 rule_id = "db6e2cad-296d-4418-9cc8-155707e06357"
 setup = """
 The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
 into the `azure.platformlogs` data stream is required for this rule. Secret get is a read operation excluded from
 `kube-audit-admin`, so clusters shipping only that category will not produce events for this rule.
 """
-severity = "medium"
+severity = "high"
 tags = [
     "Domain: Cloud",
     "Domain: Kubernetes",
@@ -87,6 +88,7 @@ data_stream.dataset:azure.platformlogs and
   azure.platformlogs.properties.log.objectRef.resource:"secrets" and
   azure.platformlogs.properties.log.verb:"get" and
   azure.platformlogs.properties.log.responseStatus.code:"200" and
+  not azure.platformlogs.properties.log.objectRef.name:sh.helm.release.* and
   not azure.platformlogs.properties.log.user.username:(
     system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
     system\:serviceaccount\:kube-system\:* or "system:apiserver" or
@@ -95,8 +97,15 @@ data_stream.dataset:azure.platformlogs and
 '''
 
 [rule.threshold]
-field = ["azure.platformlogs.properties.log.user.username"]
-value = 10
+field = [
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+]
+value = 1
+
+[[rule.threshold.cardinality]]
+field = "azure.platformlogs.properties.log.objectRef.name"
+value = 3
 
 [[rule.threat]]
 framework = "MITRE ATT&CK"

--- a/rules/integrations/azure/credential_access_azure_aks_rapid_secret_get_activity.toml
+++ b/rules/integrations/azure/credential_access_azure_aks_rapid_secret_get_activity.toml
@@ -1,0 +1,131 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+    Detects a burst of successful Kubernetes Secret get operations by the same identity on AKS (Azure Kubernetes
+    Service). Rapid enumeration of many secret objects is a common credential-harvesting step after a token or
+    kubeconfig is stolen. Node, control-plane, and kube-system service account identities are excluded.
+"""
+false_positives = [
+    """
+    Controllers, secret sync tools, backup agents, and deployments that mount many secrets can generate bursts above the
+    threshold. Baseline expected identities and raise the threshold or add targeted exclusions after review.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Rapid Secret GET Activity Against Multiple Objects"
+note = """## Triage and analysis
+
+### Investigating Azure AKS Rapid Secret GET Activity Against Multiple Objects
+
+AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree and share the ARM
+operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. This threshold rule groups
+successful (`responseStatus.code:200`) Secret `get` operations by `user.username` and alerts when a single identity
+exceeds the threshold within the rule window — a pattern consistent with secret harvesting across multiple objects.
+
+### Possible investigation steps
+
+- Identify the acting identity in `azure.platformlogs.properties.log.user.username` and whether it normally reads many
+  secrets (operators, external-secrets, CI deployers).
+- Review distinct `objectRef.namespace` / `objectRef.name` values in the threshold bucket and the client in `userAgent`
+  (`kubectl` vs scripting HTTP clients).
+- Evaluate `sourceIPs` for external or unusual origins, and correlate with nearby `list` on secrets, TokenRequest, pod
+  exec, or RBAC changes by the same identity.
+- Determine whether retrieved secrets include high-value material (cloud keys, registry pull secrets, TLS keys).
+
+### False positive analysis
+
+- GitOps/CI that reconciles many Secret-backed workloads, backup tools, and secret-management operators commonly exceed
+  low thresholds; exclude those service accounts or raise `threshold.value` after baselining.
+- A single `kubectl get secret -o yaml` against one object will not trip this rule; focus on identities spanning many
+  names.
+
+### Response and remediation
+
+- If unauthorized, revoke the identity's tokens/kubeconfig and rotate secrets that were read.
+- Tighten RBAC that grants broad `get`/`list` on secrets, and prefer namespace-scoped roles.
+- Collect kube-audit artifacts per incident response procedures.
+"""
+references = [
+    "https://kubernetes.io/docs/concepts/configuration/secret/",
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+    "https://unit42.paloaltonetworks.com/modern-kubernetes-threats/",
+]
+risk_score = 47
+rule_id = "db6e2cad-296d-4418-9cc8-155707e06357"
+setup = """
+The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
+into the `azure.platformlogs` data stream is required for this rule. Secret get is a read operation excluded from
+`kube-audit-admin`, so clusters shipping only that category will not produce events for this rule.
+"""
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "threshold"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.objectRef.resource:"secrets" and
+  azure.platformlogs.properties.log.verb:"get" and
+  azure.platformlogs.properties.log.responseStatus.code:"200" and
+  not azure.platformlogs.properties.log.user.username:(
+    system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
+    system\:serviceaccount\:kube-system\:* or "system:apiserver" or
+    "system:kube-controller-manager" or "system:kube-scheduler"
+  )
+'''
+
+[rule.threshold]
+field = ["azure.platformlogs.properties.log.user.username"]
+value = 10
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.007"
+name = "Container API"
+reference = "https://attack.mitre.org/techniques/T1552/007/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.objectRef.name",
+    "azure.platformlogs.properties.log.responseStatus.code",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds a threshold detection for AKS identities that successfully `get` **multiple distinct** Secret objects (cardinality ≥ 3 on `objectRef.name`), grouped by username + userAgent. AKS-safe parity with Kubernetes ES|QL `count_distinct(secret name)` rapid-get rule (flattened platformlogs makes production ES|QL brittle). Excludes Helm release secrets and platform identities. Severity raised to high to match the K8s twin.

Validated on sandkube-fi-aks (emulation produced ≥12 distinct secret gets by `masterclient`).

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit).

## Checklist

- [ ] Added a label for the type of pr: `Rule: New` so guidelines can be generated
- [ ] Secret and sensitive material has been managed correctly
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?