### PR TITLE
[Tuning] Remote Management Access Launch After MSI Install

### DIFF
--- a/rules/windows/command_and_control_rmm_after_msi_install.toml
+++ b/rules/windows/command_and_control_rmm_after_msi_install.toml
@@ -2,7 +2,7 @@
 creation_date = "2026/03/18"
 integration = ["endpoint", "windows", "sentinel_one_cloud_funnel", "m365_defender", "system", "crowdstrike"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/09/11"
 
 [rule]
 author = ["Elastic"]
@@ -88,7 +88,7 @@ type = "eql"
 query = '''
 sequence by host.id with maxspan=1m
  [process where host.os.type == "windows" and event.type == "start" and process.name : "msiexec.exe" and 
-  process.args : ("/i*", "-i*") and process.parent.name : ("explorer.exe", "sihost.exe")]
+  process.args : ("/i*", "-i*") and process.parent.name : ("explorer.exe", "sihost.exe", "powershell.exe", "cmd.exe")]
  [process where host.os.type == "windows" and event.type == "start" and
   (
    (process.name : "ScreenConnect.ClientService.exe" and process.command_line : "*?e=Access&y=Guest&h*&k=*") or


### PR DESCRIPTION
Resolve an FN - adds powershell and cmd as parent of msiexec.