### PR TITLE
[Rule Tuning] Entra ID High Risk Sign-in

### DIFF
--- a/rules/integrations/azure/initial_access_entra_id_high_risk_signin.toml
+++ b/rules/integrations/azure/initial_access_entra_id_high_risk_signin.toml
@@ -2,7 +2,7 @@
 creation_date = "2021/01/04"
 integration = ["azure"]
 maturity = "production"
-updated_date = "2026/07/08"
+updated_date = "2026/08/12"
 
 [rule]
 author = ["Elastic", "Willem D'Haese"]
@@ -40,7 +40,7 @@ This rule detects high-risk sign-ins in Microsoft Entra ID as identified by Iden
 - Risky sign-ins may be triggered during legitimate travel, VPN use, or remote work scenarios from unusual locations.
 - In some cases, users switching devices or networks rapidly may trigger high-risk scores.
 - Automated scanners or penetration tests using known credentials may mimic high-risk login behavior.
-- Confirm whether the risk was remediated automatically by Microsoft Identity Protection before proceeding with escalations.
+- Sign-ins already marked `risk_state` as `remediated`, `dismissed`, or `confirmedSafe` by Microsoft Identity Protection are excluded; failed attempts with no aggregated risk and no active risk state are also excluded.
 
 ### Response and remediation
 
@@ -80,7 +80,7 @@ data_stream.dataset:azure.signinlogs and
     azure.signinlogs.properties.risk_level_aggregated:high
   ) and
   not (event.outcome:failure and azure.signinlogs.properties.risk_level_aggregated:none and azure.signinlogs.properties.risk_state:none) and
-  not azure.signinlogs.properties.risk_state:(dismissed or confirmedSafe)
+  not azure.signinlogs.properties.risk_state:(remediated or dismissed or confirmedSafe)
 '''
 
 


### PR DESCRIPTION
#### Related
* https://github.com/elastic/ia-trade-team/issues/1052

Follow-up to #6408.

Excludes sign-ins where Microsoft Identity Protection already set `risk_state` to `remediated`, aligning with the sibling Entra ID Protection rules. Preserves `atRisk` and other unresolved high-risk sign-ins.