### PR TITLE
[New] Entra ID Federated Identity Credential Added

### DIFF
--- a/rules/integrations/azure/persistence_entra_id_federated_identity_credential_added.toml
+++ b/rules/integrations/azure/persistence_entra_id_federated_identity_credential_added.toml
@@ -1,0 +1,128 @@
+[metadata]
+creation_date = "2026/09/06"
+integration = ["azure"]
+maturity = "production"
+min_stack_version = "9.3.0"
+min_stack_comments = "Changing min stack to 9.3.0, the latest minimum supported version for 9.X releases."
+updated_date = "2026/09/06"
+
+[rule]
+author = ["Elastic"]
+description = """
+Detects when a federated identity credential is added to an Entra ID application that previously had none. Federated
+identity credentials establish trust with an external OpenID Connect identity provider, allowing a client to
+authenticate as the application's service principal by presenting an externally issued token instead of a managed
+secret or certificate. Adversaries with sufficient privileges (for example, Application Administrator, application
+owner, or a service principal holding Application.ReadWrite.All) can add a federated identity credential that trusts
+an attacker-controlled identity provider, establishing persistent access to Azure resources without managing any
+secret and without triggering secret- or certificate-based credential monitoring.
+"""
+from = "now-9m"
+language = "esql"
+license = "Elastic License v2"
+name = "Entra ID Federated Identity Credential Added"
+note = """## Triage and analysis
+
+### Investigating Entra ID Federated Identity Credential Added
+
+This rule detects when a federated identity credential is added to an Entra ID application that had no federated identity credential before the change. Federated identity credentials let an application authenticate using tokens minted by an external identity provider (such as GitHub Actions, AWS, or a custom OpenID Connect provider) without managing secrets or certificates. Because the trust is external, adding a federated identity credential that points to an attacker-controlled identity provider grants persistent access to the application's service principal and its assigned permissions, while bypassing secret-based credential monitoring and MFA controls.
+
+This rule is scoped to the initial addition of a federated identity credential where none existed previously. Modifications that change the issuer of an existing federated identity credential are covered by the companion rule "Entra ID Federated Identity Credential Issuer Modified".
+
+### Possible investigation steps
+
+- Review `azure.auditlogs.properties.initiated_by.user.userPrincipalName` and `ipAddress` to identify who added the credential and from where, and determine whether that account normally manages application credentials.
+- Examine `Esql.external_idp_new_issuer` to determine whether the new issuer is a known, organization-controlled identity provider or an external/suspicious domain.
+- Inspect the target application in `azure.auditlogs.properties.target_resources` and review the application's assigned roles and API permissions to understand the scope of access that the credential grants.
+- Use `azure.correlation_id` to pivot to related changes in the same session, such as role assignments or additional credential additions.
+- Check for subsequent Azure sign-in activity using the newly added federated credential (federated client-credentials sign-ins).
+- Determine whether the change is associated with a legitimate deployment, CI/CD onboarding, or workload-identity-federation project.
+
+### False positive analysis
+
+- Onboarding a workload to workload identity federation (for example, connecting GitHub Actions, GitLab, or another cloud to Azure) legitimately adds a federated identity credential.
+- DevOps teams may add federated identity credentials as part of CI/CD pipeline setup or a migration away from client secrets.
+- Validate any addition with the application owner or DevOps team before taking action.
+
+### Response and remediation
+
+- If the addition is unauthorized, immediately remove the federated identity credential from the application.
+- Review Azure sign-in logs and audit logs for any activity using the application's identity after the credential was added.
+- Rotate any other secrets or certificates associated with the application and review its assigned permissions.
+- Disable the application or service principal if compromise is confirmed.
+- Investigate how the change was made (for example, a compromised admin account or an over-privileged service principal) and remediate the source of access.
+- Implement conditional access policies and PIM (Privileged Identity Management) to protect application management operations.
+"""
+references = [
+    "https://dirkjanm.io/persisting-with-federated-credentials-entra-apps-managed-identities/",
+    "https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation",
+    "https://learn.microsoft.com/en-us/graph/api/application-post-federatedidentitycredentials",
+]
+risk_score = 73
+rule_id = "63ef7acb-f57c-4a63-a53c-0ed7073bef97"
+setup = """### Microsoft Entra ID Audit Logs
+This rule requires the Azure integration with Microsoft Entra ID Audit Logs data stream ingesting in your Elastic Stack deployment. For more information, refer to the [Microsoft Entra ID Audit Logs integration documentation](https://www.elastic.co/docs/reference/integrations/azure/adlogs).
+"""
+severity = "high"
+tags = [
+    "Domain: Cloud",
+    "Domain: Identity",
+    "Data Source: Azure",
+    "Data Source: Microsoft Entra ID",
+    "Data Source: Microsoft Entra ID Audit Logs",
+    "Use Case: Identity and Access Audit",
+    "Tactic: Persistence",
+    "Tactic: Privilege Escalation",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+from logs-azure.auditlogs-* metadata _id, _version, _index
+| where event.action == "Update application"
+| where `azure.auditlogs.properties.target_resources.0.modified_properties.0.display_name` == "FederatedIdentityCredentials"
+| eval Esql.target_resources_old_value_clean = replace(`azure.auditlogs.properties.target_resources.0.modified_properties.0.old_value`, "\\\\", "")
+| eval Esql.target_resources_new_value_clean = replace(`azure.auditlogs.properties.target_resources.0.modified_properties.0.new_value`, "\\\\", "")
+| dissect Esql.target_resources_old_value_clean "%{}\"Issuer\":\"%{Esql.external_idp_old_issuer}\"%{}"
+| dissect Esql.target_resources_new_value_clean "%{}\"Issuer\":\"%{Esql.external_idp_new_issuer}\"%{}"
+| where Esql.external_idp_new_issuer is not null and Esql.external_idp_old_issuer is null
+| keep @timestamp, Esql.*, azure.*, event.*, cloud.*, related.*, tags, source.*, agent.*, client.*, _id, _version, _index, data_stream.namespace
+'''
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.001"
+name = "Additional Cloud Credentials"
+reference = "https://attack.mitre.org/techniques/T1098/001/"
+
+[rule.threat.tactic]
+id = "TA0003"
+name = "Persistence"
+reference = "https://attack.mitre.org/tactics/TA0003/"
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[[rule.threat.technique]]
+id = "T1098"
+name = "Account Manipulation"
+reference = "https://attack.mitre.org/techniques/T1098/"
+
+[[rule.threat.technique.subtechnique]]
+id = "T1098.001"
+name = "Additional Cloud Credentials"
+reference = "https://attack.mitre.org/techniques/T1098/001/"
+
+[rule.threat.tactic]
+id = "TA0004"
+name = "Privilege Escalation"
+reference = "https://attack.mitre.org/tactics/TA0004/"


### PR DESCRIPTION
## Summary

Adds an ES|QL detection rule, **Entra ID Federated Identity Credential Added**, for the initial addition of a federated identity credential (FIC) to an Entra ID application that previously had none.

A FIC establishes trust with an external OpenID Connect identity provider, letting a client authenticate as the application's service principal by presenting an externally issued token instead of a managed secret or certificate. An adversary with Application Administrator, application-owner, or `Application.ReadWrite.All` access can add a FIC pointing to an attacker-controlled IdP to gain **persistent access without managing any secret** and without tripping secret/certificate credential monitoring or MFA controls.

Reference: [dirkjanm — Persisting with Federated Credentials in Entra ID](https://dirkjanm.io/persisting-with-federated-credentials-entra-apps-managed-identities/).

## Why this is not a duplicate

The existing rule **Entra ID Federated Identity Credential Issuer Modified** (`rule_id 498e4094-60e7-11f0-8847-f661ea17fbcd`) fires only when an **existing** FIC's issuer changes — its guard is `external_idp_old_issuer is not null and external_idp_new_issuer is not null and old != new`.

This rule covers the **inverse, non-overlapping** case: a new issuer appears in the `FederatedIdentityCredentials` modified property while **no prior issuer was present** (`external_idp_new_issuer is not null and external_idp_old_issuer is null`) — i.e. the credential was **added**, not modified. The two guards are mutually exclusive, so there is no double-alerting. Together they cover both establishing and redirecting federated trust.

Neither of the adjacent credential rules covers this either:
- `persistence_entra_id_service_principal_credentials_added` → operation `Add service principal credentials` (client secrets / certificates on a service principal, not FICs).
- `persistence_entra_id_application_credential_modification` → operation `Update application - Certificates and secrets management` (secrets / certs, not FICs).

## Detection

ES|QL over `logs-azure.auditlogs-*`, keyed on `event.action == "Update application"` with `target_resources.0.modified_properties.0.display_name == "FederatedIdentityCredentials"`, mirroring the field handling of the companion issuer-modified rule.

## Complements Prowler hardening

This detection pairs with a preventive/hardening check for the same technique in Prowler ([prowler-cloud/prowler#12748](https://github.com/prowler-cloud/prowler/pull/12748)): Prowler surfaces existing risky FIC configurations, this rule alerts in near-real-time when a new one is established.

## MITRE ATT&CK

- Persistence (TA0003) — T1098 / **T1098.001 Additional Cloud Credentials**
- Privilege Escalation (TA0004) — T1098 / **T1098.001 Additional Cloud Credentials**

## Scope / known limitation

Scoped to the initial addition where no FIC existed before (highest-signal, lowest-FP persistence establishment). Documented in the investigation guide, which points to the companion issuer-modified rule for the modification case.

## Validation

- `python -m detection_rules validate-rule <rule>` → **Rule validation successful**
- `pytest tests/test_all_rules.py` → **54 passed, 1 skipped** (skip is the remote/live-stack test requiring credentials)

DCO sign-off included.