### PR TITLE
[New Rule] Azure AKS Endpoint Permission Enumeration by User

### DIFF
--- a/rules/integrations/azure/discovery_azure_aks_endpoint_permission_enumeration_by_user.toml
+++ b/rules/integrations/azure/discovery_azure_aks_endpoint_permission_enumeration_by_user.toml
@@ -1,0 +1,108 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects SelfSubjectAccessReview/SelfSubjectRulesReview activity on AKS used to map permissions for a user or service account.
+"""
+false_positives = [
+    """
+    CI systems and operators may probe permissions. Baseline expected identities.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Endpoint Permission Enumeration by User"
+note = """
+## Triage and analysis
+
+### Investigating Azure AKS Endpoint Permission Enumeration by User
+
+AKS kube-audit events are carried under `azure.platformlogs.properties.log.*` with
+`event.action: Microsoft.ContainerService/managedClusters/diagnosticLogs/Read` and
+`azure.platformlogs.category: kube-audit`. Detects SelfSubjectAccessReview/SelfSubjectRulesReview activity on AKS used to map permissions for a user or service account.
+
+### Possible investigation steps
+
+- Review `azure.platformlogs.properties.log.user.username`, `userAgent`, and `sourceIPs`.
+- Inspect `objectRef` (resource, namespace, name, subresource) and `verb`.
+- If present, examine `requestObject` for privileged fields or binding subjects.
+- Correlate with nearby secret reads, RBAC changes, pod exec, or workload mutations by the same identity.
+
+### False positive analysis
+
+- CI systems and operators may probe permissions. Baseline expected identities.
+
+### Response and remediation
+
+- If unauthorized, revoke the identity's credentials/kubeconfig and remove malicious objects.
+- Rotate any secrets or tokens that may have been accessed.
+- Harden RBAC to least privilege and review admission controls.
+"""
+references = [
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+    "https://kubernetes.io/docs/reference/access-authn-authz/authorization/",
+]
+risk_score = 21
+rule_id = "71148e0d-f30e-4513-8b13-4a6969b8cfa0"
+setup = "The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub into the `azure.platformlogs` data stream is required for this rule."
+severity = "low"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.objectRef.resource:("selfsubjectaccessreviews" or "selfsubjectrulesreviews" or "subjectaccessreviews") and
+  azure.platformlogs.properties.log.verb:"create" and
+  not azure.platformlogs.properties.log.user.username:(
+    system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
+    system\:serviceaccount\:kube-system\:* or "system:apiserver" or
+    "system:kube-controller-manager" or "system:kube-scheduler"
+  )
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1613"
+name = "Container and Resource Discovery"
+reference = "https://attack.mitre.org/techniques/T1613/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.subresource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.objectRef.name",
+    "azure.platformlogs.properties.log.responseStatus.code",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds detection for SelfSubjectAccessReview / SelfSubjectRulesReview / SubjectAccessReview creates by non-platform identities on AKS.

Validated on sandkube-fi-aks (emulation `emul-aks-b2-b72e61`) with trade-lab `logs-azure.platformlogs-*` kube-audit telemetry. K8s twin parity reviewed (New Terms / threshold cardinality where applicable).

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit).

## Checklist

- [ ] Added a label for the type of pr: `Rule: New` so guidelines can be generated
- [ ] Secret and sensitive material has been managed correctly
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
