### PR TITLE
[Rule Tuning] SeDebugPrivilege Enabled by a Suspicious Process

### DIFF
--- a/rules/windows/privilege_escalation_tokenmanip_sedebugpriv_enabled.toml
+++ b/rules/windows/privilege_escalation_tokenmanip_sedebugpriv_enabled.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/10/20"
 integration = ["windows", "system"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/08/13"
 
 [rule]
 author = ["Elastic"]
@@ -87,18 +87,31 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
         "?:\\Program Files (x86)\\*",
         "?:\\Program Files\\*",
         "?:\\Users\\*\\AppData\\Local\\Temp\\*-*\\DismHost.exe",
+        "?:\\Windows\\CCM\\SCNotification.exe",
+        "?:\\Windows\\explorer.exe",
         "?:\\Windows\\System32\\auditpol.exe",
+        "?:\\Windows\\System32\\AutoModeDetect.exe",
         "?:\\Windows\\System32\\cleanmgr.exe",
+        "?:\\Windows\\System32\\dllhost.exe",
+        "?:\\Windows\\System32\\inetsrv\\w3wp.exe",
         "?:\\Windows\\System32\\lsass.exe",
         "?:\\Windows\\System32\\mmc.exe",
         "?:\\Windows\\System32\\MRT.exe",
         "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\NETSTAT.EXE",
+        "?:\\Windows\\System32\\netsh.exe",
         "?:\\Windows\\System32\\sdiagnhost.exe",
         "?:\\Windows\\System32\\ServerManager.exe",
+        "?:\\Windows\\System32\\SystemPropertiesAdvanced.exe",
         "?:\\Windows\\System32\\taskhostw.exe",
+        "?:\\Windows\\System32\\taskkill.exe",
+        "?:\\Windows\\System32\\tasklist.exe",
         "?:\\Windows\\System32\\wbem\\WmiPrvSe.exe",
         "?:\\Windows\\System32\\WerFault.exe",
+        "?:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell_ise.exe",
+        "?:\\Windows\\System32\\wsmprovhost.exe",
         "?:\\Windows\\SysWOW64\\msiexec.exe",
+        "?:\\Windows\\SysWOW64\\taskkill.exe",
         "?:\\Windows\\SysWOW64\\wbem\\WmiPrvSe.exe",
         "?:\\Windows\\SysWOW64\\WerFault.exe",
         "?:\\Windows\\WinSxS\\*"
@@ -118,4 +131,3 @@ reference = "https://attack.mitre.org/techniques/T1134/"
 id = "TA0004"
 name = "Privilege Escalation"
 reference = "https://attack.mitre.org/tactics/TA0004/"
-


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1071

Reduces noise from standard Windows system utilities that commonly request SeDebugPrivilege during normal operation. Adds exclusions for tasklist.exe, NETSTAT.EXE, AutoModeDetect.exe, taskkill.exe (both System32 and SysWOW64), dllhost.exe, powershell_ise.exe, w3wp.exe, wsmprovhost.exe, netsh.exe, explorer.exe, SystemPropertiesAdvanced.exe, and SCNotification.exe. PowerShell is intentionally retained as it remains the primary abuse vector for SeDebugPrivilege-based privilege escalation.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
