### PR TITLE
[New Rule] Dual-signal Suricata SnortML vs signature triage (GID 411)

### DIFF
--- a/rules/network/command_and_control_suricata_ids_signature_high_priority.toml
+++ b/rules/network/command_and_control_suricata_ids_signature_high_priority.toml
@@ -69,10 +69,13 @@ rule_id = "0296f22d-b5fe-4889-8044-e46ef4980386"
 severity = "high"
 tags = [
     "Domain: Network",
+    "Platform: Elastic",
     "Use Case: Threat Detection",
     "Tactic: Command and Control",
     "Tactic: Execution",
+    "Rule Type: Custom Query (KQL)",
     "Data Source: Suricata",
+    "Data Source: Suricata Logs",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"

--- a/rules/network/command_and_control_suricata_ids_signature_high_priority.toml
+++ b/rules/network/command_and_control_suricata_ids_signature_high_priority.toml
@@ -1,0 +1,129 @@
+[metadata]
+creation_date = "2026/08/16"
+integration = ["suricata"]
+maturity = "production"
+updated_date = "2026/08/16"
+
+[rule]
+author = ["Ahmed Hassan"]
+description = """
+Detects classic Suricata / Snort-family signature hits (Generator ID not equal to SnortML
+GID 411) with high-priority classifications commonly associated with malware C2, privilege
+gain, or known exploits.
+
+These events are stronger signature true-positive candidates than ML-only (GID 411) paths
+and may justify gated remediation after analyst or policy review. Pair with
+"Suricata SnortML GID 411 High ML-Only Alert" and
+"Suricata Signature And High Severity Corroboration".
+"""
+false_positives = [
+    """
+    Noisy signature packs or policy-violation classifications in permissive environments.
+    """,
+    """
+    Vulnerability scanners and malware sandboxes generating simulated attacks.
+    """,
+]
+from = "now-9m"
+index = ["filebeat-*", "logs-suricata.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Suricata IDS Signature High Priority Classification"
+note = """## Triage and analysis
+
+### Investigating Suricata IDS Signature High Priority Classification
+
+This rule surfaces classic IDS classifications while **excluding** SnortML Generator ID 411
+so ML-only probability alerts are not mixed into the signature TP path.
+
+### Possible investigation steps
+
+- Review `suricata.eve.alert.category`, `rule.name`, and signature ID.
+- Confirm `suricata.eve.alert.gid` is not 411.
+- Map source/destination to assets; check concurrent endpoint or identity alerts.
+- Prefer gated remediation (HITL / policy) over blind auto-contain when only this signal exists.
+
+### False positive analysis
+
+- Broad ET/Open rulesets can fire high-priority categories on scanners.
+- Lab and red-team traffic often reproduces these classifications intentionally.
+
+### Response and remediation
+
+- Treat as a stronger TP candidate than GID 411 ML-only alerts.
+- Isolate or block only after confirming scope and business impact, or when dual-signal
+  corroboration is present.
+- Tune noisy signatures rather than disabling the entire classification family.
+"""
+references = [
+    "https://www.elastic.co/docs/reference/integrations/suricata",
+    "https://github.com/elastic/detection-rules/issues/6661",
+    "https://github.com/SigmaHQ/sigma/pull/6237",
+    "https://github.com/Cisco-Talos/EvidenceForge/pull/389",
+    "https://github.com/splunk/security_content/pull/4221",
+    "https://github.com/AAH20/aegis-decision-fabric",
+    "https://a2zsoc.com/consultation",
+]
+risk_score = 73
+rule_id = "0296f22d-b5fe-4889-8044-e46ef4980386"
+severity = "high"
+tags = [
+    "Domain: Network",
+    "Use Case: Threat Detection",
+    "Tactic: Command and Control",
+    "Tactic: Execution",
+    "Data Source: Suricata",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:suricata.eve and event.kind:alert and
+not suricata.eve.alert.gid:411 and
+(
+  suricata.eve.alert.category:("A Network Trojan was detected" or
+    "Successful Administrator Privilege Gain" or
+    "Successful User Privilege Gain" or
+    "Attempted Administrator Privilege Gain" or
+    "Attempted User Privilege Gain" or
+    "Known malware command and control traffic" or
+    "Malware Command and Control Activity Detected" or
+    "A Network Trojan was Detected" or
+    "Large Scale Information Leak") or
+  rule.category:("A Network Trojan was detected" or
+    "Successful Administrator Privilege Gain" or
+    "Successful User Privilege Gain" or
+    "Malware Command and Control Activity Detected" or
+    "Potentially Bad Traffic") or
+  message:("A Network Trojan was detected" or
+    "Malware Command and Control Activity Detected" or
+    "Command and Control Traffic")
+)
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1071"
+name = "Application Layer Protocol"
+reference = "https://attack.mitre.org/techniques/T1071/"
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1203"
+name = "Exploitation for Client Execution"
+reference = "https://attack.mitre.org/techniques/T1203/"
+
+
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"

--- a/rules/network/command_and_control_suricata_signature_and_high_severity_corroboration.toml
+++ b/rules/network/command_and_control_suricata_signature_and_high_severity_corroboration.toml
@@ -1,0 +1,114 @@
+[metadata]
+creation_date = "2026/08/16"
+integration = ["suricata"]
+maturity = "production"
+updated_date = "2026/08/16"
+
+[rule]
+author = ["Ahmed Hassan"]
+description = """
+Detects dual-signal corroboration on Suricata: a classic high-priority IDS classification
+(Generator ID not SnortML GID 411) followed within a short window by another high-severity
+Suricata alert on the same source and destination.
+
+Signature + second high-severity network signal is a stronger remediation candidate than
+ML-only paths (GID 411 alone). This is the Suricata-native analogue of signature + high EVE
+corroboration used on Secure Firewall pipelines.
+"""
+false_positives = [
+    """
+    Busy egress gateways where unrelated high-severity alerts share source/destination within
+    the correlation window.
+    """,
+    """
+    Lab and red-team traffic designed to trip multiple inspectors in sequence.
+    """,
+]
+from = "now-9m"
+index = ["filebeat-*", "logs-suricata.*"]
+language = "eql"
+license = "Elastic License v2"
+name = "Suricata Signature And High Severity Corroboration"
+note = """## Triage and analysis
+
+### Investigating Suricata Signature And High Severity Corroboration
+
+This correlation requires (1) a classic high-priority classification with GID ≠ 411, then
+(2) another high-severity Suricata alert for the same 5-tuple endpoints within 5 minutes.
+That dual-signal pattern is a stronger remediation candidate than ML-only (GID 411) alerts.
+
+### Possible investigation steps
+
+- Inspect both events in Timeline; confirm the first event's category and that GID ≠ 411.
+- Validate asset ownership of source and destination; check endpoint detections.
+- Prefer gated remediation (HITL / policy Gate→Prove) when business impact is material.
+
+### False positive analysis
+
+- High-churn internet-facing services may accumulate unrelated Suricata hits.
+- Tighten by excluding known scanner ranges or requiring matching destination.port.
+
+### Response and remediation
+
+- Treat as a strong dual-signal TP candidate relative to GID 411 ML-only alerts.
+- Isolate or block after confirming scope; collect network and host forensics.
+- Do not collapse this disposition into the ML-only path in SOAR automations.
+"""
+references = [
+    "https://www.elastic.co/docs/reference/integrations/suricata",
+    "https://github.com/elastic/detection-rules/issues/6661",
+    "https://github.com/SigmaHQ/sigma/pull/6237",
+    "https://github.com/Cisco-Talos/EvidenceForge/pull/389",
+    "https://github.com/splunk/attack_data/pull/1206",
+    "https://github.com/AAH20/aegis-decision-fabric",
+    "https://a2zsoc.com/consultation",
+]
+risk_score = 73
+rule_id = "71835572-24e9-49c1-91a8-a801268f0a56"
+severity = "high"
+tags = [
+    "Domain: Network",
+    "Use Case: Threat Detection",
+    "Tactic: Command and Control",
+    "Data Source: Suricata",
+    "Resources: Investigation Guide",
+]
+type = "eql"
+
+query = '''
+sequence by source.ip, destination.ip with maxspan=5m
+  [network where data_stream.dataset == "suricata.eve" and event.kind == "alert" and
+   suricata.eve.alert.gid != 411 and
+   suricata.eve.alert.category in (
+     "A Network Trojan was detected",
+     "Successful Administrator Privilege Gain",
+     "Successful User Privilege Gain",
+     "Attempted Administrator Privilege Gain",
+     "Attempted User Privilege Gain",
+     "Malware Command and Control Activity Detected",
+     "Known malware command and control traffic",
+     "A Network Trojan was Detected",
+     "Large Scale Information Leak"
+   )]
+  [network where data_stream.dataset == "suricata.eve" and event.kind == "alert" and
+   event.severity == 1]
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1071"
+name = "Application Layer Protocol"
+reference = "https://attack.mitre.org/techniques/T1071/"
+
+[[rule.threat.technique]]
+id = "T1041"
+name = "Exfiltration Over C2 Channel"
+reference = "https://attack.mitre.org/techniques/T1041/"
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"

--- a/rules/network/command_and_control_suricata_signature_and_high_severity_corroboration.toml
+++ b/rules/network/command_and_control_suricata_signature_and_high_severity_corroboration.toml
@@ -33,8 +33,8 @@ note = """## Triage and analysis
 
 ### Investigating Suricata Signature And High Severity Corroboration
 
-This correlation requires (1) a classic high-priority classification with GID ≠ 411, then
-(2) another high-severity Suricata alert for the same 5-tuple endpoints within 5 minutes.
+This correlation requires (1) a classic high-priority classification with GID != 411, then
+(2) another high-severity Suricata alert for the same source/destination IPs and ports within 5 minutes.
 That dual-signal pattern is a stronger remediation candidate than ML-only (GID 411) alerts.
 
 ### Possible investigation steps
@@ -68,15 +68,18 @@ rule_id = "71835572-24e9-49c1-91a8-a801268f0a56"
 severity = "high"
 tags = [
     "Domain: Network",
+    "Platform: Elastic",
     "Use Case: Threat Detection",
     "Tactic: Command and Control",
+    "Rule Type: Event Correlation (EQL)",
     "Data Source: Suricata",
+    "Data Source: Suricata Logs",
     "Resources: Investigation Guide",
 ]
 type = "eql"
 
 query = '''
-sequence by source.ip, destination.ip with maxspan=5m
+sequence by source.ip, destination.ip, source.port, destination.port with maxspan=5m
   [network where data_stream.dataset == "suricata.eve" and event.kind == "alert" and
    suricata.eve.alert.gid != 411 and
    suricata.eve.alert.category in (

--- a/rules/network/command_and_control_suricata_snortml_gid411_high_ml_only.toml
+++ b/rules/network/command_and_control_suricata_snortml_gid411_high_ml_only.toml
@@ -1,0 +1,109 @@
+[metadata]
+creation_date = "2026/08/16"
+integration = ["suricata"]
+maturity = "production"
+updated_date = "2026/08/16"
+
+[rule]
+author = ["Ahmed Hassan"]
+description = """
+Detects Suricata / Snort-family intrusion alerts generated under Generator ID (GID) 411
+at elevated severity. GID 411 is used by SnortML-style machine-learning inspectors; those
+scores are probability signals and must not be treated as equivalent to a classic signature
+true positive (typically GID 1).
+
+High ML-only confidence should escalate for corroboration (classic signature, endpoint,
+threat intel, or a second network signal) — not automatic containment. Pair with
+"Suricata IDS Signature High Priority Classification" and
+"Suricata Signature And High Severity Corroboration".
+"""
+false_positives = [
+    """
+    Benign applications or uncommon encrypted protocols that resemble malware training
+    samples used by ML inspectors.
+    """,
+    """
+    Lab, scanner, or red-team traffic exercising SnortML / ML inspectors.
+    """,
+    """
+    Treat as escalate/corroborate — do not equate to classic signature true positive or
+    auto-contain without a second signal.
+    """,
+]
+from = "now-9m"
+index = ["filebeat-*", "logs-suricata.*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "Suricata SnortML GID 411 High ML-Only Alert"
+note = """## Triage and analysis
+
+### Investigating Suricata SnortML GID 411 High ML-Only Alert
+
+This rule fires when Suricata (or Snort-family events mapped into Suricata fields)
+reports Generator ID **411** at high severity. GID 411 encodes an ML probability path.
+**Never equate ML confidence to a classic signature true positive.**
+
+### Possible investigation steps
+
+- Confirm `suricata.eve.alert.gid` is 411 and review `rule.name` / `suricata.eve.alert.signature`.
+- Identify source and destination IPs, ports, and community ID; check reputation and asset criticality.
+- Search for classic signature alerts (GID ≠ 411) or endpoint detections on the same hosts within ±1h.
+- Prefer escalate / corroborate dispositions; reserve containment for dual-signal or confirmed TP.
+
+### False positive analysis
+
+- ML inspectors may score unusual-but-benign protocols highly.
+- Authorized scanning and training traffic can exercise GID 411 continuously.
+
+### Response and remediation
+
+- Do **not** auto-isolate solely on this alert.
+- Escalate for dual-signal review (classic IDS classification, endpoint, or intel).
+- If corroborated, follow standard C2 containment and credential hygiene playbooks.
+- Document ML-only vs signature dispositions in the case notes for auditability.
+"""
+references = [
+    "https://www.elastic.co/docs/reference/integrations/suricata",
+    "https://github.com/elastic/detection-rules/issues/6661",
+    "https://github.com/SigmaHQ/sigma/pull/6237",
+    "https://github.com/Cisco-Talos/EvidenceForge/pull/389",
+    "https://github.com/splunk/security_content/issues/4220",
+    "https://github.com/AAH20/aegis-decision-fabric",
+    "https://a2zsoc.com/consultation",
+]
+risk_score = 47
+rule_id = "3662828d-64b9-461d-aa0b-80b6501c9b40"
+severity = "medium"
+tags = [
+    "Domain: Network",
+    "Use Case: Threat Detection",
+    "Tactic: Command and Control",
+    "Data Source: Suricata",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "query"
+
+query = '''
+data_stream.dataset:suricata.eve and event.kind:alert and
+suricata.eve.alert.gid:411 and event.severity:1
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1071"
+name = "Application Layer Protocol"
+reference = "https://attack.mitre.org/techniques/T1071/"
+
+[[rule.threat.technique]]
+id = "T1041"
+name = "Exfiltration Over C2 Channel"
+reference = "https://attack.mitre.org/techniques/T1041/"
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"

--- a/rules/network/command_and_control_suricata_snortml_gid411_high_ml_only.toml
+++ b/rules/network/command_and_control_suricata_snortml_gid411_high_ml_only.toml
@@ -76,9 +76,12 @@ rule_id = "3662828d-64b9-461d-aa0b-80b6501c9b40"
 severity = "medium"
 tags = [
     "Domain: Network",
+    "Platform: Elastic",
     "Use Case: Threat Detection",
     "Tactic: Command and Control",
+    "Rule Type: Custom Query (KQL)",
     "Data Source: Suricata",
+    "Data Source: Suricata Logs",
     "Resources: Investigation Guide",
 ]
 timestamp_override = "event.ingested"


### PR DESCRIPTION
## Summary

Closes #6661.

Adds a small **dual-signal** Suricata pack so ML probability alerts are not flattened into classic signature true positives:

1. **Suricata SnortML GID 411 High ML-Only Alert** — medium; escalate/corroborate; do **not** auto-contain
2. **Suricata IDS Signature High Priority Classification** — high; classic classifications with `gid != 411`
3. **Suricata Signature And High Severity Corroboration** — high; EQL sequence (classic classification → high severity)

Doctrine: **ML ≠ signature TP** (`never_equate_ml_to_signature`). Portable sisters: SigmaHQ/sigma#6237, Splunk ESCU #4220/#4221, EvidenceForge #389.

## Validation

```text
python -m detection_rules validate-rule rules/network/command_and_control_suricata_snortml_gid411_high_ml_only.toml
python -m detection_rules validate-rule rules/network/command_and_control_suricata_ids_signature_high_priority.toml
python -m detection_rules validate-rule rules/network/command_and_control_suricata_signature_and_high_severity_corroboration.toml
```

All three: Rule validation successful.

## Notes for reviewers

- Uses existing Suricata ECS fields (`suricata.eve.alert.gid`, `suricata.eve.alert.category`, `event.severity`).
- GID 411 encodes SnortML-style ML inspectors; Suricata environments that only use GID 1 will not fire rule 1 (by design).
- Soft production consumer for Gate/Prove remediation: [Aegis Decision Fabric](https://github.com/AAH20/aegis-decision-fabric) / [a2zsoc.com/consultation](https://a2zsoc.com/consultation) (paid Continuous Trust — not unpaid R&D).
- CLA: will complete Elastic CLA at http://www.elastic.co/contributor-agreement/ if not already on file.

## Test plan

- [ ] Review rule metadata, notes, and MITRE mapping
- [ ] Confirm KQL/EQL against Suricata sample events with `gid:411` vs classic classifications
- [ ] Confirm rule 1 does not fire on `gid:1` high-priority classifications
- [ ] Confirm sequence rule requires both legs within 5m

Made with [Cursor](https://cursor.com)