### PR TITLE
[DaC] [Bug] KeyError when loading a production rule whose `min_stack_version` is above the package version

### DIFF
--- a/detection_rules/custom_schemas.py
+++ b/detection_rules/custom_schemas.py
@@ -21,15 +21,13 @@ RESERVED_SCHEMA_NAMES = ["beats", "ecs", "endgame"]
 
 
 def get_stack_schema_map_entry(stack_version: str) -> dict[str, Any]:
-    """Return the stack-schema-map entry for a stack version.
-
-    A rule's min_stack_version may be newer than every entry in stack-schema-map.yaml (e.g. a DaC config pinned to an
-    older Kibana release). In that case the newest entry is carried forward, mirroring `get_stack_schemas`.
-    """
+    """Return the stack-schema-map entry for a stack version, carrying the newest entry forward if needed."""
     stack_schema_map = RULES_CONFIG.stack_schema_map
     if stack_version in stack_schema_map:
         return stack_schema_map[stack_version]
 
+    # A rule's min_stack_version may be newer than every entry in stack-schema-map.yaml (e.g. a DaC config pinned to
+    # an older Kibana release). Carry the newest entry forward in that case, mirroring `get_stack_schemas`.
     newest_version = max(stack_schema_map, key=Version.parse) if stack_schema_map else None
     if newest_version and Version.parse(stack_version, optional_minor_and_patch=True) > Version.parse(newest_version):
         return stack_schema_map[newest_version]

--- a/detection_rules/custom_schemas.py
+++ b/detection_rules/custom_schemas.py
@@ -11,12 +11,30 @@ from typing import Any
 
 import eql  # type: ignore[reportMissingTypeStubs]
 from eql import load_dump, save_dump  # type: ignore[reportMissingTypeStubs]
+from semver import Version
 
 from .config import parse_rules_config
 from .utils import cached, clear_caches
 
 RULES_CONFIG = parse_rules_config()
 RESERVED_SCHEMA_NAMES = ["beats", "ecs", "endgame"]
+
+
+def get_stack_schema_map_entry(stack_version: str) -> dict[str, Any]:
+    """Return the stack-schema-map entry for a stack version.
+
+    A rule's min_stack_version may be newer than every entry in stack-schema-map.yaml (e.g. a DaC config pinned to an
+    older Kibana release). In that case the newest entry is carried forward, mirroring `get_stack_schemas`.
+    """
+    stack_schema_map = RULES_CONFIG.stack_schema_map
+    if stack_version in stack_schema_map:
+        return stack_schema_map[stack_version]
+
+    newest_version = max(stack_schema_map, key=Version.parse) if stack_schema_map else None
+    if newest_version and Version.parse(stack_version, optional_minor_and_patch=True) > Version.parse(newest_version):
+        return stack_schema_map[newest_version]
+
+    raise KeyError(f"No stack-schema-map entry found for stack version {stack_version}")
 
 
 @cached
@@ -27,7 +45,7 @@ def get_custom_schemas(stack_version: str | None = None) -> dict[str, Any]:
     stack_versions = [stack_version] if stack_version else RULES_CONFIG.stack_schema_map.keys()
 
     for version in stack_versions:
-        stack_schema_map = RULES_CONFIG.stack_schema_map[version]
+        stack_schema_map = get_stack_schema_map_entry(version)
 
         for schema, value in stack_schema_map.items():
             if schema not in RESERVED_SCHEMA_NAMES:

--- a/detection_rules/custom_schemas.py
+++ b/detection_rules/custom_schemas.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import eql  # type: ignore[reportMissingTypeStubs]
 from eql import load_dump, save_dump  # type: ignore[reportMissingTypeStubs]
+from semver import Version
 
 from .config import parse_rules_config
 from .utils import cached, clear_caches
@@ -24,13 +25,15 @@ def get_custom_schemas(stack_version: str | None = None) -> dict[str, Any]:
     """Load custom schemas if present."""
     custom_schema_dump: dict[str, Any] = {}
 
-    stack_versions = [stack_version] if stack_version else RULES_CONFIG.stack_schema_map.keys()
+    stack_schema_map = RULES_CONFIG.stack_schema_map
+    stack_versions = [stack_version] if stack_version else stack_schema_map.keys()
 
     for version in stack_versions:
-        # a rule's min_stack_version may sit above every mapped version; no custom schemas apply in that case
-        stack_schema_map = RULES_CONFIG.stack_schema_map.get(version, {})
+        # a rule's min_stack_version may sit above every mapped version; fall back to the newest mapped release to
+        # stay consistent with get_stack_schemas()
+        version_map = stack_schema_map.get(version) or stack_schema_map[max(stack_schema_map, key=Version.parse)]
 
-        for schema, value in stack_schema_map.items():
+        for schema, value in version_map.items():
             if schema not in RESERVED_SCHEMA_NAMES:
                 schema_path = Path(value)
                 if not schema_path.is_absolute():

--- a/detection_rules/custom_schemas.py
+++ b/detection_rules/custom_schemas.py
@@ -11,28 +11,12 @@ from typing import Any
 
 import eql  # type: ignore[reportMissingTypeStubs]
 from eql import load_dump, save_dump  # type: ignore[reportMissingTypeStubs]
-from semver import Version
 
 from .config import parse_rules_config
 from .utils import cached, clear_caches
 
 RULES_CONFIG = parse_rules_config()
 RESERVED_SCHEMA_NAMES = ["beats", "ecs", "endgame"]
-
-
-def get_stack_schema_map_entry(stack_version: str) -> dict[str, Any]:
-    """Return the stack-schema-map entry for a stack version, carrying the newest entry forward if needed."""
-    stack_schema_map = RULES_CONFIG.stack_schema_map
-    if stack_version in stack_schema_map:
-        return stack_schema_map[stack_version]
-
-    # A rule's min_stack_version may be newer than every entry in stack-schema-map.yaml (e.g. a DaC config pinned to
-    # an older Kibana release). Carry the newest entry forward in that case, mirroring `get_stack_schemas`.
-    newest_version = max(stack_schema_map, key=Version.parse) if stack_schema_map else None
-    if newest_version and Version.parse(stack_version, optional_minor_and_patch=True) > Version.parse(newest_version):
-        return stack_schema_map[newest_version]
-
-    raise KeyError(f"No stack-schema-map entry found for stack version {stack_version}")
 
 
 @cached
@@ -43,7 +27,8 @@ def get_custom_schemas(stack_version: str | None = None) -> dict[str, Any]:
     stack_versions = [stack_version] if stack_version else RULES_CONFIG.stack_schema_map.keys()
 
     for version in stack_versions:
-        stack_schema_map = get_stack_schema_map_entry(version)
+        # a rule's min_stack_version may sit above every mapped version; no custom schemas apply in that case
+        stack_schema_map = RULES_CONFIG.stack_schema_map.get(version, {})
 
         for schema, value in stack_schema_map.items():
             if schema not in RESERVED_SCHEMA_NAMES:

--- a/detection_rules/custom_schemas.py
+++ b/detection_rules/custom_schemas.py
@@ -28,10 +28,13 @@ def get_custom_schemas(stack_version: str | None = None) -> dict[str, Any]:
     stack_schema_map = RULES_CONFIG.stack_schema_map
     stack_versions = [stack_version] if stack_version else stack_schema_map.keys()
 
+    # fall back to the newest mapped release, matching get_stack_schemas()
+    latest_version_map: dict[str, Any] = (
+        stack_schema_map[max(stack_schema_map, key=Version.parse)] if stack_schema_map else {}
+    )
+
     for version in stack_versions:
-        # a rule's min_stack_version may sit above every mapped version; fall back to the newest mapped release to
-        # stay consistent with get_stack_schemas()
-        version_map = stack_schema_map.get(version) or stack_schema_map[max(stack_schema_map, key=Version.parse)]
+        version_map = stack_schema_map.get(version) or latest_version_map
 
         for schema, value in version_map.items():
             if schema not in RESERVED_SCHEMA_NAMES:

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -402,8 +402,7 @@ def get_stack_schemas(stack_version_val: str | None = "0.0.0") -> OrderedDictTyp
     }
 
     if stack_version > current_package:
-        # No entry exists above the current package (e.g. a DaC config pinned to an older Kibana release), so validate
-        # against the newest mapped release. The key must be a string to match the stack-schema-map.yaml entries.
+        # no mapped entry above the current package, so validate against the newest mapped release
         versions[str(stack_version)] = stack_map[max(stack_map, key=Version.parse)]
 
     return OrderedDict(sorted(versions.items(), reverse=True))

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -402,16 +402,9 @@ def get_stack_schemas(stack_version_val: str | None = "0.0.0") -> OrderedDictTyp
     }
 
     if stack_version > current_package:
-        # A rule may require a stack version newer than the current package (e.g. a DaC config pinned to an older
-        # Kibana release). Validate it against the unreleased beats/ecs branches and carry forward the endgame version
-        # from the newest mapped release, since endgame schemas are versioned independently of the stack. The key must
-        # be a string to match the entries loaded from stack-schema-map.yaml.
-        newest_mapping: dict[str, Any] = stack_map[max(stack_map, key=Version.parse)] if stack_map else {}
-        versions[str(stack_version)] = {
-            "beats": "main",
-            "ecs": "master",
-            "endgame": newest_mapping.get("endgame", definitions.DEFAULT_ENDGAME_VERSION),
-        }
+        # No entry exists above the current package (e.g. a DaC config pinned to an older Kibana release), so validate
+        # against the newest mapped release. The key must be a string to match the stack-schema-map.yaml entries.
+        versions[str(stack_version)] = stack_map[max(stack_map, key=Version.parse)]
 
     return OrderedDict(sorted(versions.items(), reverse=True))
 

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -380,6 +380,11 @@ def downgrade(
     return api_contents
 
 
+# Newest bundled endgame schema (detection_rules/etc/endgame_schemas). Used only when no stack-schema-map entry
+# defines an endgame version to inherit for a stack version above the current package.
+DEFAULT_ENDGAME_VERSION = "8.4.0"
+
+
 @cached
 def load_stack_schema_map() -> dict[str, Any]:
     return RULES_CONFIG.stack_schema_map
@@ -402,7 +407,16 @@ def get_stack_schemas(stack_version_val: str | None = "0.0.0") -> OrderedDictTyp
     }
 
     if stack_version > current_package:
-        versions[stack_version] = {"beats": "main", "ecs": "master"}
+        # A rule may require a stack version newer than the current package (e.g. a DaC config pinned to an older
+        # Kibana release). Validate it against the unreleased beats/ecs branches and carry forward the endgame version
+        # from the newest mapped release, since endgame schemas are versioned independently of the stack. The key must
+        # be a string to match the entries loaded from stack-schema-map.yaml.
+        newest_mapping: dict[str, Any] = stack_map[max(stack_map, key=Version.parse)] if stack_map else {}
+        versions[str(stack_version)] = {
+            "beats": "main",
+            "ecs": "master",
+            "endgame": newest_mapping.get("endgame", DEFAULT_ENDGAME_VERSION),
+        }
 
     return OrderedDict(sorted(versions.items(), reverse=True))
 

--- a/detection_rules/schemas/__init__.py
+++ b/detection_rules/schemas/__init__.py
@@ -380,11 +380,6 @@ def downgrade(
     return api_contents
 
 
-# Newest bundled endgame schema (detection_rules/etc/endgame_schemas). Used only when no stack-schema-map entry
-# defines an endgame version to inherit for a stack version above the current package.
-DEFAULT_ENDGAME_VERSION = "8.4.0"
-
-
 @cached
 def load_stack_schema_map() -> dict[str, Any]:
     return RULES_CONFIG.stack_schema_map
@@ -415,7 +410,7 @@ def get_stack_schemas(stack_version_val: str | None = "0.0.0") -> OrderedDictTyp
         versions[str(stack_version)] = {
             "beats": "main",
             "ecs": "master",
-            "endgame": newest_mapping.get("endgame", DEFAULT_ENDGAME_VERSION),
+            "endgame": newest_mapping.get("endgame", definitions.DEFAULT_ENDGAME_VERSION),
         }
 
     return OrderedDict(sorted(versions.items(), reverse=True))

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -87,6 +87,9 @@ ESQL_FROM_SOURCES_TERMINATOR_REGEX = re.compile(r"\||\)|\bMETADATA\b", re.IGNORE
 ESQL_INDEX_PATTERN_REGEX = re.compile(r"^[\w.*\-]+$")
 ESQL_DYNAMIC_FIELD_PREFIXES = ("Esql.", "Esql_priv.")
 BRANCH_PATTERN = f"{VERSION_PATTERN}|^master$"
+# Newest bundled endgame schema (detection_rules/etc/endgame_schemas). Used only when no stack-schema-map entry
+# defines an endgame version to inherit for a stack version above the current package.
+DEFAULT_ENDGAME_VERSION = "8.4.0"
 ELASTICSEARCH_EQL_FEATURES = {
     "allow_negation": (Version.parse("8.9.0"), None),
     "allow_runs": (Version.parse("7.16.0"), None),

--- a/detection_rules/schemas/definitions.py
+++ b/detection_rules/schemas/definitions.py
@@ -87,9 +87,6 @@ ESQL_FROM_SOURCES_TERMINATOR_REGEX = re.compile(r"\||\)|\bMETADATA\b", re.IGNORE
 ESQL_INDEX_PATTERN_REGEX = re.compile(r"^[\w.*\-]+$")
 ESQL_DYNAMIC_FIELD_PREFIXES = ("Esql.", "Esql_priv.")
 BRANCH_PATTERN = f"{VERSION_PATTERN}|^master$"
-# Newest bundled endgame schema (detection_rules/etc/endgame_schemas). Used only when no stack-schema-map entry
-# defines an endgame version to inherit for a stack version above the current package.
-DEFAULT_ENDGAME_VERSION = "8.4.0"
 ELASTICSEARCH_EQL_FEATURES = {
     "allow_negation": (Version.parse("8.9.0"), None),
     "allow_runs": (Version.parse("7.16.0"), None),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.2.3"
+version = "2.2.4"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.2.2"
+version = "2.2.3"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -20,6 +20,7 @@ from semver import Version
 
 from detection_rules import utils
 from detection_rules.config import load_current_package_version
+from detection_rules.custom_schemas import get_custom_schemas
 from detection_rules.esql_errors import EsqlSemanticError
 from detection_rules.rule import TOMLRuleContents
 from detection_rules.rule_loader import RuleCollection
@@ -861,6 +862,14 @@ class TestVersions(unittest.TestCase):
         self.assertEqual(list(schemas), [future_version])
         self.assertEqual(schemas[future_version], newest_entry)
         self.assertLessEqual({"beats", "ecs", "endgame"}, set(schemas[future_version]))
+
+        # custom schema lookups must fall back the same way rather than dropping custom schemas
+        newest_version = max(stack_map, key=Version.parse)
+        get_custom_schemas.clear()
+        try:
+            self.assertEqual(get_custom_schemas(future_version), get_custom_schemas(newest_version))
+        finally:
+            get_custom_schemas.clear()
 
 
 class TestESQLValidation(unittest.TestCase):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -20,10 +20,11 @@ from semver import Version
 
 from detection_rules import utils
 from detection_rules.config import load_current_package_version
+from detection_rules.custom_schemas import get_stack_schema_map_entry
 from detection_rules.esql_errors import EsqlSemanticError
 from detection_rules.rule import TOMLRuleContents
 from detection_rules.rule_loader import RuleCollection
-from detection_rules.schemas import RULES_CONFIG, downgrade
+from detection_rules.schemas import RULES_CONFIG, downgrade, get_stack_schemas
 from detection_rules.version_lock import VersionLockFile
 
 
@@ -843,6 +844,52 @@ class TestVersions(unittest.TestCase):
         stack_map = utils.load_etc_dump(["stack-schema-map.yaml"])
         err_msg = f"There is no entry defined for the current package ({package_version}) in the stack-schema-map"
         self.assertIn(package_version, [Version.parse(v) for v in stack_map], err_msg)
+
+    def test_stack_schemas_above_current_package(self):
+        """Test that a min_stack_version above the current package yields a complete, string-keyed mapping."""
+        stack_map = utils.load_etc_dump(["stack-schema-map.yaml"])
+        newest_entry = stack_map[max(stack_map, key=Version.parse)]
+        package_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
+        future_version = str(package_version.bump_minor())
+
+        get_stack_schemas.clear()
+        try:
+            schemas = get_stack_schemas(future_version)
+        finally:
+            get_stack_schemas.clear()
+
+        self.assertEqual(list(schemas), [future_version])
+        self.assertTrue(all(isinstance(k, str) for k in schemas))
+        mapping = schemas[future_version]
+        self.assertEqual(mapping["beats"], "main")
+        self.assertEqual(mapping["ecs"], "master")
+        self.assertEqual(mapping["endgame"], newest_entry["endgame"])
+        # every consumer indexes these keys directly, so they must all be present
+        self.assertEqual(set(mapping), {"beats", "ecs", "endgame"})
+
+    def test_stack_schemas_within_current_package(self):
+        """Test that the fallback entry is not added when min_stack_version is within the current package."""
+        package_version = str(Version.parse(load_current_package_version(), optional_minor_and_patch=True))
+        get_stack_schemas.clear()
+        try:
+            schemas = get_stack_schemas(package_version)
+        finally:
+            get_stack_schemas.clear()
+        self.assertEqual(list(schemas), [package_version])
+        self.assertNotEqual(schemas[package_version]["ecs"], "master")
+
+    def test_stack_schema_map_entry_lookup(self):
+        """Test that custom schema lookups carry the newest entry forward for versions above the stack-schema-map."""
+        stack_map = RULES_CONFIG.stack_schema_map
+        newest_version = max(stack_map, key=Version.parse)
+        oldest_version = min(stack_map, key=Version.parse)
+
+        self.assertEqual(get_stack_schema_map_entry(newest_version), stack_map[newest_version])
+        future_version = str(Version.parse(newest_version).bump_minor())
+        self.assertEqual(get_stack_schema_map_entry(future_version), stack_map[newest_version])
+        below_version = str(Version.parse(oldest_version).replace(major=0))
+        with self.assertRaises(KeyError):
+            get_stack_schema_map_entry(below_version)
 
 
 class TestESQLValidation(unittest.TestCase):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -20,7 +20,6 @@ from semver import Version
 
 from detection_rules import utils
 from detection_rules.config import load_current_package_version
-from detection_rules.custom_schemas import get_stack_schema_map_entry
 from detection_rules.esql_errors import EsqlSemanticError
 from detection_rules.rule import TOMLRuleContents
 from detection_rules.rule_loader import RuleCollection
@@ -846,7 +845,7 @@ class TestVersions(unittest.TestCase):
         self.assertIn(package_version, [Version.parse(v) for v in stack_map], err_msg)
 
     def test_stack_schemas_above_current_package(self):
-        """Test that a min_stack_version above the current package yields a complete, string-keyed mapping."""
+        """Test that a min_stack_version above the current package falls back to the newest stack-schema-map entry."""
         stack_map = utils.load_etc_dump(["stack-schema-map.yaml"])
         newest_entry = stack_map[max(stack_map, key=Version.parse)]
         package_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
@@ -858,38 +857,10 @@ class TestVersions(unittest.TestCase):
         finally:
             get_stack_schemas.clear()
 
+        # consumers index by string version and access beats/ecs/endgame directly, so the entry must be complete
         self.assertEqual(list(schemas), [future_version])
-        self.assertTrue(all(isinstance(k, str) for k in schemas))
-        mapping = schemas[future_version]
-        self.assertEqual(mapping["beats"], "main")
-        self.assertEqual(mapping["ecs"], "master")
-        self.assertEqual(mapping["endgame"], newest_entry["endgame"])
-        # every consumer indexes these keys directly, so they must all be present
-        self.assertEqual(set(mapping), {"beats", "ecs", "endgame"})
-
-    def test_stack_schemas_within_current_package(self):
-        """Test that the fallback entry is not added when min_stack_version is within the current package."""
-        package_version = str(Version.parse(load_current_package_version(), optional_minor_and_patch=True))
-        get_stack_schemas.clear()
-        try:
-            schemas = get_stack_schemas(package_version)
-        finally:
-            get_stack_schemas.clear()
-        self.assertEqual(list(schemas), [package_version])
-        self.assertNotEqual(schemas[package_version]["ecs"], "master")
-
-    def test_stack_schema_map_entry_lookup(self):
-        """Test that custom schema lookups carry the newest entry forward for versions above the stack-schema-map."""
-        stack_map = RULES_CONFIG.stack_schema_map
-        newest_version = max(stack_map, key=Version.parse)
-        oldest_version = min(stack_map, key=Version.parse)
-
-        self.assertEqual(get_stack_schema_map_entry(newest_version), stack_map[newest_version])
-        future_version = str(Version.parse(newest_version).bump_minor())
-        self.assertEqual(get_stack_schema_map_entry(future_version), stack_map[newest_version])
-        below_version = str(Version.parse(oldest_version).replace(major=0))
-        with self.assertRaises(KeyError):
-            get_stack_schema_map_entry(below_version)
+        self.assertEqual(schemas[future_version], newest_entry)
+        self.assertLessEqual({"beats", "ecs", "endgame"}, set(schemas[future_version]))
 
 
 class TestESQLValidation(unittest.TestCase):


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Resolves https://github.com/elastic/detection-rules/issues/6752

## Summary - What I changed

Loading a production rule whose `min_stack_version` is higher than the `package.name` in the active `packages.yaml`
crashed with `KeyError: 'endgame'` in `get_integration_schema_data`. This is the normal state of a Detections as Code
(DaC) repo whose config was created with `custom-rules setup-config <dir> 9.4.0` and then synced prebuilt rules that
carry `min_stack_version = "9.5.0"`.

For the fix, I added a small updated to handle this case and add the most recent Endgame schema.


### Why the fallback

`get_stack_schemas()` previously injected a synthetic `{"beats": "main", "ecs": "master"}`
entry for a `min_stack_version` above the current package. That entry is incomplete —
consumers reach for `endgame` directly, which is what produced the `KeyError: 'endgame'`.
It also keyed the entry by a `Version` object rather than a string, unlike every other
key sourced from `stack-schema-map.yaml`.

Both call sites now fall back to the newest mapped release instead:

- `get_stack_schemas()` reuses the newest `stack-schema-map.yaml` entry, so `beats`,
  `ecs`, and `endgame` are all populated, and keys it by `str(stack_version)` to stay
  consistent with the rest of the map.
- `get_custom_schemas()` falls back the same way. Using `.get(version, {})` alone would
  have avoided the `KeyError` but silently dropped custom schema entries (including
  auto-generated keys added via `update_auto_generated_schema`) whenever a rule's
  `min_stack_version` sat above the mapped versions.

This is the normal state of a DaC repo whose config was created with
`custom-rules setup-config <dir> 9.4.0` and then synced prebuilt rules carrying
`min_stack_version = "9.5.0"`.

## How To Test


Unit tests and static checks:

```
$ python -m pytest tests/test_schemas.py tests/test_custom_rules.py -q
................................                                         [100%]
32 passed in 3.27s

$ python -m pytest tests/test_schemas.py -k TestVersions -q
....                                                                     [100%]
4 passed, 27 deselected in 1.17s

$ ruff check detection_rules/schemas/__init__.py detection_rules/custom_schemas.py tests/test_schemas.py
All checks passed!
$ ruff format --check detection_rules/schemas/__init__.py detection_rules/custom_schemas.py tests/test_schemas.py
3 files already formatted
$ pyright detection_rules/schemas/__init__.py detection_rules/custom_schemas.py
0 errors, 0 warnings, 0 informations
```

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
