### PR TITLE
[New Rule] Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)

### DIFF
--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -74,7 +74,14 @@
         "Operation": "keyword",
         "OperationType": "keyword",
         "NewUACList": "keyword",
-        "SubCategory": "keyword"
+        "SubCategory": "keyword",
+        "Attributes": "keyword",
+        "CertificateTemplate": "keyword",
+        "Disposition": "keyword",
+        "Requester": "keyword",
+        "Subject": "keyword",
+        "SubjectAlternativeName": "keyword",
+        "SubjectKeyIdentifier": "keyword"
       }
     },
     "winlog.logon.type": "keyword",

--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -378,6 +378,15 @@
     "gcp.audit.service_data.policy_delta.binding_deltas.action": "keyword",
     "gcp.audit.service_data.policy_delta.binding_deltas.role": "keyword"
   },
+  "logs-system.security-*": {
+    "winlog.event_data.Attributes": "keyword",
+    "winlog.event_data.CertificateTemplate": "keyword",
+    "winlog.event_data.Disposition": "keyword",
+    "winlog.event_data.Requester": "keyword",
+    "winlog.event_data.Subject": "keyword",
+    "winlog.event_data.SubjectAlternativeName": "keyword",
+    "winlog.event_data.SubjectKeyIdentifier": "keyword"
+  },
   "metrics-*": {
     "system.process.cpu.total.norm.pct": "double",
     "system.cpu.total.norm.pct": "double"

--- a/detection_rules/etc/non-ecs-schema.json
+++ b/detection_rules/etc/non-ecs-schema.json
@@ -74,14 +74,7 @@
         "Operation": "keyword",
         "OperationType": "keyword",
         "NewUACList": "keyword",
-        "SubCategory": "keyword",
-        "Attributes": "keyword",
-        "CertificateTemplate": "keyword",
-        "Disposition": "keyword",
-        "Requester": "keyword",
-        "Subject": "keyword",
-        "SubjectAlternativeName": "keyword",
-        "SubjectKeyIdentifier": "keyword"
+        "SubCategory": "keyword"
       }
     },
     "winlog.logon.type": "keyword",

--- a/docs/audit_policies/windows/audit_certification_services.md
+++ b/docs/audit_policies/windows/audit_certification_services.md
@@ -1,0 +1,62 @@
+# Audit Certification Services
+
+## Setup
+
+Some detection rules require monitoring Active Directory Certificate Services (AD CS) operations to identify suspicious certificate requests and issuance. This audit policy applies to servers that host the Certification Authority role. Both the Windows audit policy and the certification authority (CA) audit filter must be configured to generate Certificate Services events in the Windows Security log.
+
+**Caution:** Certificate request auditing can increase Security log volume on busy certification authorities. Validate log retention and forwarding capacity before broad deployment.
+
+### Enable Audit Policy via Group Policy
+
+To enable `Audit Certification Services` on enterprise certification authorities via Group Policy, administrators must enable the `Audit Certification Services` policy. Follow these steps to configure the policy via Advanced Audit Policy Configuration:
+
+```
+Computer Configuration >
+Policies >
+Windows Settings >
+Security Settings >
+Advanced Audit Policy Configuration >
+Audit Policies >
+Object Access >
+Audit Certification Services (Success,Failure)
+```
+
+### Enable Locally using auditpol
+
+To enable this policy on a local certification authority, run the following command in an elevated command prompt:
+
+```
+auditpol.exe /set /subcategory:"Certification Services" /success:enable /failure:enable
+```
+
+### Enable Certification Authority Auditing
+
+The Windows audit policy does not generate certificate request events unless the CA audit filter is also configured. On each certification authority, open the Certification Authority snap-in (`certsrv.msc`), right-click the CA name, select **Properties**, select the **Auditing** tab, and enable **Issue and manage certificate requests**.
+
+Alternatively, run the following commands from an elevated PowerShell session. The `+4` value enables this audit category without clearing other categories from the existing CA audit filter:
+
+```
+certutil.exe -setreg CA\AuditFilter +4
+Restart-Service certsvc
+```
+
+Restarting Certificate Services briefly interrupts certificate enrollment. Apply the change during an approved maintenance window.
+
+### Collect Windows Security Events
+
+Collect the Windows Security log from each certification authority. Detection rules that inspect certificate request attributes require the complete multiline `winlog.event_data.Attributes` value. Dropped, truncated, or rewritten attributes create a visibility gap.
+
+## Event IDs
+
+When this audit policy and the **Issue and manage certificate requests** CA audit filter are enabled, the following request-lifecycle event IDs may be generated:
+
+* **4886**: Certificate Services received a certificate request.
+* **4887**: Certificate Services approved a certificate request and issued a certificate.
+* **4888**: Certificate Services denied a certificate request.
+* **4889**: Certificate Services set the status of a certificate request to pending.
+
+## Related Rules
+
+Use the following GitHub search to identify rules that use the events listed:
+
+[Elastic Detection Rules GitHub Repo Search](https://github.com/search?q=repo%3Aelastic%2Fdetection-rules+%22Windows+Security+Event+Logs%22+AND+%28%224886%22+OR+%224887%22+OR+%224888%22+OR+%224889%22%29+language%3ATOML&type=code)

--- a/docs/audit_policies/windows/readme.md
+++ b/docs/audit_policies/windows/readme.md
@@ -5,6 +5,7 @@ Windows related audit policies that need to be implemented in order to generate 
 Audit Policies:
 
 * [Audit Authorization Policy Change](audit_authorization_policy_change.md)
+* [Audit Certification Services](audit_certification_services.md)
 * [Audit Computer Account Management](audit_computer_account_management.md)
 * [Audit Detailed File Share](audit_detailed_file_share.md)
 * [Audit Directory Service Access](audit_directory_service_access.md)

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -19,6 +19,7 @@ toc:
     children:
       - file: readme.md
       - file: audit_authorization_policy_change.md
+      - file: audit_certification_services.md
       - file: audit_computer_account_management.md
       - file: audit_detailed_file_share.md
       - file: audit_directory_service_access.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.1.1"
+version = "2.1.2"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rules/windows/credential_access_adcs_certificate_identity_transposition.toml
+++ b/rules/windows/credential_access_adcs_certificate_identity_transposition.toml
@@ -1,0 +1,242 @@
+[metadata]
+creation_date = "2026/08/12"
+integration = ["system"]
+maturity = "production"
+updated_date = "2026/08/12"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies successful Active Directory Certificate Services (AD CS) certificate issuance events where a machine-account
+requester differs from the Remote Machine Discovery (RMD) chase target while the event's DNS subject alternative name
+(SAN) matches that target. This requester-to-target mismatch may indicate CertiGhost (CVE-2026-54121) or similar abuse
+of AD CS request-context chase processing.
+"""
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)"
+references = [
+    "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-54121",
+    "https://gist.github.com/H0j3n/a5ef2609b5f2944ac2390a191a534c26",
+    "https://github.com/aniqfakhrul/CVE-2026-54121",
+]
+risk_score = 73
+rule_id = "2985ea6e-5b1e-4845-9a57-95f7f78b35f1"
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "Domain: Identity",
+    "OS: Windows",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Tactic: Privilege Escalation",
+    "Use Case: Active Directory Monitoring",
+    "Use Case: Vulnerability",
+    "Data Source: Active Directory",
+    "Data Source: Windows Security Event Logs",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM logs-system.security-* METADATA _id, _index, _version
+| WHERE event.code == "4887" AND
+    winlog.event_data.Requester LIKE "*$" AND
+    winlog.event_data.Attributes IS NOT NULL
+
+// Parse Attributes for RMD and CDC, and as a fallback when dedicated template or SAN fields are absent.
+// CDC and the effective template are retained for triage purposes
+| GROK winlog.event_data.Attributes
+    """(?im)^[ \t]*CertificateTemplate[ \t]*:[ \t]*(?<Esql.attributes_certificate_template>[^\r\n]+)\r?$"""
+| GROK winlog.event_data.Attributes
+    """(?im)^[ \t]*SAN[ \t]*:[ \t]*dns[ \t]*=[ \t]*(?<Esql.attributes_san_value>[^\r\n]+)\r?$"""
+| GROK winlog.event_data.SubjectAlternativeName
+    """(?im)^[ \t]*DNS[ \t]+Name[ \t]*=[ \t]*(?<Esql.event_san_value>[^\r\n]+)\r?$"""
+| GROK winlog.event_data.Attributes
+    """(?im)^[ \t]*cdc[ \t]*:[ \t]*(?<Esql.cdc_value>[^\r\n]+)\r?$"""
+| GROK winlog.event_data.Attributes
+    """(?im)^[ \t]*rmd[ \t]*:[ \t]*(?<Esql.rmd_value>[^\r\n]+)\r?$"""
+| EVAL Esql.effective_certificate_template = TRIM(COALESCE(
+         winlog.event_data.CertificateTemplate,
+         Esql.attributes_certificate_template
+       )),
+       Esql.san_value = TRIM(COALESCE(Esql.event_san_value, Esql.attributes_san_value)),
+       Esql.cdc_value = TRIM(Esql.cdc_value),
+       Esql.rmd_value = TRIM(Esql.rmd_value),
+       Esql.normalized_requester = TO_LOWER(
+         REPLACE(winlog.event_data.Requester, """^.*\\|\$$""", "")
+       ),
+       Esql.normalized_san_value = TO_LOWER(
+         REPLACE(Esql.san_value, """\.$""", "")
+       ),
+       Esql.normalized_rmd_value = TO_LOWER(
+         REPLACE(Esql.rmd_value, """\.$""", "")
+       )
+// Preserve IP-shaped values; shorten other SAN and RMD values to the first DNS label for machine-account comparison.
+| EVAL Esql.san_is_ip_shaped =
+          Esql.normalized_san_value RLIKE """[0-9]{1,3}(\.[0-9]{1,3}){3}""" OR Esql.normalized_san_value LIKE "*:*",
+       Esql.rmd_is_ip_shaped =
+          Esql.normalized_rmd_value RLIKE """[0-9]{1,3}(\.[0-9]{1,3}){3}""" OR Esql.normalized_rmd_value LIKE "*:*"
+| EVAL Esql.normalized_san_target = CASE(
+         Esql.san_is_ip_shaped,
+         Esql.normalized_san_value,
+         REPLACE(Esql.normalized_san_value, """\..*$""", "")
+       ),
+       Esql.normalized_rmd_target = CASE(
+         Esql.rmd_is_ip_shaped,
+         Esql.normalized_rmd_value,
+         REPLACE(Esql.normalized_rmd_value, """\..*$""", "")
+       )
+| WHERE Esql.normalized_requester IS NOT NULL AND
+    Esql.normalized_san_target IS NOT NULL AND
+    Esql.normalized_rmd_target IS NOT NULL
+| WHERE Esql.normalized_requester != Esql.normalized_rmd_target AND
+    Esql.normalized_san_target == Esql.normalized_rmd_target
+| KEEP @timestamp, _id, _index, _version, event.code, event.action, event.category, event.type, event.outcome,
+    event.created, event.ingested, data_stream.dataset, data_stream.namespace, host.id, host.name,
+    winlog.computer_name, winlog.record_id, winlog.event_data.RequestId, winlog.event_data.Requester,
+    winlog.event_data.CertificateTemplate, winlog.event_data.Subject, winlog.event_data.SubjectAlternativeName,
+    winlog.event_data.Attributes, winlog.event_data.Disposition, winlog.event_data.SubjectKeyIdentifier,
+    Esql.effective_certificate_template, Esql.san_value, Esql.cdc_value, Esql.rmd_value,
+    Esql.normalized_requester, Esql.normalized_san_target, Esql.normalized_rmd_target
+'''
+
+setup = """## Setup
+
+Audit Certification Services must be enabled on enterprise certification authorities so that successful certificate
+issuance generates Security event 4887.
+
+The Windows Security integration must retain `winlog.event_data.Attributes`, including the requested SAN and chase
+attributes. The rule prefers dedicated certificate-template and subject-alternative-name fields when present and uses
+`Attributes` as a fallback. Dropped, truncated, or rewritten attributes create a visibility gap and do not indicate
+benign activity.
+
+Setup instructions: https://ela.st/audit-certification-services
+"""
+
+note = """## Triage and analysis
+
+### Investigating Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)
+
+#### Possible investigation steps
+
+- Does the matched AD CS issuance record validate the identity mismatch?
+  - Focus: `event.code`, `winlog.event_data.RequestId`, `winlog.event_data.Requester`, `Esql.san_value`, `Esql.rmd_value`
+  - Hint: Reopen the Windows Security 4887 record on the same CA host and request ID. Compare the parsed SAN and RMD with the complete `winlog.event_data.Attributes` and dedicated SAN field; additional SAN values or disagreement keep the case unresolved. $investigate_0
+  - Implication: Event 4887 proves successful issuance, and the alert establishes that the requester differs from the RMD target while the parsed SAN matches that target. This is an operational anti-pattern. Close as benign only when CA records and test records identify an authorized CertiGhost or AD CS security test matching the exact CA, request ID, requester, target, template, and time.
+- What identity and authentication capability did the issued certificate receive?
+  - Focus: `Esql.effective_certificate_template`, `winlog.event_data.Subject`, `winlog.event_data.SubjectAlternativeName`, `winlog.event_data.SubjectKeyIdentifier`
+  - Hint: Retrieve the issued certificate and CA request/template configuration for the same request ID. Inspect the certificate's actual subject, SAN, EKUs or application policies, validity and revocation state, and the template's subject-name settings and enrollment permissions.
+  - Implication: Event 4887 and the template name alone do not establish the complete certificate contents or authentication capability. A certificate that represents the RMD target and permits authentication increases the likelihood and impact of credential abuse. Missing certificate or template configuration is unresolved, not benign.
+- What other issuances by the requester appear on the same CA host?
+  - Focus: `host.id`, `winlog.event_data.Requester`, `winlog.event_data.RequestId`, `winlog.event_data.Attributes`, `winlog.event_data.SubjectAlternativeName`
+  - Hint: Recover 4887 events for the same requester on this CA host. $investigate_1
+  - Implication: Repeated successful requests for different SAN/RMD targets expand the potential abuse scope. One isolated request does not reduce the significance of the current mismatch.
+- What other CA events reference the same target identity?
+  - Focus: `Esql.san_value`, `Esql.rmd_value`, `winlog.event_data.Attributes`, `winlog.event_data.SubjectAlternativeName`, `winlog.event_data.Requester`
+  - Hint: Copy the alert's exact SAN and RMD values into a scoped Timeline or Discover search for raw 4886, 4887, and 4888 records on the same CA host. Use contains or wildcard matching against `winlog.event_data.Attributes` and `winlog.event_data.SubjectAlternativeName`; derived `Esql.*` fields exist only on the alert.
+  - Implication: Requests for the same target from additional unexpected accounts expand the affected scope. The absence of other matching events does not clear the current issuance.
+- Did the CA connect to the CDC value during certificate processing?
+  - Focus: `host.id`, `Esql.cdc_value`, `destination.ip`, `destination.port`, `process.name`
+  - Hint: When the CDC value is an IP address, search network events from the CA host around issuance for that `destination.ip`. For a hostname, resolve it from collected DNS or asset evidence before comparing destination IPs. Review LDAP or LDAPS from `certsrv.exe` and SMB from `System` without requiring either process for all callback traffic.
+  - Implication: CA-host LDAP or SMB traffic to the CDC value supports request-context chase activity, but neither the CDC attribute nor a connection alone proves exploitation. Missing DNS or CA network telemetry is unresolved, not benign.
+- Does surrounding activity show requester creation or target-certificate use?
+  - Focus: `event.code`, `winlog.event_data.Requester`, `Esql.normalized_rmd_target`, `winlog.event_data.TargetUserName`, `winlog.event_data.PreAuthType`
+  - Hint: After validating the issuance, inspect account-management events where `winlog.event_data.TargetUserName` matches the requester account name without its domain prefix. Inspect successful 4768 events with `winlog.event_data.PreAuthType` equal to `16`. For DNS-shaped RMD values, compare `winlog.event_data.TargetUserName` with the normalized RMD target plus `$`; for IP-shaped values, first resolve the associated computer account from AD, asset, or CA evidence. Treat later authentication as corroboration unless identity and certificate evidence establish the relationship.
+  - Implication: Requester creation or change followed by target PKINIT strengthens the exploitation hypothesis. Missing account-management or domain-controller authentication telemetry is unresolved, not benign.
+
+Escalate when the mismatch is not an authorized test, the issued certificate can authenticate as the target, or callback and follow-on evidence corroborate abuse. Close only when CA, certificate, and test records establish the exact authorized scope; preserve and escalate when evidence or visibility is mixed or incomplete.
+
+### False positive analysis
+
+The detected requester-to-target relationship is an operational anti-pattern and did not appear in the self-aligned enrollment controls. Authorized CertiGhost or AD CS security testing is the only currently validated benign explanation. Treat other claimed cross-identity enrollment workflows as unresolved until the 4887 source event, CA request record, issued certificate, template configuration, requester, target, CA, and time scope align without contradictions.
+
+Do not close on recurrence, absence of related alerts, or the requester account name alone. ES|QL fields created by the query cannot be used in rule exceptions. If an exception is required for recurring authorized testing, combine narrowly scoped source fields such as the CA `host.id`, `winlog.event_data.Requester`, and the exact `winlog.event_data.Attributes` pattern. Avoid exceptions based only on a host, requester, or template.
+
+### Response and remediation
+
+- Preserve the 4887 source record, CA request and database records, issued certificate and identifiers, template configuration, and relevant authentication and network evidence before disruptive action.
+- Identify affected certification authorities and apply the Microsoft security update or mitigation for CVE-2026-54121. Review request history for the requester and target to identify additional certificates requiring action.
+- If malicious activity is confirmed, revoke the affected certificate and verify that revocation information is distributed. Disable or remove an attacker-controlled requester account after preserving evidence. Rotate the target machine credentials and invalidate affected authentication material when certificate use or impersonation is established.
+- Isolate an endpoint only when host evidence attributes compromise to that system. The requester account may not map to a managed endpoint, and the target identity alone does not prove that the target endpoint was compromised.
+- Record confirmed certificate identifiers, affected principals, CA configuration gaps, and telemetry gaps for the responsible response, PKI, identity, and detection owners.
+"""
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "event.code",
+    "host.id",
+    "host.name",
+    "winlog.computer_name",
+    "winlog.record_id",
+    "winlog.event_data.RequestId",
+    "winlog.event_data.Requester",
+    "winlog.event_data.CertificateTemplate",
+    "winlog.event_data.Subject",
+    "winlog.event_data.SubjectAlternativeName",
+    "winlog.event_data.Attributes",
+    "winlog.event_data.Disposition",
+    "winlog.event_data.SubjectKeyIdentifier",
+    "Esql.effective_certificate_template",
+    "Esql.san_value",
+    "Esql.rmd_value",
+    "Esql.cdc_value",
+    "Esql.normalized_requester",
+    "Esql.normalized_san_target",
+    "Esql.normalized_rmd_target",
+]
+
+[[transform.investigate]]
+label = "Matched certificate issuance"
+description = "Finds the Windows Security 4887 certificate issuance record on the same CA host and request ID."
+providers = [[
+    { excluded = false, field = "event.code", queryType = "phrase", value = "4887", valueType = "string" },
+    { excluded = false, field = "host.id", queryType = "phrase", value = "{{host.id}}", valueType = "string" },
+    { excluded = false, field = "winlog.event_data.RequestId", queryType = "phrase", value = "{{winlog.event_data.RequestId}}", valueType = "string" },
+]]
+relativeFrom = "now-24h"
+relativeTo = "now"
+
+[[transform.investigate]]
+label = "Same requester issuances"
+description = "Finds successful certificate issuance events for the same requester on the same CA host."
+providers = [[
+    { excluded = false, field = "event.code", queryType = "phrase", value = "4887", valueType = "string" },
+    { excluded = false, field = "host.id", queryType = "phrase", value = "{{host.id}}", valueType = "string" },
+    { excluded = false, field = "winlog.event_data.Requester", queryType = "phrase", value = "{{winlog.event_data.Requester}}", valueType = "string" },
+]]
+relativeFrom = "now-7d"
+relativeTo = "now"
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1649"
+name = "Steal or Forge Authentication Certificates"
+reference = "https://attack.mitre.org/techniques/T1649/"
+
+[[rule.threat.technique]]
+id = "T1212"
+name = "Exploitation for Credential Access"
+reference = "https://attack.mitre.org/techniques/T1212/"
+
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1068"
+name = "Exploitation for Privilege Escalation"
+reference = "https://attack.mitre.org/techniques/T1068/"
+
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"


### PR DESCRIPTION
## Issues

Part of https://github.com/elastic/ia-trade-team/issues/1062

## Summary

Identifies successful Active Directory Certificate Services (AD CS) certificate issuance events where a machine-account requester differs from the Remote Machine Discovery (RMD) chase target while the event's DNS subject alternative name (SAN) matches that target. This requester-to-target mismatch may indicate CertiGhost (CVE-2026-54121) or similar abuse of AD CS request-context chase processing.

[Link](https://trade-cloud-threat-lab-dd975d.kb.us-east-1.aws.elastic.cloud/app/r/s/bdYes) to the shared stack.