### PR TITLE
[New Rule] Azure AKS Secrets List in Sensitive Namespaces

### DIFF
--- a/rules/integrations/azure/credential_access_azure_aks_secrets_list_sensitive_namespaces.toml
+++ b/rules/integrations/azure/credential_access_azure_aks_secrets_list_sensitive_namespaces.toml
@@ -1,0 +1,139 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+    Detects Kubernetes Secrets list operations on AKS (Azure Kubernetes Service) targeting sensitive namespaces such as
+    kube-system, kube-public, gatekeeper-system, or cert-manager. Broad secret listing in control-plane and policy
+    namespaces is a common credential-discovery step after cluster access is obtained. Node, control-plane, and
+    kube-system service account identities are excluded.
+"""
+false_positives = [
+    """
+    Cluster backup, secret-management, and policy tooling may list secrets in these namespaces. Exclude known backup or
+    operator service accounts after review.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Secrets List in Sensitive Namespaces"
+note = """## Triage and analysis
+
+### Investigating Azure AKS Secrets List in Sensitive Namespaces
+
+AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree and share the ARM
+operation `event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read`. A `list` against `secrets` in
+`kube-system` (or other sensitive namespaces) exposes names and metadata that guide follow-on credential theft. Human
+users and non-platform service accounts performing this list are uncommon outside backup/admin workflows.
+
+### Possible investigation steps
+
+- Identify the acting identity in `user.username` / `user.groups` and whether cluster-admin or broad secret list rights
+  are expected.
+- Confirm the namespace in `objectRef.namespace`, the client in `userAgent`, and origin in `sourceIPs` (external IPs are
+  higher concern than in-cluster addresses).
+- Correlate with subsequent Secret `get` bursts, TokenRequest, CSR activity, or pod exec by the same identity.
+- Review RBAC bindings that granted `list` on secrets in the sensitive namespace.
+
+### False positive analysis
+
+- Velero/backup agents, external-secrets, and platform operators may list kube-system secrets; exclude those SAs.
+- Cluster administrators using `kubectl get secrets -n kube-system` during incidents will match; validate change tickets.
+
+### Response and remediation
+
+- If unauthorized, revoke the identity, rotate secrets that may have been enumerated/read, and remove overly broad
+  RoleBindings/ClusterRoleBindings.
+- Prefer namespace-scoped roles and avoid granting cluster-wide secret list to humans or workloads.
+- Collect kube-audit artifacts per incident response procedures.
+"""
+references = [
+    "https://kubernetes.io/docs/concepts/configuration/secret/",
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+    "https://unit42.paloaltonetworks.com/modern-kubernetes-threats/",
+]
+risk_score = 47
+rule_id = "d6f57280-bf37-46b9-aa81-47911b2868f5"
+setup = """
+The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
+into the `azure.platformlogs` data stream is required for this rule. Secret list is a read operation excluded from
+`kube-audit-admin`.
+"""
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.objectRef.resource:"secrets" and
+  azure.platformlogs.properties.log.verb:"list" and
+  azure.platformlogs.properties.log.objectRef.namespace:("kube-system" or "kube-public" or "gatekeeper-system" or "cert-manager") and
+  not azure.platformlogs.properties.log.user.username:(
+    system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
+    system\:serviceaccount\:kube-system\:* or "system:apiserver" or
+    "system:kube-controller-manager" or "system:kube-scheduler"
+  )
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1552.007"
+name = "Container API"
+reference = "https://attack.mitre.org/techniques/T1552/007/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1613"
+name = "Container and Resource Discovery"
+reference = "https://attack.mitre.org/techniques/T1613/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.objectRef.name",
+    "azure.platformlogs.properties.log.responseStatus.code",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds a detection for Secrets list operations on AKS targeting sensitive namespaces such as kube-system, kube-public, gatekeeper-system, or cert-manager.

Validated on sandkube-fi-aks (emulation tag `aks-cred-0f8252`) with trade-lab `logs-azure.platformlogs-*` kube-audit telemetry; query matched expected emulation events.

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit).

## Checklist

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
