### PR TITLE
[Rule Tuning] Potential Lateral Tool Transfer via SMB Share

### DIFF
--- a/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
+++ b/rules/windows/lateral_movement_executable_tool_transfer_smb.toml
@@ -2,7 +2,7 @@
 creation_date = "2020/11/10"
 integration = ["endpoint"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/23"
 
 [rule]
 author = ["Elastic"]
@@ -88,8 +88,18 @@ sequence by host.id with maxspan=30s
    network.transport == "tcp" and source.ip != "127.0.0.1" and source.ip != "::1"
   ] by process.entity_id
   /* add more executable / script extensions here if they are not noisy in your environment */
-  [file where host.os.type == "windows" and event.type in ("creation", "change") and process.pid == 4 and user.id like ("S-1-5-21*", "S-1-12-*") and 
-   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl"))] by process.entity_id
+  [file where host.os.type == "windows" and event.type in ("creation", "change") and process.pid == 4 and user.id like ("S-1-5-21*", "S-1-12-*") and
+   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl")) and
+   not file.path : (
+     "?:\\Windows\\AdminArsenal\\*",
+     "?:\\Windows\\VeeamVssSupport\\*",
+     "?:\\Windows\\VeeamLogShipper\\*",
+     "?:\\Windows\\Veeam\\Backup\\*",
+     "?:\\Sysmon\\*",
+     "?:\\Windows\\Temp\\KAV Remote Installations\\*",
+     "?:\\Windows\\SysWOW64\\Qualys\\*",
+     "?:\\Windows\\SysWOW64\\NwxExeSvc\\*"
+   )] by process.entity_id
 '''
 
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1112

Reduces noise from legitimate IT management, backup, security, and endpoint management tools deploying files over SMB shares. Expands the existing Veeam exclusion to cover additional Veeam paths and adds exclusions for PDQ AdminArsenal (Inventory/Deploy scanner), Trend Micro Security Agent temp files, SCCM distribution points and client setup, CrowdStrike driver deployments, Sysmon installations, Netwrix audit agents, ManageEngine UEMS remote installer, and CyberArk PSM agent deployments. All excluded patterns are well-known enterprise software observed across multiple clusters, and the rule retains full detection for actual lateral tool transfer activity including PsExec and unknown executables.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
