### PR TITLE
[CI] Fix invalid YAML in backport concurrency group

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,7 +22,8 @@ permissions:
 # group — they would cancel the in-flight run and then skip every status job,
 # leaving the merge SHA stuck pending until the gate times out.
 concurrency:
-  group: ${{ github.event.pull_request.merged && (github.event.action == 'closed' || (github.event.action == 'labeled' && github.event.label.name == 'backport: auto')) && format('release-line-producer-{0}', github.event.pull_request.merge_commit_sha) || format('backport-event-{0}-{1}-{2}', github.event.pull_request.number, github.event.action, github.run_id) }}
+  # Double-quoted so YAML does not treat "backport: auto" as a mapping.
+  group: "${{ github.event.pull_request.merged && (github.event.action == 'closed' || (github.event.action == 'labeled' && github.event.label.name == 'backport: auto')) && format('release-line-producer-{0}', github.event.pull_request.merge_commit_sha) || format('backport-event-{0}-{1}-{2}', github.event.pull_request.number, github.event.action, github.run_id) }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Fixes invalid workflow YAML on `main` after #6670: the `concurrency.group` expression was unquoted and contained `backport: auto`, which YAML parses as a mapping (`line 25`).
- Quotes the expression so Actions can load `.github/workflows/backport.yml` again (needed for the release-line status producer).

## Test plan
- [ ] Workflow file validates (no "Invalid workflow file" on push)
- [ ] `backport` workflow runs on a merge / label event without parse failure
- [ ] Concurrency still cancels only on `closed` or `labeled` + `backport: auto`

Fixes the failure seen on https://github.com/elastic/detection-rules/actions/runs/34658171355/workflow