### PR TITLE
fix(tests): allow same-day rule tunings without updated_date bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.2.11"
+version = "2.2.12"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -10,11 +10,13 @@ import re
 import unittest
 import uuid
 from collections import defaultdict
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import ClassVar
 
 import eql
 import kql
+import pytoml
 from marshmallow import ValidationError
 from semver import Version
 
@@ -928,7 +930,7 @@ class TestRuleMetadata(BaseRuleTest):
 
     @unittest.skipIf(os.getenv("GITHUB_EVENT_NAME") == "push", "Skipping this test when not running on pull requests.")
     def test_rule_change_has_updated_date(self):
-        """Test to ensure modified rules have updated_date field updated."""
+        """Fail when a modified rule lacks an updated_date bump and is not same-day UTC."""
 
         rules_path = get_path(["rules"])
         rules_bbr_path = get_path(["rules_building_block"])
@@ -947,11 +949,38 @@ class TestRuleMetadata(BaseRuleTest):
         if result:
             modified_rules = [path for path in result.splitlines() if path.endswith(".toml")]
             failed_rules = []
+            today_utc = datetime.now(UTC).date()
             for modified_rule_path in modified_rules:
                 diff_output = detection_rules_git("diff", "origin/main", modified_rule_path)
-                if not re.search(r"\+\s*updated_date =", diff_output):
-                    # Rule has been modified but updated_date has not been changed, add to list of failed rules
+                if re.search(r"^\+\s*updated_date\s*=", diff_output, re.MULTILINE):
+                    # updated_date has been modified in this PR
+                    continue
+
+                rule_path = get_path([modified_rule_path])
+                metadata = pytoml.loads(rule_path.read_text(encoding="utf-8")).get("metadata") or {}
+                if "updated_date" not in metadata:
+                    # Explicit updated_date was not found -> do not require a bump
+                    continue
+
+                updated_date = metadata["updated_date"]
+                if isinstance(updated_date, datetime):
+                    if updated_date.tzinfo is None:
+                        updated_date = updated_date.replace(tzinfo=UTC)
+                    updated_date = updated_date.astimezone(UTC).date()
+                elif isinstance(updated_date, date):
+                    pass
+                elif isinstance(updated_date, str):
+                    updated_date = date.fromisoformat(updated_date.replace("/", "-").split("T")[0])
+                else:
                     failed_rules.append(f"{modified_rule_path}")
+                    continue
+
+                # Same-day follow-up tunings may leave updated_date unchanged.
+                # Compare in UTC so evening local edits still match CI runners.
+                if updated_date == today_utc:
+                    continue
+
+                failed_rules.append(f"{modified_rule_path}")
 
             if failed_rules:
                 fail_msg = """

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -930,7 +930,7 @@ class TestRuleMetadata(BaseRuleTest):
 
     @unittest.skipIf(os.getenv("GITHUB_EVENT_NAME") == "push", "Skipping this test when not running on pull requests.")
     def test_rule_change_has_updated_date(self):
-        """Fail when a modified rule lacks an updated_date bump and is not same-day UTC."""
+        """Pass when a modified rule bumps updated_date, is already today UTC, or omits it; else fail."""
 
         rules_path = get_path(["rules"])
         rules_bbr_path = get_path(["rules_building_block"])
@@ -983,9 +983,10 @@ class TestRuleMetadata(BaseRuleTest):
                 failed_rules.append(f"{modified_rule_path}")
 
             if failed_rules:
-                fail_msg = """
-                The following rules in the below path(s) have been modified but updated_date has not been changed \n
-                """
+                fail_msg = (
+                    "Modified rules must bump updated_date, already be today's UTC date, "
+                    "or omit metadata.updated_date. Failed:\n"
+                )
                 self.fail(fail_msg + "\n".join(failed_rules))
 
     @unittest.skipIf(


### PR DESCRIPTION
## Summary
- Allow same-day follow-up rule tunings without a new `updated_date` hunk in the git diff
- Treat missing explicit `metadata.updated_date` as pass; require a bump when the date is stale
- Compare "today" in UTC so evening local edits still match CI runners
- Read `updated_date` via `pytoml` (aligned with endpoint-rules same-day check)
- Bump `detection_rules` package version `2.2.11` → `2.2.12`

## Test plan
- [ ] CI unit tests pass on this PR
- [ ] Same-day retune (query change only, `updated_date` already UTC today) does not fail `test_rule_change_has_updated_date`
- [ ] Stale `updated_date` with no bump still fails
- [ ] Explicit `+updated_date` in the diff still passes
