### PR TITLE
[Rule Tuning] Fix operation name in Entra ID Application Credential Modified

### DIFF
--- a/rules/integrations/azure/persistence_entra_id_application_credential_modification.toml
+++ b/rules/integrations/azure/persistence_entra_id_application_credential_modification.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/12/14"
 integration = ["azure"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/09/08"
 
 [rule]
 author = ["Elastic"]
@@ -81,7 +81,7 @@ timestamp_override = "event.ingested"
 type = "query"
 
 query = '''
-data_stream.dataset:azure.auditlogs and azure.auditlogs.operation_name:"Update application - Certificates and secrets management" and event.outcome:(success or Success)
+data_stream.dataset:azure.auditlogs and azure.auditlogs.operation_name:"Update application – Certificates and secrets management " and event.outcome:(success or Success)
 '''
 
 


### PR DESCRIPTION
# Pull Request

*Issue link(s)*: none

## Summary - What I changed

`Entra ID Application Credential Modified` selects on a plain hyphen where the audit event carries an en dash, and omits a trailing space the event carries. `azure.auditlogs.operation_name` is mapped `keyword`, so the comparison is exact and the rule cannot match. The rule was created 2020-12-14.

```diff
-azure.auditlogs.operation_name:"Update application - Certificates and secrets management"
+azure.auditlogs.operation_name:"Update application – Certificates and secrets management "
```

I want to be explicit about the trailing space before the closing quote, because it is invisible in review and easy to strip by accident. It is part of the value.

## How To Test

I have an Entra tenant and a Log Analytics workspace fed by the same diagnostic settings export this integration consumes. Asking that workspace what the value actually is:

```
AuditLogs
| where OperationName has 'Certificates'
| extend len=strlen(OperationName),
         enDash=OperationName contains '–',
         hyphen=OperationName contains '-',
         trailing=OperationName endswith ' '
| distinct OperationName, len, enDash, hyphen, trailing
```

```
OperationName : "Update application – Certificates and secrets management "
len           : 57
enDash        : True
hyphen        : False
trailing      : True
```

Controls on the same rows, so this is not just an empty workspace returning nothing:

```
| where OperationName == 'Update application - Certificates and secrets management'                       -> 0 rows
| where OperationName == strcat('Update application ','–',' Certificates and secrets management ')        -> 1 row
```

That measures what the export emits. It does not by itself prove what this integration stores, so I checked the two steps in between:

- `packages/azure/data_stream/auditlogs/elasticsearch/ingest_pipeline/default.yml` touches the value twice: a `convert` to `event.action` and a `rename` to `azure.auditlogs.operation_name`. Nothing across its 410 lines trims, gsubs, lowercases or replaces it.
- `packages/azure/data_stream/auditlogs/fields` declares `operation_name` as `keyword` with no normalizer, so the match is byte for byte.

That second one is the check most likely to have killed this. Had the field been `text`, the standard analyser would strip both dash characters and the existing query would match, and there would be nothing here to fix. It is `keyword`.

Local validation:

```
python -m detection_rules validate-rule rules/integrations/azure/persistence_entra_id_application_credential_modification.toml
Rule validation successful

python -m detection_rules test
321 passed, 19 skipped, 2 subtests passed in 415.93s
```

## Note on robustness, your call

Matching the literal is the minimal change and keeps the rule in the style used everywhere else in this folder, but it is brittle: it depends on Microsoft keeping both the en dash and the trailing space. A wildcard such as `"Update application*Certificates and secrets management*"` would survive either changing. I did not do that because no Azure rule in this repo uses wildcards on `operation_name` and I would rather not introduce a pattern you have chosen not to use. Happy to switch if you prefer it.

## Separately, and not included here

The same operation exists in a creation form, `Create application – Certificates and secrets management `, emitted when an application is created with credentials in a single Graph call. I confirmed it with a real event carrying `KeyDescription = ["[KeyIdentifier=...,KeyType=Password,KeyUsage=Verify,...]"]`. As far as I can tell no rule in this repo covers that operation, so an actor with application creation rights can add credentials at creation time rather than after it. I have left that out of this PR since it is a coverage question rather than a fix, but I am glad to open it separately if it is of interest.

## Checklist

- [x] Added a label for the type of pr: `bug`
- [x] Secret and sensitive material has been managed correctly
- [x] Documentation and comments were added for features that require explanation
