### PR TITLE
[Tuning] Protected Storage Service Access via SMB

### DIFF
--- a/rules/windows/credential_access_protected_storage_service_access.toml
+++ b/rules/windows/credential_access_protected_storage_service_access.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/06/26"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2026/06/26"
+updated_date = "2026/09/04"
 
 [rule]
 author = ["Elastic"]
@@ -70,7 +70,7 @@ tags = [
     "Data Source: Windows Security Event Logs",
 ]
 timestamp_override = "event.ingested"
-type = "query"
+type = "new_terms"
 
 query = '''
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -119,3 +119,11 @@ reference = "https://attack.mitre.org/techniques/T1021/002/"
 id = "TA0008"
 name = "Lateral Movement"
 reference = "https://attack.mitre.org/tactics/TA0008/"
+
+
+[rule.new_terms]
+field = "new_terms_fields"
+value = ["user.name", "host.name"]
+[[rule.new_terms.history_window_start]]
+field = "history_window_start"
+value = "now-7d"


### PR DESCRIPTION
convert to new_term to reduce alert volume, the FP looks exactly same as standard Windows named pipe used by services like DPAPI/LSA. the only suspicious flag is the couple user.name target host, those are the new_term values.