### PR TITLE
[Rule Tuning] Temporarily Scheduled Task Creation

### DIFF
--- a/rules/windows/persistence_temp_scheduled_task.toml
+++ b/rules/windows/persistence_temp_scheduled_task.toml
@@ -2,7 +2,7 @@
 creation_date = "2022/08/29"
 integration = ["system", "windows"]
 maturity = "production"
-updated_date = "2026/05/04"
+updated_date = "2026/07/20"
 
 [rule]
 author = ["Elastic"]
@@ -67,7 +67,24 @@ type = "eql"
 
 query = '''
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
-   [iam where host.os.type == "windows" and event.action == "scheduled-task-created" and not user.name : "*$"]
+   [iam where host.os.type == "windows" and event.action == "scheduled-task-created" and not user.name : "*$" and
+     not winlog.event_data.TaskName : (
+       "\\GoogleUserPEH\\*",
+       "\\PRTG *",
+       "*\\HP Support Assistant\\*",
+       "\\OneDrive Standalone Update Task*",
+       "*Firefox Default Browser Agent*",
+       "*\\DeviceLicensingService\\*",
+       "\\PowerToys\\Autorun*",
+       "\\Cortex-Local-Server-*",
+       "\\AMDLinkUpdate",
+       "\\RunAADCHTestConnectivityAsSystem",
+       "\\ZoomUpdateTaskUser-*",
+       "*ansible-ansible.windows.win_updates*",
+       "\\CreateExplorerShellUnelevatedTask",
+       "\\SoftLanding\\*"
+     )
+   ]
    [iam where host.os.type == "windows" and event.action == "scheduled-task-deleted" and not user.name : "*$"]
 '''
 


### PR DESCRIPTION
Resolves elastic/ia-trade-team#1114

Reduces noise from legitimate software management tools that routinely create and delete scheduled tasks in rapid succession. Adds task name exclusions for SoftLanding deployment tasks, PRTG monitoring sensors, Microsoft Edge and OneDrive update tasks, HP Support Assistant warranty checks, PowerToys autorun, Mozilla and Firefox browser agents, AMD driver updaters, Google Platform Experience Helper, Azure AD Connect Health checks, CreateExplorerShellUnelevatedTask, TeamViewer install/restore, CCleaner crash reporting, Windows Device Licensing Service, and WaveBrowser auto-start tasks. These patterns span many clusters and represent well-known benign scheduled task lifecycle behavior that does not indicate adversary abuse of T1053.005.

---

*Full telemetry triage, analytics links, and KQL verification: see linked ia-trade-team issue.*
