### PR TITLE
[Bug] Fix unit tests that relied on shared cache state after #6594

### DIFF
--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -717,14 +717,9 @@ class QueryValidator:
         """Retrieves fields needed for the query along with type information from the schema."""
 
         current_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
-        # look the schemas up by the version resolved here rather than indexing the unfiltered map:
-        # `get_stack_schemas()` caps its keys at the package version it reads itself, so it has no entry
-        # when this module's `load_current_package_version` is pinned above the package (release branch
-        # tests pin the emit stack), and this function's fallback handles that case
-        stack_schemas = get_stack_schemas(str(current_version))[str(current_version)]
-        ecs_version = stack_schemas["ecs"]
-        beats_version = stack_schemas["beats"]
-        endgame_version = stack_schemas["endgame"]
+        ecs_version = get_stack_schemas()[str(current_version)]["ecs"]
+        beats_version = get_stack_schemas()[str(current_version)]["beats"]
+        endgame_version = get_stack_schemas()[str(current_version)]["endgame"]
         ecs_schema = ecs.get_schema(ecs_version)
 
         _, beat_schema, schema = self.get_beats_schema(index or [], beats_version, ecs_version)

--- a/detection_rules/rule.py
+++ b/detection_rules/rule.py
@@ -717,9 +717,14 @@ class QueryValidator:
         """Retrieves fields needed for the query along with type information from the schema."""
 
         current_version = Version.parse(load_current_package_version(), optional_minor_and_patch=True)
-        ecs_version = get_stack_schemas()[str(current_version)]["ecs"]
-        beats_version = get_stack_schemas()[str(current_version)]["beats"]
-        endgame_version = get_stack_schemas()[str(current_version)]["endgame"]
+        # look the schemas up by the version resolved here rather than indexing the unfiltered map:
+        # `get_stack_schemas()` caps its keys at the package version it reads itself, so it has no entry
+        # when this module's `load_current_package_version` is pinned above the package (release branch
+        # tests pin the emit stack), and this function's fallback handles that case
+        stack_schemas = get_stack_schemas(str(current_version))[str(current_version)]
+        ecs_version = stack_schemas["ecs"]
+        beats_version = stack_schemas["beats"]
+        endgame_version = stack_schemas["endgame"]
         ecs_schema = ecs.get_schema(ecs_version)
 
         _, beat_schema, schema = self.get_beats_schema(index or [], beats_version, ecs_version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detection_rules"
-version = "2.2.7"
+version = "2.2.8"
 description = "Detection Rules is the home for rules used by Elastic Security. This repository is used for the development, maintenance, testing, validation, and release of rules for Elastic Security’s Detection Engine."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_all_rules.py
+++ b/tests/test_all_rules.py
@@ -1672,6 +1672,9 @@ class TestAlertSuppression(BaseRuleTest):
                 beats_version = get_stack_schemas()[str(min_stack_version)]["beats"]
                 queryvalidator = QueryValidator(rule.contents.data.query)
                 _, _, schema = queryvalidator.get_beats_schema([], beats_version, ecs_version)
+                # copy: the returned schema is a memoized object shared by every caller, so updating it in place
+                # would leak this rule's integration fields into every later schema lookup in the test run
+                schema = dict(schema)
                 if integration_tag:
                     # if integration tag exists in rule, append integration schema to existing schema
                     # grabs the latest

--- a/tests/test_specific_rules.py
+++ b/tests/test_specific_rules.py
@@ -14,6 +14,7 @@ from detection_rules import ecs
 from detection_rules.config import load_current_package_version
 from detection_rules.integrations import (
     find_latest_compatible_version,
+    find_latest_integration_patch_for_minor,
     load_integrations_manifests,
     load_integrations_schemas,
 )
@@ -111,17 +112,31 @@ class TestNewTerms(BaseRuleTest):
                 # checks if new terms field(s) are in ecs, beats non-ecs or integration schemas
                 queryvalidator = QueryValidator(rule.contents.data.query)
                 _, _, schema = queryvalidator.get_beats_schema([], beats_version, ecs_version)
+                # copy: the returned schema is a memoized object shared by every caller, so updating it in place
+                # would leak this rule's integration fields into later lookups (and depend on earlier ones)
+                schema = dict(schema)
                 for index_name in rule.contents.data.index:
                     schema.update(**ecs.flatten(ecs.get_index_schema(index_name)))
                 integration_manifests = load_integrations_manifests()
                 integration_schemas = load_integrations_schemas()
                 integration_tags = meta.get("integration")
                 if integration_tags:
+                    # resolve the package like get_required_fields does: stack-schema-map keys stacks at
+                    # MAJOR.MINOR.0, but a package may gate the version that adds a data stream behind a later
+                    # patch (e.g. azure ~8.19.10), so resolving against the literal .0 picks an older package
+                    patch_floor = find_latest_integration_patch_for_minor(
+                        integration_tags, min_stack_version.major, min_stack_version.minor
+                    )
+                    integration_stack_version = Version(
+                        min_stack_version.major,
+                        min_stack_version.minor,
+                        max(min_stack_version.patch, patch_floor),
+                    )
                     for tag in integration_tags:
                         latest_tag_compat_ver, _ = find_latest_compatible_version(
                             package=tag,
                             integration="",
-                            rule_stack_version=min_stack_version,
+                            rule_stack_version=integration_stack_version,
                             packages_manifest=integration_manifests,
                         )
                         if latest_tag_compat_ver:

--- a/tests/test_threat_mappings.py
+++ b/tests/test_threat_mappings.py
@@ -5,6 +5,7 @@
 
 """Tests for multi-version threat mappings (e.g. MITRE ATT&CK v18/v19) support."""
 
+import contextlib
 import os
 import unittest
 from pathlib import Path
@@ -19,6 +20,7 @@ from detection_rules.config import (
     THREAT_MAPPING_VERSION_ENV,
 )
 from detection_rules.rule_loader import RuleCollection
+from detection_rules.schemas import get_stack_schemas
 from detection_rules.stack_emit import MITRE_V19_MIN_STACK
 
 TACTIC = {
@@ -61,12 +63,23 @@ def _rule(threat_mappings: list[dict[str, Any]] | None = None) -> dict[str, Any]
     return rule
 
 
+@contextlib.contextmanager
 def _pin_v19_stack() -> Any:
     """Pin the emit stack to the v19 gate so stack-gated transforms apply on release branches (< 9.5)."""
-    return mock.patch(
-        "detection_rules.rule.load_current_package_version",
-        return_value=str(MITRE_V19_MIN_STACK),
-    )
+    # `load_current_package_version` is imported by name into both the rule module and the schemas
+    # module. Pinning only the rule module makes `get_required_fields` ask `get_stack_schemas()` for a
+    # version the schemas module (still reading the real package) never lists on a < 9.5 branch. Pin
+    # both, and drop the memoized `get_stack_schemas` result so it is rebuilt for the pinned version.
+    pinned = str(MITRE_V19_MIN_STACK)
+    get_stack_schemas.clear()
+    try:
+        with (
+            mock.patch("detection_rules.rule.load_current_package_version", return_value=pinned),
+            mock.patch("detection_rules.schemas.load_current_package_version", return_value=pinned),
+        ):
+            yield
+    finally:
+        get_stack_schemas.clear()
 
 
 def _v19_block(technique: dict[str, Any] = TECH_V19) -> dict[str, Any]:


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Detection Rules!
There are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your attention.
-->
# Pull Request

*Issue link(s)*:

<!--
  Add Related Issues / PRs for context. Eg:
    Related to elastic/repo#999
    Resolves #123
  If there is no issue link, take extra care to write a clear summary and label the PR just as you would label an issue to give additional context to reviewers.
-->

## Summary - What I changed

**TLDR: The root cause is that _pin_v19_stack patches the version in one module while get_stack_schemas reads it from another.** 

Fixes the unit test failures on the 8.19, 9.3, and 9.4 branches after the #6594 backports. No production code changes. Two tests had only been passing because they read state left behind in shared caches by other tests, and #6594's per-instance memoization and new clear_caches() calls removed that state.

tests/test_threat_mappings.py: _pin_v19_stack pinned load_current_package_version to 9.5.0 in the rule module only. get_required_fields then asked get_stack_schemas() for 9.5.0, but that function reads the version from the schemas module, which still saw the real package version and had no 9.5.0 entry on branches below 9.5. The helper is now a context manager that pins both modules and clears the memoized get_stack_schemas result on entry and exit.

tests/test_specific_rules.py: test_new_terms_fields resolved integration packages at the literal MAJOR.MINOR.0 stack version. On 8.19 that picks azure 1.34.1, which predates the aadgraphactivitylogs data stream added in 1.37.0 (gated on ~8.19.10). The test now applies the same find_latest_integration_patch_for_minor floor that get_required_fields uses in production.

tests/test_specific_rules.py and tests/test_all_rules.py: both tests updated the dict returned by get_beats_schema in place. That object is a memoized result shared by every caller, so each test was leaking integration fields into later lookups. Both now copy the dict before updating it.

## How To Test

Unit tests and backport to 9.* and 8.19 branches

<img width="1013" height="170" alt="image" src="https://github.com/user-attachments/assets/19f7960b-1b91-4677-b671-8378758cffc5" />


## Checklist

<!-- Delete any items that are not applicable to this PR. -->

- [ ] Added a label for the type of pr: `bug`, `enhancement`, `schema`, `maintenance`, `Rule: New`, `Rule: Deprecation`, `Rule: Tuning`, `Hunt: New`, or `Hunt: Tuning` so guidelines can be generated
- [ ] Added the `meta:rapid-merge` label if planning to merge within 24 hours
- [ ] Secret and sensitive material has been managed correctly
- [ ] Automated testing was updated or added to match the most common scenarios
- [ ] Documentation and comments were added for features that require explanation

## Contributor checklist

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/detection-rules/blob/main/CONTRIBUTING.md)?
