### PR TITLE
[FR] Upgrade eql to 1.0.1, align KQL with lark 1.x, and fix NTLM relay field comparison

### DIFF
--- a/lib/kql/kql/parser.py
+++ b/lib/kql/kql/parser.py
@@ -23,6 +23,7 @@ STRING_FIELDS = ("keyword", "text")
 
 
 class KvTree(Tree):
+    """Lark tree with position helpers compatible with lark>=1.3 meta API."""
 
     @property
     def child_trees(self):
@@ -31,6 +32,46 @@ class KvTree(Tree):
     @property
     def child_tokens(self):
         return [child for child in self.children if isinstance(child, Token)]
+
+    @property
+    def line(self):
+        """Get line number from meta or fallback to first token."""
+        if hasattr(self, "meta") and self.meta and hasattr(self.meta, "line"):
+            return self.meta.line
+        for child in self.children:
+            if isinstance(child, Token) and hasattr(child, "line"):
+                return child.line
+        return 1
+
+    @property
+    def end_line(self):
+        """Get end line number from meta or fallback to last token."""
+        if hasattr(self, "meta") and self.meta and hasattr(self.meta, "end_line"):
+            return self.meta.end_line
+        for child in reversed(self.children):
+            if isinstance(child, Token) and hasattr(child, "end_line"):
+                return child.end_line
+        return self.line
+
+    @property
+    def column(self):
+        """Get column number from meta or fallback to first token."""
+        if hasattr(self, "meta") and self.meta and hasattr(self.meta, "column"):
+            return self.meta.column
+        for child in self.children:
+            if isinstance(child, Token) and hasattr(child, "column"):
+                return child.column
+        return 1
+
+    @property
+    def end_column(self):
+        """Get end column number from meta or fallback to last token."""
+        if hasattr(self, "meta") and self.meta and hasattr(self.meta, "end_column"):
+            return self.meta.end_column
+        for child in reversed(self.children):
+            if isinstance(child, Token) and hasattr(child, "end_column"):
+                return child.end_column
+        return self.column
 
 
 grammar_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "kql.g")

--- a/lib/kql/pyproject.toml
+++ b/lib/kql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection-rules-kql"
-version = "0.1.16"
+version = "0.1.15"
 description = "Kibana Query Language parser for Elastic Detection Rules"
 license = {text = "Elastic License v2"}
 keywords = ["Elastic", "sour", "Detection Rules", "Security", "Elasticsearch", "kql"]

--- a/lib/kql/pyproject.toml
+++ b/lib/kql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection-rules-kql"
-version = "0.1.14"
+version = "0.1.15"
 description = "Kibana Query Language parser for Elastic Detection Rules"
 license = {text = "Elastic License v2"}
 keywords = ["Elastic", "sour", "Detection Rules", "Security", "Elasticsearch", "kql"]
@@ -15,7 +15,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "eql==0.9.19",
+    "eql==1.0.1",
     "lark-parser>=0.12.0",
 ]
 

--- a/lib/kql/pyproject.toml
+++ b/lib/kql/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection-rules-kql"
-version = "0.1.15"
+version = "0.1.16"
 description = "Kibana Query Language parser for Elastic Detection Rules"
 license = {text = "Elastic License v2"}
 keywords = ["Elastic", "sour", "Detection Rules", "Security", "Elasticsearch", "kql"]
@@ -16,7 +16,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "eql==1.0.1",
-    "lark-parser>=0.12.0",
+    "lark>=1.3.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.0.17"
+version = "2.1.0"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "XlsxWriter~=3.2.0",
   "semver==3.0.4",
   "PyGithub==2.9.1",
-  "detection-rules-kql @ file:./lib/kql",
+  "detection-rules-kql @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql",
   "detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana",
   "setuptools==83.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "XlsxWriter~=3.2.0",
   "semver==3.0.4",
   "PyGithub==2.9.1",
-  "detection-rules-kql @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kql",
+  "detection-rules-kql @ file:./lib/kql",
   "detection-rules-kibana @ git+https://github.com/elastic/detection-rules.git#subdirectory=lib/kibana",
   "setuptools==83.0.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.0.16"
+version = "2.0.17"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
   "Click~=8.3.0",
   "elasticsearch~=8.12.1",
-  "eql==0.9.19",
+  "eql==1.0.1",
   "jsl==0.2.4",
   "jsonschema>=4.21.1",
   "marko==2.2.1",

--- a/rules/windows/credential_access_dollar_account_relay.toml
+++ b/rules/windows/credential_access_dollar_account_relay.toml
@@ -87,12 +87,11 @@ authentication where host.os.type == "windows" and event.code in ("4624", "4625"
  endswith~(user.name, "$") and user.name != "$" and
  source.ip != null and source.ip != "::1" and source.ip != "127.0.0.1" and
 
- /* Machine account matches short hostname exactly, or FQDN prefix (ACCOUNT.) */
- (
-   (startswith~(host.name, substring(user.name, 0, -1)) and
-    startswith~(substring(user.name, 0, -1), host.name)) or
-   startswith~(host.name, concat(substring(user.name, 0, -1), "."))
- ) and
+ /* Filter for a machine account that matches the hostname */
+ startswith~(host.name, substring(user.name, 0, -1)) and
+
+ /* Verify the machine account matches the full hostname, not just a prefix substring */
+ (startswith~(substring(user.name, 0, -1), host.name) or startswith~(host.name, concat(substring(user.name, 0, -1), "."))) and
 
  /* Verify if the Source IP belongs to the host */
  not endswith(string(source.ip), string(host.ip)) and

--- a/rules/windows/credential_access_dollar_account_relay.toml
+++ b/rules/windows/credential_access_dollar_account_relay.toml
@@ -2,7 +2,7 @@
 creation_date = "2024/07/24"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2026/07/28"
+updated_date = "2026/08/06"
 
 [rule]
 author = ["Elastic"]
@@ -87,11 +87,12 @@ authentication where host.os.type == "windows" and event.code in ("4624", "4625"
  endswith~(user.name, "$") and user.name != "$" and
  source.ip != null and source.ip != "::1" and source.ip != "127.0.0.1" and
 
- /* Filter for a machine account that matches the hostname */
- startswith~(host.name, substring(user.name, 0, -1)) and
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
+ /* Machine account matches short hostname exactly, or FQDN prefix (ACCOUNT.) */
+ (
+   (startswith~(host.name, substring(user.name, 0, -1)) and
+    startswith~(substring(user.name, 0, -1), host.name)) or
+   startswith~(host.name, concat(substring(user.name, 0, -1), "."))
+ ) and
 
  /* Verify if the Source IP belongs to the host */
  not endswith(string(source.ip), string(host.ip)) and


### PR DESCRIPTION
## Summary
- Fixes widespread rule execution failures.
- Root cause: #6431 added `length(host.name) == length(user.name) - 1`, which **SIEM** EQL rejects (`Comparisons against fields are not currently supported`). local (pyeql) validation did not catch.
- Replaces that check with equivalent logic: mutual `startswith~` for exact short-hostname match, or `startswith~(host.name, concat(account, "."))` for FQDN — preserves the FP reduction intent without field arithmetic in `==`.
- Pulls in logic from from eql upstream
