### PR TITLE
UnifiedLogs SIEM Detection Coverage.

### DIFF
--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -203,6 +203,7 @@ EXPECTED_RULE_TAGS = [
     "Data Source: Splunk Forwarded Events",
     "Data Source: Suricata Logs",
     "Data Source: Sysmon Only",
+    "Data Source: Unified Logs",
     "Data Source: Windows Security Event Logs",
     "Data Source: Windows Sysmon Logs",
     "Data Source: Windows System Event Logs",

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -52,7 +52,7 @@ toc:
       - file: sysmon_eventid19_20_21_wmi_event.md
       - file: sysmon_eventid22_dns_query.md
       - file: sysmon_eventid23_file_delete.md
-  - folder: unified_logs
+  - folder: unifiedlogs
     children:
       - file: readme.md
       - file: com_apple_appleevents.md

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -52,3 +52,7 @@ toc:
       - file: sysmon_eventid19_20_21_wmi_event.md
       - file: sysmon_eventid22_dns_query.md
       - file: sysmon_eventid23_file_delete.md
+  - folder: unified_logs
+    children:
+      - file: readme.md
+      - file: com_apple_appleevents.md

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -56,3 +56,4 @@ toc:
     children:
       - file: readme.md
       - file: com_apple_appleevents.md
+      - file: com_apple_tccevents.md

--- a/docs/unifiedlogs/com_apple_appleevents.md
+++ b/docs/unifiedlogs/com_apple_appleevents.md
@@ -1,0 +1,50 @@
+# Apple Events
+
+## Setup
+
+Some detection rules require Apple Event debug telemetry from the `com.apple.appleevents` Unified Logs subsystem. Complete the [macOS Unified Logs](readme.md) setup first, then enable OS-level debug emission on each monitored macOS host.
+
+> **Note:** This step is specific to rules that depend on `com.apple.appleevents`. It is not required for general Unified Logs collection.
+
+The integration's debug flag controls what `log stream` displays but does **not** enable debug emission for subsystems suppressed at the OS level. The `com.apple.appleevents` subsystem is suppressed by default and must be explicitly enabled on each monitored host:
+
+```
+sudo log config --subsystem com.apple.appleevents --mode level:debug
+```
+
+Verify:
+
+```
+sudo log config --status --subsystem com.apple.appleevents
+```
+
+Expected output:
+
+```
+Mode for 'com.apple.appleevents'  DEBUG PERSIST_DEFAULT
+```
+
+Without this, `apple_event.type_code` will not populate and Apple Event detection rules will not fire.
+
+In a fleet deployment, run this command on each macOS endpoint or deploy via MDM/configuration management (for example, Jamf or Munki). The `sudo log config` change persists across reboots on the local host.
+
+## Fields
+
+When the integration is collecting debug-level logs and OS-level debug emission is enabled, the following structured fields may be populated for `com.apple.appleevents` events:
+
+* **unified_log.subsystem**: `com.apple.appleevents`
+* **apple_event.type_code**: four-character Apple Event class and ID (for example, `Jons,gClp`, `syso,dlog`, `aevt,odoc`)
+* **apple_event.parameters**: Apple Event parameter codes (for example, `htxt`)
+* **apple_event.direction**: send or receive direction
+* **apple_event.target_process**: target process for the Apple Event
+* **message**: raw Unified Log message, including patterns such as `AECreateAppleEvent`
+
+Rules that use structured `apple_event.*` fields require Unified Logs integration package version ≥ 0.5.0.
+
+## Related Rules
+
+* [Suspicious MacOS Apple Events Activity via Scripting Binary](https://github.com/elastic/detection-rules/blob/main/rules/integrations/unifiedlogs/collection_suspicious_apple_events_activity_via_scripting_binary.toml)
+
+Use the following GitHub search to identify additional rules that use these events:
+
+[Elastic Detection Rules GitHub Repo Search](https://github.com/search?q=repo%3Aelastic%2Fdetection-rules+%22Data+Source%3A+Unified+Logs%22+AND+%22com.apple.appleevents%22+language%3ATOML&type=code)

--- a/docs/unifiedlogs/com_apple_tccevents.md
+++ b/docs/unifiedlogs/com_apple_tccevents.md
@@ -1,0 +1,44 @@
+# TCC (Transparency, Consent, and Control) Events
+
+## Setup
+
+Some detection rules require Apple Event debug telemetry from the `com.apple.TCC` Unified Logs subsystem. Complete the [macOS Unified Logs](readme.md) setup first, then TCC subsystem require no additional OS-level log configuration
+
+> **Note:** This verification step is specific to rules that depend on `com.apple.TCC`.
+
+The integration's debug flag controls what `log stream` displays but does **not** enable debug emission for subsystems suppressed at the OS level. The `com.apple.appleevents` subsystem is suppressed by default and must be explicitly enabled on each monitored host:
+
+Verify:
+```
+sudo log config --status --subsystem com.apple.tcc
+```
+
+Expected output:
+
+```
+Mode for 'com.apple.tcc' INFO PERSIST_DEFAULT
+```
+
+When the Unified Logs integration is collecting, the following fields are populated for `com.apple.TCC` events
+under the default logging preset:
+
+* **unified_log.subsystem**: `com.apple.TCC`
+* **unified_log.category**: `access` (access decisions), among others
+* **message**: raw Unified Log message, including patterns such as `Handling access request to <service>`,
+  `... Denied (Service Policy)`, `does not allow prompting; recording denied`, and
+  `Publishing <TCCDEvent...> ... publishAccessChangedEvent`
+* **process.name / process.executable**: the requesting process, when resolvable from the log line
+
+Common TCC service identifiers seen in `message`: `kTCCServiceSystemPolicyAllFiles` (Full Disk Access),
+`kTCCServiceScreenCapture` (Screen Recording), `kTCCServiceCamera`, `kTCCServiceMicrophone`,
+`kTCCServiceListenEvent` (Input Monitoring).
+
+Rules that use structured `unified_log.*` fields require Unified Logs integration package version ≥ 0.5.0.
+
+## Related Rules
+
+* [Full Disk Access Denied via TCC](https://github.com/elastic/detection-rules/blob/main/rules/integrations/unifiedlogs/collection_full_disk_access_denied_via_tcc.toml)
+
+Use the following GitHub search to identify additional rules that use these events:
+
+[Elastic Detection Rules GitHub Repo Search](https://github.com/search?q=repo%3Aelastic%2Fdetection-rules+%22Data+Source%3A+Unified+Logs%22+AND+%22com.apple.TCC%22+language%3ATOML&type=code)

--- a/docs/unifiedlogs/readme.md
+++ b/docs/unifiedlogs/readme.md
@@ -1,0 +1,44 @@
+# macOS Unified Logs
+
+macOS Unified Logs configuration required to generate the events that power our detection rules. It serves as a centralized view of the Fleet integration and host-level logging settings we use so you don't need to go through every rule to know the different prerequisites.
+
+Some detection rules require collecting macOS Unified Logs through the Elastic Unified Logs integration. Complete the steps below on each monitored macOS host before enabling those rules.
+
+## Setup
+
+### Install the Unified Logs Integration
+
+The Unified Logs integration (Technical Preview) must be installed and healthy on the macOS host via Fleet.
+
+- In Kibana, go to **Management → Integrations**
+- Toggle on **Display beta integrations**
+- Search for **Unified Logs** and add it to your agent policy
+- Assign the policy to the macOS host running Elastic Agent ≥ 8.19.0
+
+For package details, see the [Custom macOS Unified Logs](https://www.elastic.co/docs/reference/integrations/unifiedlogs) integration documentation.
+
+### Enable debug log collection in the integration
+
+In the Fleet integration config, enable the following toggles:
+
+- **Include info** → on (required; default is off)
+- **Include debug** → on (required for Apple Event telemetry and other debug-level subsystems)
+- **Must backfill** → on (recommended for initial validation only — disable after confirming data flows)
+
+**Caution:** Debug-level Unified Logs can generate a high volume of events. Enable debug collection on a representative set of hosts, measure volume, and disable **Must backfill** after confirming data flows.
+
+## Additional Notes
+
+- Detection rules that use structured `apple_event.*` fields require Unified Logs integration package version ≥ 0.5.0.
+- Minimum Kibana version: 8.19.0.
+- Some Unified Log subsystems are suppressed at the OS level and will not emit events even when the integration debug flag is enabled. Those subsystems require an additional host-level `log config` change. See [Apple Events](com_apple_appleevents.md).
+
+## Related Guides
+
+* [Apple Events](com_apple_appleevents.md)
+
+## Related Rules
+
+Use the following GitHub search to identify rules that use Unified Logs:
+
+[Elastic Detection Rules GitHub Repo Search](https://github.com/search?q=repo%3Aelastic%2Fdetection-rules+%22Data+Source%3A+Unified+Logs%22+language%3ATOML&type=code)

--- a/rules/integrations/unifiedlogs/collection_denied_camera_or_microphone_access_via_tcc.toml
+++ b/rules/integrations/unifiedlogs/collection_denied_camera_or_microphone_access_via_tcc.toml
@@ -1,0 +1,109 @@
+[metadata]
+creation_date = "2026/09/03"
+integration = ["unifiedlogs"]
+maturity = "production"
+updated_date = "2026/09/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects a denied Camera or Microphone consent prompt via macOS TCC telemetry. 
+Spyware and surveillance tools attempt to activate the camera or microphone to record the user without authorization.
+Detection is based on the tccd CFUserNotification response decision record for kTCCServiceCamera or kTCCServiceMicrophone.
+"""
+false_positives = [
+    """
+    Video conferencing tools (Zoom, FaceTime, Teams), voice recording applications, and communication software
+    will trigger camera and microphone denials before the user grants access. Browser-based conferencing may also
+    trigger these events when requesting media permissions for the first time.
+    """,
+]
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Camera or Microphone Access Denied via TCC"
+note = """## Triage and analysis
+
+### Investigating Camera or Microphone Access Denied via TCC
+
+This rule detects when an application is denied Camera or Microphone access by macOS TCC. The `kTCCServiceCamera` and `kTCCServiceMicrophone` services control which applications can access the device's camera and microphone respectively.
+
+### Possible investigation steps
+
+- Review the `message` field to identify which service was denied (Camera vs. Microphone) and the process identity (bundle ID, binary path, PID).
+- Correlate the denied process with Elastic Defend telemetry to understand how the process was launched.
+- Check if the application is a known communication or conferencing tool, or if it is unexpected on the host.
+- Look for related TCC denials (e.g., screen capture) from the same process, which may indicate surveillance or spyware behavior.
+- Check if the same process has been repeatedly denied, which could indicate persistent spyware attempting to activate recording.
+- Review the host for recently installed applications or persistence mechanisms that could be associated with the denied process.
+
+### False positive analysis
+
+- Zoom, FaceTime, Microsoft Teams, Slack, and other conferencing tools generate these events before being granted access.
+- Web browsers (Safari, Chrome) trigger camera/mic denials when websites request media access.
+- Voice memo, dictation, and accessibility tools may access the microphone legitimately.
+
+### Response and remediation
+
+- If the denied application is unknown or suspicious, isolate the host and investigate the process.
+- Check for indicators of spyware or surveillance tools (persistent camera/mic access attempts, exfiltration behaviors).
+- Review network connections from the denied process for data exfiltration.
+"""
+references = [
+    "https://www.phorion.tech/articles/the-clock-is-tccing/",
+    "https://www.elastic.co/docs/reference/integrations/unifiedlogs",
+]
+risk_score = 21
+rule_id = "816933da-57dd-4c07-a65a-91616b8871cb"
+setup = """## Setup
+
+The Unified Logs integration must be installed and collecting debug-level telemetry on the macOS host.
+
+Specific Setup instructions can be found in the following documentation:
+- [macOS Unified Logs](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/readme)
+- [TCC Events](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/com_apple_tccevents)
+"""
+severity = "low"
+tags = [
+    "Tactic: Collection",
+    "Use Case: Threat Detection",
+    "Data Source: Unified Logs",
+    "Rule Type: ESQL",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM logs-unifiedlogs* METADATA _id, _version, _index
+| WHERE event.dataset == "unifiedlogs.log" AND host.os.type == "macos" AND unified_log.subsystem == "com.apple.TCC"
+    AND unified_log.category == "access"
+    AND message LIKE "*CFUserNotification response*"
+    AND (message LIKE "*kTCCServiceMicrophone*" OR message LIKE "*kTCCServiceCamera*")
+| KEEP _id, _version, _index,
+    @timestamp,
+    host.name,
+    data_stream.namespace,
+    data_stream.type,
+    process.name,
+    process.pid,
+    unified_log.subsystem,
+    message
+| SORT @timestamp DESC
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1125"
+name = "Video Capture"
+reference = "https://attack.mitre.org/techniques/T1125/"
+
+[[rule.threat.technique]]
+id = "T1123"
+name = "Audio Capture"
+reference = "https://attack.mitre.org/techniques/T1123/"
+
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"

--- a/rules/integrations/unifiedlogs/collection_denied_screen_capture_via_tcc.toml
+++ b/rules/integrations/unifiedlogs/collection_denied_screen_capture_via_tcc.toml
@@ -1,0 +1,106 @@
+[metadata]
+creation_date = "2026/09/03"
+integration = ["unifiedlogs"]
+maturity = "production"
+updated_date = "2026/09/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects a denied Screen Capture access request via macOS TCC telemetry. 
+Attackers and spyware use screen recording to capture credentials, chat logs, and sensitive on-screen content. 
+Detection is based on the tccd `Update Access Record` decision record for `kTCCServiceScreenCapture` set to Denied.
+"""
+false_positives = [
+    """
+    Video conferencing tools (Zoom, Teams, Slack), screen recording software, and remote desktop applications will
+    trigger denied events before the user grants screen capture access. Accessibility and assistive technology tools
+    may also generate these events during normal operation.
+    """,
+]
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Screen Capture Access Denied via TCC"
+note = """## Triage and analysis
+
+### Investigating Screen Capture Access Denied via TCC
+
+This rule detects when an application is denied Screen Capture permission by macOS TCC. The `kTCCServiceScreenCapture` service controls which applications can capture the contents of the screen.
+
+### Possible investigation steps
+
+- Review the `message` field to extract the process identity (bundle ID, binary path, PID) of the denied application.
+- Correlate the denied process with Elastic Defend telemetry to determine how the process was launched and its parent chain.
+- Check if the application is a known screen sharing or conferencing tool, or if it is unexpected on the host.
+- Look for related TCC denials (e.g., camera, microphone) from the same process, which may indicate spyware behavior.
+- Check for preceding Apple Event activity such as `syso,exec` or `syso,dlog` that may indicate the screen capture attempt was part of a stealer payload.
+
+### False positive analysis
+
+- Zoom, Microsoft Teams, Slack, Google Meet, and other conferencing tools commonly trigger screen capture denials before being granted access.
+- Screen recording and screenshot utilities will trigger these events.
+- Remote desktop and IT support tools may generate denials during initial deployment.
+
+### Response and remediation
+
+- If the denied application is unknown or suspicious, isolate the host and investigate the process.
+- Review whether the application has other suspicious behaviors (network connections, file access, clipboard access).
+- Check for data exfiltration indicators if the application was recently granted screen capture access.
+"""
+references = [
+    "https://www.phorion.tech/articles/the-clock-is-tccing/",
+    "https://www.elastic.co/docs/reference/integrations/unifiedlogs",
+]
+risk_score = 21
+rule_id = "bd1a7412-cfbe-4d32-af9d-e969482a1400"
+setup = """## Setup
+
+The Unified Logs integration must be installed and collecting debug-level telemetry on the macOS host.
+
+Specific Setup instructions can be found in the following documentation:
+- [macOS Unified Logs](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/readme)
+- [TCC Events](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/com_apple_tccevents)
+"""
+severity = "low"
+tags = [
+    "Tactic: Collection",
+    "Use Case: Threat Detection",
+    "Data Source: Unified Logs",
+    "Rule Type: ESQL",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM logs-unifiedlogs* METADATA _id, _version, _index
+| WHERE event.dataset == "unifiedlogs.log" AND host.os.type == "macos" AND unified_log.subsystem == "com.apple.TCC"
+    AND unified_log.category == "access"
+    AND message LIKE "*kTCCServiceScreenCapture*"
+    AND (
+    (message LIKE "*Update Access Record*" AND message LIKE "*to Denied*")
+    OR message LIKE "*does not allow prompting*"
+    )
+| KEEP _id, _version, _index,
+    @timestamp,
+    host.name,
+    data_stream.namespace,
+    data_stream.type,
+    process.name,
+    process.pid,
+    unified_log.subsystem,
+    message
+| SORT @timestamp DESC
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1113"
+name = "Screen Capture"
+reference = "https://attack.mitre.org/techniques/T1113/"
+
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"

--- a/rules/integrations/unifiedlogs/collection_full_disk_access_denied_via_tcc.toml
+++ b/rules/integrations/unifiedlogs/collection_full_disk_access_denied_via_tcc.toml
@@ -1,0 +1,105 @@
+[metadata]
+creation_date = "2026/09/03"
+integration = ["unifiedlogs"]
+maturity = "production"
+updated_date = "2026/09/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects a denied Full Disk Access (FDA) request via macOS's Transparency, Consent, and Control (TCC) privacy framework. 
+Attackers abuse or probe kTCCServiceSystemPolicyAllFiles to access files protected by Full Disk Access, including Mail databases, 
+Safari data, and Time Machine backups, without holding the required entitlement. Detection is based on direct tccd access-decision 
+message matching, identifying explicit denial events emitted when the requesting process lacks Full Disk Access.
+"""
+false_positives = [
+    """
+    Legitimate applications that have not been granted Full Disk Access will generate denied events during normal
+    operation. Common examples include backup utilities, antivirus software, and file management tools that attempt
+    to access protected directories. Review the source process and determine if the application is expected on the host.
+    """,
+]
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Full Disk Access Denied via TCC"
+note = """## Triage and analysis
+
+### Investigating Full Disk Access Denied via TCC
+
+This rule detects when an application is denied Full Disk Access by macOS TCC (Transparency, Consent, and Control). The `kTCCServiceSystemPolicyAllFiles` service controls access to all files on disk, including protected directories like Mail, Safari, and Time Machine data.
+
+### Possible investigation steps
+
+- Review the `message` field to extract the process identity (bundle ID, binary path, PID) of the application that was denied.
+- Correlate the denied process with Elastic Defend telemetry to understand what the process is and how it was launched.
+- Check if the application is known/expected on the host or if it was recently installed.
+- Look for repeated FDA denial events from the same process, which may indicate persistent attempts to access protected data.
+- Check for other TCC denials or Apple Event activity on the same host that may indicate a broader attack chain (e.g., credential harvesting followed by data collection attempts).
+
+### False positive analysis
+
+- Security tools, backup utilities, and IT management software commonly trigger FDA denials before being explicitly granted access by an administrator.
+- Applications launched for the first time may trigger denials before the user grants access via System Settings > Privacy & Security.
+- Development tools and terminal emulators may trigger denials when accessing protected directories.
+
+### Response and remediation
+
+- If the denied application is unknown or suspicious, isolate the host and investigate the process origin.
+- Check whether the application attempted to access sensitive data directories (Mail, Safari, SSH keys, etc.).
+- Review the host for additional indicators of compromise or stealer malware activity.
+"""
+references = [
+    "https://www.phorion.tech/articles/the-clock-is-tccing/",
+    "https://www.elastic.co/docs/reference/integrations/unifiedlogs",
+]
+risk_score = 47
+rule_id = "543e1a79-acec-4389-8e76-58d69f502c26"
+setup = """## Setup
+
+The Unified Logs integration must be installed and collecting debug-level telemetry on the macOS host.
+
+Specific Setup instructions can be found in the following documentation:
+- [macOS Unified Logs](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/readme)
+- [TCC Events](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/com_apple_tccevents)
+"""
+severity = "medium"
+tags = [
+    "Tactic: Collection",
+    "Use Case: Threat Detection",
+    "Data Source: Unified Logs",
+    "Rule Type: ESQL",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM logs-unifiedlogs* METADATA _id, _version, _index
+| WHERE event.dataset == "unifiedlogs.log" AND host.os.type == "macos" AND unified_log.subsystem == "com.apple.TCC"
+    AND unified_log.category == "access"
+    AND message LIKE "*kTCCServiceSystemPolicyAllFiles*"
+    AND message LIKE "*Handling access request*"
+    AND message LIKE "*Denied*"
+| KEEP _id, _version, _index,
+    @timestamp,
+    host.name,
+    data_stream.namespace,
+    data_stream.type,
+    process.name,
+    process.pid,
+    unified_log.subsystem,
+    message
+| SORT @timestamp DESC
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1005"
+name = "Data from Local System"
+reference = "https://attack.mitre.org/techniques/T1005/"
+
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"

--- a/rules/integrations/unifiedlogs/collection_suspicious_apple_events_activity_via_scripting_binary.toml
+++ b/rules/integrations/unifiedlogs/collection_suspicious_apple_events_activity_via_scripting_binary.toml
@@ -1,0 +1,159 @@
+[metadata]
+creation_date = "2026/09/03"
+integration = ["unifiedlogs"]
+maturity = "production"
+updated_date = "2026/09/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects suspicious use of Apple Events macOS's inter-process communication mechanism by scripting binaries. 
+Attackers abuse Apple Events to perform privileged actions without elevated permissions, including clipboard theft, 
+keystroke capture, screenshot capture, shell execution, and browser or credential access. 
+Detection is layered with direct event type matching (type_code) covering first-invocation structured events, 
+AECreateAppleEvent message patterns covering repeat invocations, and 
+coercion burst signals provide a catch-all for every new process initialization.
+"""
+false_positives = [
+    "Legitimate automation scripts using osascript for system administration may trigger this rule. Validate the process parent, user context, and whether the script is signed or comes from a known path.",
+    "Audio or accessibility tools that set volume via osascript may trigger aevt,stvl.",
+    "Password dialogs shown by legitimate CoreServices apps via scripting bridges may trigger syso,dlog.",
+]
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Suspicious macOS Apple Events Activity via Scripting Binary"
+references = [
+    "https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptLangGuide/introduction/ASLR_intro.html",
+    "https://pberba.github.io/security/2026/02/21/aemonitor/",
+]
+risk_score = 47
+rule_id = "efbb19c3-45e2-4e3a-968e-0d97d5691c71"
+setup = """## Setup
+
+The Unified Logs integration must be installed and collecting debug-level telemetry on the macOS host.
+
+Specific Setup instructions can be found in the following documentation:
+- [macOS Unified Logs](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/readme)
+- [Apple Events](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/com_apple_appleevents)
+"""
+severity = "medium"
+tags = [
+    "Tactic: Collection",
+    "Tactic: Execution",
+    "Tactic: Discovery",
+    "Tactic: Credential Access",
+    "Tactic: Defense Evasion",
+    "Use Case: Threat Detection",
+    "Data Source: Unified Logs",
+    "Rule Type: ESQL",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM logs-unifiedlogs* METADATA _id, _index, _version
+| WHERE host.os.type == "macos"
+    AND unified_log.subsystem == "com.apple.appleevents"
+    AND (
+        process.name IN ("osascript", "bash", "zsh", "sh", "tcsh", "fish", "ksh", "dash", "node")
+        OR process.name RLIKE "python.*|ruby.*|perl.*"
+    )
+    AND (
+        apple_event.type_code IN (
+        "Jons,gClp", "aevt,stvl", "syso,ntoc",
+        "syso,exec", "syso,dsct", "Jons,doSH", "Jons,kGET",
+        "Jons,sSCR", "Jons,gSYS", "fndr,read", "aevt,odoc", "core,getd"
+        )
+    OR (apple_event.type_code == "syso,dlog" AND apple_event.parameters == "htxt")
+    OR message RLIKE ".*AECreateAppleEvent.*\\((Jons,gClp| syso,dlog| aevt,stvl| syso,ntoc| syso,exec| syso,dsct| Jons,doSH| Jons,kGET| Jons,sSCR| Jons,gSYS| fndr,read| aevt,odoc| core,getd) .*"
+    OR CONTAINS(message, "Add coercion from TEXT to url")
+    OR CONTAINS(message, "ALLOWING SAFE EVENT")
+)
+| KEEP _id, _version, _index,
+    @timestamp,
+    host.name,
+    data_stream.namespace,
+    data_stream.type,
+    process.name,
+    process.pid,
+    unified_log.subsystem,
+    apple_event.type_code,
+    apple_event.direction,
+    apple_event.target_process,
+    apple_event.parameters,
+    message
+| SORT @timestamp DESC
+| LIMIT 100
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1115"
+name = "Clipboard Data"
+reference = "https://attack.mitre.org/techniques/T1115/"
+[[rule.threat.technique]]
+id = "T1113"
+name = "Screen Capture"
+reference = "https://attack.mitre.org/techniques/T1113/"
+[[rule.threat.technique]]
+id = "T1056"
+name = "Input Capture"
+reference = "https://attack.mitre.org/techniques/T1056/"
+[rule.threat.tactic]
+id = "TA0009"
+name = "Collection"
+reference = "https://attack.mitre.org/tactics/TA0009/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1059"
+name = "Command and Scripting Interpreter"
+reference = "https://attack.mitre.org/techniques/T1059/"
+[[rule.threat.technique.subtechnique]]
+id = "T1059.002"
+name = "AppleScript"
+reference = "https://attack.mitre.org/techniques/T1059/002/"
+[rule.threat.tactic]
+id = "TA0002"
+name = "Execution"
+reference = "https://attack.mitre.org/tactics/TA0002/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1082"
+name = "System Information Discovery"
+reference = "https://attack.mitre.org/techniques/T1082/"
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1552"
+name = "Unsecured Credentials"
+reference = "https://attack.mitre.org/techniques/T1552/"
+[[rule.threat.technique]]
+id = "T1056"
+name = "Input Capture"
+reference = "https://attack.mitre.org/techniques/T1056/"
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1027"
+name = "Obfuscated Files or Information"
+reference = "https://attack.mitre.org/techniques/T1027/"
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"

--- a/rules/integrations/unifiedlogs/collection_suspicious_apple_events_activity_via_scripting_binary.toml
+++ b/rules/integrations/unifiedlogs/collection_suspicious_apple_events_activity_via_scripting_binary.toml
@@ -84,7 +84,6 @@ FROM logs-unifiedlogs* METADATA _id, _index, _version
     apple_event.parameters,
     message
 | SORT @timestamp DESC
-| LIMIT 100
 '''
 
 [[rule.threat]]

--- a/rules/integrations/unifiedlogs/defense_evasion_tcc_permission_change_detected.toml
+++ b/rules/integrations/unifiedlogs/defense_evasion_tcc_permission_change_detected.toml
@@ -1,0 +1,110 @@
+[metadata]
+creation_date = "2026/09/03"
+integration = ["unifiedlogs"]
+maturity = "production"
+updated_date = "2026/09/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects TCC permission changes on macOS via the publishAccessChangedEvent message in the com.apple.TCC Unified Logs subsystem. 
+Permissions can be granted (auth_value=2) or revoked/denied (auth_value=0) for services like Full Disk Access, Screen Capture,
+Camera, Microphone, or Accessibility. Unexpected changes may indicate TCC database tampering, a known technique used by macOS malware 
+to bypass privacy protections.
+"""
+false_positives = [
+    """
+    Users granting or revoking application permissions via System Settings > Privacy & Security will generate these
+    events. MDM-managed permission profiles and IT administration changes will also trigger this rule. Review the
+    context of the permission change to determine if it was user-initiated.
+    """,
+]
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "TCC Privacy Permission Change Detected"
+note = """## Triage and analysis
+
+### Investigating TCC Privacy Permission Change Detected
+
+This rule detects `publishAccessChangedEvent` in TCC logs, which fires when a TCC permission entry is created, modified, or removed. This includes both user-initiated changes (via System Settings) and programmatic modifications (via `tccutil`, direct TCC.db manipulation, or MDM profiles). The query keeps both allowed and denied outcomes because `auth_value=2` can indicate a new grant while `auth_value=0` can indicate a denial, revocation, or reset.
+
+### Possible investigation steps
+
+- Review the `message` field to determine which TCC service permission was changed and for which application.
+- Check if the change was user-initiated by correlating with System Settings or MDM activity.
+- Look for `tccutil reset` or direct TCC.db file access events that may indicate programmatic permission manipulation.
+- Check if the permission change grants access to sensitive services (Full Disk Access, Accessibility, Screen Capture) for an unexpected application.
+- Correlate with process execution logs to determine if any suspicious process triggered the permission change.
+- Review the host for signs of TCC.db manipulation (e.g., SIP bypass, direct database writes, fake TCC.db attacks).
+
+### False positive analysis
+
+- User-initiated permission changes via System Settings are normal administrative activity.
+- MDM-managed devices commonly have permissions pushed via configuration profiles, which generate these events.
+- Application installers may request and receive permissions during setup.
+- macOS updates may reset or modify TCC permissions.
+
+### Response and remediation
+
+- If the permission change is unauthorized, immediately review what access was granted and to which application.
+- Revoke any suspicious permissions via System Settings or `tccutil reset`.
+- Investigate the source of the change — if TCC.db was directly modified, this may indicate SIP bypass or privilege escalation.
+- Check for persistence mechanisms associated with the application that received the permission change.
+"""
+references = [
+    "https://www.phorion.tech/articles/the-clock-is-tccing/",
+    "https://www.elastic.co/docs/reference/integrations/unifiedlogs",
+]
+risk_score = 47
+rule_id = "a96b3d0f-beb1-413d-b498-114ad6d26965"
+setup = """## Setup
+
+The Unified Logs integration must be installed and collecting debug-level telemetry on the macOS host.
+
+Specific Setup instructions can be found in the following documentation:
+- [macOS Unified Logs](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/readme)
+- [TCC Events](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/com_apple_tccevents)
+"""
+severity = "medium"
+tags = [
+    "Tactic: Defense Evasion",
+    "Use Case: Threat Detection",
+    "Data Source: Unified Logs",
+    "Rule Type: ESQL",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM logs-unifiedlogs* METADATA _id, _version, _index
+| WHERE event.dataset == "unifiedlogs.log" AND host.os.type == "macos" AND unified_log.subsystem == "com.apple.TCC"
+AND message LIKE "*publishAccessChangedEvent*"
+| KEEP _id, _version, _index,
+    @timestamp,
+    host.name,
+    data_stream.namespace,
+    data_stream.type,
+    process.name,
+    process.pid,
+    unified_log.subsystem,
+    message
+| SORT @timestamp DESC
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1562"
+name = "Impair Defenses"
+reference = "https://attack.mitre.org/techniques/T1562/"
+[[rule.threat.technique.subtechnique]]
+id = "T1562.001"
+name = "Disable or Modify Tools"
+reference = "https://attack.mitre.org/techniques/T1562/001/"
+
+[rule.threat.tactic]
+id = "TA0005"
+name = "Defense Evasion"
+reference = "https://attack.mitre.org/tactics/TA0005/"
+

--- a/rules/integrations/unifiedlogs/discovery_tcc_permission_probing_without_prompt.toml
+++ b/rules/integrations/unifiedlogs/discovery_tcc_permission_probing_without_prompt.toml
@@ -1,0 +1,109 @@
+[metadata]
+creation_date = "2026/09/03"
+integration = ["unifiedlogs"]
+maturity = "production"
+updated_date = "2026/09/03"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects applications probing TCC-protected services they cannot prompt for, via the com.apple.TCC subsystem's access category. 
+When a service "does not allow prompting" and the request is auto-denied, it indicates an app attempted a protected resource 
+(e.g., Accessibility, Full Disk Access, Screen Capture) without the entitlement to trigger a user consent prompt. 
+Malware may probe TCC services to discover available permissions without user interaction.
+"""
+false_positives = [
+    """
+    Some legitimate applications may probe TCC services during initialization to determine available capabilities.
+    Security tools and endpoint agents commonly check for accessibility or full disk access permissions on startup.
+    Review the source process and frequency of probing events to determine if the activity is expected.
+    """,
+]
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "TCC Permission Probing Without Prompt Entitlement"
+note = """## Triage and analysis
+
+### Investigating TCC Permission Probing Without Prompt Entitlement
+
+This rule detects the "does not allow prompting" TCC pattern, which indicates an application attempted to access a protected service but lacks the entitlement to trigger the user consent dialog. The request is automatically denied. This is distinct from a user-denied request and often indicates unauthorized permission probing. The query requires a denied result to avoid matching unknown permission lookups.
+
+### Possible investigation steps
+
+- Review the `message` field to identify which TCC service was probed and the process identity (bundle ID, binary path, PID).
+- Check if the application is known and whether it legitimately requires the probed permission.
+- Look for multiple distinct TCC services being probed by the same process, which may indicate systematic permission enumeration.
+- Correlate with Elastic Defend telemetry to understand how the process was launched and its parent chain.
+- Check if the probing process was recently installed, downloaded, or executed from a suspicious location (e.g., `/tmp/`, `/Users/Shared/`).
+- Review other TCC events and Apple Event activity on the same host for related attack chain indicators.
+
+### False positive analysis
+
+- Endpoint security agents and IT management tools commonly probe for Accessibility and Full Disk Access permissions on startup.
+- Applications performing feature discovery may check which permissions are available before offering functionality.
+- Development tools and scripts may trigger this pattern during testing.
+
+### Response and remediation
+
+- If the probing application is unknown or suspicious, investigate its origin and purpose.
+- Systematic probing across multiple TCC services from a single process is a strong indicator of malicious reconnaissance.
+- Isolate the host if additional indicators of compromise are identified.
+"""
+references = [
+    "https://www.phorion.tech/articles/the-clock-is-tccing/",
+    "https://www.elastic.co/docs/reference/integrations/unifiedlogs",
+]
+risk_score = 47
+rule_id = "f08230a3-4bf1-488c-953d-6f4853f1bbfc"
+setup = """## Setup
+
+The Unified Logs integration must be installed and collecting debug-level telemetry on the macOS host.
+
+Specific Setup instructions can be found in the following documentation:
+- [macOS Unified Logs](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/readme)
+- [TCC Events](https://www.elastic.co/docs/reference/security/prebuilt-rules/unified_logs/com_apple_tccevents)
+"""
+severity = "medium"
+tags = [
+    "Tactic: Discovery",
+    "Use Case: Threat Detection",
+    "Data Source: Unified Logs",
+    "Rule Type: ESQL",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+FROM logs-unifiedlogs* METADATA _id, _version, _index 
+| WHERE event.dataset == "unifiedlogs.log" AND host.os.type == "macos" AND unified_log.subsystem == "com.apple.TCC"
+    AND unified_log.category == "access"
+    AND message LIKE "*does not allow prompting*"
+    AND (message LIKE "*returning denied*" OR message LIKE "*recording denied*")
+| KEEP _id, _version, _index,
+    @timestamp,
+    host.name,
+    data_stream.namespace,
+    data_stream.type,
+    process.name,
+    process.pid,
+    unified_log.subsystem,
+    message
+| SORT @timestamp DESC
+'''
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1518"
+name = "Software Discovery"
+reference = "https://attack.mitre.org/techniques/T1518/"
+[[rule.threat.technique.subtechnique]]
+id = "T1518.001"
+name = "Security Software Discovery"
+reference = "https://attack.mitre.org/techniques/T1518/001/"
+
+[rule.threat.tactic]
+id = "TA0007"
+name = "Discovery"
+reference = "https://attack.mitre.org/tactics/TA0007/"


### PR DESCRIPTION
## Summary

Blocked on https://github.com/elastic/integrations/issues/21060

<details><summary><b>macOS Apple Events Activity</b></summary>

#### Overview

Adds a new ES|QL detection rule covering suspicious macOS Apple Events activity originating from scripting binaries. The rule detects a broad range of attacker techniques that leverage the macOS Apple Events inter-process communication subsystem from clipboard theft to credential harvesting using a layered three-tier detection approach that overcomes a fundamental macOS privacy logging limitation.

macOS Unified Logs expose Apple Events activity via com.apple.appleevents, but only log structured event payloads (type_code, direction, parameters) on the first Apple Events framework initialisation per process lifecycle a behaviour controlled by the %{public}s / %{private}s logging privacy tiers. All subsequent Apple Events from the same process fall back to low-level AEGetAttributePtr calls with <private> redacted payloads. A rule relying solely on apple_event.type_code therefore fires once per attacker session at most missing all repeat executions.

#### Validation Results

Telemetry Available on Trade Threat Lab

<img width="1722" height="862" alt="image" src="https://github.com/user-attachments/assets/798ee826-ba0c-4995-be21-19e2ee6d0a98" />


| PID | Timestamp (UTC) | Scenario | Signal Fired | Result |
|---|---|---|---|---|
| 1391 | 2026-08-20T13:21:56 | Volume mute | `sendToSelf(aevt,stvl)` reply `{mute=true}` | ✅ |
| 1401 | 2026-08-20T13:22:08 | Password prompt spoof | `sendToSelf(syso,dlog)` reply `{bhit=OK, ttxt=123}` | ✅ |
| 1413 | 2026-08-20T13:22:14 | Clipboard access | `AECreateAppleEvent(Jons,gClp)` reply `{----=sensitive_data}` | ✅ |
| 1417 | 2026-08-20T13:22:19 | ASCII obfuscation + shell exec | `sendToSelf(syso,ntoc)` reply `{----="l"}` then `{----="s"}` → `sendToSelf(syso,exec)` reply exposes directory listing | ✅ |
| 1423 | 2026-08-20T13:22:24 | Hidden file exec | `sendToSelf(syso,exec)` payload contains `/tmp/.hidden_test.sh` | ✅ |
| 1429 | 2026-08-20T13:22:30 | Safari URL access | `AECreateAppleEvent(core,getd)` → `sendToModernProcess(Safari port:28931)` → `ALLOWING SAFE EVENT aevt/ansr` | ✅ |
| 1433 | 2026-08-20T13:22:35 | Keychain access via shell | `sendToSelf(syso,exec)` payload contains `security find-generic-password` | ✅ |

</details>

<details><summary><b> TCC Event Details </b></summary>

#### Overview

Adds 5 new ES|QL detection rules for macOS TCC (Transparency, Consent, and Control) privacy framework abuse, built on the `logs-unifiedlogs*` Unified Logs integration. Covers denial and probing patterns across Full Disk Access, Screen Capture, Camera/Microphone, and TCC database tampering. All rules query the `com.apple.TCC` subsystem's `access` category and run at **default INFO log level** no debug-mode logging configuration required.

#### Validation

All data is available in TRADE Threat Lab 

<img width="1619" height="913" alt="image" src="https://github.com/user-attachments/assets/7a894adf-1fbb-4987-8a2a-0fdfa13c6e2f" />

<img width="1632" height="913" alt="image" src="https://github.com/user-attachments/assets/540b204d-349a-4901-8d82-2e7d4c67b0ef" />

<img width="1630" height="911" alt="image" src="https://github.com/user-attachments/assets/d46d4f1e-6d2c-478e-aaf7-317084e059e7" />

<img width="1627" height="909" alt="image" src="https://github.com/user-attachments/assets/feb4bd3f-2cd6-4084-8512-976ebbfcdf20" />

<img width="1626" height="912" alt="image" src="https://github.com/user-attachments/assets/a5fc19fa-b1cf-4323-9f4e-ef2944a04e86" />

</details> 