### PR TITLE
[Rule Tuning] M365 OneDrive/SharePoint Excessive File Downloads

### DIFF
--- a/rules/integrations/o365/collection_onedrive_excessive_file_downloads.toml
+++ b/rules/integrations/o365/collection_onedrive_excessive_file_downloads.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/19"
 integration = ["o365"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/09/08"
 
 [rule]
 author = ["Elastic"]
@@ -99,6 +99,7 @@ from logs-o365.audit-* metadata _id, _version, _index
     )
 | eval session.id = coalesce(o365.audit.AppAccessContext.AADSessionId, session.id, null)
 | where session.id is not null
+| eval file.size = to_long(file.size)
 | eval Esql.time_window_date_trunc = date_trunc(3 minutes, @timestamp)
 | stats
     Esql.file_directory_values = values(file.directory),


### PR DESCRIPTION
# Pull Request

*Issue link(s)*:

Closes #6750
Related to elastic/integrations#21137

## Summary - What I changed

`file.size` is mapped as `long` in older `logs-o365.audit-*` backing indices and as `keyword` in newer ones (see elastic/integrations#21137). ES|QL treats it as a union type and the rule fails at execution time with a mapping conflict.

This adds `| eval file.size = to_long(file.size)` before the `stats`. Applying a conversion function directly to a union-typed field resolves the conflict, so both mappings work. Values that fail conversion become `null` and drop out of `mv_sum`.

The mapping itself needs fixing in the O365 integration. This change keeps the rule running until that lands and existing indices roll over.

## How To Test

```
python -m detection_rules test
```

330 passed, 19 skipped (remote validation, no stack config) locally. `view-rule` compiles the query with the new `to_long` line.

## Checklist

- [x] Added a label for the type of pr: `Rule: Tuning`
- [x] Secret and sensitive material has been managed correctly
