### PR TITLE
[New Rule] Azure AKS Denied Service Account Request via Unusual User Agent

### DIFF
--- a/rules/integrations/azure/discovery_azure_aks_denied_service_account_request.toml
+++ b/rules/integrations/azure/discovery_azure_aks_denied_service_account_request.toml
@@ -1,0 +1,119 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+    Detects a Kubernetes service account on AKS (Azure Kubernetes Service) receiving a forbidden (HTTP 403) API response
+    from a previously unseen user agent. Service accounts follow predictable client patterns; a denied request from a
+    new or non-standard user agent often indicates stolen tokens used with recon tooling. Parity with the Kubernetes
+    New Terms rule for denied service account requests. Kube-system service accounts are excluded.
+"""
+false_positives = [
+    """
+    Misconfigured workload service accounts with insufficient RBAC can generate denials. New controllers with custom
+    user agents alert once until the 7-day history window learns them. Exclude validated service accounts after review.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Denied Service Account Request via Unusual User Agent"
+note = """## Triage and analysis
+
+### Investigating Azure AKS Denied Service Account Request via Unusual User Agent
+
+AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree. This New Terms
+rule alerts when `system:serviceaccount:*` (outside kube-system) receives HTTP 403 from a `userAgent` not seen for that
+baseline window. A stolen SA token used with curl, peirates, or other clients commonly produces this pattern.
+
+### Possible investigation steps
+
+- Identify the service account in `user.username` and the new `userAgent`.
+- Review `objectRef.resource` / `verb` / `requestURI` and `responseStatus.message` for what was probed.
+- Evaluate `sourceIPs` and hunt for later successful (2xx) calls or TokenRequest/exec from the same SA.
+- Validate RBAC for the SA — over-broad bindings plus denials may indicate recon after foothold.
+
+### False positive analysis
+
+- Controllers with incomplete RBAC during rollout; exclude the SA after confirming expected behavior.
+- Default `kubernetes/$Format` client-go agents are excluded from the query.
+
+### Response and remediation
+
+- If unauthorized, revoke/rotate the SA token, delete compromised pods, and tighten RoleBindings.
+- Collect kube-audit artifacts per incident response procedures.
+"""
+references = [
+    "https://research.nccgroup.com/2021/11/10/detection-engineering-for-kubernetes-clusters/#part3-kubernetes-detections",
+    "https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens",
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+]
+risk_score = 21
+rule_id = "14846e23-adb6-4996-8080-e877435cccdb"
+setup = """
+The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
+into the `azure.platformlogs` data stream is required for this rule.
+"""
+severity = "low"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "new_terms"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.responseStatus.code:"403" and
+  azure.platformlogs.properties.log.user.username:system\:serviceaccount\:* and
+  not azure.platformlogs.properties.log.user.username:system\:serviceaccount\:kube-system\:* and
+  azure.platformlogs.properties.log.userAgent:(* and not (*kubernetes/$Format))
+'''
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["azure.platformlogs.properties.log.userAgent"]
+
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-7d"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1613"
+name = "Container and Resource Discovery"
+reference = "https://attack.mitre.org/techniques/T1613/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.responseStatus.code",
+    "azure.platformlogs.properties.log.responseStatus.message",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds **New Terms** detection for service-account HTTP 403 responses from a previously unseen userAgent (7d). Parity with Kubernetes denied SA request New Terms rule.

Validated on sandkube-fi-aks (emulation `emul-aks-b2-b72e61`) with trade-lab `logs-azure.platformlogs-*` kube-audit telemetry. K8s twin parity reviewed (New Terms / threshold cardinality where applicable).

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit).

## Checklist

- [ ] Added a label for the type of pr: `Rule: New` so guidelines can be generated
- [ ] Secret and sensitive material has been managed correctly
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
