### PR TITLE
[Rule Tuning] A scheduled task was created

### DIFF
--- a/rules/windows/persistence_scheduled_task_creation_winlog.toml
+++ b/rules/windows/persistence_scheduled_task_creation_winlog.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/10"
 
 [rule]
 author = ["Elastic"]
@@ -74,12 +74,12 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
  not winlog.event_data.TaskName : (
               "\\CreateExplorerShellUnelevatedTask",
               "\\Hewlett-Packard\\HPDeviceCheck",
-              "\\Hewlett-Packard\\HP Support Assistant\\WarrantyChecker",
-              "\\Hewlett-Packard\\HP Support Assistant\\WarrantyChecker_backup",
+              "\\Hewlett-Packard\\HP Support Assistant\\WarrantyChecker*",
               "\\Hewlett-Packard\\HP Web Products Detection",
               "\\Microsoft\\VisualStudio\\Updates\\BackgroundDownload",
               "\\OneDrive Standalone Update Task-S-1-5-21*",
               "\\OneDrive Standalone Update Task-S-1-12-1-*",
+              "\\OneDrive Per-Machine Standalone Update Task",
               "\\SoftLanding\\S-1-5-21-*\\SoftLanding*",
               "\\SoftLanding\\S-1-12-*\\SoftLanding*",
               "\\OneDrive Reporting Task-S-1-5-21-*",
@@ -87,7 +87,19 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
               "\\GoogleUserPEH\\RunPlatformExperienceHelper*",
               "\\Mozilla\\Firefox Default Browser Agent*",
               "\\Microsoft\\Office\\Office Background Push Maintenance",
-              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate"
+              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate",
+              "\\Microsoft\\Windows\\DeviceLicensingService\\*",
+              "\\Microsoft\\Windows\\RemovalTools\\MRT_ERROR_HB",
+              "\\PRTG Windows Update Sensor",
+              "\\AMDLinkUpdate",
+              "\\AMDInstallLauncher",
+              "\\PowerToys\\Autorun for *",
+              "\\Lenovo\\LenovoMachineFixUser*",
+              "\\Barco ClickShare Update Task",
+              "\\npcapwatchdog",
+              "\\BlazerBrowserStartupTask",
+              "\\BlazerBrowserUpdateTask",
+              "\\ZoomVDIMGMTTaskUser"
  )
 '''
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1104

Reduces noise from legitimate software maintenance tasks including PRTG monitoring sensors, AMD driver updaters, Microsoft Edge maintenance, PowerToys autorun, Zoom VDI management, Ansible automation, and several Windows built-in tasks. Broadens existing Hewlett-Packard exclusions to cover all HP Support Assistant variants with serial-number suffixes, expands OneDrive exclusions to catch username-based and Per-Machine update/startup task variants, widens the GPUpdate exclusion to handle user-scoped variants, and extends the Firefox exclusion to cover Developer Edition. Also adds exclusions for npcapwatchdog, TVInstallRestore, CCleanerCrashReporting, ArcGIS Pro Indexing, DeviceLicensingService, MRT_ERROR_HB, and SnapshotCleanupTask.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
