### PR TITLE
[Rule Tuning] M365 OneDrive/SharePoint Excessive File Downloads - fix file.size mapping conflict

### DIFF
--- a/rules/integrations/o365/collection_onedrive_excessive_file_downloads.toml
+++ b/rules/integrations/o365/collection_onedrive_excessive_file_downloads.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/02/19"
 integration = ["o365"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/09/09"
 
 [rule]
 author = ["Elastic"]
@@ -100,12 +100,14 @@ from logs-o365.audit-* metadata _id, _version, _index
 | eval session.id = coalesce(o365.audit.AppAccessContext.AADSessionId, session.id, null)
 | where session.id is not null
 | eval Esql.time_window_date_trunc = date_trunc(3 minutes, @timestamp)
+// file.size is dynamically mapped in o365.audit and can be keyword or long across backing indices
+| eval Esql.file_size_bytes = to_long(file.size)
 | stats
     Esql.file_directory_values = values(file.directory),
     Esql.file_extension_values = values(file.extension),
     Esql.application_name_values = values(application.name),
     Esql.file_name_count_distinct = count_distinct(file.name),
-    Esql.total_file_size_mb = round((mv_sum(values(file.size))) / 1048576.0, 2),
+    Esql.total_file_size_mb = round((mv_sum(values(Esql.file_size_bytes))) / 1048576.0, 2),
     Esql.o365_audit_Site_values = values(o365.audit.Site),
     Esql.o365_audit_SiteUrl_values = values(o365.audit.SiteUrl),
     Esql.user_domain_values = values(user.domain),


### PR DESCRIPTION
## Summary

`M365 OneDrive/SharePoint Excessive File Downloads` fails to execute due to a mapping conflict on `file.size`. This casts the field with `to_long()` so the query runs again.

Closes #6750

## Root cause

`file.size` has no explicit mapping in the o365 audit data stream, so it is dynamically mapped per backing index. Since o365 package 3.8.2 ([elastic/integrations#19245](https://github.com/elastic/integrations/pull/19245)) the value arrives as a string, so newer indices map it `keyword` while older ones remain `long`. ES|QL rejects the query at verification time:

```
Cannot use field [file.size] due to ambiguities being mapped as [2] incompatible types:
[keyword] in [.ds-logs-o365.audit-default-2026.07.02-000027],
[long]    in [.ds-logs-o365.audit-default-2025.08.06-000010, ...]
```

Tracked upstream in [elastic/integrations#21137](https://github.com/elastic/integrations/issues/21137). An integration-side mapping only applies to new backing indices, so the rule still needs to tolerate the indices already written.

## Changes

- Added `| eval Esql.file_size_bytes = to_long(file.size)` before `stats` to resolve the union type.
- `Esql.total_file_size_mb` now aggregates the cast field. It is dropped by `stats`, so no new field reaches the alert doc and `non-ecs-schema.json` is unchanged.
- Bumped `updated_date`.

No change to detection logic, thresholds, or index patterns.

## Validation
<img width="1352" height="680" alt="Screenshot 2026-09-09 at 10 17 42 AM" src="https://github.com/user-attachments/assets/b9ce1b08-8008-4296-a036-8e3d3ee452a2" />


Query verifies and executes against `logs-o365.audit-*`, returning values from both `long`-mapped and `keyword`-mapped indices. All 145 documents with `file.size` populated cast successfully. `to_long()` is a no-op on `long`, so the fix stays correct if the integration mapping lands later.

`pytest tests/test_all_rules.py` - 54 passed, 1 skipped.
