### PR TITLE
[Bug] ES|QL Remote Validation: field_extract() on flattened types causes ambiguous schema mapping error

### DIFF
--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -435,6 +435,73 @@ def find_flattened_fields_with_subfields(mapping: dict[str, Any], path: str = ""
     return flattened_fields_with_subfields
 
 
+def find_flattened_fields(mapping: dict[str, Any], path: str = "") -> set[str]:
+    """Recursively collect the dotted paths of every field typed `flattened` in Elasticsearch mappings."""
+    flattened_fields: set[str] = set()
+
+    for field, properties in mapping.items():
+        if not isinstance(properties, dict):
+            continue
+        current_path = f"{path}.{field}" if path else field
+
+        if properties.get("type") == "flattened":  # type: ignore[reportUnknownMemberType]
+            flattened_fields.add(current_path)
+
+        # Recurse into subfields
+        if "properties" in properties:
+            flattened_fields |= find_flattened_fields(properties["properties"], current_path)  # type: ignore[reportUnknownArgumentType]
+
+    return flattened_fields
+
+
+def coerce_field_to_flattened(mapping: dict[str, Any], field_path: str) -> bool:
+    """Map `field_path` as `flattened`, dropping its subfields. Returns True if the mapping changed."""
+    parts = field_path.split(".")
+    current_level: dict[str, Any] = mapping
+    for part in parts[:-1]:
+        node: dict[str, Any] = current_level.get(part) or {}
+        properties: dict[str, Any] = node.get("properties") or {}
+        if not properties:
+            return False
+        current_level = properties
+
+    field: dict[str, Any] = current_level.get(parts[-1]) or {}
+    if not field or field.get("type") == "flattened":
+        return False
+
+    field.pop("properties", None)
+    field.pop("fields", None)
+    field["type"] = "flattened"
+    return True
+
+
+def reconcile_flattened_object_conflicts(mappings: dict[str, dict[str, Any]], log: Callable[[str], None]) -> None:
+    """
+    Align `flattened` fields across the mappings the test indices are built from.
+
+    An integration can type a field as `flattened` (e.g. `azure.platformlogs.properties`) while the
+    non-ecs, custom or ECS schemas only declare its subfields, which leaves the parent as an implicit
+    `object` in the index built from those. ES|QL then refuses to read the parent across the union of
+    the test indices with an ambiguous mapping error, even though the field is unambiguously
+    `flattened` in a real deployment, so the `flattened` definition is treated as authoritative.
+
+    Dropping those subfields matches a real deployment as well: ES|QL cannot read a subfield of a
+    flattened field as a column (hence `field_extract`), while KQL predicates against subfields keep
+    working through the `flattened` parent.
+    """
+    flattened_fields: set[str] = set()
+    for mapping in mappings.values():
+        flattened_fields |= find_flattened_fields(mapping)
+
+    for field_path in sorted(flattened_fields):
+        for name, mapping in mappings.items():
+            if coerce_field_to_flattened(mapping, field_path):
+                log(
+                    f"Warning: field `{field_path}` is mapped as `flattened` in another data source but as "
+                    f"an object in `{name}`. Mapping it as `flattened` for ES|QL validation."
+                )
+
+
 def get_ecs_schema_mappings(current_version: Version) -> dict[str, Any]:
     """Get the ECS schema in an index mapping format (nested schema) handling scaled floats."""
     ecs_version = get_stack_schemas()[str(current_version)]["ecs"]

--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -454,51 +454,58 @@ def find_flattened_fields(mapping: dict[str, Any], path: str = "") -> set[str]:
     return flattened_fields
 
 
-def coerce_field_to_flattened(mapping: dict[str, Any], field_path: str) -> bool:
-    """Map `field_path` as `flattened`, dropping its subfields. Returns True if the mapping changed."""
+def coerce_field_to_flattened(mapping: dict[str, Any], field_path: str) -> str | None:
+    """Map `field_path` as `flattened`, dropping its subfields, and return the replaced type or None if unchanged."""
     parts = field_path.split(".")
     current_level: dict[str, Any] = mapping
     for part in parts[:-1]:
         node: dict[str, Any] = current_level.get(part) or {}
         properties: dict[str, Any] = node.get("properties") or {}
         if not properties:
-            return False
+            return None
         current_level = properties
 
     field: dict[str, Any] = current_level.get(parts[-1]) or {}
     if not field or field.get("type") == "flattened":
-        return False
+        return None
 
+    previous_type = str(field.get("type", "object"))
     field.pop("properties", None)
     field.pop("fields", None)
     field["type"] = "flattened"
-    return True
+    return previous_type
 
 
-def reconcile_flattened_object_conflicts(mappings: dict[str, dict[str, Any]], log: Callable[[str], None]) -> None:
-    """
-    Align `flattened` fields across the mappings the test indices are built from.
+def reconcile_flattened_object_conflicts(
+    authoritative: dict[str, dict[str, Any]], targets: dict[str, dict[str, Any]], log: Callable[[str], None]
+) -> None:
+    """Align the `targets` mappings with every field the `authoritative` mappings type as `flattened`."""
+    # An integration can type a field as `flattened` (e.g. `azure.platformlogs.properties`) while the
+    # non-ecs, custom or ECS schemas only declare its subfields, which leaves the parent as an implicit
+    # `object` in the test index built from those. ES|QL then refuses to read the parent across the union
+    # of the test indices with an ambiguous mapping error, even though the field is unambiguously
+    # `flattened` in a real deployment where those schema-only indices do not exist.
+    #
+    # Only the schema-derived (`targets`) mappings are coerced. The integration and existing index
+    # template mappings (`authoritative`) describe real indices, so a `flattened` vs `object` conflict
+    # between two of them is a genuine one that ES|QL should keep reporting.
+    #
+    # Dropping the subfields matches a real deployment as well: ES|QL cannot read a subfield of a
+    # flattened field as a column (hence `field_extract`), while KQL predicates against subfields keep
+    # working through the `flattened` parent.
+    flattened_fields: dict[str, str] = {}
+    for name, mapping in authoritative.items():
+        for field_path in find_flattened_fields(mapping):
+            if field_path not in flattened_fields:
+                flattened_fields[field_path] = name
 
-    An integration can type a field as `flattened` (e.g. `azure.platformlogs.properties`) while the
-    non-ecs, custom or ECS schemas only declare its subfields, which leaves the parent as an implicit
-    `object` in the index built from those. ES|QL then refuses to read the parent across the union of
-    the test indices with an ambiguous mapping error, even though the field is unambiguously
-    `flattened` in a real deployment, so the `flattened` definition is treated as authoritative.
-
-    Dropping those subfields matches a real deployment as well: ES|QL cannot read a subfield of a
-    flattened field as a column (hence `field_extract`), while KQL predicates against subfields keep
-    working through the `flattened` parent.
-    """
-    flattened_fields: set[str] = set()
-    for mapping in mappings.values():
-        flattened_fields |= find_flattened_fields(mapping)
-
-    for field_path in sorted(flattened_fields):
-        for name, mapping in mappings.items():
-            if coerce_field_to_flattened(mapping, field_path):
+    for field_path, source in sorted(flattened_fields.items()):
+        for name, mapping in targets.items():
+            previous_type = coerce_field_to_flattened(mapping, field_path)
+            if previous_type:
                 log(
-                    f"Warning: field `{field_path}` is mapped as `flattened` in another data source but as "
-                    f"an object in `{name}`. Mapping it as `flattened` for ES|QL validation."
+                    f"Warning: field `{field_path}` is mapped as `flattened` in `{source}` but as "
+                    f"`{previous_type}` in `{name}`. Mapping it as `flattened` for ES|QL validation."
                 )
 
 
@@ -580,6 +587,20 @@ def prepare_mappings(  # noqa: PLR0913, PLR0917
     # Load ECS in an index mapping format (nested schema)
     current_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
     ecs_schema = get_ecs_schema_mappings(current_version)
+
+    # A field an integration types as `flattened` is an implicit `object` in the schema-derived mappings
+    # when they only declare its subfields. Align them before the test indices and the combined mapping
+    # are built so ES|QL does not report an ambiguous mapping across the test indices.
+    reconcile_flattened_object_conflicts(
+        {"existing-index-template-mappings": existing_mappings, **integration_index_lookup},
+        {
+            "rule-ecs-index": ecs_schema,
+            "rule-non-ecs-index": non_ecs_schema,
+            **{f"non-ecs {index}": mapping for index, mapping in non_ecs_mapping.items()},
+            **{f"custom {index}": mapping for index, mapping in custom_mapping.items()},
+        },
+        log,
+    )
 
     # Filter combined mappings based on the provided indices
     combined_mappings, index_lookup = get_filtered_index_schema(

--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -525,6 +525,9 @@ def get_ecs_schema_mappings(
     log: Callable[[str], None] = print,
 ) -> dict[str, Any]:
     """Get the ECS schema in an index mapping format (nested schema) handling scaled floats."""
+    # NOTE: the result depends on `flattened_fields` (the rule's integration and index template mappings),
+    # not only on `current_version`. Do not memoize it by stack version alone; if caching is ever needed,
+    # cache the version-only flat ECS schema and keep the alignment and nesting per rule.
     ecs_version = get_stack_schemas()[str(current_version)]["ecs"]
     ecs_schemas = ecs.get_schemas()
     ecs_flat_schema: dict[str, Any] = {}

--- a/detection_rules/index_mappings.py
+++ b/detection_rules/index_mappings.py
@@ -454,73 +454,93 @@ def find_flattened_fields(mapping: dict[str, Any], path: str = "") -> set[str]:
     return flattened_fields
 
 
-def coerce_field_to_flattened(mapping: dict[str, Any], field_path: str) -> str | None:
-    """Map `field_path` as `flattened`, dropping its subfields, and return the replaced type or None if unchanged."""
+def collect_flattened_fields(mappings: dict[str, dict[str, Any]]) -> dict[str, str]:
+    """Map every dotted path typed `flattened` in `mappings` to the name of the first mapping declaring it."""
+    flattened_fields: dict[str, str] = {}
+    for name, mapping in mappings.items():
+        for field_path in find_flattened_fields(mapping):
+            _ = flattened_fields.setdefault(field_path, name)
+    return flattened_fields
+
+
+def find_flattened_ancestor(field_path: str, flattened_fields: dict[str, str]) -> str | None:
+    """Return the outermost known `flattened` field that is `field_path` or one of its ancestors."""
     parts = field_path.split(".")
-    current_level: dict[str, Any] = mapping
-    for part in parts[:-1]:
-        node: dict[str, Any] = current_level.get(part) or {}
-        properties: dict[str, Any] = node.get("properties") or {}
-        if not properties:
-            return None
-        current_level = properties
-
-    field: dict[str, Any] = current_level.get(parts[-1]) or {}
-    if not field or field.get("type") == "flattened":
-        return None
-
-    previous_type = str(field.get("type", "object"))
-    field.pop("properties", None)
-    field.pop("fields", None)
-    field["type"] = "flattened"
-    return previous_type
+    for depth in range(1, len(parts) + 1):
+        candidate = ".".join(parts[:depth])
+        if candidate in flattened_fields:
+            return candidate
+    return None
 
 
-def reconcile_flattened_object_conflicts(
-    authoritative: dict[str, dict[str, Any]], targets: dict[str, dict[str, Any]], log: Callable[[str], None]
-) -> None:
-    """Align the `targets` mappings with every field the `authoritative` mappings type as `flattened`."""
+def align_flat_schema_to_flattened_fields(
+    flat_schema: dict[str, str], flattened_fields: dict[str, str], source: str, log: Callable[[str], None]
+) -> dict[str, str]:
+    """Collapse every `flat_schema` entry at or below a known `flattened` field onto that field, typed `flattened`."""
     # An integration can type a field as `flattened` (e.g. `azure.platformlogs.properties`) while the
-    # non-ecs, custom or ECS schemas only declare its subfields, which leaves the parent as an implicit
-    # `object` in the test index built from those. ES|QL then refuses to read the parent across the union
-    # of the test indices with an ambiguous mapping error, even though the field is unambiguously
-    # `flattened` in a real deployment where those schema-only indices do not exist.
-    #
-    # Only the schema-derived (`targets`) mappings are coerced. The integration and existing index
-    # template mappings (`authoritative`) describe real indices, so a `flattened` vs `object` conflict
-    # between two of them is a genuine one that ES|QL should keep reporting.
+    # non-ecs, custom or ECS schemas only declare its subfields. Nesting those subfields as-is would leave
+    # the parent as an implicit `object` in the test index built from that schema, and ES|QL then refuses
+    # to read the parent across the union of the test indices with an ambiguous mapping error, even though
+    # the field is unambiguously `flattened` in a real deployment where those schema-only indices do not exist.
     #
     # Dropping the subfields matches a real deployment as well: ES|QL cannot read a subfield of a
     # flattened field as a column (hence `field_extract`), while KQL predicates against subfields keep
-    # working through the `flattened` parent.
-    flattened_fields: dict[str, str] = {}
-    for name, mapping in authoritative.items():
-        for field_path in find_flattened_fields(mapping):
-            if field_path not in flattened_fields:
-                flattened_fields[field_path] = name
+    # working through the `flattened` parent. The dotted entries stay in the source schema files.
+    if not flattened_fields:
+        return dict(flat_schema)
 
-    for field_path, source in sorted(flattened_fields.items()):
-        for name, mapping in targets.items():
-            previous_type = coerce_field_to_flattened(mapping, field_path)
-            if previous_type:
-                log(
-                    f"Warning: field `{field_path}` is mapped as `flattened` in `{source}` but as "
-                    f"`{previous_type}` in `{name}`. Mapping it as `flattened` for ES|QL validation."
-                )
+    aligned: dict[str, str] = {}
+    replaced: dict[str, str] = {}
+    for field_path, field_type in flat_schema.items():
+        parent = find_flattened_ancestor(field_path, flattened_fields)
+        if parent is None:
+            aligned[field_path] = field_type
+            continue
+        aligned[parent] = "flattened"
+        if field_path == parent:
+            if field_type != "flattened":
+                replaced[parent] = field_type
+        else:
+            _ = replaced.setdefault(parent, "object")
+
+    for parent, previous_type in sorted(replaced.items()):
+        log(
+            f"Warning: field `{parent}` is mapped as `flattened` in `{flattened_fields[parent]}` but as "
+            f"`{previous_type}` in `{source}`. Mapping it as `flattened` for ES|QL validation."
+        )
+    return aligned
 
 
-def get_ecs_schema_mappings(current_version: Version) -> dict[str, Any]:
+def flat_schema_to_nested_mapping(
+    flat_schema: dict[str, str], flattened_fields: dict[str, str], source: str, log: Callable[[str], None]
+) -> dict[str, Any]:
+    """Convert a flat schema to a nested index mapping, aligned with the known `flattened` fields."""
+    aligned = align_flat_schema_to_flattened_fields(flat_schema, flattened_fields, source, log)
+    return utils.convert_to_nested_schema(aligned)
+
+
+def get_ecs_schema_mappings(
+    current_version: Version,
+    flattened_fields: dict[str, str] | None = None,
+    log: Callable[[str], None] = print,
+) -> dict[str, Any]:
     """Get the ECS schema in an index mapping format (nested schema) handling scaled floats."""
     ecs_version = get_stack_schemas()[str(current_version)]["ecs"]
     ecs_schemas = ecs.get_schemas()
-    ecs_schema_flattened: dict[str, Any] = {}
+    ecs_flat_schema: dict[str, Any] = {}
     ecs_schema_scaled_floats: dict[str, Any] = {}
     for index, info in ecs_schemas[ecs_version]["ecs_flat"].items():
         if info["type"] == "scaled_float":
             ecs_schema_scaled_floats.update({index: info["scaling_factor"]})
-        ecs_schema_flattened.update({index: info["type"]})
-    ecs_schema = utils.convert_to_nested_schema(ecs_schema_flattened)
+        ecs_flat_schema.update({index: info["type"]})
+    ecs_flat_schema = align_flat_schema_to_flattened_fields(
+        ecs_flat_schema, flattened_fields or {}, "rule-ecs-index", log
+    )
+    ecs_schema = utils.convert_to_nested_schema(ecs_flat_schema)
     for index, info in ecs_schema_scaled_floats.items():
+        if ecs_flat_schema.get(index) != "scaled_float":
+            # Collapsed onto a `flattened` parent above
+            continue
         parts = index.split(".")
         current = ecs_schema
 
@@ -556,6 +576,17 @@ def prepare_mappings(  # noqa: PLR0913, PLR0917
 
     index_lookup.update(integration_index_lookup)
 
+    # The integration and existing index template mappings describe real indices, so a field they type as
+    # `flattened` is authoritative. The schema-derived mappings built below (ECS, non-ecs, custom) may only
+    # declare its subfields, which would leave the parent as an implicit `object` in their test indices and
+    # make ES|QL reject the field as ambiguously mapped across the test indices. Their entries at or below a
+    # known `flattened` field are therefore collapsed onto it while they are converted to index mappings.
+    # NOTE: this relies on both authoritative sources being loaded before any schema-derived mapping is
+    # converted. `test_prepare_mappings_aligns_schema_mappings_with_flattened_fields` pins that ordering.
+    known_flattened_fields = collect_flattened_fields(
+        {"existing-index-template-mappings": existing_mappings, **integration_index_lookup}
+    )
+
     # Load non-ecs schema and convert to index mapping format (nested schema)
     # For non_ecs we need both a mapping and a schema as custom schemas can override non-ecs fields
     # In these cases we need to accept the overwrite keep the original non-ecs field in the schema
@@ -565,14 +596,16 @@ def prepare_mappings(  # noqa: PLR0913, PLR0917
     for index in indices:
         index_mapping = non_ecs.get(index, {})
         non_ecs_schema.update(index_mapping)
-        index_mapping = ecs.flatten(index_mapping)
-        index_mapping = utils.convert_to_nested_schema(index_mapping)
+        index_mapping = flat_schema_to_nested_mapping(
+            ecs.flatten(index_mapping), known_flattened_fields, f"non-ecs {index}", log
+        )
         non_ecs_mapping.update({index: index_mapping})
 
     # These need to be handled separately as we need to be able to validate non-ecs fields as a whole
     # and also at a per index level as custom schemas can override non-ecs fields and/or indices
-    non_ecs_schema = ecs.flatten(non_ecs_schema)
-    non_ecs_schema = utils.convert_to_nested_schema(non_ecs_schema)
+    non_ecs_schema = flat_schema_to_nested_mapping(
+        ecs.flatten(non_ecs_schema), known_flattened_fields, "rule-non-ecs-index", log
+    )
     non_ecs_schema = prune_mappings_of_unsupported_types("non-ecs", non_ecs_schema, log)
 
     # Load custom schema and convert to index mapping format (nested schema)
@@ -580,27 +613,14 @@ def prepare_mappings(  # noqa: PLR0913, PLR0917
     custom_indices = ecs.get_custom_schemas()
     for index in indices:
         index_mapping = custom_indices.get(index, {})
-        index_mapping = ecs.flatten(index_mapping)
-        index_mapping = utils.convert_to_nested_schema(index_mapping)
+        index_mapping = flat_schema_to_nested_mapping(
+            ecs.flatten(index_mapping), known_flattened_fields, f"custom {index}", log
+        )
         custom_mapping.update({index: index_mapping})
 
     # Load ECS in an index mapping format (nested schema)
     current_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
-    ecs_schema = get_ecs_schema_mappings(current_version)
-
-    # A field an integration types as `flattened` is an implicit `object` in the schema-derived mappings
-    # when they only declare its subfields. Align them before the test indices and the combined mapping
-    # are built so ES|QL does not report an ambiguous mapping across the test indices.
-    reconcile_flattened_object_conflicts(
-        {"existing-index-template-mappings": existing_mappings, **integration_index_lookup},
-        {
-            "rule-ecs-index": ecs_schema,
-            "rule-non-ecs-index": non_ecs_schema,
-            **{f"non-ecs {index}": mapping for index, mapping in non_ecs_mapping.items()},
-            **{f"custom {index}": mapping for index, mapping in custom_mapping.items()},
-        },
-        log,
-    )
+    ecs_schema = get_ecs_schema_mappings(current_version, known_flattened_fields, log)
 
     # Filter combined mappings based on the provided indices
     combined_mappings, index_lookup = get_filtered_index_schema(

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -39,6 +39,7 @@ from .index_mappings import (
     execute_query_against_indices,
     get_rule_integrations,
     prepare_mappings,
+    reconcile_flattened_object_conflicts,
 )
 from .integrations import (
     find_latest_integration_patch_for_minor,
@@ -915,6 +916,14 @@ class ESQLValidator(QueryValidator):
         )
         self.log(f"Collected mappings: {len(existing_mappings)}")
         self.log(f"Combined mappings prepared: {len(combined_mappings)}")
+
+        # A field an integration types as `flattened` can be an implicit `object` in the mappings built
+        # from the non-ecs, custom or ECS schemas, which only declare its subfields. Reading the parent
+        # across the union of the resulting test indices then fails with an ambiguous mapping error, so
+        # align those mappings on `flattened` before the indices are created.
+        reconcile_flattened_object_conflicts(
+            {"existing-index-template-mappings": existing_mappings, **index_lookup}, self.log
+        )
 
         # Create remote indices
         full_index_str = create_remote_indices(elastic_client, existing_mappings, index_lookup, self.log)

--- a/detection_rules/rule_validators.py
+++ b/detection_rules/rule_validators.py
@@ -39,7 +39,6 @@ from .index_mappings import (
     execute_query_against_indices,
     get_rule_integrations,
     prepare_mappings,
-    reconcile_flattened_object_conflicts,
 )
 from .integrations import (
     find_latest_integration_patch_for_minor,
@@ -916,14 +915,6 @@ class ESQLValidator(QueryValidator):
         )
         self.log(f"Collected mappings: {len(existing_mappings)}")
         self.log(f"Combined mappings prepared: {len(combined_mappings)}")
-
-        # A field an integration types as `flattened` can be an implicit `object` in the mappings built
-        # from the non-ecs, custom or ECS schemas, which only declare its subfields. Reading the parent
-        # across the union of the resulting test indices then fails with an ambiguous mapping error, so
-        # align those mappings on `flattened` before the indices are created.
-        reconcile_flattened_object_conflicts(
-            {"existing-index-template-mappings": existing_mappings, **index_lookup}, self.log
-        )
 
         # Create remote indices
         full_index_str = create_remote_indices(elastic_client, existing_mappings, index_lookup, self.log)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.1.10"
+version = "2.1.11"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -90,12 +90,14 @@ class TestESQLRemoteValidation(unittest.TestCase):
         self.assertIn("9.3.0", prepared_stack_versions)
 
     @staticmethod
-    def flattened_conflict_mappings() -> dict[str, dict[str, object]]:
-        """Integration mapping typing a field as `flattened` alongside a non-ecs mapping of its subfields."""
-        return {
+    def flattened_conflict_mappings() -> tuple[dict[str, dict[str, object]], dict[str, dict[str, object]]]:
+        """Integration mapping typing a field as `flattened` alongside schema mappings of its subfields."""
+        authoritative: dict[str, dict[str, object]] = {
             "azure-platformlogs": {
                 "azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}
             },
+        }
+        targets: dict[str, dict[str, object]] = {
             "rule-non-ecs-index": {
                 "azure": {
                     "properties": {
@@ -107,33 +109,57 @@ class TestESQLRemoteValidation(unittest.TestCase):
                     }
                 }
             },
+            "rule-ecs-index": {"user": {"properties": {"name": {"type": "keyword"}}}},
         }
+        return authoritative, targets
 
     def test_flattened_object_conflict_reconciled(self):
-        """A field typed `flattened` in one data source is mapped as `flattened` in all of them."""
-        mappings = self.flattened_conflict_mappings()
+        """A field typed `flattened` in an integration is mapped as `flattened` in the schema-derived mappings."""
+        authoritative, targets = self.flattened_conflict_mappings()
+        expected_authoritative = deepcopy(authoritative)
+        expected_ecs = deepcopy(targets["rule-ecs-index"])
         logged: list[str] = []
 
-        reconcile_flattened_object_conflicts(mappings, logged.append)
+        reconcile_flattened_object_conflicts(authoritative, targets, logged.append)
 
         expected = {"azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}}
-        self.assertEqual(mappings["rule-non-ecs-index"], expected)
-        self.assertEqual(mappings["azure-platformlogs"], expected)
+        self.assertEqual(targets["rule-non-ecs-index"], expected)
+        # Unrelated mappings and the authoritative integration mappings are left alone
+        self.assertEqual(targets["rule-ecs-index"], expected_ecs)
+        self.assertEqual(authoritative, expected_authoritative)
         self.assertEqual(len(logged), 1)
-        self.assertIn("azure.platformlogs.properties", logged[0])
+        self.assertIn("`azure.platformlogs.properties`", logged[0])
+        self.assertIn("`flattened` in `azure-platformlogs`", logged[0])
+        self.assertIn("`object` in `rule-non-ecs-index`", logged[0])
 
-    def test_mappings_without_flattened_conflict_untouched(self):
-        """Mappings that do not collide with a `flattened` field are left alone."""
-        mappings = self.flattened_conflict_mappings()
-        # An unrelated index whose object subtree shares no path with the flattened field
-        mappings["rule-ecs-index"] = {"user": {"properties": {"name": {"type": "keyword"}}}}
-        expected = deepcopy(mappings["rule-ecs-index"])
+    def test_flattened_conflict_between_authoritative_mappings_not_reconciled(self):
+        """A `flattened` vs `object` conflict between two real data sources is not masked."""
+        authoritative, targets = self.flattened_conflict_mappings()
+        authoritative["other-integration"] = deepcopy(targets["rule-non-ecs-index"])
+        expected_authoritative = deepcopy(authoritative)
         logged: list[str] = []
 
-        reconcile_flattened_object_conflicts(mappings, logged.append)
+        reconcile_flattened_object_conflicts(authoritative, targets, logged.append)
 
-        self.assertEqual(mappings["rule-ecs-index"], expected)
-        self.assertNotIn("rule-ecs-index", "".join(logged))
+        self.assertEqual(authoritative, expected_authoritative)
+        self.assertNotIn("other-integration", "".join(logged))
+
+    def test_flattened_scalar_conflict_reconciled(self):
+        """A field typed `flattened` in an integration overrides a scalar type in the schema-derived mappings."""
+        authoritative, _ = self.flattened_conflict_mappings()
+        targets: dict[str, dict[str, object]] = {
+            "custom logs-azure.platformlogs-*": {
+                "azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "keyword"}}}}}
+            }
+        }
+        logged: list[str] = []
+
+        reconcile_flattened_object_conflicts(authoritative, targets, logged.append)
+
+        expected = {"azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}}
+        self.assertEqual(targets["custom logs-azure.platformlogs-*"], expected)
+        self.assertEqual(len(logged), 1)
+        self.assertIn("`keyword` in `custom logs-azure.platformlogs-*`", logged[0])
 
 
 @unittest.skipIf(get_default_config() is None, "Skipping remote validation due to missing config")

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -16,6 +16,7 @@ from detection_rules.esql_errors import (
     EsqlTypeMismatchError,
     EsqlUnknownIndexError,
 )
+from detection_rules.index_mappings import reconcile_flattened_object_conflicts
 from detection_rules.misc import (
     get_default_config,
     getdefault,
@@ -87,6 +88,52 @@ class TestESQLRemoteValidation(unittest.TestCase):
         self.assertIn("9.2.0", prepared_stack_versions)
         self.assertIn("9.2.4", prepared_stack_versions)
         self.assertIn("9.3.0", prepared_stack_versions)
+
+    @staticmethod
+    def flattened_conflict_mappings() -> dict[str, dict[str, object]]:
+        """Integration mapping typing a field as `flattened` alongside a non-ecs mapping of its subfields."""
+        return {
+            "azure-platformlogs": {
+                "azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}
+            },
+            "rule-non-ecs-index": {
+                "azure": {
+                    "properties": {
+                        "platformlogs": {
+                            "properties": {
+                                "properties": {"properties": {"log": {"properties": {"verb": {"type": "keyword"}}}}}
+                            }
+                        }
+                    }
+                }
+            },
+        }
+
+    def test_flattened_object_conflict_reconciled(self):
+        """A field typed `flattened` in one data source is mapped as `flattened` in all of them."""
+        mappings = self.flattened_conflict_mappings()
+        logged: list[str] = []
+
+        reconcile_flattened_object_conflicts(mappings, logged.append)
+
+        expected = {"azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}}
+        self.assertEqual(mappings["rule-non-ecs-index"], expected)
+        self.assertEqual(mappings["azure-platformlogs"], expected)
+        self.assertEqual(len(logged), 1)
+        self.assertIn("azure.platformlogs.properties", logged[0])
+
+    def test_mappings_without_flattened_conflict_untouched(self):
+        """Mappings that do not collide with a `flattened` field are left alone."""
+        mappings = self.flattened_conflict_mappings()
+        # An unrelated index whose object subtree shares no path with the flattened field
+        mappings["rule-ecs-index"] = {"user": {"properties": {"name": {"type": "keyword"}}}}
+        expected = deepcopy(mappings["rule-ecs-index"])
+        logged: list[str] = []
+
+        reconcile_flattened_object_conflicts(mappings, logged.append)
+
+        self.assertEqual(mappings["rule-ecs-index"], expected)
+        self.assertNotIn("rule-ecs-index", "".join(logged))
 
 
 @unittest.skipIf(get_default_config() is None, "Skipping remote validation due to missing config")

--- a/tests/test_rules_remote.py
+++ b/tests/test_rules_remote.py
@@ -16,7 +16,11 @@ from detection_rules.esql_errors import (
     EsqlTypeMismatchError,
     EsqlUnknownIndexError,
 )
-from detection_rules.index_mappings import reconcile_flattened_object_conflicts
+from detection_rules.index_mappings import (
+    align_flat_schema_to_flattened_fields,
+    collect_flattened_fields,
+    prepare_mappings,
+)
 from detection_rules.misc import (
     get_default_config,
     getdefault,
@@ -89,77 +93,136 @@ class TestESQLRemoteValidation(unittest.TestCase):
         self.assertIn("9.2.4", prepared_stack_versions)
         self.assertIn("9.3.0", prepared_stack_versions)
 
-    @staticmethod
-    def flattened_conflict_mappings() -> tuple[dict[str, dict[str, object]], dict[str, dict[str, object]]]:
-        """Integration mapping typing a field as `flattened` alongside schema mappings of its subfields."""
-        authoritative: dict[str, dict[str, object]] = {
+    def test_collect_flattened_fields_keeps_first_source(self):
+        """Known `flattened` fields are collected with the name of the first mapping that declares them."""
+        mappings: dict[str, dict[str, object]] = {
+            "existing-index-template-mappings": {"custom_ns": {"properties": {"payload": {"type": "flattened"}}}},
             "azure-platformlogs": {
                 "azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}
             },
+            "other-integration": {"custom_ns": {"properties": {"payload": {"type": "flattened"}}}},
         }
-        targets: dict[str, dict[str, object]] = {
-            "rule-non-ecs-index": {
-                "azure": {
-                    "properties": {
-                        "platformlogs": {
-                            "properties": {
-                                "properties": {"properties": {"log": {"properties": {"verb": {"type": "keyword"}}}}}
-                            }
-                        }
-                    }
-                }
+        self.assertEqual(
+            collect_flattened_fields(mappings),
+            {
+                "custom_ns.payload": "existing-index-template-mappings",
+                "azure.platformlogs.properties": "azure-platformlogs",
             },
-            "rule-ecs-index": {"user": {"properties": {"name": {"type": "keyword"}}}},
-        }
-        return authoritative, targets
+        )
 
-    def test_flattened_object_conflict_reconciled(self):
-        """A field typed `flattened` in an integration is mapped as `flattened` in the schema-derived mappings."""
-        authoritative, targets = self.flattened_conflict_mappings()
-        expected_authoritative = deepcopy(authoritative)
-        expected_ecs = deepcopy(targets["rule-ecs-index"])
+    def test_flat_schema_subfields_collapsed_onto_flattened_parent(self):
+        """Entries below a known `flattened` field collapse onto that field instead of nesting as `object`."""
+        flattened_fields = {"azure.platformlogs.properties": "azure-platformlogs"}
+        flat_schema = {
+            "azure.platformlogs.properties.log.verb": "keyword",
+            "azure.platformlogs.properties.id": "keyword",
+            "azure.platformlogs.category": "keyword",
+            "user.name": "keyword",
+        }
         logged: list[str] = []
 
-        reconcile_flattened_object_conflicts(authoritative, targets, logged.append)
+        aligned = align_flat_schema_to_flattened_fields(
+            flat_schema, flattened_fields, "rule-non-ecs-index", logged.append
+        )
 
-        expected = {"azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}}
-        self.assertEqual(targets["rule-non-ecs-index"], expected)
-        # Unrelated mappings and the authoritative integration mappings are left alone
-        self.assertEqual(targets["rule-ecs-index"], expected_ecs)
-        self.assertEqual(authoritative, expected_authoritative)
+        self.assertEqual(
+            aligned,
+            {
+                "azure.platformlogs.properties": "flattened",
+                "azure.platformlogs.category": "keyword",
+                "user.name": "keyword",
+            },
+        )
         self.assertEqual(len(logged), 1)
         self.assertIn("`azure.platformlogs.properties`", logged[0])
         self.assertIn("`flattened` in `azure-platformlogs`", logged[0])
         self.assertIn("`object` in `rule-non-ecs-index`", logged[0])
 
-    def test_flattened_conflict_between_authoritative_mappings_not_reconciled(self):
-        """A `flattened` vs `object` conflict between two real data sources is not masked."""
-        authoritative, targets = self.flattened_conflict_mappings()
-        authoritative["other-integration"] = deepcopy(targets["rule-non-ecs-index"])
-        expected_authoritative = deepcopy(authoritative)
-        logged: list[str] = []
-
-        reconcile_flattened_object_conflicts(authoritative, targets, logged.append)
-
-        self.assertEqual(authoritative, expected_authoritative)
-        self.assertNotIn("other-integration", "".join(logged))
-
-    def test_flattened_scalar_conflict_reconciled(self):
-        """A field typed `flattened` in an integration overrides a scalar type in the schema-derived mappings."""
-        authoritative, _ = self.flattened_conflict_mappings()
-        targets: dict[str, dict[str, object]] = {
-            "custom logs-azure.platformlogs-*": {
-                "azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "keyword"}}}}}
-            }
+    def test_flat_schema_scalar_conflict_collapsed_onto_flattened_field(self):
+        """An entry typed differently from a known `flattened` field is retyped as `flattened`."""
+        flattened_fields = {"azure.platformlogs.properties": "azure-platformlogs"}
+        flat_schema = {
+            "azure.platformlogs.properties": "keyword",
+            "azure.platformlogs.properties.log.verb": "keyword",
         }
         logged: list[str] = []
 
-        reconcile_flattened_object_conflicts(authoritative, targets, logged.append)
+        aligned = align_flat_schema_to_flattened_fields(
+            flat_schema, flattened_fields, "custom logs-azure.platformlogs-*", logged.append
+        )
 
-        expected = {"azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}}
-        self.assertEqual(targets["custom logs-azure.platformlogs-*"], expected)
+        self.assertEqual(aligned, {"azure.platformlogs.properties": "flattened"})
         self.assertEqual(len(logged), 1)
         self.assertIn("`keyword` in `custom logs-azure.platformlogs-*`", logged[0])
+
+    def test_flat_schema_unchanged_without_conflicts(self):
+        """Schemas that already agree with the known `flattened` fields, or have none, are left as they are."""
+        flat_schema = {"azure.platformlogs.properties": "flattened", "user.name": "keyword"}
+        logged: list[str] = []
+
+        self.assertEqual(align_flat_schema_to_flattened_fields(flat_schema, {}, "x", logged.append), flat_schema)
+        self.assertEqual(
+            align_flat_schema_to_flattened_fields(
+                flat_schema, {"azure.platformlogs.properties": "azure-platformlogs"}, "x", logged.append
+            ),
+            flat_schema,
+        )
+        self.assertEqual(logged, [])
+
+    def test_prepare_mappings_aligns_schema_mappings_with_flattened_fields(self):
+        """`prepare_mappings` collapses non-ecs and custom subfields onto `flattened` fields from both real sources.
+
+        This pins the ordering inside `prepare_mappings`: the integration and existing index template mappings
+        must be loaded before the schema-derived mappings are converted, otherwise the known `flattened` fields
+        are empty at conversion time and the ambiguous mapping error from #6724 silently returns.
+        """
+        index = "logs-azure.platformlogs-*"
+        # `flattened` in the existing index template mappings only
+        existing_mappings: dict[str, object] = {"custom_ns": {"properties": {"payload": {"type": "flattened"}}}}
+        # `flattened` in the integration mappings only
+        integration_mapping: dict[str, object] = {
+            "azure": {"properties": {"platformlogs": {"properties": {"properties": {"type": "flattened"}}}}}
+        }
+        non_ecs_schema = {index: {"azure": {"platformlogs": {"properties": {"log": {"verb": "keyword"}}}}}}
+        custom_schema = {index: {"custom_ns": {"payload": {"key": "keyword"}}}}
+        logged: list[str] = []
+
+        with (
+            unittest.mock.patch(
+                "detection_rules.index_mappings.get_existing_mappings",
+                return_value=(existing_mappings, {index: deepcopy(existing_mappings)}),
+            ),
+            unittest.mock.patch("detection_rules.index_mappings.get_rule_integrations", return_value=["azure"]),
+            unittest.mock.patch("detection_rules.index_mappings.load_integrations_manifests", return_value={}),
+            unittest.mock.patch("detection_rules.index_mappings.load_integrations_schemas", return_value={}),
+            unittest.mock.patch(
+                "detection_rules.index_mappings.prepare_integration_mappings",
+                return_value=(deepcopy(integration_mapping), {"azure-platformlogs": integration_mapping}),
+            ),
+            unittest.mock.patch("detection_rules.ecs.get_non_ecs_schema", return_value=non_ecs_schema),
+            unittest.mock.patch("detection_rules.ecs.get_custom_schemas", return_value=custom_schema),
+        ):
+            _, index_lookup, combined_mappings = prepare_mappings(
+                elastic_client=object(),  # type: ignore[reportArgumentType]
+                indices=[index],
+                event_dataset_integrations=[],
+                metadata=SimpleNamespace(),  # type: ignore[reportArgumentType]
+                stack_version="9.3.0",
+                log=logged.append,
+            )
+
+        # non-ecs subfields collapsed onto the integration's `flattened` field
+        self.assertEqual(
+            index_lookup["rule-non-ecs-index"]["azure"]["properties"]["platformlogs"]["properties"]["properties"],
+            {"type": "flattened"},
+        )
+        # custom subfields collapsed onto the existing index template's `flattened` field
+        self.assertEqual(combined_mappings["custom_ns"]["properties"]["payload"], {"type": "flattened"})
+        warnings = [line for line in logged if "Mapping it as `flattened`" in line]
+        self.assertEqual(len(warnings), 3)
+        self.assertTrue(any("`azure.platformlogs.properties`" in w and "`non-ecs logs-azure" in w for w in warnings))
+        self.assertTrue(any("`azure.platformlogs.properties`" in w and "`rule-non-ecs-index`" in w for w in warnings))
+        self.assertTrue(any("`custom_ns.payload`" in w and "`existing-index-template-mappings`" in w for w in warnings))
 
 
 @unittest.skipIf(get_default_config() is None, "Skipping remote validation due to missing config")


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/6724

## Summary - What I changed


Historically, ES|QL did not support flattened fields at all so we had to for non-ecs convert those to `Object` types. Now we have to handle certain specific case where flattened is supported, while also maintaining the Object type workaround for cases where flattened is not supported.

ES|QL remote validation failed for rules that read a `flattened` field directly (for example `field_extract(azure.platformlogs.properties, "log.verb")` in [#6580](https://github.com/elastic/detection-rules/pull/6580)):

```
Error (EsqlTypeMismatchError): BadRequestError(400, 'verification_exception', 'Found 1 problem
line 5:34: Cannot use field [azure.platformlogs.properties] due to ambiguities being mapped as [2]
incompatible types: [flattened] in [test-azure-platformlogs...], [object] in [test-rule-non-ecs-index...]')
```

Both conflicting types come from mappings the validator itself generates, so the fix reconciles them before the test indices are created: when a field is typed `flattened` anywhere, that definition wins and conflicting `object` definitions are coerced to `flattened` (dropping their subfields).


## How To Test

1. Fetch and check out the rule file from PR #6580:
```
# Fetch the PR branch
git fetch origin pull/6580/head:pr-6580

# Copy just the rule file into the working tree
git checkout pr-6580 -- rules/integrations/azure/discovery_azure_aks_multi_resource_discovery.toml
```
2. Activate the venv and run remote validation:
```
source env/detection-rules-build/bin/activate

python -m detection_rules view-rule \
  --esql-remote-validation \
  rules/integrations/azure/discovery_azure_aks_multi_resource_discovery.toml
```

<img width="1400" height="419" alt="image" src="https://github.com/user-attachments/assets/bc8a4d12-9090-48fb-a6ef-487ec6fafaec" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
