### PR TITLE
[Tuning] AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN

### DIFF
--- a/rules/integrations/aws/initial_access_assume_role_with_web_identity_kubernetes_sa_from_external_asn.toml
+++ b/rules/integrations/aws/initial_access_assume_role_with_web_identity_kubernetes_sa_from_external_asn.toml
@@ -92,7 +92,8 @@ data_stream.dataset:aws.cloudtrail and
     *container.googleapis.com*
   ) and
   source.as.organization.name:("Microsoft Corporation" or "Google LLC")
-)
+) and 
+not user.id:((*oidc.s3* and *ocp*) or (*s3* and *amazonaws.com* and *oidc*))
 '''
 
 [rule.investigation_fields]

--- a/rules/integrations/aws/initial_access_assume_role_with_web_identity_kubernetes_sa_from_external_asn.toml
+++ b/rules/integrations/aws/initial_access_assume_role_with_web_identity_kubernetes_sa_from_external_asn.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/04/22"
 integration = ["aws"]
 maturity = "production"
-updated_date = "2026/06/01"
+updated_date = "2026/09/05"
 
 [rule]
 author = ["Elastic"]
@@ -85,7 +85,14 @@ data_stream.dataset:aws.cloudtrail and
  event.provider:sts.amazonaws.com and 
  event.action:AssumeRoleWithWebIdentity and 
  event.outcome:success and user.name:(system\:serviceaccount\:* and not system\:serviceaccount\:kube-system\:aws-load-balancer-controller) and 
- source.as.organization.name:(* and not (Amazon* or AMAZON*))
+ source.as.organization.name:(* and not (Amazon* or AMAZON*)) and 
+ not (
+  user.id:(
+    *oic.prod-aks.azure.com* or
+    *container.googleapis.com*
+  ) and
+  source.as.organization.name:("Microsoft Corporation" or "Google LLC")
+)
 '''
 
 [rule.investigation_fields]


### PR DESCRIPTION
Excludes cross-cloud workloads (GKA / AKS SA -> AWS) and Self-managed OCP and Generic S3-hosted OIDC.