### PR TITLE
[Rule Tuning] Suricata and Elastic Defend Network Correlation

### DIFF
--- a/rules/cross-platform/command_and_control_suricata_elastic_defend_c2.toml
+++ b/rules/cross-platform/command_and_control_suricata_elastic_defend_c2.toml
@@ -2,7 +2,7 @@
 creation_date = "2025/12/10"
 integration = ["endpoint", "suricata"]
 maturity = "production"
-updated_date = "2026/04/10"
+updated_date = "2026/09/10"
 
 [rule]
 author = ["Elastic"]
@@ -40,7 +40,6 @@ query = '''
 sequence by source.port, source.ip, destination.ip with maxspan=5s
  [network where data_stream.dataset == "suricata.eve" and event.kind == "alert" and
   event.severity != 3 and source.ip != null and destination.ip != null and
-  not source.domain : ("*nessusscan*", "SCCMPS*") and
   not rule.name in ("ET INFO SMB2 NT Create AndX Request For a Powershell .ps1 File", "ET SCAN MS Terminal Server Traffic on Non-standard Port")]
  [network where event.module == "endpoint" and event.action in ("disconnect_received", "connection_attempted") and
   not process.executable in ("System", "C:\\Program Files (x86)\\Admin Arsenal\\PDQ Inventory\\PDQInventoryService.exe") and 


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

Related to https://github.com/elastic/detection-rules/pull/6491

## Summary - What I changed

Small tuning PR to reconcile a cross platform rule with our updated ECS restrictions. Previously, it appeared that `source.domain` was present in Suricata, but it is not.  See https://github.com/elastic/detection-rules/pull/6491#discussion_r3971528599 and https://github.com/elastic/ia-trade-team/issues/1036 for more detail.


## How To Test

Verify in telemetry and test against https://github.com/elastic/detection-rules/pull/6491.

<img width="1897" height="1344" alt="Image" src="https://github.com/user-attachments/assets/8f6b4e4c-ee2e-4b0e-a3b9-32387e5b943e" />

## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
