### PR TITLE
[Rule Tuning] GenAI or MCP Server Child Process Execution

### DIFF
--- a/rules_building_block/execution_mcp_server_child_process.toml
+++ b/rules_building_block/execution_mcp_server_child_process.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/12/04"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender"]
 maturity = "production"
-updated_date = "2026/04/21"
+updated_date = "2026/08/10"
 
 [rule]
 author = ["Elastic"]
@@ -104,19 +104,45 @@ process where event.type == "start"
     (process.parent.name in ("deno", "deno.exe") and process.name in ("deno", "deno.exe")) or
     (process.parent.name in ("bun", "bun.exe") and process.name in ("bun", "bun.exe")) or
     
-    // Helper process self-spawns
-    (process.parent.name == "Cursor" and process.name like~ "Cursor Helper*") or
-    (process.parent.name == "Claude" and process.name like~ "Claude Helper*") or
-    (process.parent.name == "Windsurf" and process.name like~ "Windsurf Helper*") or
-    (process.parent.name == "Code" and process.name like~ "Code Helper*") or
-    (process.parent.name == "Jan" and process.name like~ "Jan Helper*") or
-    (process.parent.name == "LM Studio" and process.name like~ "LM Studio Helper*") or
-    (process.parent.name == "Ollama" and process.name like~ "Ollama Helper*") or
-    
+    // Electron helper noise: app -> helper, and helper -> helper
+    (process.parent.name like~ ("Cursor", "Cursor.exe", "Cursor Helper*") and
+     process.name like~ "Cursor Helper*") or
+    (process.parent.name like~ ("Claude", "Claude.exe", "Claude Helper*") and
+     process.name like~ "Claude Helper*") or
+    (process.parent.name like~ ("Windsurf", "Windsurf.exe", "Windsurf Helper*") and
+     process.name like~ "Windsurf Helper*") or
+    (process.parent.name like~ ("Code", "Code.exe", "Code Helper*") and
+     process.name like~ "Code Helper*") or
+    (process.parent.name like~ ("Jan", "Jan.exe", "Jan Helper*") and
+     process.name like~ "Jan Helper*") or
+    (process.parent.name like~ ("LM Studio", "LM Studio.exe", "LM Studio Helper*") and
+     process.name like~ "LM Studio Helper*") or
+    (process.parent.name like~ ("Ollama", "Ollama.exe", "Ollama Helper*") and
+     process.name like~ "Ollama Helper*") or
+
+    // GenAI client same-name self-spawns (explicit pairs; no field-to-field compare)
+    (process.parent.name like~ ("cursor", "cursor.exe") and
+     process.name like~ ("cursor", "cursor.exe")) or
+    (process.parent.name like~ ("claude", "claude.exe") and
+     process.name like~ ("claude", "claude.exe")) or
+    (process.parent.name like~ ("windsurf", "windsurf.exe") and
+     process.name like~ ("windsurf", "windsurf.exe")) or
+    (process.parent.name like~ ("code", "code.exe") and
+     process.name like~ ("code", "code.exe")) or
+    (process.parent.name like~ ("codex", "codex.exe") and
+     process.name like~ ("codex", "codex.exe")) or
+    (process.parent.name like~ ("copilot", "copilot.exe") and
+     process.name like~ ("copilot", "copilot.exe")) or
+    (process.parent.name like~ ("jan", "jan.exe") and
+     process.name like~ ("jan", "jan.exe")) or
+    (process.parent.name like~ ("ollama", "ollama.exe") and
+     process.name like~ ("ollama", "ollama.exe")) or
+
     // docker
     (process.name in ("docker", "docker.exe") and process.args == "context" and process.args == "ls") or
     // neighbor / arp / ps / which (args tokens or full /bin/sh -c)
     (
+      process.name in ("ps", "getconf", "lsb_release") or
       process.args in (
         "ip neigh show",
         "arp -a -n -l",

--- a/rules_building_block/execution_mcp_server_child_process.toml
+++ b/rules_building_block/execution_mcp_server_child_process.toml
@@ -116,7 +116,7 @@ process where event.type == "start"
     (process.parent.name like~ ("Jan", "Jan.exe", "Jan Helper*") and
      process.name like~ "Jan Helper*") or
     (process.parent.name like~ ("LM Studio", "LM Studio.exe", "LM Studio Helper*") and
-     process.name like~ "LM Studio Helper*") or
+     process.name like~ ("LM Studio", "LM Studio.exe", "LM Studio Helper*")) or
     (process.parent.name like~ ("Ollama", "Ollama.exe", "Ollama Helper*") and
      process.name like~ "Ollama Helper*") or
 

--- a/rules_building_block/execution_mcp_server_child_process.toml
+++ b/rules_building_block/execution_mcp_server_child_process.toml
@@ -140,7 +140,7 @@ process where event.type == "start"
 
     // docker
     (process.name in ("docker", "docker.exe") and process.args == "context" and process.args == "ls") or
-    // neighbor / arp / ps / which (args tokens or full /bin/sh -c)
+    // env probes: ps/getconf/lsb_release by name; neighbor/arp/which by args or /bin/sh -c
     (
       process.name in ("ps", "getconf", "lsb_release") or
       process.args in (


### PR DESCRIPTION
## Summary

Excludes GenAI/Electron same-name self-spawns and helper-to-helper process noise from the GenAI or MCP Server Child Process Execution building block, plus cheap OS probes (`ps`, `getconf`, `lsb_release`). Keeps real tool children (shells, interpreters, downloaders, cross-product GenAI spawns) for correlation.