### PR TITLE
[New Rule] Credential Access Alert from an RMM Process Descendant

### DIFF
--- a/rules/windows/credential_access_rmm_descendant_credaccess_alert.toml
+++ b/rules/windows/credential_access_rmm_descendant_credaccess_alert.toml
@@ -1,0 +1,257 @@
+[metadata]
+creation_date = "2026/09/10"
+integration = ["endpoint"]
+maturity = "production"
+min_stack_comments = "ES|QL FROM subqueries and SET unmapped_fields=load require Elastic Stack 9.5.0 or later."
+min_stack_version = "9.5.0"
+updated_date = "2026/09/10"
+
+[rule]
+author = ["Elastic"]
+description = """
+Identifies high- or critical-severity Elastic Security alerts mapped to Credential Access when the alerted process has a
+recognized RMM process identified by a known signer subject in its ancestry. This relationship can indicate
+credential-access activity executed through remote-management software and helps prioritize the underlying alert for investigation.
+"""
+false_positives = [
+    """
+    Authorized IT or managed service provider activity can produce this relationship, especially when the underlying
+    Credential Access alert is benign. Validate both the source alert and the RMM session or operator authorization.
+    """,
+]
+from = "now-12h"
+interval = "5m"
+language = "esql"
+license = "Elastic License v2"
+name = "Credential Access Alert from an RMM Process Descendant"
+references = [
+    "https://www.microsoft.com/en-us/security/blog/2022/06/13/the-many-lives-of-blackcat-ransomware/",
+    "https://thedfirreport.com/2023/10/30/netsupport-intrusion-results-in-domain-compromise/",
+    "https://attack.mitre.org/techniques/T1219/002/",
+]
+risk_score = 73
+rule_id = "4d243b7c-ab5f-4df1-80a7-162a35060d5a"
+severity = "high"
+tags = [
+    "Domain: Endpoint",
+    "OS: Windows",
+    "Platform: Windows",
+    "Use Case: Threat Detection",
+    "Tactic: Credential Access",
+    "Tactic: Command and Control",
+    "Rule Type: Higher-Order Rule",
+    "Data Source: Elastic Defend",
+    "Resources: Investigation Guide",
+]
+timestamp_override = "event.ingested"
+type = "esql"
+
+query = '''
+// process.Ext.ancestry is unmapped in the .alerts-security.alerts-*, so we need to load it from the _source.
+SET unmapped_fields="load";
+
+FROM (
+  FROM logs-endpoint.events.process-* METADATA _id, _index, _version
+  | WHERE @timestamp >= NOW() - 12 hours AND
+      @timestamp < NOW() AND
+      host.os.type == "windows" AND
+      MV_CONTAINS(event.type, "start") AND
+      process.code_signature.subject_name IN (
+        "Action1 Corporation", "Aeroadmin LLC", "AeroAdmin LLC", "AmidaWare LLC", "Ammyy LLC", "AnyDesk Software GmbH",
+        "AOMEI International Network Limited", "Atera Networks Ltd", "AWERAY PTE. LTD.", "BeamYourScreen GmbH",
+        "Bomgar Corporation", "BreakingSecurity.net", "ConnectWise, Inc.", "ConnectWise, LLC", "Connectwise, LLC",
+        "Devolutions Inc", "Devolutions inc.", "DOMOTZ INC.", "DUC FABULOUS CO.,LTD", "DWSNET OÜ", "DWSNET srl",
+        "Electronic Team, Inc.", "Famatech Corp.", "FleetDeck Inc", "GlavSoft LLC", "GlavSoft LLC.",
+        "GoTo Technologies USA, LLC", "Hefei Pingbo Network Technology Co. Ltd", "IDrive, Inc.",
+        "Impero Solutions Limited", "IMPERO SOLUTIONS LIMITED", "Instant Housecall", "ISL Online Ltd.", "JumpCloud Inc",
+        "Level Software, Inc.", "LogMeIn, Inc.", "LUNIXAR SAS DE CV", "MMSOFT Design Ltd.", "Monitoring Client",
+        "MSPBytes Corp", "MSPBytes, Corp.", "N-ABLE TECHNOLOGIES LTD", "Nanosystems S.r.l.", "NetSupport Ltd",
+        "NetSupport Ltd.", "NETSUPPORT LTD.", "NinjaOne LLC", "NinjaRMM, LLC", "Open Source Developer, Huabing Zhou",
+        "Parallels International GmbH", "philandro Software GmbH", "Pro Softnet Corporation", "PURSLANE", "RealVNC",
+        "RealVNC Limited", "REMOTE UTILITIES PTE. LTD.", "Remote Utilities LLC", "Rocket Software, Inc.",
+        "Rsupport Co., Ltd.", "SAFIB", "ScreenConnect Client", "Servably, Inc.", "Servably Inc.", "ShowMyPC INC",
+        "SimpleHelp Ltd", "Splashtop Inc.", "Superops Inc.", "Tailscale Inc.", "TeamViewer", "TeamViewer GmbH",
+        "TeamViewer Germany GmbH", "Techinline Limited", "uvnc bvba", "Yakhnovets Denis Aleksandrovich IP",
+        "Zhou Huabing", "ZOHO Corporation Private Limited"
+      )
+  | EVAL
+      Esql.stage = "rmm_exec",
+      Esql.lineage_entity_id = process.entity_id,
+      Esql.rmm_support_start = @timestamp,
+      Esql.rmm_support_process_name = process.name,
+      Esql.rmm_support_executable = process.executable,
+      Esql.rmm_support_signer = process.code_signature.subject_name
+  | KEEP host.id, Esql.stage, Esql.lineage_entity_id, Esql.rmm_support_start, Esql.rmm_support_process_name,
+    Esql.rmm_support_executable, Esql.rmm_support_signer, _id, _index, _version
+),
+(
+  FROM .alerts-security.alerts-* METADATA _id, _index, _version
+  | WHERE @timestamp >= NOW() - 10 minutes AND
+      @timestamp < NOW() AND
+      host.os.type == "windows" AND
+      kibana.alert.severity IN ("high", "critical") AND
+      MV_CONTAINS(kibana.alert.rule.threat.tactic.id, "TA0006") AND
+      NOT KQL("""kibana.alert.rule.tags : "Rule Type: Higher-Order Rule" """)
+  | KEEP @timestamp, event.kind, event.category, event.type, event.action, event.dataset, _id, _index, _version,
+         agent.id, host.id, host.name, user.id, user.name, process.entity_id, process.name, process.executable,
+         process.command_line, process.parent.entity_id, process.parent.name, process.Ext.ancestry, kibana.alert.*
+  
+  | EVAL Esql.stage = "credential_access_alert", Esql.lineage_entity_id = process.Ext.ancestry
+  
+  // Scalarize ancestry before grouping to prevent cross-entity context; a support start proves an exact same-host match.
+  | MV_EXPAND Esql.lineage_entity_id
+  | WHERE Esql.lineage_entity_id IS NOT NULL AND Esql.lineage_entity_id != ""
+)
+
+// Enrich each alert ancestry row with same-host RMM context for that exact process entity ID.
+| INLINE STATS
+    Esql.matched_rmm_start = MAX(Esql.rmm_support_start),
+    Esql.matched_rmm_process_names = VALUES(Esql.rmm_support_process_name),
+    Esql.matched_rmm_executables = VALUES(Esql.rmm_support_executable),
+    Esql.matched_rmm_signers = VALUES(Esql.rmm_support_signer)
+  BY host.id, Esql.lineage_entity_id
+| WHERE Esql.stage == "credential_access_alert" AND
+    Esql.matched_rmm_start IS NOT NULL
+| EVAL Esql.matched_rmm_direct_parent =
+    COALESCE(process.parent.entity_id == Esql.lineage_entity_id, false)
+
+// Select one alert row: direct parent first, then newest RMM start, with entity ID as a stable tiebreaker.
+| SORT
+    Esql.matched_rmm_direct_parent DESC,
+    Esql.matched_rmm_start DESC,
+    Esql.lineage_entity_id ASC
+| LIMIT 1 BY _index, _id
+
+// Preserve source alert identity for recovery
+| EVAL
+    Esql.source_siem_alert_index = _index,
+    Esql.source_siem_alert_id = _id,
+    Esql.source_siem_alert_timestamp = @timestamp
+| RENAME
+    Esql.lineage_entity_id AS Esql.rmm_selected_entity_id,
+    Esql.matched_rmm_start AS Esql.rmm_selected_start,
+    Esql.matched_rmm_process_names AS Esql.rmm_selected_process_names,
+    Esql.matched_rmm_executables AS Esql.rmm_selected_executables,
+    Esql.matched_rmm_signers AS Esql.rmm_selected_signers
+| KEEP
+    @timestamp, event.kind, event.category, event.type, event.action, event.dataset, _id, _index, _version, agent.id,
+    host.id, host.name, user.id, user.name, process.entity_id, process.name, process.executable, process.command_line,
+    process.parent.entity_id, process.parent.name, process.Ext.ancestry, kibana.alert.*,
+    Esql.source_siem_alert_index, Esql.source_siem_alert_id, Esql.source_siem_alert_timestamp,
+    Esql.rmm_selected_entity_id, Esql.rmm_selected_start,
+    Esql.rmm_selected_process_names, Esql.rmm_selected_executables, Esql.rmm_selected_signers
+| SORT @timestamp DESC, _index ASC, _id ASC
+'''
+
+setup = """## Setup
+
+This rule requires Windows process events from [Elastic Defend](https://www.elastic.co/security/endpoint-security) and
+Elastic Security detection alerts. Enable the source detection rules whose high- or critical-severity Credential Access
+alerts should be correlated.
+
+Elastic Defend setup instructions: https://ela.st/install-elastic-defend
+"""
+
+note = """## Triage and analysis
+
+### Investigating Credential Access Alert from an RMM Process Descendant
+
+#### Possible investigation steps
+
+- What did the underlying Credential Access alert detect?
+  - Focus: Treat `Esql.source_siem_alert_index`, `Esql.source_siem_alert_id`, and `Esql.source_siem_alert_timestamp` as pointers to the source alert, not source-event evidence.
+  - Hint: Recover that alert, review `kibana.alert.rule.name` and `kibana.alert.reason`, then use Investigate in Timeline to inspect its source events.
+  - Implication: Credential dumping, credential-store access, or credential use supports concern; a recognized password-migration, credential-backup, or support-driven reset workflow lowers concern only when its source events and RMM context agree.
+
+- What binary did the selected RMM entity represent?
+  - Focus: Treat `Esql.rmm_selected_entity_id`, `Esql.rmm_selected_start`, `Esql.rmm_selected_process_names`, `Esql.rmm_selected_executables`, and `Esql.rmm_selected_signers` as alert-local summaries.
+  - Hint: Recover the process start on the same `host.id` using `process.entity_id` = `Esql.rmm_selected_entity_id`; verify `process.hash.sha256`, `process.code_signature.status`, and `process.code_signature.thumbprint_sha256`.
+  - Implication: A coherent vendor name, installed path, hash, and signer establish identity but not benignity; path or metadata mismatches, hash drift, or an invalid or revoked signature increase concern.
+
+- Does the recovered process tree confirm RMM-mediated execution?
+  - Focus: Compare `Esql.rmm_selected_entity_id` with the alerted process's `process.Ext.ancestry`, then reconstruct intervening processes from `process.entity_id` and `process.parent.entity_id` on the same host.
+  - Implication: Shells, scripting engines, credential utilities, browser tools, or unexplained re-parenting between the RMM process and alerted process strengthen the relationship; a stable vendor helper chain is more explainable but does not clear the source alert.
+
+- What credential-access behavior did the descendant perform?
+  - Focus: In the source events, inspect `process.command_line`, `process.executable`, `process.parent.command_line`, and child processes tied to the alerted lineage.
+  - Implication: Memory access, credential-store copying, password or token extraction, dumping utilities, or encoded and hidden execution indicate likely abuse; behavior confined to the exact benign task identified in the source alert weakens that conclusion.
+
+- Which account and session launched the RMM-backed chain?
+  - Focus: Recover `process.Ext.authentication_id` from the RMM and descendant process events, then bridge it on the same `host.id` to `winlog.logon.id` or `winlog.event_data.TargetLogonId`.
+  - Hint: Use `winlog.event_data.TargetUserName`, `source.ip`, and `winlog.logon.type` to identify the authenticated account and session origin; compare product audit records when available.
+  - Implication: An unusual remote source, unexpected account, explicit-credential use, or elevated session increases concern. Missing RMM audit or Windows Security telemetry is unresolved, not benign.
+
+- Did the descendant stage credential material or additional tooling?
+  - Focus: Scope file events by `host.id` and the recovered descendant `process.entity_id`; review `event.action`, `file.path`, and `file.origin_url`, then determine whether written content was executed.
+  - Implication: Credential-store copies, dumps, archives, executable or script content in user-writable paths, and rapid write-then-execute behavior corroborate theft or staging; routine vendor cache and update artifacts should match the recovered RMM identity and workflow.
+
+- Did the descendant contact infrastructure outside the expected RMM channel?
+  - Focus: Scope DNS events and connection events by `host.id` and the recovered process entity; use `dns.question.name` for DNS and `destination.ip` / `destination.port` for connections.
+  - Implication: Destinations unrelated to the RMM vendor or support task, direct public-IP connections, or transfer activity after credential access increase concern. Vendor control-plane traffic may be expected; missing network telemetry is unresolved, not benign.
+
+- If local findings remain suspicious or unresolved, does the same pattern affect other assets or identities?
+  - Focus: Search related alerts and process events using the source `kibana.alert.rule.name`, recovered RMM `process.hash.sha256` or `process.code_signature.thumbprint_sha256`, and the involved `host.id` or `user.id`.
+  - Implication: The same abnormal descendant behavior, binary identity, or account across unrelated hosts broadens containment scope; isolated recurrence on one managed host keeps scope local but does not establish benignity.
+
+Disposition: escalate when credible credential-access evidence is supported by the lineage, session, artifact, or network findings; close only when source evidence and RMM records align with one recognized support workflow; preserve volatile evidence and escalate when findings conflict or required telemetry is missing.
+
+### False positive analysis
+
+- Authorized IT or managed service provider activity can trigger this rule during password migration, credential backup, browser-profile repair, account recovery, or controlled security testing. Confirm the exact source-alert behavior, RMM operator and session records, ticket or change record, host, account, time, and complete process chain.
+- Do not except a signer subject alone: validly signed, revoked, compromised, or repackaged RMM software can be abused. Prefer the narrow combination of executable path and hash or certificate thumbprint, managed host or user scope, RMM session context, and the specific benign source-alert workflow.
+
+### Response and remediation
+
+- If confirmed benign, document the source alert, RMM session and operator, process lineage, and organizational record. Tune with the narrow stable anchors above, preferably at the source rule when it alone misclassified the activity.
+- If suspicious but unconfirmed, export the alert and source evidence to the case and preserve volatile RMM-session state, relevant process memory, and staged files before cleanup. Suspend the remote session or apply temporary destination restrictions first; isolate the host if credential access or follow-on activity remains active and its role permits isolation.
+- If confirmed malicious, use Elastic Defend response actions to isolate the endpoint when available, then terminate the RMM session and malicious descendants after evidence collection. If direct response is unavailable, escalate with the source-alert IDs, process lineage, session details, and artifacts to the team that can contain the host.
+- Disable or revoke abused RMM operator accounts, access tokens, and unattended-access credentials; reset credentials exposed or used by the descendant; block confirmed malicious hashes, certificates, domains, and IPs; review related hosts and identities before removing unauthorized RMM software or other artifacts.
+- Harden remote-management access with an inventory of permitted products, MFA, least-privilege operator roles, restricted unattended access, application control where practical, and retained RMM audit logs.
+"""
+
+[rule.investigation_fields]
+field_names = [
+    "@timestamp",
+    "host.name",
+    "host.id",
+    "user.name",
+    "user.id",
+    "process.name",
+    "process.executable",
+    "process.command_line",
+    "process.parent.name",
+    "Esql.source_siem_alert_index",
+    "Esql.source_siem_alert_id",
+    "Esql.source_siem_alert_timestamp",
+    "Esql.rmm_selected_entity_id",
+    "Esql.rmm_selected_start",
+    "Esql.rmm_selected_process_names",
+    "Esql.rmm_selected_executables",
+    "Esql.rmm_selected_signers",
+]
+
+
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+
+[rule.threat.tactic]
+id = "TA0006"
+name = "Credential Access"
+reference = "https://attack.mitre.org/tactics/TA0006/"
+[[rule.threat]]
+framework = "MITRE ATT&CK"
+[[rule.threat.technique]]
+id = "T1219"
+name = "Remote Access Tools"
+reference = "https://attack.mitre.org/techniques/T1219/"
+[[rule.threat.technique.subtechnique]]
+id = "T1219.002"
+name = "Remote Desktop Software"
+reference = "https://attack.mitre.org/techniques/T1219/002/"
+
+
+
+[rule.threat.tactic]
+id = "TA0011"
+name = "Command and Control"
+reference = "https://attack.mitre.org/tactics/TA0011/"

--- a/rules/windows/credential_access_rmm_descendant_credaccess_alert.toml
+++ b/rules/windows/credential_access_rmm_descendant_credaccess_alert.toml
@@ -47,7 +47,7 @@ timestamp_override = "event.ingested"
 type = "esql"
 
 query = '''
-// process.Ext.ancestry is unmapped in the .alerts-security.alerts-*, so we need to load it from the _source.
+// process.Ext.ancestry is unmapped in .alerts-security.*, so we need to load it from the _source.
 SET unmapped_fields="load";
 
 FROM (
@@ -85,13 +85,18 @@ FROM (
     Esql.rmm_support_executable, Esql.rmm_support_signer, _id, _index, _version
 ),
 (
-  FROM .alerts-security.alerts-* METADATA _id, _index, _version
+  FROM .alerts-security.* METADATA _id, _index, _version
   | WHERE @timestamp >= NOW() - 10 minutes AND
       @timestamp < NOW() AND
       host.os.type == "windows" AND
       kibana.alert.severity IN ("high", "critical") AND
       MV_CONTAINS(kibana.alert.rule.threat.tactic.id, "TA0006") AND
-      NOT KQL("""kibana.alert.rule.tags : "Rule Type: Higher-Order Rule" """)
+      NOT KQL("""
+        kibana.alert.rule.tags : (
+          "Rule Type: Higher-Order" OR
+          "Rule Type: Higher-Order Rule"
+        )
+      """)
   | KEEP @timestamp, event.kind, event.category, event.type, event.action, event.dataset, _id, _index, _version,
          agent.id, host.id, host.name, user.id, user.name, process.entity_id, process.name, process.executable,
          process.command_line, process.parent.entity_id, process.parent.name, process.Ext.ancestry, kibana.alert.*

--- a/rules/windows/credential_access_rmm_descendant_credaccess_alert.toml
+++ b/rules/windows/credential_access_rmm_descendant_credaccess_alert.toml
@@ -91,12 +91,7 @@ FROM (
       host.os.type == "windows" AND
       kibana.alert.severity IN ("high", "critical") AND
       MV_CONTAINS(kibana.alert.rule.threat.tactic.id, "TA0006") AND
-      NOT KQL("""
-        kibana.alert.rule.tags : (
-          "Rule Type: Higher-Order" OR
-          "Rule Type: Higher-Order Rule"
-        )
-      """)
+      NOT KQL("""kibana.alert.rule.tags : ("Rule Type: Higher-Order" OR "Rule Type: Higher-Order Rule") """)
   | KEEP @timestamp, event.kind, event.category, event.type, event.action, event.dataset, _id, _index, _version,
          agent.id, host.id, host.name, user.id, user.name, process.entity_id, process.name, process.executable,
          process.command_line, process.parent.entity_id, process.parent.name, process.Ext.ancestry, kibana.alert.*


### PR DESCRIPTION
## Issues

Part of https://github.com/elastic/ia-trade-team/issues/984

## Summary

Identifies high- or critical-severity Elastic Security alerts mapped to Credential Access when the alerted process has a recognized RMM process identified by a known signer subject in its ancestry. This relationship can indicate credential-access activity executed through remote-management software and helps prioritize the underlying alert for investigation.

This introduces another mechanism for doing `descendant of`-style queries. More on it below.

RMM starts (12h) + source alerts (10m)
-> expand alert ancestry
-> correlate by `host.id` and process entity ID
-> select one RMM ancestor
-> emit one alert per source alert

Shared Stack TP for query testing: 2026-09-02T18:42:00Z → 2026-09-02T18:46:00Z (To replay the query, replace `NOW()` with `TO_DATETIME("2026-09-02T18:45:00Z")`)

## Questions you may have

Q: Where does the correlation happen?
A: `INLINE STATS` annotates the unioned rows by `host.id` and `Esql.lineage_entity_id`, then the WHERE retains only alert rows whose exact host/entity group has an RMM start.

Q: Why use `FROM` subqueries?
A: They apply the 12-hour RMM and 10-minute alert windows, filters, and projections independently before INLINE STATS usage. This narrows the input reaching it.

Q:Why not use `MV_INTERSECTION`?
A:Tried both, they produced equivalent matched IDs and similar performance at the 12h window. But MV_EXPAND seems to scale better at bigger windows and from the profiler, we can tell it had lower CPU usage.

Q:Why is `MV_EXPAND` needed?
A:`process.Ext.ancestry` is multivalued. `MV_EXPAND` creates one row per ancestor so each alert row can be enriched and selected using one concrete (host.id, entity ID) key.

Q:Why use `SET unmapped_fields="load"`?
A:`process.Ext.ancestry` exists in the alert `_source` but is unmapped in `.alerts-security.alerts-*`. Without `load`, the query fails with an unknown-column error. This also establishes the 9.5.0 minimum Stack version.
