### PR TITLE
[New Rule] AWS Root Console Login Password Spraying

### DIFF
--- a/rules/integrations/aws/credential_access_root_console_password_spraying.toml
+++ b/rules/integrations/aws/credential_access_root_console_password_spraying.toml
@@ -19,8 +19,7 @@ false_positives = [
     an expected corporate or administrator address before escalating.
     """,
 ]
-from = "now-1d"
-interval = "6h"
+from = "now-1h"
 index = ["logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/credential_access_root_console_password_spraying.toml
+++ b/rules/integrations/aws/credential_access_root_console_password_spraying.toml
@@ -19,7 +19,8 @@ false_positives = [
     an expected corporate or administrator address before escalating.
     """,
 ]
-from = "now-20m"
+from = "now-1d"
+interval = "6h"
 index = ["logs-aws.cloudtrail-*"]
 language = "kuery"
 license = "Elastic License v2"

--- a/rules/integrations/aws/credential_access_root_console_password_spraying.toml
+++ b/rules/integrations/aws/credential_access_root_console_password_spraying.toml
@@ -1,0 +1,142 @@
+[metadata]
+creation_date = "2026/09/01"
+integration = ["aws"]
+maturity = "production"
+updated_date = "2026/09/01"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies failed authentication attempts against the AWS Management Console root user from the same source IP address
+targeting multiple AWS accounts. Password spraying uses few attempts per target across many accounts to avoid lockout,
+making per-account volume an unreliable signal. This rule detects the cross-account breadth pattern: a single source IP
+generating root ConsoleLogin failures across two or more distinct AWS accounts. Requires an AWS Organizations-level
+CloudTrail trail aggregating events from member accounts.
+"""
+false_positives = [
+    """
+    A legitimate administrator may mistype the root account password multiple times. Verify whether the source IP is
+    an expected corporate or administrator address before escalating.
+    """,
+]
+from = "now-20m"
+index = ["logs-aws.cloudtrail-*"]
+language = "kuery"
+license = "Elastic License v2"
+name = "AWS Root Console Login Password Spraying"
+note = """## Triage and analysis
+
+### Investigating AWS Root Console Login Password Spraying
+
+Password spraying is a credential access technique where an attacker tries a small number of commonly used or leaked passwords across many accounts. Unlike brute force, the per-account attempt count is intentionally low — often 2–8 attempts — to stay below lockout thresholds and evade high-volume detections. Attackers targeting AWS root accounts typically hold a pre-enumerated list of root account email addresses and route attempts through proxy or residential IP infrastructure.
+
+This rule fires when a single source IP generates failed root `ConsoleLogin` events against two or more distinct AWS accounts within a 20-minute window, requiring an AWS Organizations-level CloudTrail trail. The cross-account breadth is the defining spray signal; brute force against a single account is covered by a separate rule.
+
+#### Possible investigation steps
+
+- **Assess the source IP.**
+Determine whether the IP belongs to a known corporate range, VPN, or expected admin location. Use threat intelligence tools to check if it is flagged as a proxy, Tor exit node, or residential proxy service.
+
+- **Review the user agent string.**
+Outdated browser user agents (for example, Chrome 85 or Firefox 120) are common indicators of spray-campaign tooling. Cross-reference `user_agent.original` across the contributing events in Timeline.
+
+- **Check for a subsequent successful login.**
+Query CloudTrail for a `ConsoleLogin` success for the root identity in the same timeframe. A success immediately after failures indicates the spray succeeded — escalate immediately.
+
+- **Examine follow-on API calls.**
+If a successful login did occur, review high-risk API calls that followed: `CreateUser`, `CreateAccessKey`, `AttachRolePolicy`, `DeleteTrail`, or `StopLogging`.
+
+- **Widen the scope across accounts.**
+If your organization uses AWS Organizations, check whether the same source IP triggered root login failures in other member accounts during the same window.
+
+### False positive analysis
+
+- **Mistyped credentials.** A root credential custodian mistyping the password multiple times is the most likely benign cause. Confirm whether the source IP is a known admin location and whether a successful login followed shortly after.
+- **Stale automation.** Misconfigured scripts or browser sessions with cached root credentials may retry on failure. Check whether the user agent matches known internal tooling.
+
+### Response and remediation
+
+- **If no successful root login is found:**
+  - Rotate the root password to a strong, unique credential stored in an offline vault.
+  - Confirm MFA is enabled and enforced on the root account.
+  - Block the source IP at AWS WAF or network ACLs if confirmed malicious.
+
+- **If a successful root login is found:**
+  - Treat as Priority-1 account compromise and immediately follow the *AWS Management Console Root Login* investigation guide.
+  - Initiate an emergency root password reset and MFA re-enrollment.
+  - Preserve all CloudTrail events from ±1 hour around the login in an immutable evidence bucket.
+  - Audit all API calls made during the session for persistence: new users, access keys, policy changes.
+
+### Additional information
+
+- [AWS root user best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user.html)
+- [AWS IR Playbooks — Credential Compromise](https://github.com/aws-samples/aws-incident-response-playbooks)
+"""
+setup = """## Setup
+
+This rule requires an AWS Organizations-level CloudTrail trail that aggregates management events from all member accounts into a single destination. A single-account trail will only ever contain one `cloud.account.id` value and the cross-account cardinality signal will never fire.
+
+To configure an org-level trail: in the AWS CloudTrail console, create a trail scoped to your AWS Organization and enable it in all regions. Ensure the Elastic AWS integration is ingesting from the aggregated trail destination."""
+references = [
+    "https://securitylabs.datadoghq.com/articles/aws-root-user-bruteforce-campaign/",
+]
+risk_score = 47
+rule_id = "171d3cdd-0c04-47c2-b392-65719284ae25"
+severity = "medium"
+tags = [
+    "Domain: Cloud",
+    "Domain: Identity",
+    "Platform: AWS",
+    "Data Source: AWS CloudTrail",
+    "Use Case: Identity and Access Audit",
+    "Tactic: Credential Access",
+    "Rule Type: Threshold",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "threshold"
+
+query = '''
+data_stream.dataset:aws.cloudtrail and
+event.provider:signin.amazonaws.com and
+event.action:ConsoleLogin and
+aws.cloudtrail.user_identity.type:Root and
+event.outcome:failure
+'''
+
+[rule.investigation_fields]
+field_names = [
+    "source.ip",
+    "user_agent.original",
+    "cloud.account.id",
+    "aws.cloudtrail.user_identity.type",
+    "event.outcome",
+    "aws.cloudtrail.error_message",
+    "@timestamp",
+]
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1110"
+name = "Brute Force"
+reference = "https://attack.mitre.org/techniques/T1110/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1110.003"
+name = "Password Spraying"
+reference = "https://attack.mitre.org/techniques/T1110/003/"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[rule.threshold]
+field = ["source.ip"]
+value = 1
+
+[[rule.threshold.cardinality]]
+field = "cloud.account.id"
+value = 2

--- a/rules/integrations/aws/credential_access_root_console_password_spraying.toml
+++ b/rules/integrations/aws/credential_access_root_console_password_spraying.toml
@@ -15,8 +15,13 @@ CloudTrail trail aggregating events from member accounts.
 """
 false_positives = [
     """
-    A legitimate administrator may mistype the root account password multiple times. Verify whether the source IP is
-    an expected corporate or administrator address before escalating.
+    Administrators behind a shared egress address, such as a corporate NAT gateway or VPN
+    concentrator, can trigger this rule when separate people mistype root passwords for different
+    accounts within the window, since a single failure per account is sufficient. An administrator
+    who legitimately holds root credentials for several accounts can also match. Verify whether the
+    source IP is an expected corporate or administrator address, and whether the targeted accounts
+    correspond to that person's scope, before escalating. Repeated failures against a single account
+    do not trigger this rule and are covered by the separate brute-force rule.
     """,
 ]
 from = "now-1h"
@@ -140,3 +145,8 @@ value = 1
 [[rule.threshold.cardinality]]
 field = "cloud.account.id"
 value = 2
+
+[rule.alert_suppression]
+group_by = ["source.ip"]
+duration = {value = 1, unit = "h"}
+missing_fields_strategy = "suppress"

--- a/rules/integrations/aws/credential_access_root_console_password_spraying.toml
+++ b/rules/integrations/aws/credential_access_root_console_password_spraying.toml
@@ -147,6 +147,4 @@ field = "cloud.account.id"
 value = 2
 
 [rule.alert_suppression]
-group_by = ["source.ip"]
 duration = {value = 1, unit = "h"}
-missing_fields_strategy = "suppress"

--- a/rules/integrations/aws/credential_access_root_console_password_spraying.toml
+++ b/rules/integrations/aws/credential_access_root_console_password_spraying.toml
@@ -30,7 +30,7 @@ note = """## Triage and analysis
 
 Password spraying is a credential access technique where an attacker tries a small number of commonly used or leaked passwords across many accounts. Unlike brute force, the per-account attempt count is intentionally low — often 2–8 attempts — to stay below lockout thresholds and evade high-volume detections. Attackers targeting AWS root accounts typically hold a pre-enumerated list of root account email addresses and route attempts through proxy or residential IP infrastructure.
 
-This rule fires when a single source IP generates failed root `ConsoleLogin` events against two or more distinct AWS accounts within a 20-minute window, requiring an AWS Organizations-level CloudTrail trail. The cross-account breadth is the defining spray signal; brute force against a single account is covered by a separate rule.
+This rule fires when a single source IP generates failed root `ConsoleLogin` events against two or more distinct AWS accounts within a 1 hour window, requiring an AWS Organizations-level CloudTrail trail. The cross-account breadth is the defining spray signal; brute force against a single account is covered by a separate rule.
 
 #### Possible investigation steps
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:
* https://github.com/elastic/ia-trade-team/issues/889

## Summary - What I changed

Added a threshold rule that detects AWS root account password spraying by identifying a single source IP generating failed `ConsoleLogin` events across two or more distinct AWS accounts within a 1 day window.

## Why it matters

Password spraying against AWS root accounts uses intentionally low per-account attempt volumes to stay below lockout thresholds and evade high-volume brute-force detections. The existing brute-force rule (`credential_access_root_console_failure_brute_force`) fires at 10 failures per account. This rule detects the cross-account breadth pattern that is the defining signal of spray behavior: the same source IP failing against multiple AWS accounts. Requires an AWS Organizations-level CloudTrail trail aggregating events from member accounts.

- https://securitylabs.datadoghq.com/articles/aws-root-user-bruteforce-campaign/

## How To Test

Query to verify in our TRaDE stack:

```kql
data_stream.dataset: "aws.cloudtrail"
    and event.provider: "signin.amazonaws.com"
    and event.action: "ConsoleLogin"
    and aws.cloudtrail.user_identity.type: "Root"
    and event.outcome: "failure"
```

To emulate: from a single source IP, attempt root console login with a wrong password against two or more member account root emails. Confirm the threshold fires on the aggregated trail within the 1-hour window.

## Checklist

- [ ] Added a label for the type of pr: `Rule: New`
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
