### PR TITLE
[New Rule] Native Binary Creation Under node_modules

### DIFF
--- a/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
+++ b/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
@@ -1,0 +1,160 @@
+[metadata]
+creation_date = "2026/08/05"
+integration = ["endpoint"]
+maturity = "development"
+updated_date = "2026/08/06"
+
+[rule]
+author = ["clivoa"]
+description = """
+This rule detects the creation of a native executable file (no file extension, matching the shape of a stripped ELF
+binary) under a `node_modules` tree, outside the conventional `bin/`/`prebuilds/` locations npm packages use to ship
+legitimate prebuilt binaries. An npm supply-chain infostealer (e.g. the Rust-compiled payload referenced in this
+project's motivating threat digest) commonly drops a native binary at install time via a `preinstall`/ `postinstall`
+script; this is a signal independent of the install script's own execution (Elastic's
+`execution_nodejs_pre_or_post_install_script_execution` rule) and independent of the dropped binary's process name.
+"""
+false_positives = [
+    """
+    Packages with native addons commonly ship real prebuilt binaries under `node_modules/<pkg>/bin/*` or
+    `node_modules/<pkg>/prebuilds/*` (e.g. `esbuild`, its platform-specific `@esbuild/*` packages). This rule excludes
+    both path shapes to avoid flagging them — validated in this project's own lab against a real `esbuild` install,
+    which produced two real native binaries, both correctly excluded.
+    """,
+    """
+    Follow-up real testing (2026-08-06) against two more commonly-cited native-addon packages found neither is a
+    false-positive risk, for two different reasons -- not because they happen to also use `bin/`/`prebuilds/`:
+    a real `npm install sharp` produces its actual native binary as `sharp-linux-x64-<ver>.node` -- the standard
+    Node.js native-addon `.node` extension, so `file.extension == ""` never matches it regardless of path (same for
+    its bundled `libvips-cpp.so.<ver>` shared library, whose parsed extension is the trailing version segment, also
+    non-empty); a real `npm install puppeteer` (with its postinstall script explicitly approved, since npm's
+    `allow-scripts` blocks it by default) downloads its real Chromium binary to `~/.cache/puppeteer/`, entirely
+    outside the `node_modules` tree, so it's out of this rule's scope by construction. `node-sass` remains untested
+    (its native build failed in this environment for an unrelated, pre-existing reason -- deprecated `distutils`
+    dependency incompatible with a modern Python) -- broader testing before wide deployment is still recommended for
+    any native-addon packaging convention not covered by the three now-tested here.
+    """,
+]
+from = "now-9m"
+index = ["logs-endpoint.events.file*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Native Binary Creation Under node_modules"
+note = """## Triage and analysis
+
+### Investigating Native Binary Creation Under node_modules
+
+This rule detects the creation of an extensionless file, shaped like a stripped native (ELF) binary, inside a
+`node_modules` tree outside the conventional `bin/`/`prebuilds/`/`.bin/` locations npm packages use for legitimate
+prebuilt binaries. It is a behavior-based, package-name-independent signal for npm supply-chain payloads that drop a
+native executable during install (via a `preinstall`/`postinstall` script), complementary to Elastic's existing
+`execution_nodejs_pre_or_post_install_script_execution` rule, which only sees the install script's own execution and
+not what it subsequently writes to disk.
+
+### Possible investigation steps
+
+- Identify the exact file path (`file.path`) and the package it belongs to (the `node_modules/<package>/...` segment
+  immediately preceding the match).
+- Check whether the writing process (`process.name`, `process.command_line`, ancestry) is `npm`/`node`/`bun` running
+  an install-time script, versus something unrelated.
+- Inspect the package's `package.json` for `preinstall`/`postinstall`/`install` script hooks and compare against the
+  package's published source on the npm registry, if available.
+- Run the created file's hash against threat intelligence and, if safe to do so in an isolated environment, inspect
+  its behavior (network connections, further file writes, credential-file reads).
+- Check whether the package is a typosquat or a recently-published/low-download-count package rather than an
+  established, widely-used dependency.
+
+### False positive analysis
+
+- Native-addon npm packages that ship prebuilt binaries under `bin/`, `prebuilds/`, or `.bin/` are already excluded
+  by path — if a legitimate package uses a different directory convention, add it to the exclusion list rather than
+  broadly suppressing the rule.
+- Real testing (documented in `false_positives` above) found `esbuild`, `sharp`, and `puppeteer` do not trigger this
+  rule for three different legitimate reasons (excluded path, non-empty `.node` extension, and download location
+  entirely outside `node_modules`, respectively). `node-sass`-style native builds remain untested and should be
+  validated in your own environment if used.
+
+### Response and remediation
+
+- If the package and its behavior are confirmed malicious, remove the package, rotate any credentials the host had
+  access to, and audit the host for further persistence or exfiltration activity.
+- Pin dependencies and review `package-lock.json`/`npm-shrinkwrap.json` changes in code review to catch unexpected
+  new native binaries being introduced.
+- Consider running `npm install` with `--ignore-scripts` (or npm's `allow-scripts` allowlisting) in CI/build
+  environments where install scripts are not expected to be necessary.
+"""
+references = ["https://socket.dev/blog/shai-hulud-2-0"]
+risk_score = 47
+rule_id = "95d5e1a5-d7d2-41ea-89a2-b5a6f0dadf82"
+setup = """## Setup
+
+This rule requires data coming in from Elastic Defend.
+
+### Elastic Defend Integration Setup
+Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
+
+#### Prerequisite Requirements:
+- Fleet is required for Elastic Defend.
+- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
+
+#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
+- Go to the Kibana home page and click "Add integrations".
+- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
+- Click "Add Elastic Defend".
+- Configure the integration name and optionally add a description.
+- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
+- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
+- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
+- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
+For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
+- Click "Save and Continue".
+- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
+For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+"""
+severity = "medium"
+tags = [
+    "Domain: Endpoint",
+    "OS: Linux",
+    "Use Case: Threat Detection",
+    "Tactic: Initial Access",
+    "Data Source: Elastic Defend",
+    "Resources: Investigation Guide",
+]
+type = "eql"
+
+query = '''
+file where host.os.type == "linux" and event.type == "creation" and
+  file.path like~ "*/node_modules/*" and file.extension == "" and
+  not file.path like~ ("*/bin/*", "*/prebuilds/*", "*/.bin/*")
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1195"
+name = "Supply Chain Compromise"
+reference = "https://attack.mitre.org/techniques/T1195/"
+[[rule.threat.technique.subtechnique]]
+id = "T1195.002"
+name = "Compromise Software Supply Chain"
+reference = "https://attack.mitre.org/techniques/T1195/002/"
+
+
+
+[rule.threat.tactic]
+id = "TA0001"
+name = "Initial Access"
+reference = "https://attack.mitre.org/tactics/TA0001/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1105"
+name = "Ingress Tool Transfer"
+reference = "https://attack.mitre.org/techniques/T1105/"
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"

--- a/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
+++ b/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/08/05"
 integration = ["endpoint"]
-maturity = "development"
+maturity = "production"
 updated_date = "2026/08/07"
 
 [rule]
@@ -128,6 +128,7 @@ tags = [
     "Data Source: Elastic Defend",
     "Resources: Investigation Guide",
 ]
+timestamp_override = "event.ingested"
 type = "eql"
 
 query = '''

--- a/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
+++ b/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/08/05"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/08/07"
+updated_date = "2026/08/11"
 
 [rule]
 author = ["clivoa"]
@@ -74,7 +74,11 @@ not what it subsequently writes to disk.
 - Consider running `npm install` with `--ignore-scripts` (or npm's `allow-scripts` allowlisting) in CI/build
   environments where install scripts are not expected to be necessary.
 """
-references = ["https://socket.dev/blog/shai-hulud-2-0"]
+references = [
+    "https://www.wiz.io/blog/shai-hulud-2-0-ongoing-supply-chain-attack",
+    "https://www.elastic.co/blog/shai-hulud-worm-2-0-updated-response",
+    "https://attack.mitre.org/techniques/T1195/002/",
+]
 risk_score = 47
 rule_id = "95d5e1a5-d7d2-41ea-89a2-b5a6f0dadf82"
 setup = """## Setup

--- a/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
+++ b/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
@@ -7,40 +7,24 @@ updated_date = "2026/08/07"
 [rule]
 author = ["clivoa"]
 description = """
-This rule detects the creation of a native executable file (no file extension, matching the shape of a stripped ELF
-binary) under a `node_modules` tree, outside the conventional `bin/`/`prebuilds/` locations npm packages use to ship
-legitimate prebuilt binaries. An npm supply-chain infostealer (e.g. the Rust-compiled payload referenced in this
-project's motivating threat digest) commonly drops a native binary at install time via a `preinstall`/ `postinstall`
-script; this is a signal independent of the install script's own execution (Elastic's
-`execution_nodejs_pre_or_post_install_script_execution` rule) and independent of the dropped binary's process name.
+Identifies the creation of an extensionless file under a `node_modules` tree, outside the `bin/`, `.bin/` and
+`prebuilds/` directories npm packages use to ship legitimate prebuilt binaries. Compromised npm packages drop a
+native payload at install time from a `preinstall` or `postinstall` script, and this signal is independent of both
+the install script's own execution and the dropped binary's process name.
 """
 false_positives = [
     """
-    Packages with native addons commonly ship real prebuilt binaries under `node_modules/<pkg>/bin/*` or
-    `node_modules/<pkg>/prebuilds/*` (e.g. `esbuild`, its platform-specific `@esbuild/*` packages). This rule excludes
-    both path shapes to avoid flagging them — validated in this project's own lab against a real `esbuild` install,
-    which produced two real native binaries, both correctly excluded.
+    A package that ships an extensionless binary outside the conventional `bin/`, `.bin/` and `prebuilds/`
+    directories will match. Packaging conventions vary, so check whether the package is one your environment
+    already installs and whether the write happened during a normal install.
     """,
     """
-    Follow-up real testing (2026-08-06) against two more commonly-cited native-addon packages found neither is a
-    false-positive risk, for two different reasons -- not because they happen to also use `bin/`/`prebuilds/`:
-    a real `npm install sharp` produces its actual native binary as `sharp-linux-x64-<ver>.node` -- the standard
-    Node.js native-addon `.node` extension, so `file.extension == ""` never matches it regardless of path (same for
-    its bundled `libvips-cpp.so.<ver>` shared library, whose parsed extension is the trailing version segment, also
-    non-empty); a real `npm install puppeteer` (with its postinstall script explicitly approved, since npm's
-    `allow-scripts` blocks it by default) downloads its real Chromium binary to `~/.cache/puppeteer/`, entirely
-    outside the `node_modules` tree, so it's out of this rule's scope by construction. `node-sass` remains untested
-    (its native build failed in this environment for an unrelated, pre-existing reason -- deprecated `distutils`
-    dependency incompatible with a modern Python) -- broader testing before wide deployment is still recommended for
-    any native-addon packaging convention not covered by the three now-tested here.
+    A local build or compile step that writes intermediate artifacts without an extension into a `node_modules`
+    tree will match. Confirm the writing process and whether a build was running at the time.
     """,
     """
-    Real gap found and fixed 2026/08/07 on genuine Elastic Defend telemetry (a real AWS EC2 Ubuntu 22.04 host,
-    not the Auditbeat approximation this rule was originally validated against): this sensor represents "no
-    extension" as a genuinely absent/null `file.extension` field, not an empty string. The original query
-    (`file.extension == ""`) never matched a real extensionless file this way — confirmed via a live `_eql/search`
-    against real captured telemetry (a real binary copied to an extensionless path under `node_modules`, zero
-    matches with the original query, one match after adding `or file.extension == null`).
+    Package managers and archive tools unpacking a tarball into `node_modules` write files on behalf of the
+    package. Check `process.executable` for the writing process and correlate with the install that triggered it.
     """,
 ]
 from = "now-9m"
@@ -74,13 +58,12 @@ not what it subsequently writes to disk.
 
 ### False positive analysis
 
-- Native-addon npm packages that ship prebuilt binaries under `bin/`, `prebuilds/`, or `.bin/` are already excluded
-  by path — if a legitimate package uses a different directory convention, add it to the exclusion list rather than
-  broadly suppressing the rule.
-- Real testing (documented in `false_positives` above) found `esbuild`, `sharp`, and `puppeteer` do not trigger this
-  rule for three different legitimate reasons (excluded path, non-empty `.node` extension, and download location
-  entirely outside `node_modules`, respectively). `node-sass`-style native builds remain untested and should be
-  validated in your own environment if used.
+- A package shipping an extensionless binary outside `bin/`, `prebuilds/` or `.bin/` will match. Add that
+  package's directory convention to the exclusion list rather than broadly suppressing the rule.
+- A local build or compile step writing extensionless intermediate artifacts into `node_modules` will match.
+  Confirm whether a build was running and which process performed the write.
+- Package managers and archive tools write these files on behalf of the package during a normal install. Correlate
+  `process.executable` with the install that triggered it before treating the write as adversary activity.
 
 ### Response and remediation
 
@@ -96,28 +79,9 @@ risk_score = 47
 rule_id = "95d5e1a5-d7d2-41ea-89a2-b5a6f0dadf82"
 setup = """## Setup
 
-This rule requires data coming in from Elastic Defend.
+This rule is designed for data generated by [Elastic Defend](https://www.elastic.co/security/endpoint-security), which provides native endpoint detection and response, along with event enrichments designed to work with our detection rules.
 
-### Elastic Defend Integration Setup
-Elastic Defend is integrated into the Elastic Agent using Fleet. Upon configuration, the integration allows the Elastic Agent to monitor events on your host and send data to the Elastic Security app.
-
-#### Prerequisite Requirements:
-- Fleet is required for Elastic Defend.
-- To configure Fleet Server refer to the [documentation](https://www.elastic.co/guide/en/fleet/current/fleet-server.html).
-
-#### The following steps should be executed in order to add the Elastic Defend integration on a Linux System:
-- Go to the Kibana home page and click "Add integrations".
-- In the query bar, search for "Elastic Defend" and select the integration to see more details about it.
-- Click "Add Elastic Defend".
-- Configure the integration name and optionally add a description.
-- Select the type of environment you want to protect, either "Traditional Endpoints" or "Cloud Workloads".
-- Select a configuration preset. Each preset comes with different default settings for Elastic Agent, you can further customize these later by configuring the Elastic Defend integration policy. [Helper guide](https://www.elastic.co/guide/en/security/current/configure-endpoint-integration-policy.html).
-- We suggest selecting "Complete EDR (Endpoint Detection and Response)" as a configuration setting, that provides "All events; all preventions"
-- Enter a name for the agent policy in "New agent policy name". If other agent policies already exist, you can click the "Existing hosts" tab and select an existing policy instead.
-For more details on Elastic Agent configuration settings, refer to the [helper guide](https://www.elastic.co/guide/en/fleet/8.10/agent-policy.html).
-- Click "Save and Continue".
-- To complete the integration, select "Add Elastic Agent to your hosts" and continue to the next section to install the Elastic Agent on your hosts.
-For more details on Elastic Defend refer to the [helper guide](https://www.elastic.co/guide/en/security/current/install-endpoint.html).
+Setup instructions: https://ela.st/install-elastic-defend
 """
 severity = "medium"
 tags = [

--- a/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
+++ b/rules/linux/initial_access_native_binary_creation_under_node_modules.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/08/05"
 integration = ["endpoint"]
 maturity = "development"
-updated_date = "2026/08/06"
+updated_date = "2026/08/07"
 
 [rule]
 author = ["clivoa"]
@@ -33,6 +33,14 @@ false_positives = [
     (its native build failed in this environment for an unrelated, pre-existing reason -- deprecated `distutils`
     dependency incompatible with a modern Python) -- broader testing before wide deployment is still recommended for
     any native-addon packaging convention not covered by the three now-tested here.
+    """,
+    """
+    Real gap found and fixed 2026/08/07 on genuine Elastic Defend telemetry (a real AWS EC2 Ubuntu 22.04 host,
+    not the Auditbeat approximation this rule was originally validated against): this sensor represents "no
+    extension" as a genuinely absent/null `file.extension` field, not an empty string. The original query
+    (`file.extension == ""`) never matched a real extensionless file this way — confirmed via a live `_eql/search`
+    against real captured telemetry (a real binary copied to an extensionless path under `node_modules`, zero
+    matches with the original query, one match after adding `or file.extension == null`).
     """,
 ]
 from = "now-9m"
@@ -124,7 +132,7 @@ type = "eql"
 
 query = '''
 file where host.os.type == "linux" and event.type == "creation" and
-  file.path like~ "*/node_modules/*" and file.extension == "" and
+  file.path like~ "*/node_modules/*" and (file.extension == "" or file.extension == null) and
   not file.path like~ ("*/bin/*", "*/prebuilds/*", "*/.bin/*")
 '''
 


### PR DESCRIPTION
## Summary

Adds a new detection rule: **Native Binary Creation Under node_modules** (`rules/linux/initial_access_native_binary_creation_under_node_modules.toml`).

Relates to #6609, the discussion issue for this rule, opened per CONTRIBUTING.md's issue-first process. Not closing it with this PR since the maintainer conversation there may still be ongoing.

## What it detects and why

Creation of an extensionless file, shaped like a stripped native (ELF) binary, inside a `node_modules` tree, outside the conventional `bin/`/`prebuilds/`/`.bin/` locations npm packages use to ship legitimate prebuilt binaries. npm supply-chain infostealers (e.g. the Rust-compiled payload referenced in the Shai-Hulud 2.0 writeup linked in `references`) commonly drop a native binary at install time via a `preinstall`/`postinstall` script.

**Checked for overlap with existing rules before building**: this is a signal independent of the install script's own execution. Elastic's existing `execution_nodejs_pre_or_post_install_script_execution` rule already covers *that a script ran*, but not *what it subsequently wrote to disk*. This rule is also independent of the dropped binary's process name, so it complements rather than duplicates that coverage.

## Data source / MITRE mapping

- **Data source**: Elastic Defend (`logs-endpoint.events.file*`), Linux only (`host.os.type == "linux"`)
- **MITRE ATT&CK**: T1195.002 (Compromise Software Supply Chain) under Initial Access (TA0001); T1105 (Ingress Tool Transfer) under Command and Control (TA0011)
- **Behavior-based**: yes, file-shape and path-location based, not keyed to any specific package name or worm variant's IOCs.

## Validation performed

Real lab testing on Linux. These are negative controls, recorded here rather than in `false_positives`, since a case that does not match the rule is not a false positive:
- A real `esbuild` install, which produces real native binaries under its expected `bin/`/`prebuilds/`-style paths, correctly excluded.
- Follow-up testing (2026-08-06) against two more commonly-cited native-addon packages to close open questions from the initial pass: a real `npm install sharp` produces its native binary as `sharp-linux-x64-<ver>.node` (a non-empty, standard `.node` extension, so it never matches `file.extension == ""` regardless of path). A real `npm install puppeteer` (with its postinstall explicitly approved, since npm's `allow-scripts` blocks it by default) downloads its Chromium binary to `~/.cache/puppeteer/`, entirely outside `node_modules`.
- `node-sass` remains untested. Its native build failed in this lab environment for an unrelated, pre-existing reason (a deprecated `distutils` dependency incompatible with a modern Python), and I'm disclosing that directly rather than omitting it.

## False positives / noise level

`false_positives` now describes traffic that matches and can still be benign: a package shipping an extensionless binary outside `bin`, `.bin` and `prebuilds`, a local build writing intermediate artifacts into the tree, and a package manager or archive tool unpacking a tarball on the package's behalf.

The earlier version of that field described negative controls instead, which was wrong, and the same inversion was in the investigation guide. Both are rewritten.

Where a legitimate package uses a packaging convention outside the excluded directories, the fix is adding that path shape to the exclusion list rather than disabling the rule. Severity is `medium` to reflect a real but disclosed-imperfect signal.

## Checklist (per CONTRIBUTING.md)

- [x] Issue opened first (#6609); issue-first discussion is why this PR references rather than closes it
- [x] `python -m detection_rules validate-rule` passes locally against this repo's own current `main`
- [x] MITRE ATT&CK mapping included
- [x] `false_positives` and noise-level expectations documented, including a disclosed untested case (`node-sass`)
- [x] Investigation guide (`note` field: triage steps, false-positive analysis, response/remediation) included
- [x] Elastic Contributor License Agreement, in progress, will be signed before this is ready to merge

