### PR TITLE
[New Rule] Azure AKS Secret get or list from Node or Pod Service Account

### DIFF
--- a/rules/integrations/azure/credential_access_azure_aks_secret_read_by_node_or_pod_sa.toml
+++ b/rules/integrations/azure/credential_access_azure_aks_secret_read_by_node_or_pod_sa.toml
@@ -1,0 +1,127 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+    Detects successful Kubernetes Secret get or list operations on AKS (Azure Kubernetes Service) performed by node
+    identities (`system:node:*`) or pod service accounts (`system:serviceaccount:*`) outside kube-system. Compromised
+    workloads and nodes commonly enumerate or read secrets after establishing a foothold. Kube-system service accounts
+    are excluded to reduce control-plane noise.
+"""
+false_positives = [
+    """
+    Controllers and operators outside kube-system with intentional secret read permissions (external-secrets,
+    cert-manager in its own namespace, CSI drivers, GitOps) will match repeatedly. Scope to sensitive namespaces or
+    exclude verified service accounts after baselining.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Secret get or list from Node or Pod Service Account"
+note = """## Triage and analysis
+
+### Investigating Azure AKS Secret get or list from Node or Pod Service Account
+
+AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree and share the ARM
+operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. This rule focuses on
+in-cluster identities — nodes and pod service accounts — reading secrets, which is the common path after container
+compromise when an adversary uses the mounted token against the API.
+
+### Possible investigation steps
+
+- Identify the service account or node in `user.username` (`system:serviceaccount:<ns>:<name>` or `system:node:<node>`)
+  and whether that identity should read the targeted secret.
+- Inspect `objectRef.namespace` / `objectRef.name`, `verb` (`get` vs broad `list`), `userAgent` (curl/Go-http vs
+  client-go controller), and `sourceIPs`.
+- Correlate with pod exec, TokenRequest, RBAC changes, or multi-secret bursts from the same SA.
+- If a node identity is reading arbitrary secrets via the API, treat as high severity — kubelet normally consumes
+  secrets through the projected volume path rather than listing namespace secrets.
+
+### False positive analysis
+
+- Secret-management and GitOps operators running outside kube-system are the dominant FP class; exclude those SAs.
+- Applications reading only their own mounted secret object may still appear as API `get` depending on client libraries;
+  prefer exclusions by SA rather than disabling the rule.
+- For scripting clients specifically, the suspicious user-agent secret-access rule provides stronger fidelity.
+
+### Response and remediation
+
+- If unauthorized, revoke/rotate the service account token, delete compromised pods, and rotate accessed secrets.
+- Remove excessive Role/ClusterRole bindings that grant secret `get`/`list` to workload SAs.
+- Collect kube-audit artifacts per incident response procedures.
+"""
+references = [
+    "https://kubernetes.io/docs/concepts/configuration/secret/",
+    "https://kubernetes.io/docs/reference/access-authn-authz/authentication/",
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+    "https://unit42.paloaltonetworks.com/hildegard-malware-teamtnt/",
+]
+risk_score = 47
+rule_id = "591b91df-b6b0-412f-b6c1-d105f44113b8"
+setup = """
+The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
+into the `azure.platformlogs` data stream is required for this rule. Secret get/list are read operations excluded from
+`kube-audit-admin`.
+"""
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.objectRef.resource:"secrets" and
+  azure.platformlogs.properties.log.verb:("get" or "list") and
+  azure.platformlogs.properties.log.responseStatus.code:"200" and
+  azure.platformlogs.properties.log.user.username:(system\:node\:* or system\:serviceaccount\:*) and
+  not azure.platformlogs.properties.log.user.username:system\:serviceaccount\:kube-system\:*
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.007"
+name = "Container API"
+reference = "https://attack.mitre.org/techniques/T1552/007/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.objectRef.name",
+    "azure.platformlogs.properties.log.responseStatus.code",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds a detection for successful Secret get/list on AKS by node identities or pod service accounts outside kube-system.

Validated on sandkube-fi-aks (emulation tag `aks-cred-0f8252`) with trade-lab `logs-azure.platformlogs-*` kube-audit telemetry; query matched expected emulation events.

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit).

## Checklist

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
