### PR TITLE
[Deprecation] K8s overlap rules, GKE TokenRequest, and GWS MFA duplicate

### DIFF
--- a/rules/_deprecated/credential_access_gcp_gke_service_account_token_created_via_tokenrequest.toml
+++ b/rules/_deprecated/credential_access_gcp_gke_service_account_token_created_via_tokenrequest.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2026/07/13"
 deprecation_date = "2026/08/21"
-deprecated_reason = "GKE Cloud Audit Logs do not export TokenRequest (serviceaccounts/token) activity. Coverage remains on Kubernetes Service Account Token Created via TokenRequest API using Kubernetes API server audit logs."
+deprecated_reason = "GKE Cloud Audit Logs do not export TokenRequest (serviceaccounts/token) activity."
 integration = ["gcp"]
 maturity = "deprecated"
 updated_date = "2026/08/21"

--- a/rules/_deprecated/credential_access_gcp_gke_service_account_token_created_via_tokenrequest.toml
+++ b/rules/_deprecated/credential_access_gcp_gke_service_account_token_created_via_tokenrequest.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2026/07/13"
+deprecation_date = "2026/08/21"
+deprecated_reason = "GKE Cloud Audit Logs do not export TokenRequest (serviceaccounts/token) activity. Coverage remains on Kubernetes Service Account Token Created via TokenRequest API using Kubernetes API server audit logs."
 integration = ["gcp"]
-maturity = "production"
-updated_date = "2026/07/13"
+maturity = "deprecated"
+updated_date = "2026/08/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/discovery_denied_service_account_request.toml
+++ b/rules/_deprecated/discovery_denied_service_account_request.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2022/09/13"
+deprecation_date = "2026/08/21"
+deprecated_reason = "Subset of Kubernetes Forbidden Request from Unusual User Agent, which already detects forbidden API requests from unusual user agents including service accounts."
 integration = ["kubernetes"]
-maturity = "production"
-updated_date = "2026/04/10"
+maturity = "deprecated"
+updated_date = "2026/08/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/execution_unusual_request_response_by_user_agent.toml
+++ b/rules/_deprecated/execution_unusual_request_response_by_user_agent.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2025/06/18"
+deprecation_date = "2026/08/21"
+deprecated_reason = "Overlaps with Kubernetes Anonymous Request Authorized by Unusual User Agent and Kubernetes Forbidden Request from Unusual User Agent, which cover the same audit decision and user-agent anomaly signal more precisely."
 integration = ["kubernetes"]
-maturity = "production"
-updated_date = "2026/04/10"
+maturity = "deprecated"
+updated_date = "2026/08/21"
 
 [rule]
 author = ["Elastic"]

--- a/rules/_deprecated/persistence_mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/_deprecated/persistence_mfa_disabled_for_google_workspace_organization.toml
@@ -1,8 +1,10 @@
 [metadata]
 creation_date = "2020/11/17"
+deprecation_date = "2026/08/21"
+deprecated_reason = "Replaced by Google Workspace MFA Enforcement Disabled For Organization, which covers the same org-level MFA/2SV admin telemetry."
 integration = ["google_workspace"]
-maturity = "production"
-updated_date = "2026/07/08"
+maturity = "deprecated"
+updated_date = "2026/08/21"
 
 [rule]
 author = ["Elastic"]
@@ -21,10 +23,10 @@ index = ["filebeat-*", "logs-google_workspace*"]
 interval = "10m"
 language = "kuery"
 license = "Elastic License v2"
-name = "Deprecated - MFA Disabled for Google Workspace Organization"
+name = "MFA Disabled for Google Workspace Organization"
 note = """## Triage and analysis
 
-### Investigating Deprecated - MFA Disabled for Google Workspace Organization
+### Investigating MFA Disabled for Google Workspace Organization
 
 Multi-factor authentication (MFA) is a process in which users are prompted for an additional form of identification, such as a code on their cell phone or a fingerprint scan, during the sign-in process.
 

--- a/rules/_deprecated/persistence_mfa_disabled_for_google_workspace_organization.toml
+++ b/rules/_deprecated/persistence_mfa_disabled_for_google_workspace_organization.toml
@@ -1,7 +1,7 @@
 [metadata]
 creation_date = "2020/11/17"
 deprecation_date = "2026/08/21"
-deprecated_reason = "Replaced by Google Workspace MFA Enforcement Disabled For Organization, which covers the same org-level MFA/2SV admin telemetry."
+deprecated_reason = "Overlap with Google Workspace MFA Enforcement Disabled For Organization, which covers the same org-level MFA/2SV admin telemetry."
 integration = ["google_workspace"]
 maturity = "deprecated"
 updated_date = "2026/08/21"


### PR DESCRIPTION

- https://github.com/elastic/ia-trade-team/issues/1072)

## Summary

Deprecation for overlap and non-firing K8s/GKE rules, plus a Google Workspace production rule that was already titled `Deprecated -`.

## Changes

- **Kubernetes Unusual Decision by User Agent** → `_deprecated/`
  - Overlaps with *Kubernetes Anonymous Request Authorized by Unusual User Agent* and *Kubernetes Forbidden Request from Unusual User Agent*
- **Kubernetes Denied Service Account Request via Unusual User Agent** → `_deprecated/`
  - Subset of *Kubernetes Forbidden Request from Unusual User Agent*
- **GKE Service Account Token Created via TokenRequest API** → `_deprecated/`
  - GKE Cloud Audit does not export TokenRequest value needed for rule
- **MFA Disabled for Google Workspace Organization** → `_deprecated/` (left over from GWS audit)
  - Already production with `Deprecated -` title (from #6226); replaced by *Google Workspace MFA Enforcement Disabled For Organization*
  - Removed `Deprecated -` from `name` / investigation guide heading

All four: `maturity = "deprecated"`, `deprecation_date` / `updated_date` = `2026/08/21`, `deprecated_reason` set.

