### PR TITLE
[Bug] [DaC] Fix: validate `threat_query` against `threat_index` schemas

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -1161,7 +1161,16 @@ class ThreatMatchRuleData(QueryRuleData):
             else:
                 return
 
-            threat_query_validator.validate(self, meta)
+            # The threat query runs against the indicator indices, so schemas must be built from
+            # `threat_index` rather than the rule's source `index` patterns
+            threat_data = dataclasses.replace(
+                self,
+                index=self.threat_index,
+                data_view_id=None,
+                query=self.threat_query,
+                language=self.threat_language,
+            )
+            threat_query_validator.validate(threat_data, meta)
 
     def validate(self, meta: RuleMeta) -> None:  # noqa: ARG002
         """Validate negate usage and group semantics for threat mapping."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.1.10"
+version = "2.1.11"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/6712

## Summary - What I changed

Indicator match (`threat_match`) rules validated the `threat_query` against schemas built from the rule's source `index` patterns instead of `threat_index`. As a result, custom schemas keyed by the indicator index name (via `stack-schema-map.yaml`) were silently ignored, and validation failed with `Unknown field` for any custom field used in the threat query.

## How To Test


### 1. Create a custom rules directory and config

```bash
python -m detection_rules custom-rules setup-config /tmp/dac-6712
```

### 2. Add a custom schema keyed on the indicator index pattern

The key must match the `threat_index` entry exactly.

```bash
cat > /tmp/dac-6712/etc/custom-schemas.json <<'JSON'
{
  "logs-ti_custom.indicators-*": {
    "my_indicator": {
      "my_field": "keyword",
      "score": "long"
    }
  }
}
JSON
```

### 3. Register the schema in `stack-schema-map.yaml`

Edit `/tmp/dac-6712/etc/stack-schema-map.yaml` and add a `custom` entry under the generated stack version:

```yaml
9.6.0:
  beats: 9.5.0
  custom: custom-schemas.json
  ecs: 9.5.0
  endgame: 8.4.0
```

### 4. Add a test rule

Save as `/tmp/dac-6712/rules/test_custom_indicator_match.toml`. The threat query uses fields that exist only in the indicator index schema.

```toml
[metadata]
creation_date = "2026/09/02"
maturity = "production"
updated_date = "2026/09/02"

[rule]
author = ["Elastic"]
description = "Test rule for issue 6712: threat_query uses a custom field defined only for the indicator index."
from = "now-65m"
index = ["logs-*"]
interval = "1h"
language = "kuery"
license = "Elastic License v2"
name = "Test Custom Indicator Index Match"
query = "destination.ip:*"
risk_score = 47
rule_id = "9d8f5b2a-1c3e-4f6a-8b7d-2e1f0a9c6712"
severity = "medium"
threat_index = ["logs-ti_custom.indicators-*"]
threat_indicator_path = "my_indicator"
threat_language = "kuery"
threat_query = "my_indicator.my_field:* and my_indicator.score >= 50"
type = "threat_match"

[[rule.threat_mapping]]
[[rule.threat_mapping.entries]]
field = "destination.ip"
type = "mapping"
value = "my_indicator.my_field"
```

### 5. Validate the rule

```bash
CUSTOM_RULES_DIR=/tmp/dac-6712 python -m detection_rules view-rule /tmp/dac-6712/rules/test_custom_indicator_match.toml
```

**On `main`** the load fails. The caret sits under the threat query, confirming it was checked against the source index schema:

```
kql.errors.KqlParseError: Error at line:1,column:1
Unknown field
my_indicator.my_field:* and my_indicator.score >= 50
^^^^^^^^^^^^^^^^^^^^^
stack: 9.6.0, beats: 9.5.0, ecs: 9.5.0
rule: Test Custom Indicator Index Match - 9d8f5b2a-1c3e-4f6a-8b7d-2e1f0a9c6712
Error loading rule in /tmp/dac-6712/rules/test_custom_indicator_match.toml
```

**On this branch** the rule prints as JSON with no error.

<img width="1398" height="384" alt="image" src="https://github.com/user-attachments/assets/4b9c352c-1fc8-4801-b561-2c2e8c99a646" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
