### PR TITLE
[New Rule] Azure AKS Secret Access via Unusual Client Fingerprint

### DIFF
--- a/rules/integrations/azure/credential_access_azure_aks_secret_get_access.toml
+++ b/rules/integrations/azure/credential_access_azure_aks_secret_get_access.toml
@@ -7,51 +7,52 @@ updated_date = "2026/08/04"
 [rule]
 author = ["Elastic"]
 description = """
-    Detects successful Kubernetes Secret get operations on AKS (Azure Kubernetes Service) by non-platform identities.
-    Individual secret reads are common in healthy clusters; this rule is intended as a broad credential-access signal to
-    correlate with unusual identities, user agents, source IPs, or follow-on activity such as rapid multi-secret access
-    or pod exec. Node, control-plane, and kube-system service account identities are excluded.
+    Detects Kubernetes Secret get or list operations on AKS (Azure Kubernetes Service) from a previously unseen
+    combination of identity, user agent, and source IP. Mirrors the Kubernetes audit New Terms secret-access rule:
+    routine application reads from known clients are learned over the history window, while a new client fingerprint
+    reading secrets is surfaced for review. Node, control-plane, and kube-system service account identities are
+    excluded, as are default client-go user agents (`kubernetes/$Format`).
 """
 false_positives = [
     """
-    Applications and operators routinely read their own secrets. Expect high volume unless further scoped by identity,
-    namespace, or correlated with suspicious user agents. Prefer pairing with the suspicious-user-agent and rapid-get
-    rules for higher fidelity.
+    New deployers, CI runners, or operators reading secrets from a first-seen workstation or user agent will alert once
+    until the 7-day history window learns that fingerprint. Validate change tickets and expected automation before
+    treating as compromise.
     """,
 ]
 from = "now-9m"
 index = ["logs-azure.platformlogs-*"]
 language = "kuery"
 license = "Elastic License v2"
-name = "Azure AKS Secret get Access"
+name = "Azure AKS Secret Access via Unusual Client Fingerprint"
 note = """## Triage and analysis
 
-### Investigating Azure AKS Secret get Access
+### Investigating Azure AKS Secret Access via Unusual Client Fingerprint
 
 AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree and share the ARM
-operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. This rule matches any
-successful Secret `get` by an identity outside the excluded platform set. Use it as context for hunting and correlation
-rather than as a standalone high-confidence compromise indicator.
+operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. This New Terms rule alerts
+when a Secret `get` or `list` comes from a combination of `user.username`, `userAgent`, and `sourceIPs` not seen in the
+prior 7 days. That fingerprint-based approach is the AKS counterpart to the Kubernetes audit rule "Kubernetes Secret
+Access via Unusual User Agent" and reduces noise from steady-state application secret reads.
 
 ### Possible investigation steps
 
-- Review `user.username`, `user.groups`, `userAgent`, and `sourceIPs` for rarity relative to the namespace.
-- Inspect `objectRef.namespace` / `objectRef.name` and whether the secret is high value (cloud keys, registry, TLS).
-- Correlate with threshold bursts (many gets by one identity), scripting user agents, TokenRequest, pod exec, or RBAC
-  changes in the same window.
-- Confirm authorization decision annotations when present and whether the identity should have secret read rights.
+- Identify the new fingerprint: `user.username`, `userAgent`, and `sourceIPs`, and whether it maps to a known admin
+  workstation, CI runner, or compromised workload token.
+- Review targeted `objectRef.namespace` / `objectRef.name` for high-value secrets (tokens, registry, TLS, cloud keys).
+- Correlate with rapid multi-secret gets, scripting user agents, TokenRequest, pod exec, or RBAC changes nearby.
+- Confirm authorization decision annotations and whether the identity should have secret read rights.
 
 ### False positive analysis
 
-- Nearly all workload service accounts that mount secrets will generate matching gets; exclude stable application SAs or
-  restrict alerting to sensitive namespaces after baselining.
-- Deployers and GitOps controllers reading secrets during rollout are expected; exclude those identities.
-- For higher-fidelity coverage of non-kubectl clients, prefer the dedicated suspicious user-agent secret-access rule.
+- First-time use of a new kubectl version, bastion, or CI pool will alert until learned; exclude stable automation
+  fingerprints only after review.
+- Prefer the dedicated suspicious-user-agent secret-access rule when the client is already a known scripting UA.
 
 ### Response and remediation
 
-- If the identity or secret scope is unauthorized, revoke credentials and rotate the accessed secret.
-- Reduce standing `get`/`list` on secrets via least-privilege RBAC and namespace boundaries.
+- If unauthorized, revoke the identity's credentials/kubeconfig and rotate accessed secrets.
+- Tighten RBAC granting secret `get`/`list` and force admin access through approved bastions.
 - Collect kube-audit artifacts per incident response procedures.
 """
 references = [
@@ -63,8 +64,9 @@ risk_score = 21
 rule_id = "7aa48317-0f50-4118-9350-5fc6e6bf18cb"
 setup = """
 The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
-into the `azure.platformlogs` data stream is required for this rule. Secret get is a read operation excluded from
-`kube-audit-admin`, so clusters shipping only that category will not produce events for this rule.
+into the `azure.platformlogs` data stream is required for this rule. Secret get/list are read operations excluded from
+`kube-audit-admin`. New Terms requires sufficient historical events in the lookback window to learn baseline
+fingerprints.
 """
 severity = "low"
 tags = [
@@ -78,15 +80,16 @@ tags = [
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"
-type = "query"
+type = "new_terms"
 
 query = '''
 data_stream.dataset:azure.platformlogs and
   event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
   azure.platformlogs.category:"kube-audit" and
   azure.platformlogs.properties.log.objectRef.resource:"secrets" and
-  azure.platformlogs.properties.log.verb:"get" and
+  azure.platformlogs.properties.log.verb:("get" or "list") and
   azure.platformlogs.properties.log.responseStatus.code:"200" and
+  azure.platformlogs.properties.log.userAgent:(* and not (*kubernetes/$Format)) and
   not azure.platformlogs.properties.log.user.username:(
     system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
     system\:serviceaccount\:kube-system\:* or "system:apiserver" or
@@ -110,6 +113,18 @@ reference = "https://attack.mitre.org/techniques/T1552/007/"
 id = "TA0006"
 name = "Credential Access"
 reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = [
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+]
+
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-7d"
 
 [rule.investigation_fields]
 field_names = [

--- a/rules/integrations/azure/credential_access_azure_aks_secret_get_access.toml
+++ b/rules/integrations/azure/credential_access_azure_aks_secret_get_access.toml
@@ -1,0 +1,127 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+    Detects successful Kubernetes Secret get operations on AKS (Azure Kubernetes Service) by non-platform identities.
+    Individual secret reads are common in healthy clusters; this rule is intended as a broad credential-access signal to
+    correlate with unusual identities, user agents, source IPs, or follow-on activity such as rapid multi-secret access
+    or pod exec. Node, control-plane, and kube-system service account identities are excluded.
+"""
+false_positives = [
+    """
+    Applications and operators routinely read their own secrets. Expect high volume unless further scoped by identity,
+    namespace, or correlated with suspicious user agents. Prefer pairing with the suspicious-user-agent and rapid-get
+    rules for higher fidelity.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Secret get Access"
+note = """## Triage and analysis
+
+### Investigating Azure AKS Secret get Access
+
+AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree and share the ARM
+operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. This rule matches any
+successful Secret `get` by an identity outside the excluded platform set. Use it as context for hunting and correlation
+rather than as a standalone high-confidence compromise indicator.
+
+### Possible investigation steps
+
+- Review `user.username`, `user.groups`, `userAgent`, and `sourceIPs` for rarity relative to the namespace.
+- Inspect `objectRef.namespace` / `objectRef.name` and whether the secret is high value (cloud keys, registry, TLS).
+- Correlate with threshold bursts (many gets by one identity), scripting user agents, TokenRequest, pod exec, or RBAC
+  changes in the same window.
+- Confirm authorization decision annotations when present and whether the identity should have secret read rights.
+
+### False positive analysis
+
+- Nearly all workload service accounts that mount secrets will generate matching gets; exclude stable application SAs or
+  restrict alerting to sensitive namespaces after baselining.
+- Deployers and GitOps controllers reading secrets during rollout are expected; exclude those identities.
+- For higher-fidelity coverage of non-kubectl clients, prefer the dedicated suspicious user-agent secret-access rule.
+
+### Response and remediation
+
+- If the identity or secret scope is unauthorized, revoke credentials and rotate the accessed secret.
+- Reduce standing `get`/`list` on secrets via least-privilege RBAC and namespace boundaries.
+- Collect kube-audit artifacts per incident response procedures.
+"""
+references = [
+    "https://kubernetes.io/docs/concepts/configuration/secret/",
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+    "https://unit42.paloaltonetworks.com/modern-kubernetes-threats/",
+]
+risk_score = 21
+rule_id = "7aa48317-0f50-4118-9350-5fc6e6bf18cb"
+setup = """
+The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
+into the `azure.platformlogs` data stream is required for this rule. Secret get is a read operation excluded from
+`kube-audit-admin`, so clusters shipping only that category will not produce events for this rule.
+"""
+severity = "low"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.objectRef.resource:"secrets" and
+  azure.platformlogs.properties.log.verb:"get" and
+  azure.platformlogs.properties.log.responseStatus.code:"200" and
+  not azure.platformlogs.properties.log.user.username:(
+    system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
+    system\:serviceaccount\:kube-system\:* or "system:apiserver" or
+    "system:kube-controller-manager" or "system:kube-scheduler"
+  )
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.007"
+name = "Container API"
+reference = "https://attack.mitre.org/techniques/T1552/007/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.objectRef.name",
+    "azure.platformlogs.properties.log.responseStatus.code",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds a **New Terms** detection for AKS Secret get/list from a previously unseen combination of identity, user agent, and source IP (7-day history). Parity with Kubernetes `credential_access_get_secrets_access` (New Terms on IP/user/UA). Excludes platform identities and default `kubernetes/$Format` user agents.

Validated kube-audit telemetry on sandkube-fi-aks; retargeted from flat KQL after K8s parity review.

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit). New Terms needs history window to learn baselines.

## Checklist

- [ ] Added a label for the type of pr: `Rule: New` so guidelines can be generated
- [ ] Secret and sensitive material has been managed correctly
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?