### PR TITLE
[Rule Tuning] Potential Credential Access via DCSync

### DIFF
--- a/rules/windows/credential_access_dcsync_replication_rights.toml
+++ b/rules/windows/credential_access_dcsync_replication_rights.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/02/08"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2026/07/10"
+updated_date = "2026/08/09"
 
 [rule]
 author = ["Elastic"]
@@ -97,7 +97,7 @@ host.os.type:"windows" and event.code:"4662" and
     *DS-Replication-Get-Changes-In-Filtered-Set* or *1131f6ad-9c07-11d1-f79f-00c04fc2dcd2* or
     *1131f6aa-9c07-11d1-f79f-00c04fc2dcd2* or *89e95b76-444d-4c62-991a-0facbeda640c*
   ) and winlog.event_data.AccessMask : "0x100" and
-  not winlog.event_data.SubjectUserName:(*$ or MSOL_*) and
+  not winlog.event_data.SubjectUserName:(*$ or MSOL_* or *ADSync* or *ADConnect* or *DirSync* or *Entra* or *MIMAD*) and
   not winlog.event_data.SubjectUserSid:"S-1-0-0"
 '''
 
@@ -142,4 +142,4 @@ field = "new_terms_fields"
 value = ["winlog.event_data.SubjectUserSid", "winlog.event_data.ObjectName"]
 [[rule.new_terms.history_window_start]]
 field = "history_window_start"
-value = "now-12h"
+value = "now-14d"


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1059

Reduces noise from Microsoft identity synchronization service accounts performing expected Active Directory replication. Expands the existing MSOL_ exclusion to also cover common Azure AD Connect, Entra Connect, Microsoft Identity Manager, and DirSync service account naming conventions using wildcard patterns on SubjectUserName. Additionally extends the new_terms history window from 12 hours to 14 days so that recurring legitimate replication activity by known service accounts is suppressed after the first observation window.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
