### PR TITLE
[New Rule] Azure AKS Forbidden Request from Unusual User Agent

### DIFF
--- a/rules/integrations/azure/execution_azure_aks_forbidden_request_unusual_user_agent.toml
+++ b/rules/integrations/azure/execution_azure_aks_forbidden_request_unusual_user_agent.toml
@@ -1,0 +1,129 @@
+[metadata]
+creation_date = "2026/08/04"
+integration = ["azure"]
+maturity = "production"
+updated_date = "2026/08/04"
+
+[rule]
+author = ["Elastic"]
+description = """
+    Detects forbidden (HTTP 403) Kubernetes API requests on AKS (Azure Kubernetes Service) from a previously unseen
+    user agent. Adversary tooling often uses non-standard clients; combined with a deny, this is a strong recon or
+    exploitation signal. Parity with the Kubernetes New Terms rule for forbidden requests from unusual user agents.
+    Platform control-plane identities are excluded.
+"""
+false_positives = [
+    """
+    New automation with custom user agents that lacks RBAC will alert until learned. Exclude validated clients after
+    review rather than removing the New Terms condition.
+    """,
+]
+from = "now-9m"
+index = ["logs-azure.platformlogs-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Azure AKS Forbidden Request from Unusual User Agent"
+note = """## Triage and analysis
+
+### Investigating Azure AKS Forbidden Request from Unusual User Agent
+
+AKS kube-audit events are carried under the flattened `azure.platformlogs.properties.log.*` subtree. This New Terms
+rule flags HTTP 403 responses where `userAgent` is not a default client-go agent (`kubernetes/$Format`) and has not
+been seen in the 7-day history window.
+
+### Possible investigation steps
+
+- Identify `user.username`, the new `userAgent`, `sourceIPs`, and the denied `objectRef` / `verb`.
+- Determine whether the client is scripting (curl/python/Go-http) or spoofed kubectl.
+- Hunt for successful follow-on activity from the same identity or source.
+
+### False positive analysis
+
+- First deploy of a custom controller can deny until RBAC is fixed; exclude the stable UA after validation.
+- Default `kubernetes/$Format` agents are excluded by query.
+
+### Response and remediation
+
+- If unauthorized, revoke credentials, block the source if external, and fix RBAC gaps that were probed.
+- Collect kube-audit artifacts per incident response procedures.
+"""
+references = [
+    "https://microsoft.github.io/Threat-Matrix-for-Kubernetes/",
+    "https://research.nccgroup.com/2021/11/10/detection-engineering-for-kubernetes-clusters/#part3-kubernetes-detections",
+]
+risk_score = 47
+rule_id = "842071d3-6483-457c-8ff6-ec74f6e1bc51"
+setup = """
+The Azure Fleet integration collecting AKS diagnostic logs with the `kube-audit` category forwarded through Event Hub
+into the `azure.platformlogs` data stream is required for this rule.
+"""
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Domain: Kubernetes",
+    "Data Source: Azure",
+    "Data Source: Azure Platform Logs",
+    "Data Source: Kubernetes",
+    "Use Case: Threat Detection",
+    "Tactic: Execution",
+    "Tactic: Discovery",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "new_terms"
+
+query = '''
+data_stream.dataset:azure.platformlogs and
+  event.action:"Microsoft.ContainerService/managedClusters/diagnosticLogs/Read" and
+  azure.platformlogs.category:"kube-audit" and
+  azure.platformlogs.properties.log.stage:"ResponseComplete" and
+  azure.platformlogs.properties.log.responseStatus.code:"403" and
+  azure.platformlogs.properties.log.userAgent:(* and not (*kubernetes/$Format)) and
+  not azure.platformlogs.properties.log.user.username:(
+    system\:node\:* or "aksService" or "hcpService" or "readinessChecker" or
+    system\:serviceaccount\:kube-system\:* or "system:apiserver" or
+    "system:kube-controller-manager" or "system:kube-scheduler"
+  )
+'''
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["azure.platformlogs.properties.log.userAgent"]
+
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-7d"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1613"
+name = "Container and Resource Discovery"
+reference = "https://attack.mitre.org/techniques/T1613/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.action",
+    "azure.platformlogs.category",
+    "azure.platformlogs.properties.log.verb",
+    "azure.platformlogs.properties.log.user.username",
+    "azure.platformlogs.properties.log.userAgent",
+    "azure.platformlogs.properties.log.sourceIPs",
+    "azure.platformlogs.properties.log.objectRef.resource",
+    "azure.platformlogs.properties.log.objectRef.namespace",
+    "azure.platformlogs.properties.log.responseStatus.code",
+]


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/725
* https://github.com/elastic/ia-trade-team/issues/875

## Summary - What I changed
Adds **New Terms** detection for HTTP 403 ResponseComplete events from a previously unseen non-client-go userAgent (7d). Parity with Kubernetes forbidden unusual-UA New Terms rule.

Validated on sandkube-fi-aks (emulation `emul-aks-b2-b72e61`) with trade-lab `logs-azure.platformlogs-*` kube-audit telemetry. K8s twin parity reviewed (New Terms / threshold cardinality where applicable).

## How To Test
Query can be used in TRADE stack against `logs-azure.platformlogs-*` (kube-audit).

## Checklist

- [ ] Added a label for the type of pr: `Rule: New` so guidelines can be generated
- [ ] Secret and sensitive material has been managed correctly
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
